### PR TITLE
Add Zod validation for agent and Outlook inbox API responses

### DIFF
--- a/apps/agents/content-generation/src/index.test.ts
+++ b/apps/agents/content-generation/src/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { formatNewsletterContent } from "./format-newsletter-content.js";
+import { parseNewsletterJson } from "./parse-newsletter-json.js";
 
 describe("formatNewsletterContent", () => {
   it("formats executive summary and top 3 news into plain text", () => {
@@ -57,5 +58,44 @@ describe("formatNewsletterContent", () => {
     // Assert
     expect(content).toContain("1. Only one");
     expect(content).not.toContain("2.");
+  });
+});
+
+describe("parseNewsletterJson", () => {
+  it("parses valid newsletter JSON", () => {
+    // Setup
+    const raw = JSON.stringify({
+      subject: "Daily Brief",
+      executiveSummary: "Markets up.",
+      topNews: [{ title: "Headline", summary: "Summary text." }],
+    });
+
+    // Act
+    const result = parseNewsletterJson(raw);
+
+    // Assert
+    expect(result.subject).toBe("Daily Brief");
+    expect(result.executiveSummary).toBe("Markets up.");
+    expect(result.topNews).toHaveLength(1);
+    expect(result.topNews?.[0]?.title).toBe("Headline");
+  });
+
+  it("throws when JSON is malformed", () => {
+    // Act & Assert
+    expect(() => parseNewsletterJson("not valid json")).toThrow(
+      "OpenAI returned invalid JSON",
+    );
+  });
+
+  it("throws when topNews item has invalid shape", () => {
+    // Setup: topNews item missing required title/summary strings
+    const raw = JSON.stringify({
+      subject: "x",
+      executiveSummary: "y",
+      topNews: [{ title: 123, summary: "ok" }],
+    });
+
+    // Act & Assert
+    expect(() => parseNewsletterJson(raw)).toThrow();
   });
 });

--- a/apps/agents/content-generation/src/index.ts
+++ b/apps/agents/content-generation/src/index.ts
@@ -24,11 +24,7 @@ interface GeneratedContent {
   description?: string;
 }
 
-interface NewsletterStructure {
-  subject: string;
-  executiveSummary: string;
-  topNews: Array<{ title: string; summary: string }>;
-}
+import { parseNewsletterJson } from "./parse-newsletter-json.js";
 
 const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY });
 
@@ -136,19 +132,19 @@ Return a JSON object with:
     throw new Error("OpenAI returned an empty response");
   }
 
-  const parsed = JSON.parse(result) as NewsletterStructure;
-  const topNews = Array.isArray(parsed.topNews)
-    ? parsed.topNews.slice(0, 3)
+  const validated = parseNewsletterJson(result);
+  const topNews = Array.isArray(validated.topNews)
+    ? validated.topNews.slice(0, 3)
     : [];
   const content = formatNewsletterContent(
-    parsed.executiveSummary ?? "",
+    validated.executiveSummary ?? "",
     topNews,
   );
 
   return {
-    subject: parsed.subject ?? "Your daily briefing",
+    subject: validated.subject ?? "Your daily briefing",
     content,
-    description: parsed.executiveSummary?.trim() || undefined,
+    description: validated.executiveSummary?.trim() || undefined,
   };
 }
 

