### PR TITLE
Add DataQueue configuration and rules documentation

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "dataqueue": {
+      "command": "npx",
+      "args": [
+        "@nicnocquee/dataqueue",
+        "mcp"
+      ]
+    }
+  }
+}

--- a/.cursor/rules/dataqueue-advanced.mdc
+++ b/.cursor/rules/dataqueue-advanced.mdc
@@ -1,0 +1,186 @@
+# DataQueue — Advanced Rules
+
+## Step Memoization (ctx.run)
+
+Wrap side-effectful work in `ctx.run(stepName, fn)` for durability. Cached results replay on re-invocation after a wait.
+
+```typescript
+const data = await ctx.run('fetch', async () => fetchFromAPI(url));
+await ctx.waitFor({ hours: 1 });
+await ctx.run('notify', async () => sendNotification(data));
+```
+
+Step names must be unique within a handler and stable across deployments.
+
+## Waits
+
+- `ctx.waitFor({ hours: 24 })` — pause for a duration (seconds, minutes, hours, days, weeks, months, years).
+- `ctx.waitUntil(date)` — pause until a specific date.
+- `ctx.waitForToken(tokenId)` — pause until an external actor completes the token.
+
+Waiting jobs release their worker lock and concurrency slot. They consume no resources.
+
+Wait calls use a positional counter internally. Do not add/remove waits conditionally between re-invocations.
+
+## Token System
+
+```typescript
+const token = await ctx.createToken({ timeout: '48h', tags: ['approval'] });
+const result = await ctx.waitForToken<{ approved: boolean }>(token.id);
+if (result.ok) {
+  /* result.output.approved */
+}
+```
+
+Complete externally: `await queue.completeToken(tokenId, { approved: true })`.
+Expire timed-out tokens: `await queue.expireTimedOutTokens()`.
+
+## Cron Scheduling
+
+```typescript
+await queue.addCronJob({
+  scheduleName: 'daily-cleanup',
+  cronExpression: '0 2 * * *',
+  jobType: 'cleanup',
+  payload: { days: 30 },
+  timezone: 'UTC',
+  allowOverlap: false,
+});
+```
+
+The processor auto-enqueues due cron jobs before each batch. Manage with `pauseCronJob`, `resumeCronJob`, `editCronJob`, `removeCronJob`, `listCronJobs`.
+
+## Timeout Management
+
+- `ctx.prolong(ms)` — proactively reset deadline. `ctx.prolong()` resets to original `timeoutMs`.
+- `ctx.onTimeout(() => ms)` — reactive; return ms to extend, or nothing to let timeout proceed.
+- `forceKillOnTimeout: true` — terminates handler via Worker Thread. Requires Node.js, serializable handler, and disables `ctx.run`/waits/`prolong`/`onTimeout`.
+
+## Tags and Filtering
+
+```typescript
+await queue.addJob({ jobType: 'email', payload, tags: ['welcome', 'user'] });
+const jobs = await queue.getJobsByTags(['welcome'], 'any');
+await queue.cancelAllUpcomingJobs({ tags: { values: ['user'], mode: 'all' } });
+```
+
+Modes: `exact` (exact set), `all` (superset), `any` (intersection), `none` (exclusion).
+
+## Idempotency
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload,
+  idempotencyKey: `welcome-${userId}`,
+});
+```
+
+Returns existing job ID if key already exists. Key persists until `cleanupOldJobs` removes the job.
+
+## Transactional Job Creation (PostgreSQL Only)
+
+Pass a `pg.PoolClient` inside a transaction via the `{ db }` option to enqueue a job atomically with other writes:
+
+```typescript
+const client = await pool.connect();
+await client.query('BEGIN');
+await client.query('INSERT INTO users (email) VALUES ($1)', [email]);
+await queue.addJob(
+  {
+    jobType: 'send_email',
+    payload: { to: email, subject: 'Welcome!', body: '...' },
+  },
+  { db: client },
+);
+await client.query('COMMIT');
+client.release();
+```
+
+If the transaction rolls back, the job and its event are never persisted. The `db` option accepts any object with a `.query(text, values)` method matching `pg`'s signature. Using `{ db }` with the Redis backend throws an error.
+
+## Retry Strategy
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload,
+  retryDelay: 10, // base 10s
+  retryBackoff: true, // exponential (default)
+  retryDelayMax: 300, // cap at 5 min
+});
+```
+
+- `retryBackoff: false` — fixed delay of `retryDelay` seconds.
+- `retryBackoff: true` (default) — `retryDelay * 2^attempts` with jitter, capped by `retryDelayMax`.
+- No config — legacy `2^attempts * 60s` formula (backward compatible).
+- Cron schedules propagate retry config to enqueued jobs.
+
+## Dead-Letter Routing
+
+Configure dead-letter capture with `deadLetterJobType`:
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload,
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+When retries are exhausted, DataQueue creates a pending dead-letter job with envelope payload containing `originalJob`, `originalPayload`, and `failure`. Source jobs remain `failed` and store linkage metadata (`deadLetteredAt`, `deadLetterJobId`).
+
+## Event Hooks
+
+Subscribe to real-time lifecycle events via `on`, `once`, `off`, `removeAllListeners`. Works with both Postgres and Redis.
+
+```typescript
+queue.on('job:completed', ({ jobId, jobType }) => {
+  metrics.increment('job.completed', { jobType });
+});
+queue.on('job:failed', ({ jobId, jobType, error, willRetry }) => {
+  if (!willRetry) alertOps(`Permanent failure: ${jobId}`);
+});
+queue.on('error', (error) => Sentry.captureException(error));
+```
+
+Events: `job:added`, `job:processing`, `job:completed`, `job:failed` (with `willRetry`), `job:cancelled`, `job:retried`, `job:waiting`, `job:progress`, `job:output`, `error`.
+
+`error` events fire alongside `onError` callbacks in `ProcessorOptions` / `SupervisorOptions` — both mechanisms work independently.
+
+## Scaling
+
+- Increase `batchSize` and `concurrency` for higher throughput.
+- Use `group: { id }` on jobs with `groupConcurrency` on processors when you need global per-tenant/per-account fairness.
+- Run multiple processor instances with unique `workerId` values — `FOR UPDATE SKIP LOCKED` (PostgreSQL) or Lua scripts (Redis) prevent double-claiming.
+- Use `jobType` filter for specialized workers.
+- Use `createSupervisor()` to automate maintenance (reclaim stuck jobs, cleanup, token expiry). Safe to run across multiple instances.
+
+## Progress Tracking
+
+```typescript
+await ctx.setProgress(50); // 0–100, persisted to DB
+```
+
+Read via `queue.getJob(id)` (`progress` field) or React SDK's `useJob` hook.
+
+## Job Output
+
+Store results via `ctx.setOutput(data)` or by returning a value from the handler:
+
+```typescript
+// Option 1: return a value
+const handler = async (payload, signal, ctx) => {
+  const result = await doWork(payload);
+  return { url: result.downloadUrl };
+};
+
+// Option 2: ctx.setOutput (takes precedence over return value)
+const handler = async (payload, signal, ctx) => {
+  const result = await doWork(payload);
+  await ctx.setOutput({ url: result.downloadUrl });
+};
+```
+
+Read via `queue.getJob(id)` (`output` field) or React SDK's `useJob` hook (`output` property).

