### PR TITLE
Update route-action-gen

### DIFF
--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -27,7 +27,7 @@
     "next-themes": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "route-action-gen": "0.0.2",
+    "route-action-gen": "catalog:",
     "sonner": "catalog:",
     "zod": "catalog:"
   },

--- a/apps/hermes/next-env.d.ts
+++ b/apps/hermes/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/hermes/package.json
+++ b/apps/hermes/package.json
@@ -32,7 +32,7 @@
     "node-cron": "^4.2.1",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "route-action-gen": "^0.0.8",
+    "route-action-gen": "catalog:",
     "sonner": "catalog:",
     "zod": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ catalogs:
     react-dom:
       specifier: 19.2.3
       version: 19.2.3
+    route-action-gen:
+      specifier: ^0.0.10
+      version: 0.0.10
     sonner:
       specifier: ^2.0.7
       version: 2.0.7
@@ -393,8 +396,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(react@19.2.3)
       route-action-gen:
-        specifier: 0.0.2
-        version: 0.0.2(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+        specifier: 'catalog:'
+        version: 0.0.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -505,8 +508,8 @@ importers:
         specifier: 'catalog:'
         version: 19.2.3(react@19.2.3)
       route-action-gen:
-        specifier: ^0.0.8
-        version: 0.0.8(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76)
+        specifier: 'catalog:'
+        version: 0.0.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -7578,21 +7581,8 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
-  route-action-gen@0.0.2:
-    resolution: {integrity: sha512-CSxFa+4EMorwYVZwfE/gz3FThAsS5stUTaRz0U0beVbSwt13r+kmQ9g3LsVSIk0i2/9cpGGNX8Lwz6YiXHG0aw==}
-    hasBin: true
-    peerDependencies:
-      next: '>=14.0.0'
-      react: '>=18.0.0'
-      zod: ^3.0.0
-    peerDependenciesMeta:
-      next:
-        optional: true
-      react:
-        optional: true
-
-  route-action-gen@0.0.8:
-    resolution: {integrity: sha512-unN3NtSSDKgPSLimSLy7cynl3mhsCu+c6QCSvzhHq6alRpdJNUJT+wtD62DuHMEA1lj6QJrW4+cB0oiQW9TSPg==}
+  route-action-gen@0.0.10:
+    resolution: {integrity: sha512-mMNlFPyuvBBI8UQLsdw6Ch4Hokz0o9URqCvVQB+UK5Vn4Y+mH2AhRoXsktCHcI8bsbs/Gwqx7MRp/NSK1jwH3g==}
     hasBin: true
     peerDependencies:
       next: '>=14.0.0'
@@ -16200,15 +16190,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.2(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76):
-    dependencies:
-      glob: 13.0.2
-      zod: 3.25.76
-    optionalDependencies:
-      next: 16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-
-  route-action-gen@0.0.8(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.1.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ catalog:
   "next": "^16.1.1"
   "next-themes": "^0.4.6"
   "pg": ^8.18.0
+  "route-action-gen": "^0.0.10"
   "@types/pg": ^8.16.0
   "react": "19.2.3"
   "react-dom": "19.2.3"


### PR DESCRIPTION
This should fix the missing route generated by route-action-gen. For example, when importing json file in the ticker page in hermes.