--- a/apps/agents/content-generation/src/parse-newsletter-json.ts
+++ b/apps/agents/content-generation/src/parse-newsletter-json.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+
+/** Zod schema for OpenAI LLM newsletter JSON output. */
+export const newsletterStructureSchema = z.object({
+  subject: z.string().optional(),
+  executiveSummary: z.string().optional(),
+  topNews: z
+    .array(
+      z.object({
+        title: z.string(),
+        summary: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Parses and validates raw JSON string from OpenAI into newsletter structure.
+ *
+ * @param raw - Raw JSON string from LLM response.
+ * @returns Validated newsletter structure.
+ * @throws Error when JSON is invalid or structure does not match schema.
+ */
+export function parseNewsletterJson(
+  raw: string,
+): z.infer<typeof newsletterStructureSchema> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("OpenAI returned invalid JSON");
+  }
+  return newsletterStructureSchema.parse(parsed);
+}

--- a/apps/agents/data-collection/src/utilities/web-fetch.ts
+++ b/apps/agents/data-collection/src/utilities/web-fetch.ts
@@ -1,4 +1,5 @@
 import got from "got";
+import { z } from "zod";
 import { sleep } from "@workspace/utils";
 
 import type { WebSearchResult } from "./web-search.js";
@@ -14,9 +15,19 @@ export interface WebFetchDeps {
   gotClient?: typeof got;
 }
 
-export type WebFetchResponse = {
-  data?: { url?: string; title?: string; content?: string };
-};
+/** Zod schema for Jina AI Reader API response data object. */
+const jinaDataSchema = z.object({
+  url: z.string().optional(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+});
+
+/** Zod schema for Jina AI Reader API response. */
+export const webFetchResponseSchema = z.object({
+  data: jinaDataSchema.optional(),
+});
+
+export type WebFetchResponse = z.infer<typeof webFetchResponseSchema>;
 
 /**
  * Fetches and enriches web page contents for each search result using the Jina AI API.
@@ -44,7 +55,7 @@ export async function performWebFetch(
       continue;
     }
 
-    const json = await gotClient
+    const raw = await gotClient
       .post("https://r.jina.ai/", {
         json: { url: result.url },
         headers: {
@@ -53,7 +64,9 @@ export async function performWebFetch(
           Authorization: `Bearer ${jinaApiKey}`,
         },
       })
-      .json<WebFetchResponse>();
+      .json<unknown>();
+
+    const json = webFetchResponseSchema.parse(raw);
 
     pages.push({
       url: json.data?.url ?? result.url,

--- a/apps/agents/data-collection/src/utilities/web-search.ts
+++ b/apps/agents/data-collection/src/utilities/web-search.ts
@@ -1,4 +1,5 @@
 import got from "got";
+import { z } from "zod";
 import { sleep } from "@workspace/utils";
 
 export interface SearchQuery {
@@ -21,13 +22,19 @@ export interface WebSearchDeps {
   gotClient?: typeof got;
 }
 
-export type SerperResponse = {
-  organic?: Array<{
-    link?: string;
-    title?: string;
-    snippet?: string;
-  }>;
-};
+/** Zod schema for Serper.dev API organic search result item. */
+const serperOrganicItemSchema = z.object({
+  link: z.string().optional(),
+  title: z.string().optional(),
+  snippet: z.string().optional(),
+});
+
+/** Zod schema for Serper.dev API search response. */
+export const serperResponseSchema = z.object({
+  organic: z.array(serperOrganicItemSchema).optional(),
+});
+
+export type SerperResponse = z.infer<typeof serperResponseSchema>;
 
 /**
  * Performs web search for each query using the Serper.dev API and returns a web search result per query.
@@ -48,7 +55,7 @@ export async function performWebSearch(
       await sleep(1_000);
     }
 
-    const response = await gotClient
+    const raw = await gotClient
       .post("https://google.serper.dev/search", {
         json: { q: query.text },
         headers: {
@@ -56,9 +63,11 @@ export async function performWebSearch(
           "X-API-KEY": serperApiKey,
         },
       })
-      .json<SerperResponse>();
+      .json<unknown>();
 
-    for (const item of response?.organic ?? []) {
+    const response = serperResponseSchema.parse(raw);
+
+    for (const item of response.organic ?? []) {
       results.push({
         url: item.link ?? "",
         title: item.title ?? "",

--- a/apps/agents/data-collection/tests/web-fetch.test.ts
+++ b/apps/agents/data-collection/tests/web-fetch.test.ts
@@ -59,4 +59,33 @@ describe("performWebFetch", () => {
       searchQueryText: "query",
     });
   });
+
+  it("throws when Jina returns invalid response shape", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue({
+      json: vi.fn().mockResolvedValue({
+        data: "not-an-object",
+      }),
+    });
+
+    const fakeGot = { post: postMock } as any;
+    const searchResults = [
+      {
+        url: "http://example.com",
+        title: "Snippet",
+        content: "Snippet",
+        tickerId: "ticker-1",
+        searchQueryId: "q1",
+        searchQueryText: "query",
+      },
+    ];
+
+    // Act & Assert
+    await expect(
+      performWebFetch(searchResults, {
+        jinaApiKey: "jina-key",
+        gotClient: fakeGot,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/apps/agents/data-collection/tests/web-search.test.ts
+++ b/apps/agents/data-collection/tests/web-search.test.ts
@@ -64,4 +64,24 @@ describe("performWebSearch", () => {
       searchQueryText: "search",
     });
   });
+
+  it("throws when Serper returns invalid response shape", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue({
+      json: vi.fn().mockResolvedValue({
+        organic: "not-an-array",
+      }),
+    });
+
+    const fakeGot = { post: postMock } as any;
+    const queries = [{ id: "q1", text: "search", tickerId: "ticker-1" }] as any;
+
+    // Act & Assert
+    await expect(
+      performWebSearch(queries, {
+        serperApiKey: "serper-key",
+        gotClient: fakeGot,
+      }),
+    ).rejects.toThrow();
+  });
 });

--- a/apps/hermes/next-env.d.ts
+++ b/apps/hermes/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/user-registration/lib/read-tickers.test.ts
+++ b/apps/user-registration/lib/read-tickers.test.ts
@@ -50,4 +50,25 @@ describe("readTickers", () => {
 
     await fs.unlink(tmpFile);
   });
+
+  it("returns empty array when JSON has invalid ticker shape", async () => {
+    // Setup: valid JSON but ticker missing required fields
+    const tmpFile = path.join(
+      os.tmpdir(),
+      `tickers-bad-shape-${Date.now()}.json`,
+    );
+    await fs.writeFile(
+      tmpFile,
+      JSON.stringify([{ KodeEmiten: "AADI" }]),
+      "utf8",
+    );
+
+    // Act
+    const result = await readTickers(tmpFile);
+
+    // Assert
+    expect(result).toEqual([]);
+
+    await fs.unlink(tmpFile);
+  });
 });

--- a/apps/user-registration/lib/read-tickers.ts
+++ b/apps/user-registration/lib/read-tickers.ts
@@ -1,9 +1,11 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { Ticker } from "./tickers";
+import { tickersArraySchema } from "./tickers";
 
 /**
  * Reads slim tickers from the public/tickers.json file.
+ *
  * @param filePath - Path to the tickers JSON file (defaults to public/tickers.json in cwd).
  * @returns Array of slim tickers, or empty array if the file is missing or invalid.
  */
@@ -12,8 +14,9 @@ export const readTickers = async (
 ): Promise<Ticker[]> => {
   try {
     const raw = await fs.readFile(filePath, "utf8");
-
-    return JSON.parse(raw) as Ticker[];
+    const parsed = JSON.parse(raw) as unknown;
+    const result = tickersArraySchema.safeParse(parsed);
+    return result.success ? result.data : [];
   } catch {
     return [];
   }

--- a/apps/user-registration/lib/tickers.ts
+++ b/apps/user-registration/lib/tickers.ts
@@ -1,8 +1,16 @@
+import { z } from "zod";
+
+/** Zod schema for a slim ticker from tickers.json. */
+export const tickerSchema = z.object({
+  KodeEmiten: z.string(),
+  NamaEmiten: z.string(),
+});
+
 /** Slim ticker representation used throughout the app. */
-export type Ticker = {
-  KodeEmiten: string;
-  NamaEmiten: string;
-};
+export type Ticker = z.infer<typeof tickerSchema>;
+
+/** Zod schema for tickers.json array. */
+export const tickersArraySchema = z.array(tickerSchema);
 
 /**
  * Filters tickers by matching the query against both code and name.

--- a/apps/user-registration/next-env.d.ts
+++ b/apps/user-registration/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/outlook-inbox/package.json
+++ b/packages/outlook-inbox/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint \"src/**/*.ts\""
   },
   "dependencies": {
-    "got": "catalog:"
+    "got": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/outlook-inbox/src/create-outlook-inbox-client.test.ts
+++ b/packages/outlook-inbox/src/create-outlook-inbox-client.test.ts
@@ -133,7 +133,12 @@ describe("createOutlookInboxClient", () => {
       });
       const postFn = vi.fn().mockResolvedValue({
         statusCode: 200,
-        body: JSON.stringify({ id: "msg-1", subject: "X" }),
+        body: JSON.stringify({
+          id: "msg-1",
+          subject: "X",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: false,
+        }),
       });
       const client = createOutlookInboxClient(
         { getAccessToken },
@@ -173,7 +178,12 @@ describe("createOutlookInboxClient", () => {
       });
       const postFn = vi.fn().mockResolvedValue({
         statusCode: 200,
-        body: JSON.stringify({ id: "msg-2" }),
+        body: JSON.stringify({
+          id: "msg-2",
+          subject: "Y",
+          receivedDateTime: "2024-01-02T00:00:00Z",
+          isRead: true,
+        }),
       });
       const client = createOutlookInboxClient(
         { getAccessToken },
@@ -221,10 +231,26 @@ describe("createOutlookInboxClient", () => {
           ],
         }),
       });
-      const postFn = vi.fn().mockResolvedValue({
-        statusCode: 200,
-        body: JSON.stringify({}),
-      });
+      const postFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: JSON.stringify({
+            id: "1",
+            subject: "A",
+            receivedDateTime: "2024-01-01T00:00:00Z",
+            isRead: false,
+          }),
+        })
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: JSON.stringify({
+            id: "2",
+            subject: "B",
+            receivedDateTime: "2024-01-02T00:00:00Z",
+            isRead: false,
+          }),
+        });
       const client = createOutlookInboxClient(
         { getAccessToken },
         { graphClientOptions: { getFn, postFn } },
@@ -324,7 +350,12 @@ describe("createOutlookInboxClient", () => {
       const getAccessToken = vi.fn().mockResolvedValue("t");
       const postFn = vi.fn().mockResolvedValue({
         statusCode: 200,
-        body: JSON.stringify({ id: "del-1" }),
+        body: JSON.stringify({
+          id: "del-1",
+          subject: null,
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: false,
+        }),
       });
       const client = createOutlookInboxClient(
         { getAccessToken },
@@ -348,7 +379,12 @@ describe("createOutlookInboxClient", () => {
       const getAccessToken = vi.fn().mockResolvedValue("t");
       const postFn = vi.fn().mockResolvedValue({
         statusCode: 200,
-        body: JSON.stringify({ id: "x" }),
+        body: JSON.stringify({
+          id: "x",
+          subject: null,
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: false,
+        }),
       });
       const client = createOutlookInboxClient(
         { getAccessToken },

--- a/packages/outlook-inbox/src/get-access-token.test.ts
+++ b/packages/outlook-inbox/src/get-access-token.test.ts
@@ -163,4 +163,20 @@ describe("getAccessTokenFromClientCredentials", () => {
       ),
     ).rejects.toThrow("Token request failed: 500");
   });
+
+  it("throws when success response has invalid token shape", async () => {
+    // Setup: access_token must be string, not number
+    const requestFn = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      body: JSON.stringify({ access_token: 12345 }),
+    });
+
+    // Act & Assert
+    await expect(
+      getAccessTokenFromClientCredentials(
+        { clientId: "a", clientSecret: "b", tenantId: "c" },
+        { requestFn },
+      ),
+    ).rejects.toThrow();
+  });
 });

--- a/packages/outlook-inbox/src/get-access-token.ts
+++ b/packages/outlook-inbox/src/get-access-token.ts
@@ -1,4 +1,5 @@
 import got from "got";
+import { z } from "zod";
 
 const GRAPH_SCOPE = "https://graph.microsoft.com/.default";
 
@@ -9,12 +10,12 @@ export type ClientCredentialsConfig = {
   tenantId: string;
 };
 
-/** Response shape from Microsoft token endpoint. */
-type TokenResponse = {
-  access_token?: string;
-  error?: string;
-  error_description?: string;
-};
+/** Zod schema for Microsoft OAuth token endpoint response. */
+export const tokenResponseSchema = z.object({
+  access_token: z.string().optional(),
+  error: z.string().optional(),
+  error_description: z.string().optional(),
+});
 
 /** Options for getAccessTokenFromClientCredentials (DI). */
 export type GetAccessTokenOptions = {
@@ -56,16 +57,21 @@ export async function getAccessTokenFromClientCredentials(
   if (res.statusCode < 200 || res.statusCode >= 300) {
     let message = `Token request failed: ${res.statusCode}`;
     try {
-      const err = JSON.parse(res.body) as TokenResponse;
-      if (err.error_description) message += ` - ${err.error_description}`;
-      else if (err.error) message += ` - ${err.error}`;
+      const parsed = JSON.parse(res.body) as unknown;
+      const result = tokenResponseSchema.safeParse(parsed);
+      if (result.success) {
+        if (result.data.error_description)
+          message += ` - ${result.data.error_description}`;
+        else if (result.data.error) message += ` - ${result.data.error}`;
+      }
     } catch {
       // use status only
     }
     throw new Error(message);
   }
 
-  const data = JSON.parse(res.body) as TokenResponse;
+  const parsed = JSON.parse(res.body) as unknown;
+  const data = tokenResponseSchema.parse(parsed);
   if (typeof data.access_token !== "string") {
     throw new Error("Token response missing access_token");
   }

--- a/packages/outlook-inbox/src/graph-client.test.ts
+++ b/packages/outlook-inbox/src/graph-client.test.ts
@@ -117,6 +117,22 @@ describe("createGraphClient", () => {
       // Assert
       expect(result).toEqual([]);
     });
+
+    it("throws when list response has invalid value shape", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: "not-an-array" }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act & Assert
+      await expect(client.listMessages("me", {})).rejects.toThrow();
+    });
   });
 
   describe("moveMessage", () => {
@@ -170,6 +186,24 @@ describe("createGraphClient", () => {
       await expect(
         client.moveMessage("me", "bad-id", "archive"),
       ).rejects.toThrow("Graph move message failed: 404");
+    });
+
+    it("throws when move response has invalid message shape", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const postFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ id: 123, subject: "x" }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn: vi.fn(),
+        postFn,
+      });
+
+      // Act & Assert
+      await expect(
+        client.moveMessage("me", "msg-1", "archive"),
+      ).rejects.toThrow();
     });
   });
 

