### PR TITLE
Add Cursor Prisma strong-typing rules and skill docs

### DIFF
--- a/.cursor/rules/prisma-strong-typing.mdc
+++ b/.cursor/rules/prisma-strong-typing.mdc
@@ -1,0 +1,36 @@
+---
+description: Enforce strong Prisma typing patterns in TS/TSX files
+globs: **/*.{ts,tsx}
+alwaysApply: true
+---
+
+# Prisma Strong Typing
+
+Apply this rule whenever code uses Prisma (`prisma`, `Prisma`, model delegates, or Prisma query objects).
+
+## Required patterns
+
+- Use generated Prisma helpers instead of hand-written query shapes:
+  - `Prisma.<Model>FindManyArgs` / `Prisma.<Model>FindUniqueArgs` for args.
+  - `Prisma.<Model>GetPayload<...>` for result payloads.
+- Prefer `satisfies` for query objects:
+  - `const args = { ... } satisfies Prisma.DataSourceFindManyArgs;`
+- Type dependency-injected DB collaborators with delegate method picks:
+  - `Pick<typeof prisma.dataSource, "findMany">`
+  - `Pick<typeof prisma.newsletter, "create">`
+- Keep strict mode clean: no implicit `any`, no untyped callback params.
+
+## Avoid
+
+- Do not hand-write deep structural types for Prisma args/results.
+- Do not use `any` for Prisma values, delegates, or query payloads.
+- Avoid broad `as unknown as ...` casts in app code. If tests require a cast for mocks, keep it local and minimal.
+
+## Test typing guidance
+
+- For mocked Prisma/service functions, use `vi.mocked(...)` before `.mockResolvedValue(...)`.
+- Provide complete typed fixtures for required Prisma model fields.
+
+## Skill
+
+Use the `/prisma-strong-typing` skill for implementation recipes and examples.

--- a/.cursor/rules/typescript-javascript-standards.mdc
+++ b/.cursor/rules/typescript-javascript-standards.mdc
@@ -111,6 +111,10 @@ Use the /react-component skill when creating a React component.
 
 Use the /email-template skill when creating an email template.
 
+## Prisma code
+
+Use the /prisma-strong-typing skill when creating or updating Prisma queries, Prisma service-layer code, or Prisma-related tests.
+
 ## React Server Action/Function
 
 Follow the /route-action-gen-workflow rule when creating a server action/function.

--- a/.cursor/skills/prisma-strong-typing/SKILL.md
+++ b/.cursor/skills/prisma-strong-typing/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: prisma-strong-typing
+description: Write strongly typed Prisma code using generated Prisma args/payload helpers, typed delegate DI, and typed Vitest mocking patterns. Use when creating or updating Prisma queries, Prisma service layers, or tests around Prisma-backed code.
+---
+
+# Prisma Strong Typing
+
+Use this skill whenever code touches Prisma queries or Prisma-backed services.
+
+## 1) Use Prisma-generated types first
+
+- Import Prisma types from the workspace database package:
+  - `import type { Prisma } from "@workspace/database";`
+- Type query objects with `satisfies`:
+  - `const args = { ... } satisfies Prisma.DataSourceFindManyArgs;`
+- Type query payloads with `GetPayload`:
+  - `type Row = Prisma.DataSourceGetPayload<{ include: { articleRelevances: { select: { score: true } } } }>;`
+
+## 2) Type DI with delegate method picks
+
+Prefer minimal but strict delegate contracts for testability.
+
+```ts
+type ContentGenerationDb = {
+  dataSource: Pick<typeof prisma.dataSource, "findMany">;
+  newsletter: Pick<typeof prisma.newsletter, "create">;
+};
+```
+
+This keeps production defaults simple while allowing focused fakes in tests.
+
+## 3) Keep callbacks and transforms typed
+
+If strict mode cannot infer callback parameters, type from Prisma payload aliases.
+
+```ts
+type DataSourceWithScore = Prisma.DataSourceGetPayload<{
+  include: { articleRelevances: { select: { score: true } } };
+}>;
+
+rows.sort((left: DataSourceWithScore, right: DataSourceWithScore) => ...);
+```
+
+## 4) Testing patterns (Vitest)
+
+- Use `vi.mocked(fn)` before `.mockResolvedValue(...)`.
+- Keep casts local and narrow in tests only.
+- Prefer fixture factories that satisfy required model fields.
+
+```ts
+vi.mocked(service.getDataSourcesForTicker).mockResolvedValue([fixture]);
+```
+
+## 5) Anti-patterns
+
+- Hand-written deep Prisma arg/result object types.
+- Broad app-code casts like `as unknown as PrismaClient`.
+- `any` in Prisma service layers or query mappers.
+
+## 6) Final check
+
+After edits:
+
+1. Ensure no implicit `any` in callbacks.
+2. Ensure query objects use `satisfies Prisma.<...>Args`.
+3. Ensure payload aliases come from `Prisma.<Model>GetPayload<...>`.
+4. Run `pnpm code-quality`.


### PR DESCRIPTION
## Summary

Adds Cursor rule guidance and a dedicated Prisma strong-typing skill to standardize how Prisma code and tests are written in this repo. This helps keep query/result typing consistent and reduces ad-hoc typing patterns in future changes.

## Important changes

- Added `.cursor/rules/prisma-strong-typing.mdc` with required patterns for Prisma args, payloads, delegate DI typing, and test mocking.
- Updated `.cursor/rules/typescript-javascript-standards.mdc` to reference/use the Prisma typing guidance.
- Added `.cursor/skills/prisma-strong-typing/SKILL.md` with implementation recipes and examples for strongly typed Prisma usage.

## Other changes

- No runtime application code changes; this PR is tooling/rules/docs-only.
- Scope is isolated to `.cursor` rule and skill assets for easier review.

## How to test

1. Open `.cursor/rules/prisma-strong-typing.mdc` and confirm required/avoid sections match the team’s Prisma typing conventions.
2. Open `.cursor/skills/prisma-strong-typing/SKILL.md` and verify examples use generated Prisma args/payload helpers and typed delegate DI.
3. Confirm `.cursor/rules/typescript-javascript-standards.mdc` includes the Prisma strong-typing reference so TS/JS workflows pick it up.