### PR TITLE
Add agent config picker to pipeline step editor and step list

### DIFF
--- a/apps/hermes/app/dashboard/pipelines/[id]/pipeline-detail-content.tsx
+++ b/apps/hermes/app/dashboard/pipelines/[id]/pipeline-detail-content.tsx
@@ -53,7 +53,7 @@ export type PipelineDetailContentProps = {
 };
 
 /**
- * Encapsulates pipeline detail state: selection, name/description, step input/config, save logic, and sync effects.
+ * Encapsulates pipeline detail state: selection, name/description, step input and agent-config picker, save logic, and sync effects.
  */
 const usePipelineDetailState = (
   pipeline: PipelineWithSteps,
@@ -67,7 +67,7 @@ const usePipelineDetailState = (
     pipeline.description ?? "",
   );
   const [stepInput, setStepInput] = useState<Record<string, unknown>>({});
-  const [stepConfig, setStepConfig] = useState<Record<string, unknown>>({});
+  const [stepAgentConfigId, setStepAgentConfigId] = useState<string>("");
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveWarnings, setSaveWarnings] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
@@ -90,7 +90,7 @@ const usePipelineDetailState = (
   useEffect(() => {
     if (!selectedStep) {
       setStepInput({});
-      setStepConfig({});
+      setStepAgentConfigId("");
       return;
     }
     const rawInput =
@@ -99,14 +99,8 @@ const usePipelineDetailState = (
       !Array.isArray(selectedStep.input)
         ? (selectedStep.input as Record<string, unknown>)
         : {};
-    const rawConfig =
-      selectedStep.config != null &&
-      typeof selectedStep.config === "object" &&
-      !Array.isArray(selectedStep.config)
-        ? (selectedStep.config as Record<string, unknown>)
-        : {};
     setStepInput(rawInput);
-    setStepConfig(rawConfig);
+    setStepAgentConfigId(selectedStep.agentConfigId ?? "");
   }, [selectedStep]);
 
   const handleSave = useCallback(async () => {
@@ -144,12 +138,9 @@ const usePipelineDetailState = (
         stepFormData.set("body.stepId", selectedStep.id);
         stepFormData.set("body.agentId", selectedStep.agentId);
         stepFormData.set("body.agentVersion", selectedStep.agentVersion);
-        stepFormData.set(
-          "body.agentConfigId",
-          selectedStep.agentConfigId ?? "",
-        );
+        stepFormData.set("body.agentConfigId", stepAgentConfigId);
         stepFormData.set("body.input", JSON.stringify(stepInput));
-        stepFormData.set("body.config", JSON.stringify(stepConfig));
+        stepFormData.set("body.config", "{}");
         const stepResult = await updateStepFormAction(null, stepFormData);
         const stepOk =
           stepResult != null &&
@@ -193,7 +184,7 @@ const usePipelineDetailState = (
     pipelineDescription,
     selectedStep,
     stepInput,
-    stepConfig,
+    stepAgentConfigId,
     router,
     updatePipelineFormAction,
     updateStepFormAction,
@@ -208,8 +199,8 @@ const usePipelineDetailState = (
     setPipelineDescription,
     stepInput,
     setStepInput,
-    stepConfig,
-    setStepConfig,
+    stepAgentConfigId,
+    setStepAgentConfigId,
     saveError,
     saveWarnings,
     saving,
@@ -242,8 +233,8 @@ export const PipelineDetailContent = ({
     setPipelineDescription,
     stepInput,
     setStepInput,
-    stepConfig,
-    setStepConfig,
+    stepAgentConfigId,
+    setStepAgentConfigId,
     saveError,
     saveWarnings,
     saving,
@@ -348,9 +339,16 @@ export const PipelineDetailContent = ({
           <PipelineStepEditorPanel
             selectedStep={selectedStep}
             stepInput={stepInput}
-            stepConfig={stepConfig}
             onStepInputChange={setStepInput}
-            onStepConfigChange={setStepConfig}
+            configsForAgent={
+              selectedStep
+                ? (configsByAgentKey[
+                    `${selectedStep.agentId}@${selectedStep.agentVersion}`
+                  ] ?? [])
+                : []
+            }
+            stepAgentConfigId={stepAgentConfigId}
+            onStepAgentConfigIdChange={setStepAgentConfigId}
             disabled={saving}
             variableKeys={variableKeys}
             expansionTemplates={expansionTemplates}

--- a/apps/hermes/app/dashboard/pipelines/[id]/pipeline-step-editor-panel.test.tsx
+++ b/apps/hermes/app/dashboard/pipelines/[id]/pipeline-step-editor-panel.test.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { PipelineStepEditorPanel } from "./pipeline-step-editor-panel";
+
+const mockSetActiveTab = vi.fn();
+
+vi.mock("./use-step-editor-panel-state", () => ({
+  useStepEditorPanelState: () => ({
+    schemas: {
+      inputSchema: { type: "object", properties: {} },
+      configSchema: null,
+    },
+    schemaLoading: false,
+    activeTab: "config" as const,
+    setActiveTab: mockSetActiveTab,
+  }),
+}));
+
+vi.mock("@workspace/ui/components/tabs", () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tabs">{children}</div>
+  ),
+  TabsList: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="tabs-list">{children}</div>
+  ),
+  TabsTrigger: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => (
+    <button type="button" data-testid={`tab-${value}`}>
+      {children}
+    </button>
+  ),
+  TabsContent: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <div data-testid={`tab-content-${value}`}>{children}</div>,
+}));
+
+vi.mock("@workspace/json-schema-form", () => ({
+  SchemaForm: ({
+    value,
+    onChange,
+  }: {
+    schema?: unknown;
+    value: unknown;
+    onChange: (v: unknown) => void;
+  }) => (
+    <div data-testid="schema-form">
+      <input
+        data-testid="schema-form-input"
+        value={JSON.stringify(value)}
+        onChange={(e) => {
+          try {
+            onChange(JSON.parse(e.target.value));
+          } catch {
+            onChange({});
+          }
+        }}
+      />
+    </div>
+  ),
+}));
+
+vi.mock("@/components/variable-expansion-input", () => ({
+  VariableExpansionInput: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (v: string) => void;
+  }) => (
+    <input
+      data-testid="variable-expansion-input"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+const selectedStep = {
+  id: "step-1",
+  order: 0,
+  agentId: "summarizer",
+  agentVersion: "1.0",
+  agentConfigId: null as string | null,
+  input: {},
+  config: {},
+};
+
+describe("PipelineStepEditorPanel", () => {
+  it("shows select-step message when no step selected", () => {
+    render(
+      <PipelineStepEditorPanel
+        selectedStep={null}
+        stepInput={{}}
+        onStepInputChange={() => {}}
+        configsForAgent={[]}
+        stepAgentConfigId=""
+        onStepAgentConfigIdChange={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Select a step in the pipeline to edit its input and config.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("Config tab shows empty state with link when no configs for agent", () => {
+    render(
+      <PipelineStepEditorPanel
+        selectedStep={selectedStep}
+        stepInput={{}}
+        onStepInputChange={() => {}}
+        configsForAgent={[]}
+        stepAgentConfigId=""
+        onStepAgentConfigIdChange={() => {}}
+      />,
+    );
+
+    expect(
+      screen.getByText("No agent configs for this agent. Create one first."),
+    ).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "Go to Agent configs" });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/dashboard/agent-configs");
+  });
+
+  it("Config tab shows picker when configs exist and calls onStepAgentConfigIdChange on change", () => {
+    const onStepAgentConfigIdChange = vi.fn();
+    const configs = [
+      {
+        id: "cfg-1",
+        name: "Config A",
+        description: "First config",
+        configSchemaFingerprint: null,
+      },
+      {
+        id: "cfg-2",
+        name: "Config B",
+        description: null,
+        configSchemaFingerprint: null,
+      },
+    ];
+
+    render(
+      <PipelineStepEditorPanel
+        selectedStep={selectedStep}
+        stepInput={{}}
+        onStepInputChange={() => {}}
+        configsForAgent={configs}
+        stepAgentConfigId=""
+        onStepAgentConfigIdChange={onStepAgentConfigIdChange}
+      />,
+    );
+
+    const picker = screen.getByRole("combobox", {
+      name: "Choose a saved agent config",
+    });
+    expect(picker).toBeInTheDocument();
+    expect(screen.getByLabelText("Agent config")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "None" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Config A — First config" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("option", { name: "Config B" }),
+    ).toBeInTheDocument();
+
+    fireEvent.change(picker, { target: { value: "cfg-1" } });
+
+    expect(onStepAgentConfigIdChange).toHaveBeenCalledWith("cfg-1");
+  });
+});

--- a/apps/hermes/app/dashboard/pipelines/[id]/pipeline-step-editor-panel.tsx
+++ b/apps/hermes/app/dashboard/pipelines/[id]/pipeline-step-editor-panel.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import Link from "next/link";
+
 import { SchemaForm, type StringFieldProps } from "@workspace/json-schema-form";
+import { Label } from "@workspace/ui/components/label";
 import {
   Tabs,
   TabsContent,
@@ -9,6 +12,7 @@ import {
 } from "@workspace/ui/components/tabs";
 
 import { VariableExpansionInput } from "@/components/variable-expansion-input";
+import type { AgentConfigSummary } from "@/lib/agent-configs";
 
 import { useStepEditorPanelState } from "./use-step-editor-panel-state";
 
@@ -33,9 +37,11 @@ export type ExpansionTemplateOption = {
 export type PipelineStepEditorPanelProps = {
   selectedStep: Step | null;
   stepInput: Record<string, unknown>;
-  stepConfig: Record<string, unknown>;
   onStepInputChange: (value: Record<string, unknown>) => void;
-  onStepConfigChange: (value: Record<string, unknown>) => void;
+  /** Agent configs for the selected step's agent (for Config tab picker). */
+  configsForAgent: AgentConfigSummary[];
+  stepAgentConfigId: string;
+  onStepAgentConfigIdChange: (id: string) => void;
   disabled?: boolean;
   /** Variable keys for the insert picker ({{key}}). */
   variableKeys?: VariableKeyOption[];
@@ -64,15 +70,16 @@ const createStringFieldComponent = (
 };
 
 /**
- * Renders the selected agent's input and config forms from its schemas.
+ * Renders the selected agent's input form and config picker (saved agent configs only).
  * Third column only; pipeline name/description and Save live above the layout.
  */
 export const PipelineStepEditorPanel = ({
   selectedStep,
   stepInput,
-  stepConfig,
   onStepInputChange,
-  onStepConfigChange,
+  configsForAgent = [],
+  stepAgentConfigId,
+  onStepAgentConfigIdChange,
   disabled = false,
   variableKeys = [],
   expansionTemplates = [],
@@ -139,19 +146,38 @@ export const PipelineStepEditorPanel = ({
           )}
         </TabsContent>
         <TabsContent value="config" className="mt-4">
-          {schemas.configSchema ? (
-            <SchemaForm
-              schema={schemas.configSchema}
-              value={stepConfig}
-              onChange={onStepConfigChange}
-              disabled={disabled}
-              seedRequiredDefaults={true}
-              components={{ StringField: stringFieldComponent }}
-            />
+          {configsForAgent.length === 0 ? (
+            <div className="flex flex-col gap-2">
+              <p className="text-sm text-muted-foreground">
+                No agent configs for this agent. Create one first.
+              </p>
+              <Link
+                href="/dashboard/agent-configs"
+                className="text-sm font-medium text-primary underline underline-offset-4 hover:no-underline"
+              >
+                Go to Agent configs
+              </Link>
+            </div>
           ) : (
-            <p className="text-xs text-muted-foreground">
-              No config schema for this agent.
-            </p>
+            <div className="grid gap-2">
+              <Label htmlFor="step-agent-config-picker">Agent config</Label>
+              <select
+                id="step-agent-config-picker"
+                className="flex h-9 w-full max-w-md rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                value={stepAgentConfigId}
+                onChange={(e) => onStepAgentConfigIdChange(e.target.value)}
+                disabled={disabled}
+                aria-label="Choose a saved agent config"
+              >
+                <option value="">None</option>
+                {configsForAgent.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                    {c.description ? ` — ${c.description}` : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
           )}
         </TabsContent>
       </Tabs>

--- a/apps/hermes/app/dashboard/pipelines/[id]/step-list.tsx
+++ b/apps/hermes/app/dashboard/pipelines/[id]/step-list.tsx
@@ -17,6 +17,7 @@ type Step = {
   agentId: string;
   agentVersion: string;
   agentConfigId?: string | null;
+  input?: unknown;
   config?: unknown;
 };
 
@@ -92,11 +93,6 @@ const useStepRowState = (
   const [editSavedConfigId, setEditSavedConfigId] = useState<string | "">(
     step.agentConfigId ?? "",
   );
-  const [editCustomConfigJson, setEditCustomConfigJson] = useState(
-    step.config != null && typeof step.config === "object"
-      ? JSON.stringify(step.config, null, 2)
-      : "{}",
-  );
 
   const {
     FormWithAction: RemoveForm,
@@ -128,7 +124,6 @@ const useStepRowState = (
   const savedConfigs = editAgentKey
     ? (configsByAgentKey[editAgentKey] ?? [])
     : [];
-  const useSavedConfig = editSavedConfigId !== "";
 
   return {
     isEditing,
@@ -137,15 +132,12 @@ const useStepRowState = (
     setEditAgentKey,
     editSavedConfigId,
     setEditSavedConfigId,
-    editCustomConfigJson,
-    setEditCustomConfigJson,
     RemoveForm,
     UpdateForm,
     removePending,
     updatePending,
     updateErrorMessage,
     savedConfigs,
-    useSavedConfig,
   };
 };
 
@@ -172,15 +164,12 @@ const StepRow = ({
     setEditAgentKey,
     editSavedConfigId,
     setEditSavedConfigId,
-    editCustomConfigJson,
-    setEditCustomConfigJson,
     RemoveForm,
     UpdateForm,
     removePending,
     updatePending,
     updateErrorMessage,
     savedConfigs,
-    useSavedConfig,
   } = useStepRowState(step, pipelineId, configsByAgentKey);
 
   if (isEditing) {
@@ -213,15 +202,22 @@ const StepRow = ({
           <input
             type="hidden"
             name="body.agentConfigId"
-            value={useSavedConfig ? editSavedConfigId : ""}
+            value={editSavedConfigId}
             readOnly
           />
           <input
             type="hidden"
-            name="body.config"
-            value={useSavedConfig ? "{}" : editCustomConfigJson}
+            name="body.input"
+            value={JSON.stringify(
+              step.input != null &&
+                typeof step.input === "object" &&
+                !Array.isArray(step.input)
+                ? step.input
+                : {},
+            )}
             readOnly
           />
+          <input type="hidden" name="body.config" value="{}" readOnly />
           <select
             className="flex h-9 w-[280px] rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
             value={editAgentKey}
@@ -238,42 +234,31 @@ const StepRow = ({
               </option>
             ))}
           </select>
-          {savedConfigs.length > 0 ? (
-            <div className="w-full grid gap-1.5">
-              <Label htmlFor={`step-saved-config-${step.id}`}>
-                Saved config (optional)
-              </Label>
-              <select
-                id={`step-saved-config-${step.id}`}
-                className="flex h-9 w-full max-w-md rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                value={editSavedConfigId}
-                onChange={(e) => setEditSavedConfigId(e.target.value)}
-                disabled={updatePending}
-              >
-                <option value="">None (use custom below)</option>
-                {savedConfigs.map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                    {c.description ? ` — ${c.description}` : ""}
-                  </option>
-                ))}
-              </select>
-            </div>
-          ) : null}
-          {!useSavedConfig ? (
-            <div className="w-full grid gap-1.5">
-              <Label htmlFor={`step-config-${step.id}`}>Config (JSON)</Label>
-              <textarea
-                id={`step-config-${step.id}`}
-                value={editCustomConfigJson}
-                onChange={(e) => setEditCustomConfigJson(e.target.value)}
-                rows={3}
-                disabled={updatePending}
-                className="w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-2 text-sm font-mono shadow-xs outline-none transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
-                placeholder="{}"
-              />
-            </div>
-          ) : null}
+          <div className="w-full grid gap-1.5">
+            <Label htmlFor={`step-saved-config-${step.id}`}>Agent config</Label>
+            <select
+              id={`step-saved-config-${step.id}`}
+              className="flex h-9 w-full max-w-md rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              value={editSavedConfigId}
+              onChange={(e) => setEditSavedConfigId(e.target.value)}
+              disabled={updatePending}
+              aria-label="Choose a saved agent config"
+            >
+              <option value="">None</option>
+              {savedConfigs.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                  {c.description ? ` — ${c.description}` : ""}
+                </option>
+              ))}
+            </select>
+            {savedConfigs.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No agent configs for this agent. Create one in Agent configs
+                first.
+              </p>
+            ) : null}
+          </div>
           <Button
             type="submit"
             variant="secondary"

--- a/apps/hermes/next-env.d.ts
+++ b/apps/hermes/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/user-registration/next-env.d.ts
+++ b/apps/user-registration/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

Pipeline steps now assign config only via saved agent configs. The step editor Config tab and the step list row edit use a dropdown to pick an agent config (or "None") instead of editing raw config JSON. Save still sends `agentConfigId` and sends `config` as `{}`.

## Important changes

- **Step editor panel:** Config tab shows a picker of saved configs for the selected step’s agent; empty state with link to "Go to Agent configs" when none exist. Replaces the previous config schema form.
- **Pipeline detail state:** `stepConfig` (object) replaced with `stepAgentConfigId` (string). Parent passes `configsForAgent` from `configsByAgentKey` and syncs from the selected step’s `agentConfigId`.
- **Step list row edit:** Custom config JSON textarea and "None (use custom below)" removed. Row edit only supports choosing a saved agent config or "None"; form submits `body.input` from step data and `body.config` as `"{}"`.

## Other changes

- New `pipeline-step-editor-panel.test.tsx` for select-step message, Config empty state with link, and Config picker + `onStepAgentConfigIdChange`.
- `next-env.d.ts` touched in hermes and user-registration (tooling/format).

## How to test

1. Open a pipeline that has at least one step with an agent that has saved agent configs.
2. Select the step; in the right-hand editor, open the "Config" tab. Confirm a dropdown "Agent config" with "None" and the saved configs for that agent; choose one and save; reload and confirm the selection is persisted.
3. For the same pipeline, click Edit on a step row. Confirm the row shows an "Agent config" dropdown (no custom JSON). Change the config, save; confirm the step’s `agentConfigId` updates.
4. For an agent with no saved configs, confirm the Config tab shows "No agent configs for this agent. Create one first." and the "Go to Agent configs" link goes to `/dashboard/agent-configs`.