--- a/packages/outlook-inbox/src/graph-client.ts
+++ b/packages/outlook-inbox/src/graph-client.ts
@@ -1,9 +1,10 @@
 import got from "got";
-import type {
-  GraphMessage,
-  ListMessagesResponse,
-  MessageFilter,
-} from "./types.js";
+import type { MessageFilter } from "./types.js";
+import {
+  type GraphMessage,
+  graphMessageSchema,
+  listMessagesResponseSchema,
+} from "./schemas.js";
 import { applySubjectFilter, buildFilterForGraph } from "./build-filter.js";
 
 const DEFAULT_GRAPH_BASE = "https://graph.microsoft.com/v1.0";
@@ -80,7 +81,8 @@ export function createGraphClient(
         );
       }
 
-      const data = JSON.parse(res.body) as ListMessagesResponse;
+      const parsed = JSON.parse(res.body) as unknown;
+      const data = listMessagesResponseSchema.parse(parsed);
       const messages = data.value ?? [];
       return applySubjectFilter(messages, filter);
     },
@@ -115,7 +117,8 @@ export function createGraphClient(
         );
       }
 
-      return JSON.parse(res.body) as GraphMessage;
+      const parsed = JSON.parse(res.body) as unknown;
+      return graphMessageSchema.parse(parsed);
     },
   };
 }

