### PR TITLE
Add agent description and Updated column to agent management

### DIFF
--- a/apps/agents/ticker-echo/src/index.ts
+++ b/apps/agents/ticker-echo/src/index.ts
@@ -10,8 +10,9 @@ type Input = z.infer<typeof InputSchema>;
 
 const app = createAgentApp<Input, typeof InputSchema>(
   {
-    agentId: "ticker-echo",
-    agentVersion: "1.0.0",
+    agentId: "ticker-echo", // this should be stable for the lifetime of the agent
+    agentVersion: "1.0.0", // this should be incremented when the agent is updated
+    description: "Echoes ticker ID from input for testing pipelines.",
     inputSchema: InputSchema,
     run: async ({ input }) => {
       console.log("--> ticker-echo received tickerId", input.tickerId);

--- a/apps/hermes/app/dashboard/agents/[id]/agent-details-content.test.tsx
+++ b/apps/hermes/app/dashboard/agents/[id]/agent-details-content.test.tsx
@@ -91,9 +91,12 @@ describe("AgentDetailsContent", () => {
     );
   });
 
-  it("renders Details section with Agent ID, Version, Description, Active, Created in General tab", () => {
-    // Setup
-    const agent = createMockAgent();
+  it("renders Details section with Agent ID, Version, Description, Active, Created, Last updated in General tab", () => {
+    // Setup: use distinct updatedAt so Last updated value is unique in the document
+    const agent = {
+      ...createMockAgent(),
+      updatedAt: new Date("2024-02-20"),
+    };
 
     // Act
     render(<AgentDetailsContent agent={agent} />);
@@ -108,6 +111,8 @@ describe("AgentDetailsContent", () => {
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("Yes")).toBeInTheDocument();
     expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Last updated")).toBeInTheDocument();
+    expect(screen.getByText("Feb 20, 2024")).toBeInTheDocument();
   });
 
   it("renders Endpoint section via EndpointDisplay in General tab", () => {

--- a/apps/hermes/app/dashboard/agents/[id]/agent-details-content.tsx
+++ b/apps/hermes/app/dashboard/agents/[id]/agent-details-content.tsx
@@ -80,6 +80,12 @@ export const AgentDetailsContent = ({ agent }: AgentDetailsContentProps) => {
                   {format(agent.createdAt, "LLL d, yyyy")}
                 </span>
               </div>
+              <div className={ROW_CLASS}>
+                <span className={LABEL_CLASS}>Last updated</span>
+                <span className="min-w-0 flex-1 text-sm text-muted-foreground normal-case font-normal text-right">
+                  {format(agent.updatedAt, "LLL d, yyyy")}
+                </span>
+              </div>
             </div>
           </section>
           <section className="min-h-0">

--- a/apps/hermes/app/dashboard/agents/agents-table.test.tsx
+++ b/apps/hermes/app/dashboard/agents/agents-table.test.tsx
@@ -98,6 +98,7 @@ describe("AgentsTable", () => {
     expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("Created")).toBeInTheDocument();
+    expect(screen.getByText("Updated")).toBeInTheDocument();
   });
 
   it("renders empty state when no agents", () => {
@@ -128,6 +129,7 @@ describe("AgentsTable", () => {
     expect(screen.getByText("test-agent")).toBeInTheDocument();
     expect(screen.getByText("1.0")).toBeInTheDocument();
     expect(screen.getByText("Test description")).toBeInTheDocument();
+    // Created and Updated columns both show formatted dates; header "Updated" confirms the column is present
   });
 
   it("displays Yes badge for active agents", () => {

--- a/apps/hermes/app/dashboard/agents/agents-table.tsx
+++ b/apps/hermes/app/dashboard/agents/agents-table.tsx
@@ -54,7 +54,7 @@ type AgentsTableProps = {
 };
 
 /**
- * Renders the agents list as a table with sortable Agent ID, Version, Description, Active, Created columns and row actions.
+ * Renders the agents list as a table with sortable Agent ID, Version, Description, Active, Created, Updated columns and row actions.
  */
 export const AgentsTable = ({
   agents,
@@ -114,6 +114,9 @@ export const AgentsTable = ({
             <TableHead className="w-[120px]">
               {sortLink("created", "Created")}
             </TableHead>
+            <TableHead className="w-[120px]">
+              {sortLink("updated", "Updated")}
+            </TableHead>
             <TableHead className="w-12" />
           </TableRow>
         </TableHeader>
@@ -121,7 +124,7 @@ export const AgentsTable = ({
           {agents.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={7}
                 className="text-center text-muted-foreground"
               >
                 No agents yet.
@@ -164,6 +167,9 @@ export const AgentsTable = ({
                 </TableCell>
                 <TableCell className="text-muted-foreground text-sm">
                   {format(agent.createdAt, "LLL d, yyyy")}
+                </TableCell>
+                <TableCell className="text-muted-foreground text-sm">
+                  {format(agent.updatedAt, "LLL d, yyyy")}
                 </TableCell>
                 <TableCell className="text-right">
                   <AgentRowActions

--- a/apps/hermes/app/dashboard/agents/page.tsx
+++ b/apps/hermes/app/dashboard/agents/page.tsx
@@ -12,7 +12,12 @@ import { AgentsSearch } from "./agents-search";
 
 const DEFAULT_PAGE_SIZE = 15;
 
-const SORT_FIELDS: AgentSortField[] = ["agentId", "agentVersion", "created"];
+const SORT_FIELDS: AgentSortField[] = [
+  "agentId",
+  "agentVersion",
+  "created",
+  "updated",
+];
 const SORT_DIRS: AgentSortDir[] = ["asc", "desc"];
 
 const parseSort = (
@@ -30,7 +35,7 @@ const parseSort = (
 
 /**
  * Agents list page. Fetches paginated agents and renders table with edit/delete row actions.
- * Supports search by agent ID or description and sort by agentId, agentVersion, or created.
+ * Supports search by agent ID or description and sort by agentId, agentVersion, created, or updated.
  */
 const AgentsPage = async ({
   searchParams,

--- a/apps/hermes/lib/agents.test.ts
+++ b/apps/hermes/lib/agents.test.ts
@@ -115,6 +115,26 @@ describe("getAgentsPage", () => {
     });
   });
 
+  it("uses sortBy updated when specified", async () => {
+    const db = createMockDb();
+    db.agentRegistry.findMany.mockResolvedValue([]);
+    db.agentRegistry.count.mockResolvedValue(0);
+
+    await getAgentsPage(
+      1,
+      10,
+      { sortBy: "updated", sortDir: "desc" },
+      asDb(db),
+    );
+
+    expect(db.agentRegistry.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      skip: 0,
+      take: 10,
+      orderBy: { updatedAt: "desc" },
+    });
+  });
+
   it("returns agents, total, page, and pageSize", async () => {
     const db = createMockDb();
     const agents = [

--- a/apps/hermes/lib/agents.ts
+++ b/apps/hermes/lib/agents.ts
@@ -35,7 +35,7 @@ const agentSearchWhere = (
   };
 };
 
-export type AgentSortField = "agentId" | "agentVersion" | "created";
+export type AgentSortField = "agentId" | "agentVersion" | "created" | "updated";
 export type AgentSortDir = "asc" | "desc";
 
 const SORT_DEFAULT: { sortBy: AgentSortField; sortDir: AgentSortDir } = {
@@ -44,9 +44,9 @@ const SORT_DEFAULT: { sortBy: AgentSortField; sortDir: AgentSortDir } = {
 };
 
 /**
- * Builds Prisma orderBy from sort field and direction. "created" maps to createdAt.
+ * Builds Prisma orderBy from sort field and direction. "created" maps to createdAt, "updated" to updatedAt.
  *
- * @param sortBy - Field to sort by (agentId, agentVersion, or created).
+ * @param sortBy - Field to sort by (agentId, agentVersion, created, or updated).
  * @param sortDir - asc or desc.
  * @returns Prisma orderBy object.
  */
@@ -57,9 +57,11 @@ const agentOrderBy = (
   agentId?: "asc" | "desc";
   agentVersion?: "asc" | "desc";
   createdAt?: "asc" | "desc";
+  updatedAt?: "asc" | "desc";
 } => {
   const dir = sortDir === "asc" ? "asc" : "desc";
   if (sortBy === "created") return { createdAt: dir };
+  if (sortBy === "updated") return { updatedAt: dir };
   if (sortBy === "agentVersion") return { agentVersion: dir };
   return { agentId: dir };
 };
@@ -69,7 +71,7 @@ const agentOrderBy = (
  *
  * @param page - 1-based page number.
  * @param pageSize - Number of items per page.
- * @param options - Optional search term and sort (sortBy: agentId | agentVersion | created, sortDir: asc | desc).
+ * @param options - Optional search term and sort (sortBy: agentId | agentVersion | created | updated, sortDir: asc | desc).
  * @param db - Prisma client (injectable for tests).
  * @returns Agents for the page plus total count and pagination info.
  */

--- a/packages/agent-runtime/src/create-agent-app.test.ts
+++ b/packages/agent-runtime/src/create-agent-app.test.ts
@@ -371,4 +371,36 @@ describe("createAgentApp", () => {
     expect(body.inputSchema).toBeDefined();
     expect(body.configSchema).toBeDefined();
   });
+
+  it("sends config description in register body when autoRegister is set", async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true });
+    createAgentApp<Input, typeof schema>(
+      {
+        agentId: "desc-agent",
+        agentVersion: "1.0.0",
+        description: "My agent",
+        inputSchema: schema,
+        run: async () => ({ success: true }),
+      },
+      {
+        verifyToken: async () => true,
+        autoRegister: {
+          registryUrl: "https://registry.test",
+          apiKey: "key",
+          agentUrl: "https://agent.test",
+          fetchFn,
+        },
+      },
+    );
+
+    await new Promise<void>((r) => setImmediate(r));
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    const [, options] = fetchFn.mock.calls[0] as [
+      string,
+      { method: string; headers: Record<string, string>; body: string },
+    ];
+    const body = JSON.parse(options.body);
+    expect(body.description).toBe("My agent");
+  });
 });

--- a/packages/agent-runtime/src/create-agent-app.ts
+++ b/packages/agent-runtime/src/create-agent-app.ts
@@ -69,8 +69,7 @@ export function createAgentApp<
   app.use("*", bearerAuth({ verifyToken }));
 
   if (options.autoRegister) {
-    const { registryUrl, apiKey, agentUrl, description, fetchFn } =
-      options.autoRegister;
+    const { registryUrl, apiKey, agentUrl, fetchFn } = options.autoRegister;
     const inputSchemaJson = zodToJsonSchema(config.inputSchema, {
       $refStrategy: "none",
     }) as Record<string, unknown>;
@@ -90,7 +89,7 @@ export function createAgentApp<
             agentUrl,
             inputSchema: inputSchemaJson,
             configSchema: configSchemaJson,
-            description,
+            description: config.description,
             fetchFn,
           });
           logger.info?.(

--- a/packages/agent-runtime/src/types.ts
+++ b/packages/agent-runtime/src/types.ts
@@ -46,8 +46,6 @@ export type AutoRegisterOptions = {
   apiKey: string;
   /** Public URL where this agent is reachable (e.g. https://agent.example.com). */
   agentUrl: string;
-  /** Optional description stored in the registry. */
-  description?: string;
   /** Optional fetch implementation (for tests). */
   fetchFn?: typeof fetch;
 };
@@ -75,6 +73,8 @@ export type AgentConfig<
   agentId: string;
   /** Agent version string (e.g. "1.0.0"). */
   agentVersion: string;
+  /** Optional short description for admins (e.g. in Hermes agents table). */
+  description?: string;
   /** Zod schema to parse and validate the request body's `input` field. */
   inputSchema: TSchema;
   /** Zod schema to parse and validate the request body's `config` field. Defaults to empty object. */


### PR DESCRIPTION
## Summary

Agents now declare an optional `description` in their config (used in the registry and Hermes UI), and the agents list and detail views show a "Last updated" / "Updated" column using `updatedAt`. Sort by "updated" is supported on the agents page.

## Important changes

- **Agent config**: `description` is now on `AgentConfig` (optional). It is sent to the registry on auto-register; the previous `AutoRegisterOptions.description` has been removed.
- **Hermes agents table**: New sortable "Updated" column showing `updatedAt` (formatted date). Empty state colspan increased to 7.
- **Agent details (General tab)**: New "Last updated" row showing `updatedAt`.
- **Sort options**: Agents page supports `sortBy=updated` in addition to agentId, agentVersion, and created; `AgentSortField` and `getAgentsPage` support `"updated"`.

## Other changes

- Ticker-echo agent: added `description` and comments for `agentId` / `agentVersion`.
- Tests: AgentDetailsContent (Last updated), AgentsTable (Updated column), `getAgentsPage` (sortBy updated), `createAgentApp` (description in register body).

## How to test

1. Open Hermes → Agents. Confirm the table has an "Updated" column and dates render; sort by "Updated" (header link) and confirm order and URL (e.g. `?sortBy=updated&sortDir=desc`).
2. Open an agent’s detail page. In the General tab, confirm "Last updated" appears with the correct date.
3. Run the agent registry and ticker-echo (or another agent with `description`). Confirm the agent registers with the given description and that it appears in the registry/Hermes (e.g. in the table or detail view if you display it there).
4. Run `pnpm code-quality` and ensure type-check, lint, and tests pass.