--- a/.cursor/rules/dataqueue-basic.mdc
+++ b/.cursor/rules/dataqueue-basic.mdc
@@ -1,0 +1,176 @@
+# DataQueue — Basic Rules
+
+## Imports
+
+Always import from `@nicnocquee/dataqueue`. There is no subpath like `/v2` or `/v3`.
+
+```typescript
+import { initJobQueue, JobHandlers } from '@nicnocquee/dataqueue';
+```
+
+## PayloadMap Pattern
+
+Define an object type where keys are job type strings and values are payload shapes. This powers type-safe `addJob`, `createProcessor`, and handler completeness checking.
+
+```typescript
+type JobPayloadMap = {
+  send_email: { to: string; subject: string; body: string };
+  generate_report: { reportId: string; userId: string };
+};
+```
+
+## Initialization (Singleton)
+
+Never call `initJobQueue` per request — each call creates a new database connection pool. Use a module-level singleton:
+
+```typescript
+import { initJobQueue } from '@nicnocquee/dataqueue';
+
+let jobQueue: ReturnType<typeof initJobQueue<JobPayloadMap>> | null = null;
+
+export const getJobQueue = () => {
+  if (!jobQueue) {
+    jobQueue = initJobQueue<JobPayloadMap>({
+      databaseConfig: { connectionString: process.env.PG_DATAQUEUE_DATABASE },
+    });
+  }
+  return jobQueue;
+};
+```
+
+For Redis, set `backend: 'redis'` and use `redisConfig` with `url` or `host`/`port`/`password`. Install `ioredis` as a peer dependency.
+
+### Bring Your Own Pool / Client
+
+Pass an existing `pg.Pool` or `ioredis` client instead of connection config:
+
+```typescript
+import { Pool } from 'pg';
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+jobQueue = initJobQueue<JobPayloadMap>({ pool });
+```
+
+```typescript
+import IORedis from 'ioredis';
+const redis = new IORedis(process.env.REDIS_URL);
+jobQueue = initJobQueue<JobPayloadMap>({
+  backend: 'redis',
+  client: redis,
+  keyPrefix: 'myapp:',
+});
+```
+
+The library will **not** close externally provided connections on shutdown.
+
+## Adding Jobs
+
+Use `addJob` for a single job, `addJobs` for bulk inserts (single DB round-trip).
+
+```typescript
+const id = await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'a@x.com', subject: 'Hi', body: '...' },
+});
+
+const ids = await queue.addJobs([
+  {
+    jobType: 'send_email',
+    payload: { to: 'a@x.com', subject: 'Hi', body: '...' },
+  },
+  {
+    jobType: 'send_email',
+    payload: { to: 'b@x.com', subject: 'Hi', body: '...' },
+    priority: 10,
+  },
+]);
+// ids[i] corresponds to the i-th input job
+```
+
+Both support `idempotencyKey`, `priority`, `runAt`, `tags`, optional `group: { id, tier? }`, and `{ db }` for transactional inserts (PostgreSQL only).
+
+## Handlers
+
+Type handlers as `JobHandlers<PayloadMap>` so TypeScript enforces a handler for every job type.
+
+```typescript
+export const jobHandlers: JobHandlers<JobPayloadMap> = {
+  send_email: async (payload, signal, ctx) => {
+    await sendEmail(payload.to, payload.subject, payload.body);
+  },
+  generate_report: async (payload) => {
+    await generateReport(payload.reportId, payload.userId);
+  },
+};
+```
+
+Handler signature: `(payload: T, signal: AbortSignal, ctx: JobContext) => Promise<void>`. You can omit arguments you don't need.
+
+## Processing
+
+**Serverless** — call `processor.start()` which processes one batch and stops:
+
+```typescript
+const processor = queue.createProcessor(handlers, {
+  batchSize: 10,
+  concurrency: 3,
+  groupConcurrency: 2, // optional global cap per group.id
+});
+await processor.start();
+```
+
+**Long-running** — call `processor.startInBackground()` which polls continuously, and `createSupervisor()` to automate maintenance:
+
+```typescript
+processor.startInBackground();
+
+const supervisor = queue.createSupervisor({
+  intervalMs: 60_000,
+  stuckJobsTimeoutMinutes: 10,
+  cleanupJobsDaysToKeep: 30,
+});
+supervisor.startInBackground();
+
+process.on('SIGTERM', async () => {
+  await Promise.all([
+    processor.stopAndDrain(30000),
+    supervisor.stopAndDrain(30000),
+  ]);
+  queue.getPool().end(); // or queue.getRedisClient().quit() for Redis
+  process.exit(0);
+});
+```
+
+## Retry Configuration
+
+Control retry behavior per-job with optional fields on `addJob`:
+
+- `retryDelay` (seconds, default 60) — base delay between retries.
+- `retryBackoff` (boolean, default true) — enable exponential backoff with jitter.
+- `retryDelayMax` (seconds, optional) — cap the maximum delay.
+
+When none are set, the legacy `2^attempts * 60s` formula is used.
+
+## Dead-Letter Queue
+
+Use `deadLetterJobType` for jobs that must be captured after exhausting retries:
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: '...' },
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+On exhaustion, the source job stays `failed` and a new pending dead-letter job is created with envelope payload: `{ originalJob, originalPayload, failure }`.
+
+## Common Mistakes
+
+1. Creating `initJobQueue` per request — use a singleton.
+2. Missing handler for a job type — fails with `NoHandler`. Type as `JobHandlers<PayloadMap>`.
+3. Not checking `signal.aborted` in long handlers — timed-out jobs keep running.
+4. Skipping maintenance — use `createSupervisor()` to automate reclaim, cleanup, and token expiry. Without it, stuck jobs and old data accumulate.
+5. Skipping migrations (PostgreSQL) — run `dataqueue-cli migrate` first. Redis needs none.
+6. Using `stop()` instead of `stopAndDrain()` — leaves in-flight jobs stuck.
+7. Expecting dead-letter routing without setting `deadLetterJobType` — DLQ is opt-in.

--- a/.cursor/rules/dataqueue-react-dashboard.mdc
+++ b/.cursor/rules/dataqueue-react-dashboard.mdc
@@ -1,0 +1,87 @@
+# DataQueue — React & Dashboard Rules
+
+## React SDK (@nicnocquee/dataqueue-react)
+
+Install: `npm install @nicnocquee/dataqueue-react` (requires React 18+).
+
+### useJob Hook
+
+```tsx
+'use client';
+import { useJob } from '@nicnocquee/dataqueue-react';
+
+const { status, progress, output, data, isLoading, error } = useJob(jobId, {
+  fetcher: (id) =>
+    fetch(`/api/jobs/${id}`)
+      .then((r) => r.json())
+      .then((d) => d.job),
+  pollingInterval: 1000,
+  onComplete: (job) => {
+    /* job completed */
+  },
+  onFailed: (job) => {
+    /* job failed */
+  },
+});
+```
+
+Polling auto-stops on terminal statuses (`completed`, `failed`, `cancelled`).
+
+### DataqueueProvider
+
+Wrap app in `DataqueueProvider` to share `fetcher` and `pollingInterval`:
+
+```tsx
+<DataqueueProvider fetcher={fetcher} pollingInterval={2000}>
+  {children}
+</DataqueueProvider>
+```
+
+### API Route (Next.js)
+
+```typescript
+// app/api/jobs/[id]/route.ts
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const job = await getJobQueue().getJob(Number(id));
+  if (!job) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json({ job });
+}
+```
+
+## Dashboard (@nicnocquee/dataqueue-dashboard)
+
+Install: `npm install @nicnocquee/dataqueue-dashboard`.
+
+### Setup (Next.js App Router)
+
+```typescript
+// app/admin/dataqueue/[[...path]]/route.ts
+import { createDataqueueDashboard } from '@nicnocquee/dataqueue-dashboard/next';
+import { getJobQueue, jobHandlers } from '@/lib/queue';
+
+const { GET, POST } = createDataqueueDashboard({
+  jobQueue: getJobQueue(),
+  jobHandlers,
+  basePath: '/admin/dataqueue',
+});
+
+export { GET, POST };
+```
+
+`basePath` must match the route directory path.
+
+### Protection
+
+Wrap handlers with your auth middleware before exporting GET/POST.
+
+## Progress Tracking
+
+Use `ctx.setProgress(percent)` in handlers (0–100). The value appears in `useJob`'s `progress` field and the dashboard detail view.
+
+## Job Output
+
+Store results via `ctx.setOutput(data)` or by returning a value from the handler. The value appears in `useJob`'s `output` field and the dashboard detail view. If both are used, `ctx.setOutput()` takes precedence.