--- a/packages/outlook-inbox/src/schemas.ts
+++ b/packages/outlook-inbox/src/schemas.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/** Zod schema for Graph API email address. */
+const emailAddressSchema = z.object({
+  address: z.string().optional(),
+  name: z.string().optional(),
+});
+
+/** Zod schema for Graph API message body. */
+const messageBodySchema = z.object({
+  content: z.string().optional(),
+  contentType: z.string().optional(),
+});
+
+/** Zod schema for Graph API message (minimal shape for list/move). */
+export const graphMessageSchema = z.object({
+  id: z.string(),
+  subject: z.string().nullable(),
+  receivedDateTime: z.string(),
+  isRead: z.boolean(),
+  body: messageBodySchema.optional(),
+  from: z.object({ emailAddress: emailAddressSchema.optional() }).optional(),
+  toRecipients: z
+    .array(z.object({ emailAddress: emailAddressSchema.optional() }))
+    .optional(),
+});
+
+/** Zod schema for Graph API list messages response. */
+export const listMessagesResponseSchema = z.object({
+  value: z.array(graphMessageSchema).optional(),
+  "@odata.nextLink": z.string().optional(),
+});
+
+export type GraphMessage = z.infer<typeof graphMessageSchema>;
+export type ListMessagesResponse = z.infer<typeof listMessagesResponseSchema>;

