### PR TITLE
Add Prisma migration guidelines and skills documentation

### DIFF
--- a/.cursor/rules/prisma-migrations.mdc
+++ b/.cursor/rules/prisma-migrations.mdc
@@ -1,0 +1,37 @@
+---
+description: Use Prisma migrate dev for schema changes; never create or edit migration SQL by hand
+globs: "**/schema.prisma,**/migrations/**"
+alwaysApply: false
+---
+
+# Prisma Migrations
+
+When adding or changing the Prisma schema (`schema.prisma`), **do not** create or edit migration SQL files manually.
+
+## Correct workflow
+
+1. Edit `packages/database/prisma/schema.prisma` only.
+2. Generate the migration by running from the repo root:
+
+   ```bash
+   cd packages/database && pnpm db:migrate:dev
+   ```
+
+   Or from root with filter:
+
+   ```bash
+   pnpm --filter @workspace/database db:migrate:dev
+   ```
+
+3. When prompted, give the migration a descriptive name (e.g. `add_variable_created_by`).
+
+Prisma will create the migration file and apply it. Do not create `migrations/<timestamp>_<name>/migration.sql` yourself or paste raw SQL into it.
+
+## When to use
+
+- Adding, removing, or changing models, fields, indexes, or relations in `schema.prisma`.
+- Fixing schema drift: prefer changing the schema and re-running `db:migrate:dev` with a new migration over hand-editing existing migration files.
+
+## Editing an existing migration
+
+Only edit an existing migration file if the user explicitly asks to update a recent migration that has not been deployed (e.g. to avoid a new migration). Even then, prefer creating a new migration when possible.

--- a/.cursor/skills/prisma-migrate-dev/SKILL.md
+++ b/.cursor/skills/prisma-migrate-dev/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: prisma-migrate-dev
+description: Create and apply Prisma schema migrations using the project's db:migrate:dev script. Use when changing schema.prisma, adding migrations, or when the user asks to run migrations or migrate the database.
+---
+
+# Prisma Migrate Dev in This Project
+
+Migrations are **never** created by hand. This project uses `prisma migrate dev` via the database package script.
+
+## When to use
+
+- User asks to add a migration, run migrations, or change the database schema.
+- You have edited `packages/database/prisma/schema.prisma` and need to persist the change.
+
+## Steps
+
+1. **Edit the schema only**  
+   Change `packages/database/prisma/schema.prisma` (models, fields, relations). Do not create or edit files under `prisma/migrations/`.
+
+2. **Run the migration command**  
+   From the repository root:
+
+   ```bash
+   cd packages/database && pnpm db:migrate:dev
+   ```
+
+   Or using the workspace filter:
+
+   ```bash
+   pnpm --filter @workspace/database db:migrate:dev
+   ```
+
+3. **Name the migration**  
+   When Prisma prompts for a migration name, use a short snake_case description (e.g. `add_variable_created_by`, `create_audit_table`).
+
+4. **Confirm**  
+   Prisma creates the migration SQL and applies it to the dev database. No manual migration file editing.
+
+## Do not
+
+- Create `migrations/<timestamp>_<name>/migration.sql` yourself.
+- Paste or write raw SQL into migration files unless the user explicitly asks to modify an existing, undeployed migration.


### PR DESCRIPTION
- Introduced a new rules file for Prisma migrations, outlining the correct workflow for schema changes and migration creation.
- Added a skill documentation for `prisma-migrate-dev`, detailing when and how to use the migration command, emphasizing the importance of not manually editing migration files.