--- a/.cursor/skills/dataqueue-advanced/SKILL.md
+++ b/.cursor/skills/dataqueue-advanced/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: dataqueue-advanced
+description: Advanced DataQueue patterns — step memoization, waits, tokens, cron, timeouts, tags, idempotency.
+---
+
+# DataQueue Advanced Patterns
+
+## Step Memoization with ctx.run()
+
+Wrap side-effectful work in `ctx.run(stepName, fn)`. Results are cached in the database — when the handler re-runs after a wait, completed steps replay from cache without re-executing.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const data = await ctx.run('fetch-data', async () => {
+    return await fetchFromAPI(payload.url);
+  });
+
+  await ctx.run('send-notification', async () => {
+    await notify(data.userId, data.message);
+  });
+};
+```
+
+**Rules:**
+
+- Step names must be unique within a handler.
+- Step names must be stable across deployments while jobs are waiting.
+- Step order must not change conditionally between re-invocations.
+
+## Time-Based Waits
+
+### waitFor (duration)
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  await ctx.run('step-1', async () => {
+    /* ... */
+  });
+  await ctx.waitFor({ hours: 24 });
+  await ctx.run('step-2', async () => {
+    /* ... */
+  });
+};
+```
+
+Duration fields: `seconds`, `minutes`, `hours`, `days`, `weeks`, `months`, `years` (additive).
+
+### waitUntil (date)
+
+```typescript
+await ctx.waitUntil(new Date('2025-03-01T09:00:00Z'));
+```
+
+### How waits work internally
+
+1. Handler throws a `WaitSignal` internally.
+2. Job moves to `'waiting'` status — worker lock is released.
+3. After the wait expires, job becomes `'pending'` again.
+4. Handler re-runs from top; `ctx.run()` replays cached steps.
+
+Waiting jobs are idle — they hold no lock, no concurrency slot, no resources.
+
+## Token-Based Waits (Human-in-the-Loop)
+
+Create a token, send it to an external actor, and wait for them to complete it.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const token = await ctx.run('create-token', async () => {
+    return await ctx.createToken({ timeout: '48h', tags: ['approval'] });
+  });
+
+  await ctx.run('notify', async () => {
+    await sendSlack(`Approve: ${token.id}`);
+  });
+
+  const result = await ctx.waitForToken<{ approved: boolean }>(token.id);
+  if (result.ok) {
+    await ctx.run('process', async () => {
+      if (result.output.approved) await approve(payload.id);
+    });
+  }
+};
+```
+
+Complete tokens externally:
+
+```typescript
+await queue.completeToken(tokenId, { approved: true });
+```
+
+Expire timed-out tokens periodically:
+
+```typescript
+await queue.expireTimedOutTokens();
+```
+
+## Cron Scheduling
+
+```typescript
+const cronId = await queue.addCronJob({
+  scheduleName: 'daily-report',
+  cronExpression: '0 9 * * *',
+  jobType: 'generate_report',
+  payload: { reportId: 'daily', userId: 'system' },
+  timezone: 'America/New_York',
+  allowOverlap: false,
+});
+```
+
+The processor automatically enqueues due cron jobs before each batch — no manual triggering needed.
+
+Manage schedules:
+
+```typescript
+await queue.pauseCronJob(cronId);
+await queue.resumeCronJob(cronId);
+await queue.editCronJob(cronId, { cronExpression: '0 */2 * * *' });
+await queue.removeCronJob(cronId);
+const schedules = await queue.listCronJobs('active');
+```
+
+## Timeout Management
+
+### Proactive — ctx.prolong()
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  ctx.prolong(60_000); // set deadline to 60s from now
+  await doHeavyWork();
+  ctx.prolong(); // reset to original timeoutMs
+};
+```
+
+### Reactive — ctx.onTimeout()
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  let step = 0;
+  ctx.onTimeout(() => {
+    if (step < 3) return 30_000; // extend 30s
+  });
+  step = 1;
+  await doStep1();
+  step = 2;
+  await doStep2();
+  step = 3;
+  await doStep3();
+};
+```
+
+Both update `locked_at` in the DB, preventing premature reclamation.
+
+### Force Kill on Timeout
+
+```typescript
+await queue.addJob({
+  jobType: 'task',
+  payload: {
+    /* ... */
+  },
+  timeoutMs: 5000,
+  forceKillOnTimeout: true,
+});
+```
+
+**Limitations of forceKillOnTimeout:**
+
+- Requires Node.js (not Bun).
+- Handler must be serializable (no closures over external variables).
+- `prolong`, `onTimeout`, `ctx.run`, waits are NOT available.
+
+## Event Hooks
+
+Subscribe to real-time job lifecycle events. Works identically with PostgreSQL and Redis.
+
+```typescript
+const queue = initJobQueue<MyPayloadMap>(config);
+
+queue.on('job:completed', ({ jobId, jobType }) => {
+  console.log(`Job ${jobId} (${jobType}) completed`);
+});
+
+queue.on('job:failed', ({ jobId, jobType, error, willRetry }) => {
+  console.error(`Job ${jobId} failed: ${error.message}`);
+  if (!willRetry) {
+    alertOps(`Permanent failure for job ${jobId}`);
+  }
+});
+
+queue.on('error', (error) => {
+  Sentry.captureException(error);
+});
+```
+
+### Available events
+
+| Event            | Payload                                |
+| ---------------- | -------------------------------------- |
+| `job:added`      | `{ jobId, jobType }`                   |
+| `job:processing` | `{ jobId, jobType }`                   |
+| `job:completed`  | `{ jobId, jobType }`                   |
+| `job:failed`     | `{ jobId, jobType, error, willRetry }` |
+| `job:cancelled`  | `{ jobId }`                            |
+| `job:retried`    | `{ jobId }`                            |
+| `job:waiting`    | `{ jobId, jobType }`                   |
+| `job:progress`   | `{ jobId, progress }`                  |
+| `error`          | `Error`                                |
+
+### Listener management
+
+```typescript
+const listener = ({ jobId }) => console.log(jobId);
+queue.on('job:completed', listener);
+queue.off('job:completed', listener);
+queue.once('job:added', ({ jobId }) => console.log('First job:', jobId));
+queue.removeAllListeners('job:completed');
+queue.removeAllListeners(); // all events
+```
+
+The `error` event fires alongside `onError` callbacks in `ProcessorOptions` and `SupervisorOptions` -- both mechanisms work independently.
+
+## Tags
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  tags: ['welcome', 'onboarding'],
+});
+
+const jobs = await queue.getJobsByTags(['welcome'], 'any');
+await queue.cancelAllUpcomingJobs({
+  tags: { values: ['onboarding'], mode: 'all' },
+});
+```
+
+Tag query modes: `'exact'`, `'all'`, `'any'`, `'none'`.
+
+## Group-Based Concurrency
+
+Use job `group.id` plus processor `groupConcurrency` to enforce a global cap per group across all workers/instances (PostgreSQL and Redis).
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  group: { id: 'tenant_abc', tier: 'gold' }, // tier is optional/reserved
+});
+
+const processor = queue.createProcessor(handlers, {
+  batchSize: 20,
+  concurrency: 10,
+  groupConcurrency: 2,
+});
+```
+
+Ungrouped jobs are unaffected by `groupConcurrency`.
+
+## Idempotency
+
+```typescript
+const jobId = await queue.addJob({
+  jobType: 'email',
+  payload: { to: 'user@example.com', subject: 'Welcome', body: '...' },
+  idempotencyKey: `welcome-${userId}`,
+});
+```
+
+If a job with the same key exists, returns the existing job ID. Key is unique across all statuses until `cleanupOldJobs` removes it.
+
+## Transactional Job Creation (PostgreSQL Only)
+
+Insert a job within an existing database transaction so the job is enqueued **atomically** with other writes:
+
+```typescript
+import { Pool } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function registerUser(email: string, name: string) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query('INSERT INTO users (email, name) VALUES ($1, $2)', [
+      email,
+      name,
+    ]);
+
+    const queue = getJobQueue();
+    await queue.addJob(
+      {
+        jobType: 'send_email',
+        payload: { to: email, subject: 'Welcome!', body: `Hi ${name}!` },
+      },
+      { db: client },
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+```
+
+The `db` option accepts any object matching `DatabaseClient { query(text, values): Promise<{ rows, rowCount }> }` — works with `pg.PoolClient`, `pg.Client`, or compatible ORM query runners.
+
+The job event (`'added'`) is also inserted within the same transaction.
+
+## Retry Strategy
+
+Configure how failed jobs are retried with `retryDelay`, `retryBackoff`, and `retryDelayMax`.
+
+### Fixed delay
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  maxAttempts: 5,
+  retryDelay: 30, // 30 seconds between each retry
+  retryBackoff: false,
+});
+```
+
+### Exponential backoff with cap
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  maxAttempts: 10,
+  retryDelay: 5, // base: 5 seconds
+  retryBackoff: true, // default — delay doubles each attempt with jitter
+  retryDelayMax: 300, // never wait more than 5 minutes
+});
+```
+
+### Cron schedules with retry config
+
+```typescript
+await queue.addCronJob({
+  scheduleName: 'daily-sync',
+  cronExpression: '0 * * * *',
+  jobType: 'sync',
+  payload: { source: 'api' },
+  retryDelay: 60,
+  retryBackoff: true,
+  retryDelayMax: 600,
+});
+```
+
+Every job enqueued by the schedule inherits the retry settings.
+
+### Dead-letter routing
+
+Set `deadLetterJobType` on jobs (or cron schedules) to route exhausted failures:
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: { to: 'user@example.com' },
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+Dead-letter jobs receive envelope payload:
+
+```typescript
+{
+  originalJob: { id, jobType, attempts, maxAttempts },
+  originalPayload: {...},
+  failure: { message, reason, failedAt }
+}
+```
+
+### Default behavior
+
+When no retry options are set, the legacy formula `2^attempts * 60 seconds` is used. This is fully backward compatible.
+
+## Maintenance
+
+Use `createSupervisor()` to automate all maintenance tasks in a long-running server:
+
+```typescript
+const supervisor = queue.createSupervisor({
+  intervalMs: 60_000,
+  stuckJobsTimeoutMinutes: 10,
+  cleanupJobsDaysToKeep: 30,
+  cleanupEventsDaysToKeep: 30,
+});
+supervisor.startInBackground();
+```
+
+For serverless or one-off scripts, call `supervisor.start()` (runs once) or use the manual methods:
+
+```typescript
+await queue.reclaimStuckJobs(10); // reclaim jobs stuck > 10 min
+await queue.cleanupOldJobs(30); // delete completed jobs > 30 days
+await queue.cleanupOldJobEvents(30); // delete old events > 30 days
+await queue.expireTimedOutTokens(); // expire overdue tokens
+```

--- a/.cursor/skills/dataqueue-core/SKILL.md
+++ b/.cursor/skills/dataqueue-core/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: dataqueue-core
+description: Core patterns for using @nicnocquee/dataqueue — typed PayloadMap, init, handlers, adding and processing jobs.
+---
+
+# DataQueue Core Patterns
+
+## Imports
+
+Always import from `@nicnocquee/dataqueue`. There is no v2/v3 subpath.
+
+```typescript
+import { initJobQueue, JobHandlers } from '@nicnocquee/dataqueue';
+```
+
+## Step 1: Define a PayloadMap
+
+Define an object type mapping job type strings to their payload shapes. This is the foundation of type safety — every API method is generic over this map.
+
+```typescript
+export type JobPayloadMap = {
+  send_email: { to: string; subject: string; body: string };
+  generate_report: { reportId: string; userId: string };
+};
+```
+
+## Step 2: Define Handlers
+
+Create a `JobHandlers<PayloadMap>` object. TypeScript enforces that every key in the PayloadMap has a handler. Each handler receives `(payload, signal, ctx)`.
+
+```typescript
+import { JobHandlers } from '@nicnocquee/dataqueue';
+import type { JobPayloadMap } from './types';
+
+export const jobHandlers: JobHandlers<JobPayloadMap> = {
+  send_email: async (payload) => {
+    await sendEmail(payload.to, payload.subject, payload.body);
+  },
+  generate_report: async (payload, signal) => {
+    if (signal.aborted) return;
+    const url = await generateReport(payload.reportId, payload.userId);
+    return { url }; // stored as job output, readable via getJob()
+  },
+};
+```
+
+## Step 3: Initialize the Queue (Singleton)
+
+Use a module-level singleton. Each `initJobQueue` call creates a new database pool — never call it per-request.
+
+### PostgreSQL
+
+```typescript
+import { initJobQueue } from '@nicnocquee/dataqueue';
+import type { JobPayloadMap } from './types';
+
+let jobQueue: ReturnType<typeof initJobQueue<JobPayloadMap>> | null = null;
+
+export const getJobQueue = () => {
+  if (!jobQueue) {
+    jobQueue = initJobQueue<JobPayloadMap>({
+      databaseConfig: {
+        connectionString: process.env.PG_DATAQUEUE_DATABASE,
+      },
+    });
+  }
+  return jobQueue;
+};
+```
+
+### Redis
+
+```typescript
+jobQueue = initJobQueue<JobPayloadMap>({
+  backend: 'redis',
+  redisConfig: {
+    url: process.env.REDIS_URL,
+    keyPrefix: 'myapp:',
+  },
+});
+```
+
+### Bring Your Own Pool / Client
+
+You can pass an existing `pg.Pool` or `ioredis` client instead of connection config:
+
+```typescript
+import { Pool } from 'pg';
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+jobQueue = initJobQueue<JobPayloadMap>({ pool });
+```
+
+```typescript
+import IORedis from 'ioredis';
+const redis = new IORedis(process.env.REDIS_URL);
+
+jobQueue = initJobQueue<JobPayloadMap>({
+  backend: 'redis',
+  client: redis,
+  keyPrefix: 'myapp:',
+});
+```
+
+When you provide your own pool/client, the library will **not** close it on shutdown — you manage its lifecycle.
+
+## Step 4: Add Jobs
+
+```typescript
+const jobId = await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  priority: 10,
+  runAt: new Date(Date.now() + 5000),
+  tags: ['welcome'],
+  idempotencyKey: 'welcome-user-123',
+  group: { id: 'tenant_123' }, // optional: for global per-group concurrency limits
+});
+```
+
+### Batch Insert
+
+Use `addJobs` to insert many jobs in a single database round-trip. Returns IDs in the same order as the input array.
+
+```typescript
+const jobIds = await queue.addJobs([
+  {
+    jobType: 'send_email',
+    payload: { to: 'a@example.com', subject: 'Hi', body: '...' },
+  },
+  {
+    jobType: 'send_email',
+    payload: { to: 'b@example.com', subject: 'Hi', body: '...' },
+    priority: 10,
+  },
+  {
+    jobType: 'generate_report',
+    payload: { reportId: '1', userId: '2' },
+    tags: ['monthly'],
+  },
+]);
+```
+
+Each job can independently have its own `idempotencyKey`, `priority`, `runAt`, `tags`, etc. The `{ db }` transactional option is also supported (PostgreSQL only).
+
+### Transactional Job Creation (PostgreSQL only)
+
+Pass an external `pg.PoolClient` inside a transaction via `{ db: client }`:
+
+```typescript
+const client = await pool.connect();
+await client.query('BEGIN');
+await client.query('INSERT INTO users (email) VALUES ($1)', [email]);
+await queue.addJob(
+  {
+    jobType: 'send_email',
+    payload: { to: email, subject: 'Welcome!', body: '...' },
+  },
+  { db: client },
+);
+await client.query('COMMIT');
+client.release();
+```
+
+If the transaction rolls back, the job is never enqueued.
+
+### Retry configuration
+
+Control retry behavior per-job with `retryDelay`, `retryBackoff`, and `retryDelayMax`:
+
+```typescript
+await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  maxAttempts: 5,
+  retryDelay: 10, // base delay: 10 seconds
+  retryBackoff: true, // exponential backoff (default)
+  retryDelayMax: 300, // cap at 5 minutes
+});
+```
+
+- **Fixed delay**: set `retryBackoff: false` for constant delay between retries.
+- **Exponential backoff** (default): delay doubles each attempt with jitter.
+- **Default**: when no retry options are set, legacy `2^attempts * 60s` is used.
+
+### Dead-letter queues
+
+Route exhausted failures into a dedicated job type with `deadLetterJobType`:
+
+```typescript
+await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+When retries are exhausted, DataQueue keeps the source job as `failed` and creates a new pending dead-letter job with envelope payload: `{ originalJob, originalPayload, failure }`.
+
+## Step 5: Process Jobs
+
+### Serverless (one-shot)
+
+```typescript
+const processor = queue.createProcessor(handlers, {
+  batchSize: 10,
+  concurrency: 3,
+  groupConcurrency: 2, // optional global cap per group.id across all workers
+});
+const processed = await processor.start();
+```
+
+### Long-running server
+
+```typescript
+const processor = queue.createProcessor(handlers, {
+  batchSize: 10,
+  concurrency: 3,
+  pollInterval: 5000,
+});
+processor.startInBackground();
+
+// Automate maintenance (reclaim stuck jobs, cleanup old data, expire tokens)
+const supervisor = queue.createSupervisor({
+  intervalMs: 60_000,
+  stuckJobsTimeoutMinutes: 10,
+  cleanupJobsDaysToKeep: 30,
+  cleanupEventsDaysToKeep: 30,
+});
+supervisor.startInBackground();
+
+process.on('SIGTERM', async () => {
+  await Promise.all([
+    processor.stopAndDrain(30000),
+    supervisor.stopAndDrain(30000),
+  ]);
+  queue.getPool().end();
+  process.exit(0);
+});
+```
+
+## Common Mistakes
+
+1. **Creating a new queue per request** — always use a singleton. Each `initJobQueue` creates a DB pool.
+2. **Missing handler for a job type** — the job fails with `FailureReason.NoHandler`. Let TypeScript enforce completeness by typing handlers as `JobHandlers<PayloadMap>`.
+3. **Not checking `signal.aborted`** — timed-out jobs keep running in the background. Always check the signal in long-running handlers.
+4. **Skipping maintenance** — use `createSupervisor()` to automate reclaiming stuck jobs, cleaning up old data, and expiring tokens. Without it, crashed workers leave jobs stuck in `processing` and tables grow unbounded.
+5. **Forgetting to run migrations** — PostgreSQL requires `dataqueue-cli migrate` before use. Redis needs no migrations.
+6. **Not calling `stopAndDrain` on shutdown** — use `stopAndDrain()` (not `stop()`) for graceful shutdown to avoid stuck jobs.
+7. **Forgetting to commit/rollback when using `db` option** — the `addJob` INSERT sits in an open transaction. If you never `COMMIT` or `ROLLBACK`, the connection leaks and the job is invisible to other sessions.
+8. **Using `db` option with Redis** — transactional job creation is PostgreSQL only. The Redis backend throws if `db` is provided.
+9. **Expecting dead-letter routing without configuration** — DLQ is opt-in. Set `deadLetterJobType` on jobs (or cron schedules) that require dead-letter capture.