--- a/packages/outlook-inbox/src/types.ts
+++ b/packages/outlook-inbox/src/types.ts
@@ -42,23 +42,4 @@ export type ProcessMessagesOptions = {
   maxMessages?: number;
 };
 
-/**
- * Minimal message shape returned by Graph API list messages.
- */
-export type GraphMessage = {
-  id: string;
-  subject: string | null;
-  receivedDateTime: string;
-  isRead: boolean;
-  body?: { content?: string; contentType?: string };
-  from?: { emailAddress?: { address?: string; name?: string } };
-  toRecipients?: Array<{ emailAddress?: { address?: string; name?: string } }>;
-};
-
-/**
- * Response shape from Graph API list messages.
- */
-export type ListMessagesResponse = {
-  value: GraphMessage[];
-  "@odata.nextLink"?: string;
-};
+export type { GraphMessage, ListMessagesResponse } from "./schemas.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,6 +980,9 @@ importers:
       got:
         specifier: 'catalog:'
         version: 14.6.6
+      zod:
+        specifier: 'catalog:'
+        version: 3.25.76
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

Adds schema-based runtime validation for external JSON responses across content generation, data collection, user registration, and Outlook inbox flows. This hardens parsing paths so invalid payloads fail fast instead of silently producing malformed data.

## Important changes

- Added `parse-newsletter-json` with Zod validation for LLM newsletter JSON before formatting/sending content.
- Added Zod validation for Serper (`web-search`) and Jina (`web-fetch`) API responses in data collection.
- Added Outlook Graph response schemas and token response schema validation, including stricter parsing in `graph-client` and `get-access-token`.
- Added ticker JSON schema validation in user registration so invalid ticker payloads safely return an empty set.

## Other changes

- Added/updated unit tests for invalid response shapes and malformed JSON across all touched modules.
- Added `zod` dependency to `@workspace/outlook-inbox` and aligned generated lockfile updates.
- Minor generated `next-env.d.ts` updates.

## How to test

1. Run `pnpm --filter content-generation-agent test`.
2. Run `pnpm --filter data-collection-agent test`.
3. Run `pnpm --filter @workspace/outlook-inbox test`.
4. Run `pnpm code-quality`.
5. Confirm all commands pass and invalid-shape test cases throw as expected.