### PR TITLE
Add PageHeader component and use it on Hermes dashboard pages

### DIFF
--- a/apps/hermes/app/dashboard/agent-configs/page.tsx
+++ b/apps/hermes/app/dashboard/agent-configs/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getAgentConfigsPage,
@@ -107,15 +108,21 @@ const AgentConfigsPage = async ({
   });
 
   return (
-    <AgentConfigsContent
-      configs={configsWithStatus}
-      agents={agentsForDropdown}
-      total={total}
-      page={currentPage}
-      pageSize={size}
-      sortBy={sortBy}
-      sortDir={sortDir}
-    />
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Agent configs"
+        description="Create and manage agent configuration presets."
+      />
+      <AgentConfigsContent
+        configs={configsWithStatus}
+        agents={agentsForDropdown}
+        total={total}
+        page={currentPage}
+        pageSize={size}
+        sortBy={sortBy}
+        sortDir={sortDir}
+      />
+    </div>
   );
 };
 

--- a/apps/hermes/app/dashboard/agents/page.tsx
+++ b/apps/hermes/app/dashboard/agents/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getAgentsPage,
@@ -66,6 +67,10 @@ const AgentsPage = async ({
 
   return (
     <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Agents"
+        description="View and manage registered agents."
+      />
       <div className="flex flex-col justify-between sm:flex-row sm:items-center">
         <AgentsSearch
           initialQuery={search ?? ""}

--- a/apps/hermes/app/dashboard/api-keys/page.tsx
+++ b/apps/hermes/app/dashboard/api-keys/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getApiKeysPage,
@@ -67,6 +68,10 @@ const ApiKeysPage = async ({
 
   return (
     <div className="flex flex-col gap-4">
+      <PageHeader
+        title="API keys"
+        description="Create and manage API keys for external access."
+      />
       <div className="flex flex-col justify-between sm:flex-row sm:items-center">
         <ApiKeysSearch
           initialQuery={search ?? ""}

--- a/apps/hermes/app/dashboard/data-source-expansions/page.tsx
+++ b/apps/hermes/app/dashboard/data-source-expansions/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getDataSourceExpansionsPage,
@@ -75,6 +76,10 @@ const DataSourceExpansionsPage = async ({
 
   return (
     <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Data source expansions"
+        description="Manage data source expansion definitions."
+      />
       <div className="flex flex-col justify-between sm:flex-row sm:items-center">
         <DataSourceExpansionsSearch
           initialQuery={search ?? ""}

--- a/apps/hermes/app/dashboard/page.tsx
+++ b/apps/hermes/app/dashboard/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 
 /**
@@ -5,12 +6,10 @@ import { withAuthProtection } from "@/components/with-auth-protection";
  */
 const DashboardPage = () => {
   return (
-    <div className="flex flex-col gap-2">
-      <h1 className="text-2xl font-semibold text-foreground">Dashboard</h1>
-      <p className="text-muted-foreground">
-        Use the sidebar to manage pipelines and agents.
-      </p>
-    </div>
+    <PageHeader
+      title="Dashboard"
+      description="Use the sidebar to manage pipelines and agents."
+    />
   );
 };
 

--- a/apps/hermes/app/dashboard/pipelines/page.tsx
+++ b/apps/hermes/app/dashboard/pipelines/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import { getPipelinesWithSteps } from "@/lib/pipelines";
 import { getPipelinesValidationMap } from "@/lib/validate-pipeline";
@@ -16,10 +17,16 @@ const PipelinesPage = async () => {
   );
 
   return (
-    <PipelinesWithModal
-      pipelines={pipelines}
-      pipelineValidationById={pipelineValidationById}
-    />
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Pipelines"
+        description="Create and manage pipelines and their steps."
+      />
+      <PipelinesWithModal
+        pipelines={pipelines}
+        pipelineValidationById={pipelineValidationById}
+      />
+    </div>
   );
 };
 

--- a/apps/hermes/app/dashboard/schedules/page.tsx
+++ b/apps/hermes/app/dashboard/schedules/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import { getPipelinesWithSteps } from "@/lib/pipelines";
 import {
@@ -80,17 +81,23 @@ const SchedulesPage = async ({
   } = schedulesResult;
 
   return (
-    <SchedulesWithModal
-      schedules={schedules}
-      pipelines={pipelines}
-      pipelineValidationById={pipelineValidationById}
-      currentPage={currentPage}
-      pageSize={size}
-      total={total}
-      searchQuery={search}
-      sortBy={sortBy}
-      sortDir={sortDir}
-    />
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Schedules"
+        description="Schedule pipelines to run on a cron or interval."
+      />
+      <SchedulesWithModal
+        schedules={schedules}
+        pipelines={pipelines}
+        pipelineValidationById={pipelineValidationById}
+        currentPage={currentPage}
+        pageSize={size}
+        total={total}
+        searchQuery={search}
+        sortBy={sortBy}
+        sortDir={sortDir}
+      />
+    </div>
   );
 };
 

--- a/apps/hermes/app/dashboard/tickers/page.tsx
+++ b/apps/hermes/app/dashboard/tickers/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getTickersPage,
@@ -67,6 +68,10 @@ const TickersPage = async ({
 
   return (
     <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Tickers"
+        description="Manage ticker symbols and company names for data sources."
+      />
       <div className="flex flex-col justify-between sm:flex-row sm:items-center">
         <TickersSearch
           initialQuery={search ?? ""}

--- a/apps/hermes/app/dashboard/variables/page.tsx
+++ b/apps/hermes/app/dashboard/variables/page.tsx
@@ -1,3 +1,4 @@
+import { PageHeader } from "@/components/page-header";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import {
   getVariablesPage,
@@ -68,6 +69,10 @@ const VariablesPage = async ({
 
   return (
     <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Variables"
+        description="Manage key-value variables for pipelines (secrets are masked)."
+      />
       <div className="flex flex-col justify-between sm:flex-row sm:items-center">
         <VariablesSearch
           initialQuery={search ?? ""}

--- a/apps/hermes/components/page-header.test.tsx
+++ b/apps/hermes/components/page-header.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageHeader } from "./page-header";
+
+describe("PageHeader", () => {
+  it("renders title as h1", () => {
+    // Act
+    render(
+      <PageHeader
+        title="Test Page"
+        description="A short description for the page."
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.getByRole("heading", { name: "Test Page", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders description text", () => {
+    // Act
+    render(
+      <PageHeader
+        title="Test Page"
+        description="A short description for the page."
+      />,
+    );
+
+    // Assert
+    expect(
+      screen.getByText("A short description for the page."),
+    ).toBeInTheDocument();
+  });
+
+  it("applies expected heading classes", () => {
+    // Act
+    render(
+      <PageHeader
+        title="Test Page"
+        description="A short description for the page."
+      />,
+    );
+
+    // Assert
+    const heading = screen.getByRole("heading", { name: "Test Page" });
+    expect(heading).toHaveClass("text-2xl");
+    expect(heading).toHaveClass("font-semibold");
+  });
+});

--- a/apps/hermes/components/page-header.tsx
+++ b/apps/hermes/components/page-header.tsx
@@ -1,0 +1,19 @@
+type PageHeaderProps = {
+  /** Main heading text for the page. */
+  title: string;
+  /** Short description shown below the title. */
+  description: string;
+};
+
+/**
+ * Renders a consistent page title and description block for dashboard pages.
+ * Matches the dashboard page pattern: h1 + muted description paragraph.
+ */
+export const PageHeader = ({ title, description }: PageHeaderProps) => {
+  return (
+    <div className="flex flex-col gap-2">
+      <h1 className="text-2xl font-semibold text-foreground">{title}</h1>
+      <p className="text-muted-foreground">{description}</p>
+    </div>
+  );
+};

--- a/apps/hermes/eslint.config.js
+++ b/apps/hermes/eslint.config.js
@@ -1,8 +1,8 @@
-import { globalIgnores } from "eslint/config"
-import { nextJsConfig } from "@workspace/eslint-config/next-js"
+import { globalIgnores } from "eslint/config";
+import { nextJsConfig } from "@workspace/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
 export default [
-  globalIgnores([".next/**", "out/**", "build/**"]),
+  globalIgnores([".next/**", "out/**", "build/**", "coverage/**"]),
   ...nextJsConfig,
-]
+];


### PR DESCRIPTION
## Summary

Introduces a shared `PageHeader` component for Hermes dashboard pages and switches all dashboard routes to use it. Keeps page titles and descriptions consistent (h1 + muted description) and centralizes the pattern in one place.

## Important changes

- New `PageHeader` component in `@/components/page-header` (title + description props, h1 + muted paragraph)
- All Hermes dashboard pages now use `PageHeader` instead of inline title/description markup (Dashboard, Agents, API Keys, Data source expansions, Pipelines, Schedules, Tickers, Variables, Agent configs)

## Other changes

- Unit tests for `PageHeader` in `page-header.test.tsx`
- ESLint global ignores updated to include `coverage/**`

## How to test

1. Open each Hermes dashboard route (e.g. `/dashboard`, `/dashboard/pipelines`, `/dashboard/agents`, `/dashboard/schedules`, etc.).
2. Confirm each page shows a clear h1 title and a short muted description below it, with consistent spacing and styling.
3. Run `pnpm code-quality` in the repo root and confirm type-check, lint, and tests pass.