--- a/.cursor/skills/dataqueue-react/SKILL.md
+++ b/.cursor/skills/dataqueue-react/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: dataqueue-react
+description: React SDK and Dashboard patterns for DataQueue — useJob hook, DataqueueProvider, admin dashboard.
+---
+
+# DataQueue React & Dashboard Patterns
+
+## React SDK — @nicnocquee/dataqueue-react
+
+### Installation
+
+```bash
+npm install @nicnocquee/dataqueue-react
+```
+
+Requires React 18+.
+
+### useJob Hook
+
+Poll a job's status and progress from the browser.
+
+```tsx
+'use client';
+import { useJob } from '@nicnocquee/dataqueue-react';
+
+function JobTracker({ jobId }: { jobId: number }) {
+  const { status, progress, data, isLoading, error } = useJob(jobId, {
+    fetcher: (id) =>
+      fetch(`/api/jobs/${id}`)
+        .then((r) => r.json())
+        .then((d) => d.job),
+    pollingInterval: 1000,
+    onComplete: (job) => toast.success('Done!'),
+    onFailed: (job) => toast.error('Failed'),
+    onStatusChange: (newStatus, oldStatus) => {
+      console.log(`${oldStatus} → ${newStatus}`);
+    },
+  });
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <div>
+      <p>Status: {status}</p>
+      <progress value={progress ?? 0} max={100} />
+    </div>
+  );
+}
+```
+
+Polling stops automatically on terminal statuses (`completed`, `failed`, `cancelled`).
+
+### DataqueueProvider
+
+Avoid repeating `fetcher` and `pollingInterval` by wrapping your app in a provider.
+
+```tsx
+'use client';
+import { DataqueueProvider } from '@nicnocquee/dataqueue-react';
+
+const fetcher = (id: number) =>
+  fetch(`/api/jobs/${id}`)
+    .then((r) => r.json())
+    .then((d) => d.job);
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <DataqueueProvider fetcher={fetcher} pollingInterval={2000}>
+      {children}
+    </DataqueueProvider>
+  );
+}
+```
+
+Then use `useJob` without config:
+
+```tsx
+const { status, progress } = useJob(jobId);
+```
+
+### API Route for Job Fetching (Next.js)
+
+```typescript
+// app/api/jobs/[id]/route.ts
+import { getJobQueue } from '@/lib/queue';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const jobQueue = getJobQueue();
+  const job = await jobQueue.getJob(Number(id));
+  if (!job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+  return NextResponse.json({ job });
+}
+```
+
+### useJob Return Value
+
+| Field       | Type                | Description                                           |
+| ----------- | ------------------- | ----------------------------------------------------- |
+| `data`      | `JobData \| null`   | Latest job data from fetcher                          |
+| `status`    | `JobStatus \| null` | Current job status                                    |
+| `progress`  | `number \| null`    | Progress percentage (0–100)                           |
+| `output`    | `unknown \| null`   | Handler output from `ctx.setOutput()` or return value |
+| `isLoading` | `boolean`           | True until first fetch resolves                       |
+| `error`     | `Error \| null`     | Last fetch error                                      |
+
+## Dashboard — @nicnocquee/dataqueue-dashboard
+
+### Installation
+
+```bash
+npm install @nicnocquee/dataqueue-dashboard
+```
+
+### Setup (Next.js App Router)
+
+Create a single catch-all route:
+
+```typescript
+// app/admin/dataqueue/[[...path]]/route.ts
+import { createDataqueueDashboard } from '@nicnocquee/dataqueue-dashboard/next';
+import { getJobQueue, jobHandlers } from '@/lib/queue';
+
+const { GET, POST } = createDataqueueDashboard({
+  jobQueue: getJobQueue(),
+  jobHandlers,
+  basePath: '/admin/dataqueue',
+});
+
+export { GET, POST };
+```
+
+Visit `/admin/dataqueue` to open the dashboard.
+
+The `basePath` must match the route file directory. For example, `app/jobs/dashboard/[[...path]]/route.ts` requires `basePath: '/jobs/dashboard'`.
+
+### Dashboard Features
+
+- Jobs list with status filter tabs, pagination, auto-refresh
+- Job detail view with payload, error history, step data, events timeline
+- Inline actions: cancel pending/waiting jobs, retry failed/cancelled jobs
+- Process Jobs button for one-shot processing (useful in dev)
+
+### Protecting the Dashboard
+
+Wrap the handlers with your auth logic:
+
+```typescript
+const dashboard = createDataqueueDashboard({
+  jobQueue: getJobQueue(),
+  jobHandlers,
+  basePath: '/admin/dataqueue',
+});
+
+export async function GET(req: Request, ctx: any) {
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return dashboard.GET(req, ctx);
+}
+
+export async function POST(req: Request, ctx: any) {
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return dashboard.POST(req, ctx);
+}
+```
+
+### Progress Tracking from Handlers
+
+Report progress via `ctx.setProgress(percent)` (0–100). The value persists to the database and is exposed via `getJob()` and the `useJob` hook's `progress` field.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  for (let i = 0; i < chunks.length; i++) {
+    await processChunk(chunks[i]);
+    await ctx.setProgress(Math.round(((i + 1) / chunks.length) * 100));
+  }
+};
+```
+
+### Job Output from Handlers
+
+Store results via `ctx.setOutput(data)` or by returning a value from the handler. Exposed via `getJob()` (`output` field) and the `useJob` hook's `output` property. If both are used, `ctx.setOutput()` takes precedence.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const result = await doWork(payload);
+  return { url: result.downloadUrl }; // stored as output
+};
+```

