### PR TITLE
fix(hermes): run pipeline agents sequentially

### DIFF
--- a/apps/hermes/app/api/pipeline/route.ts
+++ b/apps/hermes/app/api/pipeline/route.ts
@@ -68,22 +68,24 @@ export async function POST(request: Request) {
     const agents = await prisma.agentRegistry.findMany({
       where: { agentId: { in: agentIds } },
     });
+    const agentById = new Map(agents.map((a) => [a.agentId, a]));
 
     console.log("AGENTS", agents);
 
-    await Promise.all(
-      agents.map(async (agent) => {
-        const endpoint = await AgentEndpointSchema.parseAsync(agent.endpoint);
-
-        await got.post(endpoint.url, {
-          json: { tickerId: data.tickerId },
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${data.apiKey}`,
-          },
-        });
-      }),
-    );
+    for (const step of pipelineSteps) {
+      const agent = agentById.get(step.agentId);
+      if (!agent) {
+        throw new Error(`Agent ${step.agentId} not found in registry for step order ${step.order}`);
+      }
+      const endpoint = await AgentEndpointSchema.parseAsync(agent.endpoint);
+      await got.post(endpoint.url, {
+        json: { tickerId: data.tickerId },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${data.apiKey}`,
+        },
+      });
+    }
 
     return NextResponse.json({ success: true });
   } catch (error) {

--- a/apps/hermes/app/cron-jobs.ts
+++ b/apps/hermes/app/cron-jobs.ts
@@ -39,27 +39,28 @@ async function runPipeline() {
     const agents = await prisma.agentRegistry.findMany({
       where: { agentId: { in: agentIds } },
     });
+    const agentById = new Map(agents.map((a) => [a.agentId, a]));
 
     for (const ticker of tickers) {
       console.log(
         `Running pipeline "${pipeline.name}" for ticker "${ticker.symbol}"...`,
       );
 
-      await Promise.all(
-        agents.map(async (agent) => {
-          const endpoint = await AgentEndpointSchema.parseAsync(
-            agent.endpoint,
-          );
-
-          await got.post(endpoint.url, {
-            json: { tickerId: ticker.id },
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${env.AGENT_API_KEY}`,
-            },
-          });
-        }),
-      );
+      for (const step of pipelineSteps) {
+        const agent = agentById.get(step.agentId);
+        if (!agent) {
+          console.warn(`Agent ${step.agentId} not found in registry, skipping step order ${step.order}`);
+          continue;
+        }
+        const endpoint = await AgentEndpointSchema.parseAsync(agent.endpoint);
+        await got.post(endpoint.url, {
+          json: { tickerId: ticker.id },
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${env.AGENT_API_KEY}`,
+          },
+        });
+      }
 
       console.log(
         `Pipeline "${pipeline.name}" completed for ticker "${ticker.symbol}".`,


### PR DESCRIPTION
- Execute pipeline steps in order: wait for each agent to finish before
  starting the next instead of running all in parallel (Promise.all).
- Iterate over pipelineSteps (ordered by step order) and call each agent
  in sequence so execution follows the pipeline definition.
- Apply in both the cron job (runPipeline) and POST /api/pipeline.