--- a/.github/skills/dataqueue-advanced/SKILL.md
+++ b/.github/skills/dataqueue-advanced/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: dataqueue-advanced
+description: Advanced DataQueue patterns — step memoization, waits, tokens, cron, timeouts, tags, idempotency.
+---
+
+# DataQueue Advanced Patterns
+
+## Step Memoization with ctx.run()
+
+Wrap side-effectful work in `ctx.run(stepName, fn)`. Results are cached in the database — when the handler re-runs after a wait, completed steps replay from cache without re-executing.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const data = await ctx.run('fetch-data', async () => {
+    return await fetchFromAPI(payload.url);
+  });
+
+  await ctx.run('send-notification', async () => {
+    await notify(data.userId, data.message);
+  });
+};
+```
+
+**Rules:**
+
+- Step names must be unique within a handler.
+- Step names must be stable across deployments while jobs are waiting.
+- Step order must not change conditionally between re-invocations.
+
+## Time-Based Waits
+
+### waitFor (duration)
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  await ctx.run('step-1', async () => {
+    /* ... */
+  });
+  await ctx.waitFor({ hours: 24 });
+  await ctx.run('step-2', async () => {
+    /* ... */
+  });
+};
+```
+
+Duration fields: `seconds`, `minutes`, `hours`, `days`, `weeks`, `months`, `years` (additive).
+
+### waitUntil (date)
+
+```typescript
+await ctx.waitUntil(new Date('2025-03-01T09:00:00Z'));
+```
+
+### How waits work internally
+
+1. Handler throws a `WaitSignal` internally.
+2. Job moves to `'waiting'` status — worker lock is released.
+3. After the wait expires, job becomes `'pending'` again.
+4. Handler re-runs from top; `ctx.run()` replays cached steps.
+
+Waiting jobs are idle — they hold no lock, no concurrency slot, no resources.
+
+## Token-Based Waits (Human-in-the-Loop)
+
+Create a token, send it to an external actor, and wait for them to complete it.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const token = await ctx.run('create-token', async () => {
+    return await ctx.createToken({ timeout: '48h', tags: ['approval'] });
+  });
+
+  await ctx.run('notify', async () => {
+    await sendSlack(`Approve: ${token.id}`);
+  });
+
+  const result = await ctx.waitForToken<{ approved: boolean }>(token.id);
+  if (result.ok) {
+    await ctx.run('process', async () => {
+      if (result.output.approved) await approve(payload.id);
+    });
+  }
+};
+```
+
+Complete tokens externally:
+
+```typescript
+await queue.completeToken(tokenId, { approved: true });
+```
+
+Expire timed-out tokens periodically:
+
+```typescript
+await queue.expireTimedOutTokens();
+```
+
+## Cron Scheduling
+
+```typescript
+const cronId = await queue.addCronJob({
+  scheduleName: 'daily-report',
+  cronExpression: '0 9 * * *',
+  jobType: 'generate_report',
+  payload: { reportId: 'daily', userId: 'system' },
+  timezone: 'America/New_York',
+  allowOverlap: false,
+});
+```
+
+The processor automatically enqueues due cron jobs before each batch — no manual triggering needed.
+
+Manage schedules:
+
+```typescript
+await queue.pauseCronJob(cronId);
+await queue.resumeCronJob(cronId);
+await queue.editCronJob(cronId, { cronExpression: '0 */2 * * *' });
+await queue.removeCronJob(cronId);
+const schedules = await queue.listCronJobs('active');
+```
+
+## Timeout Management
+
+### Proactive — ctx.prolong()
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  ctx.prolong(60_000); // set deadline to 60s from now
+  await doHeavyWork();
+  ctx.prolong(); // reset to original timeoutMs
+};
+```
+
+### Reactive — ctx.onTimeout()
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  let step = 0;
+  ctx.onTimeout(() => {
+    if (step < 3) return 30_000; // extend 30s
+  });
+  step = 1;
+  await doStep1();
+  step = 2;
+  await doStep2();
+  step = 3;
+  await doStep3();
+};
+```
+
+Both update `locked_at` in the DB, preventing premature reclamation.
+
+### Force Kill on Timeout
+
+```typescript
+await queue.addJob({
+  jobType: 'task',
+  payload: {
+    /* ... */
+  },
+  timeoutMs: 5000,
+  forceKillOnTimeout: true,
+});
+```
+
+**Limitations of forceKillOnTimeout:**
+
+- Requires Node.js (not Bun).
+- Handler must be serializable (no closures over external variables).
+- `prolong`, `onTimeout`, `ctx.run`, waits are NOT available.
+
+## Event Hooks
+
+Subscribe to real-time job lifecycle events. Works identically with PostgreSQL and Redis.
+
+```typescript
+const queue = initJobQueue<MyPayloadMap>(config);
+
+queue.on('job:completed', ({ jobId, jobType }) => {
+  console.log(`Job ${jobId} (${jobType}) completed`);
+});
+
+queue.on('job:failed', ({ jobId, jobType, error, willRetry }) => {
+  console.error(`Job ${jobId} failed: ${error.message}`);
+  if (!willRetry) {
+    alertOps(`Permanent failure for job ${jobId}`);
+  }
+});
+
+queue.on('error', (error) => {
+  Sentry.captureException(error);
+});
+```
+
+### Available events
+
+| Event            | Payload                                |
+| ---------------- | -------------------------------------- |
+| `job:added`      | `{ jobId, jobType }`                   |
+| `job:processing` | `{ jobId, jobType }`                   |
+| `job:completed`  | `{ jobId, jobType }`                   |
+| `job:failed`     | `{ jobId, jobType, error, willRetry }` |
+| `job:cancelled`  | `{ jobId }`                            |
+| `job:retried`    | `{ jobId }`                            |
+| `job:waiting`    | `{ jobId, jobType }`                   |
+| `job:progress`   | `{ jobId, progress }`                  |
+| `error`          | `Error`                                |
+
+### Listener management
+
+```typescript
+const listener = ({ jobId }) => console.log(jobId);
+queue.on('job:completed', listener);
+queue.off('job:completed', listener);
+queue.once('job:added', ({ jobId }) => console.log('First job:', jobId));
+queue.removeAllListeners('job:completed');
+queue.removeAllListeners(); // all events
+```
+
+The `error` event fires alongside `onError` callbacks in `ProcessorOptions` and `SupervisorOptions` -- both mechanisms work independently.
+
+## Tags
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  tags: ['welcome', 'onboarding'],
+});
+
+const jobs = await queue.getJobsByTags(['welcome'], 'any');
+await queue.cancelAllUpcomingJobs({
+  tags: { values: ['onboarding'], mode: 'all' },
+});
+```
+
+Tag query modes: `'exact'`, `'all'`, `'any'`, `'none'`.
+
+## Group-Based Concurrency
+
+Use job `group.id` plus processor `groupConcurrency` to enforce a global cap per group across all workers/instances (PostgreSQL and Redis).
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  group: { id: 'tenant_abc', tier: 'gold' }, // tier is optional/reserved
+});
+
+const processor = queue.createProcessor(handlers, {
+  batchSize: 20,
+  concurrency: 10,
+  groupConcurrency: 2,
+});
+```
+
+Ungrouped jobs are unaffected by `groupConcurrency`.
+
+## Idempotency
+
+```typescript
+const jobId = await queue.addJob({
+  jobType: 'email',
+  payload: { to: 'user@example.com', subject: 'Welcome', body: '...' },
+  idempotencyKey: `welcome-${userId}`,
+});
+```
+
+If a job with the same key exists, returns the existing job ID. Key is unique across all statuses until `cleanupOldJobs` removes it.
+
+## Transactional Job Creation (PostgreSQL Only)
+
+Insert a job within an existing database transaction so the job is enqueued **atomically** with other writes:
+
+```typescript
+import { Pool } from 'pg';
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function registerUser(email: string, name: string) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+
+    await client.query('INSERT INTO users (email, name) VALUES ($1, $2)', [
+      email,
+      name,
+    ]);
+
+    const queue = getJobQueue();
+    await queue.addJob(
+      {
+        jobType: 'send_email',
+        payload: { to: email, subject: 'Welcome!', body: `Hi ${name}!` },
+      },
+      { db: client },
+    );
+
+    await client.query('COMMIT');
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+```
+
+The `db` option accepts any object matching `DatabaseClient { query(text, values): Promise<{ rows, rowCount }> }` — works with `pg.PoolClient`, `pg.Client`, or compatible ORM query runners.
+
+The job event (`'added'`) is also inserted within the same transaction.
+
+## Retry Strategy
+
+Configure how failed jobs are retried with `retryDelay`, `retryBackoff`, and `retryDelayMax`.
+
+### Fixed delay
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  maxAttempts: 5,
+  retryDelay: 30, // 30 seconds between each retry
+  retryBackoff: false,
+});
+```
+
+### Exponential backoff with cap
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: {
+    /* ... */
+  },
+  maxAttempts: 10,
+  retryDelay: 5, // base: 5 seconds
+  retryBackoff: true, // default — delay doubles each attempt with jitter
+  retryDelayMax: 300, // never wait more than 5 minutes
+});
+```
+
+### Cron schedules with retry config
+
+```typescript
+await queue.addCronJob({
+  scheduleName: 'daily-sync',
+  cronExpression: '0 * * * *',
+  jobType: 'sync',
+  payload: { source: 'api' },
+  retryDelay: 60,
+  retryBackoff: true,
+  retryDelayMax: 600,
+});
+```
+
+Every job enqueued by the schedule inherits the retry settings.
+
+### Dead-letter routing
+
+Set `deadLetterJobType` on jobs (or cron schedules) to route exhausted failures:
+
+```typescript
+await queue.addJob({
+  jobType: 'email',
+  payload: { to: 'user@example.com' },
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+Dead-letter jobs receive envelope payload:
+
+```typescript
+{
+  originalJob: { id, jobType, attempts, maxAttempts },
+  originalPayload: {...},
+  failure: { message, reason, failedAt }
+}
+```
+
+### Default behavior
+
+When no retry options are set, the legacy formula `2^attempts * 60 seconds` is used. This is fully backward compatible.
+
+## Maintenance
+
+Use `createSupervisor()` to automate all maintenance tasks in a long-running server:
+
+```typescript
+const supervisor = queue.createSupervisor({
+  intervalMs: 60_000,
+  stuckJobsTimeoutMinutes: 10,
+  cleanupJobsDaysToKeep: 30,
+  cleanupEventsDaysToKeep: 30,
+});
+supervisor.startInBackground();
+```
+
+For serverless or one-off scripts, call `supervisor.start()` (runs once) or use the manual methods:
+
+```typescript
+await queue.reclaimStuckJobs(10); // reclaim jobs stuck > 10 min
+await queue.cleanupOldJobs(30); // delete completed jobs > 30 days
+await queue.cleanupOldJobEvents(30); // delete old events > 30 days
+await queue.expireTimedOutTokens(); // expire overdue tokens
+```

--- a/.github/skills/dataqueue-core/SKILL.md
+++ b/.github/skills/dataqueue-core/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: dataqueue-core
+description: Core patterns for using @nicnocquee/dataqueue — typed PayloadMap, init, handlers, adding and processing jobs.
+---
+
+# DataQueue Core Patterns
+
+## Imports
+
+Always import from `@nicnocquee/dataqueue`. There is no v2/v3 subpath.
+
+```typescript
+import { initJobQueue, JobHandlers } from '@nicnocquee/dataqueue';
+```
+
+## Step 1: Define a PayloadMap
+
+Define an object type mapping job type strings to their payload shapes. This is the foundation of type safety — every API method is generic over this map.
+
+```typescript
+export type JobPayloadMap = {
+  send_email: { to: string; subject: string; body: string };
+  generate_report: { reportId: string; userId: string };
+};
+```
+
+## Step 2: Define Handlers
+
+Create a `JobHandlers<PayloadMap>` object. TypeScript enforces that every key in the PayloadMap has a handler. Each handler receives `(payload, signal, ctx)`.
+
+```typescript
+import { JobHandlers } from '@nicnocquee/dataqueue';
+import type { JobPayloadMap } from './types';
+
+export const jobHandlers: JobHandlers<JobPayloadMap> = {
+  send_email: async (payload) => {
+    await sendEmail(payload.to, payload.subject, payload.body);
+  },
+  generate_report: async (payload, signal) => {
+    if (signal.aborted) return;
+    const url = await generateReport(payload.reportId, payload.userId);
+    return { url }; // stored as job output, readable via getJob()
+  },
+};
+```
+
+## Step 3: Initialize the Queue (Singleton)
+
+Use a module-level singleton. Each `initJobQueue` call creates a new database pool — never call it per-request.
+
+### PostgreSQL
+
+```typescript
+import { initJobQueue } from '@nicnocquee/dataqueue';
+import type { JobPayloadMap } from './types';
+
+let jobQueue: ReturnType<typeof initJobQueue<JobPayloadMap>> | null = null;
+
+export const getJobQueue = () => {
+  if (!jobQueue) {
+    jobQueue = initJobQueue<JobPayloadMap>({
+      databaseConfig: {
+        connectionString: process.env.PG_DATAQUEUE_DATABASE,
+      },
+    });
+  }
+  return jobQueue;
+};
+```
+
+### Redis
+
+```typescript
+jobQueue = initJobQueue<JobPayloadMap>({
+  backend: 'redis',
+  redisConfig: {
+    url: process.env.REDIS_URL,
+    keyPrefix: 'myapp:',
+  },
+});
+```
+
+### Bring Your Own Pool / Client
+
+You can pass an existing `pg.Pool` or `ioredis` client instead of connection config:
+
+```typescript
+import { Pool } from 'pg';
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+jobQueue = initJobQueue<JobPayloadMap>({ pool });
+```
+
+```typescript
+import IORedis from 'ioredis';
+const redis = new IORedis(process.env.REDIS_URL);
+
+jobQueue = initJobQueue<JobPayloadMap>({
+  backend: 'redis',
+  client: redis,
+  keyPrefix: 'myapp:',
+});
+```
+
+When you provide your own pool/client, the library will **not** close it on shutdown — you manage its lifecycle.
+
+## Step 4: Add Jobs
+
+```typescript
+const jobId = await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  priority: 10,
+  runAt: new Date(Date.now() + 5000),
+  tags: ['welcome'],
+  idempotencyKey: 'welcome-user-123',
+  group: { id: 'tenant_123' }, // optional: for global per-group concurrency limits
+});
+```
+
+### Batch Insert
+
+Use `addJobs` to insert many jobs in a single database round-trip. Returns IDs in the same order as the input array.
+
+```typescript
+const jobIds = await queue.addJobs([
+  {
+    jobType: 'send_email',
+    payload: { to: 'a@example.com', subject: 'Hi', body: '...' },
+  },
+  {
+    jobType: 'send_email',
+    payload: { to: 'b@example.com', subject: 'Hi', body: '...' },
+    priority: 10,
+  },
+  {
+    jobType: 'generate_report',
+    payload: { reportId: '1', userId: '2' },
+    tags: ['monthly'],
+  },
+]);
+```
+
+Each job can independently have its own `idempotencyKey`, `priority`, `runAt`, `tags`, etc. The `{ db }` transactional option is also supported (PostgreSQL only).
+
+### Transactional Job Creation (PostgreSQL only)
+
+Pass an external `pg.PoolClient` inside a transaction via `{ db: client }`:
+
+```typescript
+const client = await pool.connect();
+await client.query('BEGIN');
+await client.query('INSERT INTO users (email) VALUES ($1)', [email]);
+await queue.addJob(
+  {
+    jobType: 'send_email',
+    payload: { to: email, subject: 'Welcome!', body: '...' },
+  },
+  { db: client },
+);
+await client.query('COMMIT');
+client.release();
+```
+
+If the transaction rolls back, the job is never enqueued.
+
+### Retry configuration
+
+Control retry behavior per-job with `retryDelay`, `retryBackoff`, and `retryDelayMax`:
+
+```typescript
+await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  maxAttempts: 5,
+  retryDelay: 10, // base delay: 10 seconds
+  retryBackoff: true, // exponential backoff (default)
+  retryDelayMax: 300, // cap at 5 minutes
+});
+```
+
+- **Fixed delay**: set `retryBackoff: false` for constant delay between retries.
+- **Exponential backoff** (default): delay doubles each attempt with jitter.
+- **Default**: when no retry options are set, legacy `2^attempts * 60s` is used.
+
+### Dead-letter queues
+
+Route exhausted failures into a dedicated job type with `deadLetterJobType`:
+
+```typescript
+await queue.addJob({
+  jobType: 'send_email',
+  payload: { to: 'user@example.com', subject: 'Hi', body: 'Hello' },
+  maxAttempts: 3,
+  deadLetterJobType: 'email_dead_letter',
+});
+```
+
+When retries are exhausted, DataQueue keeps the source job as `failed` and creates a new pending dead-letter job with envelope payload: `{ originalJob, originalPayload, failure }`.
+
+## Step 5: Process Jobs
+
+### Serverless (one-shot)
+
+```typescript
+const processor = queue.createProcessor(handlers, {
+  batchSize: 10,
+  concurrency: 3,
+  groupConcurrency: 2, // optional global cap per group.id across all workers
+});
+const processed = await processor.start();
+```
+
+### Long-running server
+
+```typescript
+const processor = queue.createProcessor(handlers, {
+  batchSize: 10,
+  concurrency: 3,
+  pollInterval: 5000,
+});
+processor.startInBackground();
+
+// Automate maintenance (reclaim stuck jobs, cleanup old data, expire tokens)
+const supervisor = queue.createSupervisor({
+  intervalMs: 60_000,
+  stuckJobsTimeoutMinutes: 10,
+  cleanupJobsDaysToKeep: 30,
+  cleanupEventsDaysToKeep: 30,
+});
+supervisor.startInBackground();
+
+process.on('SIGTERM', async () => {
+  await Promise.all([
+    processor.stopAndDrain(30000),
+    supervisor.stopAndDrain(30000),
+  ]);
+  queue.getPool().end();
+  process.exit(0);
+});
+```
+
+## Common Mistakes
+
+1. **Creating a new queue per request** — always use a singleton. Each `initJobQueue` creates a DB pool.
+2. **Missing handler for a job type** — the job fails with `FailureReason.NoHandler`. Let TypeScript enforce completeness by typing handlers as `JobHandlers<PayloadMap>`.
+3. **Not checking `signal.aborted`** — timed-out jobs keep running in the background. Always check the signal in long-running handlers.
+4. **Skipping maintenance** — use `createSupervisor()` to automate reclaiming stuck jobs, cleaning up old data, and expiring tokens. Without it, crashed workers leave jobs stuck in `processing` and tables grow unbounded.
+5. **Forgetting to run migrations** — PostgreSQL requires `dataqueue-cli migrate` before use. Redis needs no migrations.
+6. **Not calling `stopAndDrain` on shutdown** — use `stopAndDrain()` (not `stop()`) for graceful shutdown to avoid stuck jobs.
+7. **Forgetting to commit/rollback when using `db` option** — the `addJob` INSERT sits in an open transaction. If you never `COMMIT` or `ROLLBACK`, the connection leaks and the job is invisible to other sessions.
+8. **Using `db` option with Redis** — transactional job creation is PostgreSQL only. The Redis backend throws if `db` is provided.
+9. **Expecting dead-letter routing without configuration** — DLQ is opt-in. Set `deadLetterJobType` on jobs (or cron schedules) that require dead-letter capture.

--- a/.github/skills/dataqueue-react/SKILL.md
+++ b/.github/skills/dataqueue-react/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: dataqueue-react
+description: React SDK and Dashboard patterns for DataQueue — useJob hook, DataqueueProvider, admin dashboard.
+---
+
+# DataQueue React & Dashboard Patterns
+
+## React SDK — @nicnocquee/dataqueue-react
+
+### Installation
+
+```bash
+npm install @nicnocquee/dataqueue-react
+```
+
+Requires React 18+.
+
+### useJob Hook
+
+Poll a job's status and progress from the browser.
+
+```tsx
+'use client';
+import { useJob } from '@nicnocquee/dataqueue-react';
+
+function JobTracker({ jobId }: { jobId: number }) {
+  const { status, progress, data, isLoading, error } = useJob(jobId, {
+    fetcher: (id) =>
+      fetch(`/api/jobs/${id}`)
+        .then((r) => r.json())
+        .then((d) => d.job),
+    pollingInterval: 1000,
+    onComplete: (job) => toast.success('Done!'),
+    onFailed: (job) => toast.error('Failed'),
+    onStatusChange: (newStatus, oldStatus) => {
+      console.log(`${oldStatus} → ${newStatus}`);
+    },
+  });
+
+  if (isLoading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <div>
+      <p>Status: {status}</p>
+      <progress value={progress ?? 0} max={100} />
+    </div>
+  );
+}
+```
+
+Polling stops automatically on terminal statuses (`completed`, `failed`, `cancelled`).
+
+### DataqueueProvider
+
+Avoid repeating `fetcher` and `pollingInterval` by wrapping your app in a provider.
+
+```tsx
+'use client';
+import { DataqueueProvider } from '@nicnocquee/dataqueue-react';
+
+const fetcher = (id: number) =>
+  fetch(`/api/jobs/${id}`)
+    .then((r) => r.json())
+    .then((d) => d.job);
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  return (
+    <DataqueueProvider fetcher={fetcher} pollingInterval={2000}>
+      {children}
+    </DataqueueProvider>
+  );
+}
+```
+
+Then use `useJob` without config:
+
+```tsx
+const { status, progress } = useJob(jobId);
+```
+
+### API Route for Job Fetching (Next.js)
+
+```typescript
+// app/api/jobs/[id]/route.ts
+import { getJobQueue } from '@/lib/queue';
+import { NextResponse } from 'next/server';
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const jobQueue = getJobQueue();
+  const job = await jobQueue.getJob(Number(id));
+  if (!job) {
+    return NextResponse.json({ error: 'Job not found' }, { status: 404 });
+  }
+  return NextResponse.json({ job });
+}
+```
+
+### useJob Return Value
+
+| Field       | Type                | Description                                           |
+| ----------- | ------------------- | ----------------------------------------------------- |
+| `data`      | `JobData \| null`   | Latest job data from fetcher                          |
+| `status`    | `JobStatus \| null` | Current job status                                    |
+| `progress`  | `number \| null`    | Progress percentage (0–100)                           |
+| `output`    | `unknown \| null`   | Handler output from `ctx.setOutput()` or return value |
+| `isLoading` | `boolean`           | True until first fetch resolves                       |
+| `error`     | `Error \| null`     | Last fetch error                                      |
+
+## Dashboard — @nicnocquee/dataqueue-dashboard
+
+### Installation
+
+```bash
+npm install @nicnocquee/dataqueue-dashboard
+```
+
+### Setup (Next.js App Router)
+
+Create a single catch-all route:
+
+```typescript
+// app/admin/dataqueue/[[...path]]/route.ts
+import { createDataqueueDashboard } from '@nicnocquee/dataqueue-dashboard/next';
+import { getJobQueue, jobHandlers } from '@/lib/queue';
+
+const { GET, POST } = createDataqueueDashboard({
+  jobQueue: getJobQueue(),
+  jobHandlers,
+  basePath: '/admin/dataqueue',
+});
+
+export { GET, POST };
+```
+
+Visit `/admin/dataqueue` to open the dashboard.
+
+The `basePath` must match the route file directory. For example, `app/jobs/dashboard/[[...path]]/route.ts` requires `basePath: '/jobs/dashboard'`.
+
+### Dashboard Features
+
+- Jobs list with status filter tabs, pagination, auto-refresh
+- Job detail view with payload, error history, step data, events timeline
+- Inline actions: cancel pending/waiting jobs, retry failed/cancelled jobs
+- Process Jobs button for one-shot processing (useful in dev)
+
+### Protecting the Dashboard
+
+Wrap the handlers with your auth logic:
+
+```typescript
+const dashboard = createDataqueueDashboard({
+  jobQueue: getJobQueue(),
+  jobHandlers,
+  basePath: '/admin/dataqueue',
+});
+
+export async function GET(req: Request, ctx: any) {
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return dashboard.GET(req, ctx);
+}
+
+export async function POST(req: Request, ctx: any) {
+  const session = await auth();
+  if (!session?.user?.isAdmin) {
+    return new Response('Unauthorized', { status: 401 });
+  }
+  return dashboard.POST(req, ctx);
+}
+```
+
+### Progress Tracking from Handlers
+
+Report progress via `ctx.setProgress(percent)` (0–100). The value persists to the database and is exposed via `getJob()` and the `useJob` hook's `progress` field.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  for (let i = 0; i < chunks.length; i++) {
+    await processChunk(chunks[i]);
+    await ctx.setProgress(Math.round(((i + 1) / chunks.length) * 100));
+  }
+};
+```
+
+### Job Output from Handlers
+
+Store results via `ctx.setOutput(data)` or by returning a value from the handler. Exposed via `getJob()` (`output` field) and the `useJob` hook's `output` property. If both are used, `ctx.setOutput()` takes precedence.
+
+```typescript
+const handler = async (payload, signal, ctx) => {
+  const result = await doWork(payload);
+  return { url: result.downloadUrl }; // stored as output
+};
+```


### PR DESCRIPTION
## Summary

Adds Cursor rules, skills, and MCP configuration for the DataQueue library (`@nicnocquee/dataqueue`). Gives the AI and contributors consistent guidance on payload maps, singleton init, handlers, and React/Dashboard usage.

## Important changes

- **Cursor rules** (`.cursor/rules/`): `dataqueue-basic.mdc`, `dataqueue-advanced.mdc`, `dataqueue-react-dashboard.mdc` — imports, PayloadMap pattern, singleton init, handlers, and dashboard patterns
- **Skills** (`.cursor/skills/` and `.github/skills/`): `dataqueue-core`, `dataqueue-advanced`, `dataqueue-react` — reference docs for core queue usage, advanced patterns (memoization, waits, cron, idempotency), and React/Dashboard integration
- **MCP**: `.cursor/mcp.json` config for the DataQueue MCP server (`npx @nicnocquee/dataqueue mcp`)

## Other changes

- No code or app behavior changes; documentation and Cursor config only

## How to test

1. Open a file that uses `@nicnocquee/dataqueue` (e.g. Hermes worker or scheduler) and confirm rules/skills are available in Cursor.
2. Confirm `.cursor/mcp.json` is valid JSON and the `dataqueue` MCP server can be enabled in Cursor settings.
3. Spot-check one rule (e.g. `dataqueue-basic.mdc`) and one skill (e.g. `dataqueue-core/SKILL.md`) to ensure content renders and links are correct.