### PR TITLE
Adds an admin-only **Search Query** area under the Hermes dashboard so operators can browse generated `search_query` rows, filter by ticker name, paginate, and delete rows that are not referenced by `data_source`.

### DIFF
--- a/apps/hermes/app/dashboard/search-queries/actions/delete/route.post.config.test.ts
+++ b/apps/hermes/app/dashboard/search-queries/actions/delete/route.post.config.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createDeleteSearchQueryHandler } from "./route.post.config";
+
+describe("createDeleteSearchQueryHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns error when session is null", async () => {
+    // Setup
+    const deleteHandler = createDeleteSearchQueryHandler({
+      getSession: async () => null,
+      db: {} as never,
+    });
+
+    // Act
+    const result = await deleteHandler({
+      body: { searchQueryId: "00000000-0000-4000-8000-000000000001" },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: undefined,
+    } as never);
+
+    // Assert
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe("Unauthorized");
+  });
+
+  it("returns error when search query is referenced by data sources", async () => {
+    // Setup
+    const count = vi.fn().mockResolvedValue(2);
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const deleteHandler = createDeleteSearchQueryHandler({
+      getSession: async () => ({ id: "user-1", name: "A", email: "a@b.com" }),
+      db: {
+        dataSource: { count },
+        searchQuery: { delete: remove },
+      },
+    });
+
+    // Act
+    const result = await deleteHandler({
+      body: { searchQueryId: "00000000-0000-4000-8000-000000000001" },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: undefined,
+    } as never);
+
+    // Assert
+    expect(count).toHaveBeenCalledWith({
+      where: { searchQueryId: "00000000-0000-4000-8000-000000000001" },
+    });
+    expect(remove).not.toHaveBeenCalled();
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toContain(
+      "Cannot delete this search query",
+    );
+  });
+
+  it("deletes search query and returns ok when no data-source links exist", async () => {
+    // Setup
+    const count = vi.fn().mockResolvedValue(0);
+    const remove = vi.fn().mockResolvedValue(undefined);
+    const deleteHandler = createDeleteSearchQueryHandler({
+      getSession: async () => ({ id: "user-1", name: "A", email: "a@b.com" }),
+      db: {
+        dataSource: { count },
+        searchQuery: { delete: remove },
+      },
+    });
+
+    // Act
+    const result = await deleteHandler({
+      body: { searchQueryId: "00000000-0000-4000-8000-000000000001" },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: undefined,
+    } as never);
+
+    // Assert
+    expect(remove).toHaveBeenCalledWith({
+      where: { id: "00000000-0000-4000-8000-000000000001" },
+    });
+    expect(result).toMatchObject({ status: true, data: { ok: true } });
+  });
+});

--- a/apps/hermes/app/dashboard/search-queries/actions/delete/route.post.config.ts
+++ b/apps/hermes/app/dashboard/search-queries/actions/delete/route.post.config.ts
@@ -1,0 +1,83 @@
+import { prisma } from "@workspace/database";
+import {
+  createRequestValidator,
+  errorResponse,
+  type HandlerFunc,
+  successResponse,
+} from "route-action-gen/lib";
+import { z } from "zod";
+
+import {
+  getDashboardSession,
+  getDashboardSessionForRoute,
+} from "@/lib/auth-dashboard";
+
+const bodyValidator = z.object({
+  searchQueryId: z.string().uuid(),
+});
+
+export const requestValidator = createRequestValidator({
+  body: bodyValidator,
+  user: getDashboardSessionForRoute,
+});
+
+export const responseValidator = z.object({
+  ok: z.literal(true),
+});
+
+type DeleteSearchQueryHandlerDependencies = {
+  getSession?: typeof getDashboardSession;
+  db?: {
+    dataSource: Pick<typeof prisma.dataSource, "count">;
+    searchQuery: Pick<typeof prisma.searchQuery, "delete">;
+  };
+};
+
+type DeleteSearchQueryHandler = HandlerFunc<
+  typeof requestValidator,
+  typeof responseValidator,
+  undefined
+>;
+
+/**
+ * Creates the delete-search-query handler with injectable dependencies for tests.
+ * Blocks deletion when linked data-source rows exist.
+ *
+ * @param dependencies - Optional getSession and db collaborators.
+ * @returns Handler that deletes a search query by id.
+ */
+export const createDeleteSearchQueryHandler = ({
+  getSession = getDashboardSession,
+  db = prisma,
+}: DeleteSearchQueryHandlerDependencies = {}): DeleteSearchQueryHandler => {
+  return async (data) => {
+    const session = await getSession();
+    if (!session) {
+      return errorResponse("Unauthorized");
+    }
+
+    const { searchQueryId } = data.body;
+
+    const linkedDataSourceCount = await db.dataSource.count({
+      where: { searchQueryId },
+    });
+
+    if (linkedDataSourceCount > 0) {
+      return errorResponse(
+        "Cannot delete this search query because it is used by data sources.",
+      );
+    }
+
+    await db.searchQuery.delete({
+      where: { id: searchQueryId },
+    });
+
+    return successResponse({ ok: true as const });
+  };
+};
+
+/**
+ * Handles delete search query: validates session, blocks linked rows, then deletes by id.
+ */
+export const handler: DeleteSearchQueryHandler =
+  createDeleteSearchQueryHandler();

--- a/apps/hermes/app/dashboard/search-queries/actions/delete/route.ts
+++ b/apps/hermes/app/dashboard/search-queries/actions/delete/route.ts
@@ -1,0 +1,1 @@
+export * from "./.generated/route";

--- a/apps/hermes/app/dashboard/search-queries/page.tsx
+++ b/apps/hermes/app/dashboard/search-queries/page.tsx
@@ -1,0 +1,65 @@
+import { ListPagination } from "@/components/list-pagination";
+import { PageHeader } from "@/components/page-header";
+import { withAuthProtection } from "@/components/with-auth-protection";
+import { getSearchQueriesPage } from "@/lib/search-queries";
+
+import { SearchQueriesFilter } from "./search-queries-filter";
+import { SearchQueriesTable } from "./search-queries-table";
+
+const DEFAULT_PAGE_SIZE = 15;
+
+/**
+ * Search Query list page. Fetches paginated search-query rows and supports filtering by ticker name.
+ */
+const SearchQueriesPage = async ({
+  searchParams,
+}: {
+  searchParams:
+    | Promise<{ page?: string; size?: string; ticker?: string }>
+    | { page?: string; size?: string; ticker?: string };
+}) => {
+  const resolved = await Promise.resolve(searchParams);
+  const page = Math.max(1, parseInt(resolved.page ?? "1", 10) || 1);
+  const pageSize = Math.min(
+    100,
+    Math.max(
+      1,
+      parseInt(resolved.size ?? String(DEFAULT_PAGE_SIZE), 10) ||
+        DEFAULT_PAGE_SIZE,
+    ),
+  );
+  const tickerNameFilter = resolved.ticker?.trim() ?? undefined;
+
+  const {
+    searchQueries,
+    total,
+    page: currentPage,
+    pageSize: size,
+  } = await getSearchQueriesPage(page, pageSize, { tickerNameFilter });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <PageHeader
+        title="Search Query"
+        description="Manage generated search queries and remove unused rows."
+      />
+      <SearchQueriesFilter
+        initialTickerName={tickerNameFilter ?? ""}
+        pageSize={size}
+      />
+      <SearchQueriesTable searchQueries={searchQueries} />
+      <ListPagination
+        basePath="/dashboard/search-queries"
+        page={currentPage}
+        pageSize={size}
+        total={total}
+        ariaLabel="Search query list pagination"
+        extraParams={
+          tickerNameFilter ? { ticker: tickerNameFilter } : undefined
+        }
+      />
+    </div>
+  );
+};
+
+export default withAuthProtection(SearchQueriesPage);

--- a/apps/hermes/app/dashboard/search-queries/search-queries-filter.test.tsx
+++ b/apps/hermes/app/dashboard/search-queries/search-queries-filter.test.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { SearchQueriesFilter } from "./search-queries-filter";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@workspace/ui/components/button", () => ({
+  Button: ({ children, type }: React.PropsWithChildren<{ type?: string }>) => (
+    <button type={type as "submit" | "button" | "reset"}>{children}</button>
+  ),
+}));
+
+vi.mock("@workspace/ui/components/input", () => ({
+  Input: (props: React.InputHTMLAttributes<HTMLInputElement>) => (
+    <input {...props} />
+  ),
+}));
+
+vi.mock("@workspace/ui/components/label", () => ({
+  Label: ({
+    children,
+    htmlFor,
+  }: React.PropsWithChildren<{ htmlFor?: string }>) => (
+    <label htmlFor={htmlFor}>{children}</label>
+  ),
+}));
+
+describe("SearchQueriesFilter", () => {
+  it("renders filter form with role", () => {
+    // Act
+    render(<SearchQueriesFilter initialTickerName="" pageSize={15} />);
+
+    // Assert
+    expect(
+      screen.getByRole("search", {
+        name: "Filter search queries by ticker name",
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("populates input with initial ticker name", () => {
+    // Act
+    render(<SearchQueriesFilter initialTickerName="Apple" pageSize={15} />);
+
+    // Assert
+    expect(screen.getByPlaceholderText("Filter by ticker name...")).toHaveValue(
+      "Apple",
+    );
+  });
+
+  it("shows clear filter link when filter is active", () => {
+    // Act
+    render(<SearchQueriesFilter initialTickerName="Apple" pageSize={15} />);
+
+    // Assert
+    expect(screen.getByText("Clear filter")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Clear filter/i })).toHaveAttribute(
+      "href",
+      "/dashboard/search-queries?size=15",
+    );
+  });
+
+  it("hides clear filter link when no active filter", () => {
+    // Act
+    render(<SearchQueriesFilter initialTickerName="" pageSize={15} />);
+
+    // Assert
+    expect(screen.queryByText("Clear filter")).not.toBeInTheDocument();
+  });
+});

--- a/apps/hermes/app/dashboard/search-queries/search-queries-filter.tsx
+++ b/apps/hermes/app/dashboard/search-queries/search-queries-filter.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import { Search } from "lucide-react";
+
+import { Button } from "@workspace/ui/components/button";
+import { Input } from "@workspace/ui/components/input";
+import { Label } from "@workspace/ui/components/label";
+
+type SearchQueriesFilterProps = {
+  /** Current ticker-name filter shown in the input. */
+  initialTickerName?: string;
+  /** Current page size to preserve when submitting filter. */
+  pageSize: number;
+};
+
+/**
+ * Filter form for search queries by ticker name. Submits via GET to preserve URL state.
+ */
+export const SearchQueriesFilter = ({
+  initialTickerName = "",
+  pageSize,
+}: SearchQueriesFilterProps) => {
+  const hasActiveFilter = initialTickerName.trim().length > 0;
+  const clearHref = `/dashboard/search-queries?size=${pageSize}`;
+
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
+      <form
+        action="/dashboard/search-queries"
+        method="get"
+        className="flex w-full max-w-sm flex-col gap-2 sm:flex-row sm:items-center"
+        role="search"
+        aria-label="Filter search queries by ticker name"
+      >
+        <input type="hidden" name="size" value={pageSize} />
+        <input type="hidden" name="page" value="1" />
+        <div className="flex-1 space-y-2">
+          <Label htmlFor="search-queries-filter" className="sr-only">
+            Filter by ticker name
+          </Label>
+          <div className="flex h-9 items-center gap-2 rounded-md border border-input bg-background px-3 has-focus-visible:outline-none has-focus-visible:ring-2 has-focus-visible:ring-ring has-focus-visible:ring-offset-2">
+            <Search
+              className="size-4 shrink-0 text-muted-foreground"
+              aria-hidden
+            />
+            <Input
+              id="search-queries-filter"
+              type="search"
+              name="ticker"
+              defaultValue={initialTickerName}
+              placeholder="Filter by ticker name..."
+              className="min-h-0 flex-1 border-0 bg-transparent p-0 shadow-none focus-visible:ring-0"
+              autoComplete="off"
+            />
+          </div>
+        </div>
+        <Button type="submit">Filter</Button>
+      </form>
+      {hasActiveFilter ? (
+        <div className="flex h-9 shrink-0 items-center">
+          <Link
+            href={clearHref}
+            className="text-sm text-muted-foreground hover:text-foreground"
+          >
+            <span className="underline underline-offset-2 decoration-muted-foreground/40 hover:decoration-foreground">
+              Clear filter
+            </span>
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/hermes/app/dashboard/search-queries/search-queries-table.tsx
+++ b/apps/hermes/app/dashboard/search-queries/search-queries-table.tsx
@@ -1,0 +1,66 @@
+import type { SearchQueriesPageResult } from "@/lib/search-queries";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table";
+
+import { SearchQueryRowActions } from "./search-query-row-actions";
+
+type SearchQueryRow = SearchQueriesPageResult["searchQueries"][number];
+
+/**
+ * Renders search queries as a table with keywords, ticker name, and delete row action.
+ */
+export const SearchQueriesTable = ({
+  searchQueries,
+}: {
+  searchQueries: SearchQueryRow[];
+}) => {
+  return (
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader className="bg-muted/50">
+          <TableRow className="border-muted hover:bg-transparent">
+            <TableHead>Keywords</TableHead>
+            <TableHead>Ticker name</TableHead>
+            <TableHead className="w-12" />
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {searchQueries.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={3}
+                className="text-center text-muted-foreground"
+              >
+                No search queries found.
+              </TableCell>
+            </TableRow>
+          ) : (
+            searchQueries.map((searchQuery) => (
+              <TableRow key={searchQuery.id}>
+                <TableCell className="font-medium">
+                  {searchQuery.text}
+                </TableCell>
+                <TableCell className="text-muted-foreground">
+                  {searchQuery.ticker.name}
+                </TableCell>
+                <TableCell className="text-right">
+                  <SearchQueryRowActions
+                    searchQueryId={searchQuery.id}
+                    keywords={searchQuery.text}
+                  />
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+};

--- a/apps/hermes/app/dashboard/search-queries/search-query-row-actions.tsx
+++ b/apps/hermes/app/dashboard/search-queries/search-query-row-actions.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { MoreHorizontal } from "lucide-react";
+
+import { Button } from "@workspace/ui/components/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu";
+
+import { DeleteConfirmForm } from "@/components/delete-confirm-form";
+import { useFormAction } from "@/app/dashboard/search-queries/actions/delete/.generated/use-form-action";
+
+/**
+ * Encapsulates delete form action and refresh-on-success for search-query row actions.
+ */
+const useSearchQueryRowActions = () => {
+  const router = useRouter();
+  const { FormWithAction, state, pending } = useFormAction();
+
+  useEffect(() => {
+    if (state?.status === true) {
+      router.refresh();
+    }
+  }, [router, state]);
+
+  return { FormWithAction, pending };
+};
+
+/**
+ * Dropdown actions for a search-query row: Delete.
+ */
+export const SearchQueryRowActions = ({
+  searchQueryId,
+  keywords,
+}: {
+  searchQueryId: string;
+  keywords: string;
+}) => {
+  const { FormWithAction, pending } = useSearchQueryRowActions();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label="Open menu"
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-40">
+        <DropdownMenuItem variant="destructive" disabled={pending} asChild>
+          <DeleteConfirmForm
+            FormWithAction={FormWithAction}
+            confirmMessage={`Delete query "${keywords}"? This cannot be undone.`}
+            bodyField={{ name: "body.searchQueryId", value: searchQueryId }}
+            pending={pending}
+          />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/hermes/components/app-sidebar.test.tsx
+++ b/apps/hermes/components/app-sidebar.test.tsx
@@ -85,6 +85,7 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Pipelines")).toBeInTheDocument();
     expect(screen.getByText("Tickers")).toBeInTheDocument();
+    expect(screen.getByText("Search Query")).toBeInTheDocument();
     expect(screen.getByText("Agents")).toBeInTheDocument();
     expect(screen.getByText("API Keys")).toBeInTheDocument();
     expect(screen.getByText("Schedules")).toBeInTheDocument();
@@ -150,6 +151,21 @@ describe("AppSidebar", () => {
       btn.textContent?.includes("API Keys"),
     );
     expect(apiKeysButton).toHaveAttribute("data-active", "true");
+  });
+
+  it("marks Search Query as active when on /dashboard/search-queries", () => {
+    // Setup
+    usePathnameMock.mockReturnValue("/dashboard/search-queries");
+
+    // Act
+    render(<AppSidebar />);
+
+    // Assert
+    const buttons = screen.getAllByTestId("sidebar-menu-button");
+    const searchQueriesButton = buttons.find((btn) =>
+      btn.textContent?.includes("Search Query"),
+    );
+    expect(searchQueriesButton).toHaveAttribute("data-active", "true");
   });
 
   it("marks Schedules as active when on /dashboard/schedules", () => {

--- a/apps/hermes/components/app-sidebar.tsx
+++ b/apps/hermes/components/app-sidebar.tsx
@@ -10,6 +10,7 @@ import {
   GitBranch,
   Key,
   LayoutDashboard,
+  Search,
   Tags,
   TrendingUp,
   Variable,
@@ -48,6 +49,8 @@ export const AppSidebar = ({ user, ...props }: AppSidebarProps) => {
     pathname?.startsWith("/dashboard/agent-configs") ?? false;
   const isVariables = pathname?.startsWith("/dashboard/variables") ?? false;
   const isApiKeys = pathname?.startsWith("/dashboard/api-keys") ?? false;
+  const isSearchQueries =
+    pathname?.startsWith("/dashboard/search-queries") ?? false;
   const isSchedules = pathname?.startsWith("/dashboard/schedules") ?? false;
   const isDataSourceExpansions =
     pathname?.startsWith("/dashboard/data-source-expansions") ?? false;
@@ -115,6 +118,14 @@ export const AppSidebar = ({ user, ...props }: AppSidebarProps) => {
                 <Link href="/dashboard/variables">
                   <Variable className="size-4" />
                   <span>Variables</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={isSearchQueries}>
+                <Link href="/dashboard/search-queries">
+                  <Search className="size-4" />
+                  <span>Search Query</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>

--- a/apps/hermes/components/dashboard-shell.test.tsx
+++ b/apps/hermes/components/dashboard-shell.test.tsx
@@ -227,6 +227,23 @@ describe("DashboardShell", () => {
     expect(screen.getByTestId("breadcrumb-page")).toHaveTextContent("API Keys");
   });
 
+  it("shows Search Query breadcrumb on /dashboard/search-queries", () => {
+    // Setup
+    usePathnameMock.mockReturnValue("/dashboard/search-queries");
+
+    // Act
+    render(
+      <DashboardShell>
+        <div>Content</div>
+      </DashboardShell>,
+    );
+
+    // Assert
+    expect(screen.getByTestId("breadcrumb-page")).toHaveTextContent(
+      "Search Query",
+    );
+  });
+
   it("shows Schedules breadcrumb on /dashboard/schedules", () => {
     // Setup
     usePathnameMock.mockReturnValue("/dashboard/schedules");

--- a/apps/hermes/components/dashboard-shell.tsx
+++ b/apps/hermes/components/dashboard-shell.tsx
@@ -30,6 +30,7 @@ const SEGMENT_LABELS: Record<string, string> = {
   pipelines: "Pipelines",
   "relation-types": "Relation Types",
   schedules: "Schedules",
+  "search-queries": "Search Query",
   tickers: "Tickers",
   variables: "Variables",
 };

--- a/apps/hermes/components/list-pagination.test.tsx
+++ b/apps/hermes/components/list-pagination.test.tsx
@@ -263,4 +263,25 @@ describe("ListPagination", () => {
       "/dashboard/schedules/sched-1?page=2&size=10",
     );
   });
+
+  it("includes extra params in pagination links", () => {
+    // Act
+    render(
+      <ListPagination
+        basePath="/dashboard/search-queries"
+        page={1}
+        pageSize={15}
+        total={30}
+        ariaLabel="Search queries pagination"
+        extraParams={{ ticker: "Apple" }}
+      />,
+    );
+
+    // Assert
+    const nextLink = screen.getByRole("link", { name: /Next/ });
+    expect(nextLink).toHaveAttribute(
+      "href",
+      "/dashboard/search-queries?page=2&size=15&ticker=Apple",
+    );
+  });
 });

--- a/apps/hermes/components/list-pagination.tsx
+++ b/apps/hermes/components/list-pagination.tsx
@@ -19,6 +19,8 @@ export type ListPaginationProps = {
   sortBy?: string;
   /** Optional sort direction to preserve in prev/next links. */
   sortDir?: string;
+  /** Optional arbitrary query params to preserve in prev/next links. */
+  extraParams?: Record<string, string>;
 };
 
 /**
@@ -36,6 +38,7 @@ const buildQueryString = (
     searchQuery?: string;
     sortBy?: string;
     sortDir?: string;
+    extraParams?: Record<string, string>;
   },
 ): string => {
   const params = new URLSearchParams();
@@ -44,6 +47,9 @@ const buildQueryString = (
   if (options.searchQuery) params.set("q", options.searchQuery);
   if (options.sortBy) params.set("sort", options.sortBy);
   if (options.sortDir) params.set("dir", options.sortDir);
+  for (const [key, value] of Object.entries(options.extraParams ?? {})) {
+    params.set(key, value);
+  }
   return params.toString();
 };
 
@@ -59,12 +65,13 @@ export const ListPagination = ({
   searchQuery,
   sortBy,
   sortDir,
+  extraParams,
 }: ListPaginationProps) => {
   const totalPages = Math.max(1, Math.ceil(total / pageSize));
   const hasPrev = page > 1;
   const hasNext = page < totalPages;
 
-  const opts = { searchQuery, sortBy, sortDir };
+  const opts = { searchQuery, sortBy, sortDir, extraParams };
   const prevHref = hasPrev
     ? `${basePath}?${buildQueryString(page - 1, pageSize, opts)}`
     : undefined;

--- a/apps/hermes/lib/search-queries.test.ts
+++ b/apps/hermes/lib/search-queries.test.ts
@@ -1,0 +1,121 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { getSearchQueriesPage } from "./search-queries";
+
+type MockDb = {
+  searchQuery: {
+    findMany: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
+  };
+};
+
+const createMockDb = (): MockDb => ({
+  searchQuery: {
+    findMany: vi.fn(),
+    count: vi.fn(),
+  },
+});
+
+const asDb = (db: MockDb) => db as never;
+
+describe("getSearchQueriesPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches rows with default ordering and pagination", async () => {
+    // Setup
+    const db = createMockDb();
+    db.searchQuery.findMany.mockResolvedValue([]);
+    db.searchQuery.count.mockResolvedValue(0);
+
+    // Act
+    await getSearchQueriesPage(2, 10, undefined, asDb(db));
+
+    // Assert
+    expect(db.searchQuery.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      include: {
+        ticker: {
+          select: {
+            name: true,
+            symbol: true,
+          },
+        },
+      },
+      skip: 10,
+      take: 10,
+      orderBy: { createdAt: "desc" },
+    });
+    expect(db.searchQuery.count).toHaveBeenCalledWith({ where: undefined });
+  });
+
+  it("filters by ticker name when tickerNameFilter is provided", async () => {
+    // Setup
+    const db = createMockDb();
+    db.searchQuery.findMany.mockResolvedValue([]);
+    db.searchQuery.count.mockResolvedValue(0);
+
+    // Act
+    await getSearchQueriesPage(1, 15, { tickerNameFilter: "apple" }, asDb(db));
+
+    // Assert
+    const expectedWhere = {
+      ticker: {
+        name: { contains: "apple", mode: "insensitive" },
+      },
+    };
+    expect(db.searchQuery.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expectedWhere }),
+    );
+    expect(db.searchQuery.count).toHaveBeenCalledWith({ where: expectedWhere });
+  });
+
+  it("ignores empty ticker-name filter values", async () => {
+    // Setup
+    const db = createMockDb();
+    db.searchQuery.findMany.mockResolvedValue([]);
+    db.searchQuery.count.mockResolvedValue(0);
+
+    // Act
+    await getSearchQueriesPage(1, 15, { tickerNameFilter: "   " }, asDb(db));
+
+    // Assert
+    expect(db.searchQuery.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: undefined }),
+    );
+    expect(db.searchQuery.count).toHaveBeenCalledWith({ where: undefined });
+  });
+
+  it("returns rows and pagination metadata", async () => {
+    // Setup
+    const db = createMockDb();
+    const rows = [
+      {
+        id: "q1",
+        text: "latest apple earnings",
+        tickerId: "t1",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        ticker: {
+          name: "Apple Inc.",
+          symbol: "AAPL",
+        },
+      },
+    ];
+    db.searchQuery.findMany.mockResolvedValue(rows);
+    db.searchQuery.count.mockResolvedValue(1);
+
+    // Act
+    const result = await getSearchQueriesPage(1, 15, undefined, asDb(db));
+
+    // Assert
+    expect(result).toEqual({
+      searchQueries: rows,
+      total: 1,
+      page: 1,
+      pageSize: 15,
+    });
+  });
+});

--- a/apps/hermes/lib/search-queries.ts
+++ b/apps/hermes/lib/search-queries.ts
@@ -1,0 +1,85 @@
+import { prisma, type Prisma } from "@workspace/database";
+
+type SearchQueriesDb = {
+  searchQuery: Pick<typeof prisma.searchQuery, "findMany" | "count">;
+};
+
+type SearchQueryRow = Prisma.SearchQueryGetPayload<{
+  include: { ticker: { select: { name: true; symbol: true } } };
+}>;
+
+export type SearchQueriesPageResult = {
+  searchQueries: SearchQueryRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+/**
+ * Builds a Prisma where clause for ticker-name filtering (partial, case-insensitive).
+ *
+ * @param tickerNameFilter - Raw ticker-name filter; trimmed and ignored if empty.
+ * @returns Where clause object or undefined if no filter.
+ */
+const searchQueryTickerWhere = (
+  tickerNameFilter: string | undefined,
+): Prisma.SearchQueryWhereInput | undefined => {
+  const term = tickerNameFilter?.trim();
+  if (!term) return undefined;
+
+  return {
+    ticker: {
+      name: { contains: term, mode: "insensitive" },
+    },
+  };
+};
+
+/**
+ * Fetches paginated search queries with related ticker info, optionally filtered by ticker name.
+ *
+ * @param page - 1-based page number.
+ * @param pageSize - Number of rows per page.
+ * @param options - Optional ticker-name filter.
+ * @param db - Prisma collaborators (injectable for tests).
+ * @returns Search query rows plus pagination metadata.
+ */
+export const getSearchQueriesPage = async (
+  page: number,
+  pageSize: number,
+  options?: { tickerNameFilter?: string },
+  db: SearchQueriesDb = prisma,
+): Promise<SearchQueriesPageResult> => {
+  const skip = (page - 1) * pageSize;
+  const where = searchQueryTickerWhere(options?.tickerNameFilter);
+
+  const findManyArgs = {
+    where,
+    include: {
+      ticker: {
+        select: {
+          name: true,
+          symbol: true,
+        },
+      },
+    },
+    skip,
+    take: pageSize,
+    orderBy: { createdAt: "desc" },
+  } satisfies Prisma.SearchQueryFindManyArgs;
+
+  const countArgs = {
+    where,
+  } satisfies Prisma.SearchQueryCountArgs;
+
+  const [searchQueries, total] = await Promise.all([
+    db.searchQuery.findMany(findManyArgs),
+    db.searchQuery.count(countArgs),
+  ]);
+
+  return {
+    searchQueries,
+    total,
+    page,
+    pageSize,
+  };
+};

--- a/apps/user-registration/next-env.d.ts
+++ b/apps/user-registration/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/dev-docs/docs/apps/hermes/dashboard.mdx
+++ b/dev-docs/docs/apps/hermes/dashboard.mdx
@@ -17,6 +17,7 @@ Hermes is the main orchestration app: it manages **pipelines** (sequences of age
 ## Features
 
 - **Dashboard UI** — Manage pipelines, pipeline steps, tickers, agents, API keys, **data source expansions**, **entity types**, **relation types**, and schedules (CRUD).
+- **Search Query management** — Admins can view generated search queries at `/dashboard/search-queries`, filter rows by ticker name, and delete queries that are not referenced by `data_source`.
 - **Database-driven schedules** — Schedules are stored in the `Schedule` table. The **hermes-worker** app runs a DataQueue cron job every minute, polls for due schedules, and for each pipeline step expands that step's input (e.g. data-source expressions like `db:ticker:id`), then invokes the step via HTTP. Hermes does not run the queue.
 - **Manual run** — Trigger a pipeline run from the dashboard.
 - **Ticker import** — Import IDX (Indonesian Stock Exchange) listed companies via `@workspace/idx-tickers-importer`.
@@ -32,6 +33,7 @@ Hermes is the main orchestration app: it manages **pipelines** (sequences of age
 - Ticker actions: create, update, delete, import (IDX).
 - Agent actions: create, update. Agent details are on a dedicated page (`/dashboard/agents/[id]`) with tabs: **General** (details and endpoint), **Input schema** (pretty-printed JSON), **Config schema** (pretty-printed JSON).
 - **Variables** (`/dashboard/variables`): Create, edit, delete. Each variable has a unique key, value, optional note, and “Secret” flag. Use `{{KEY}}` in agent config or schedule params; hermes-scheduler substitutes values at execution time. Secret values are never returned or shown after save.
+- **Search Query** (`/dashboard/search-queries`): View generated query rows from `search_query` with columns for keywords and ticker name. Filter by ticker name. Delete rows that are not linked by `data_source` (linked rows are blocked from deletion).
 - **Data source expansions** (`/dashboard/data-source-expansions`): Create, edit, delete saved expansion templates. Each has a name, expansion string (e.g. `db:userTicker:tickerId?where.enabled=true`), and optional description. Use **Run preview** on the create/edit page to test the expansion against the DB; format docs and examples are shown on the page. See [Data source expansion](/apps/data-source-expansion) for full format and behavior.
 - **Entity types** (`/dashboard/entity-types`): Manage entity classification vocabulary used by analysis prompts.
 - **Relation types** (`/dashboard/relation-types`): Manage relation vocabulary used by analysis prompts.


### PR DESCRIPTION
## Summary

Adds an admin-only **Search Query** area under the Hermes dashboard so operators can browse generated `search_query` rows, filter by ticker name, paginate, and delete rows that are not referenced by `data_source`.

## Important changes

- New `/dashboard/search-queries` page: table, ticker-name filter, and pagination (filter preserved in query params across pages).
- Server-backed delete for search queries, with protection when a row is still linked from `data_source`.
- `getSearchQueriesPage` in `apps/hermes/lib/search-queries.ts` for typed Prisma listing/count with optional ticker filter.
- `ListPagination` supports `extraParams` so filtered lists keep `ticker` (and similar) when changing page.

## Other changes

- Sidebar/nav and dashboard-shell wiring for the new route.
- Unit tests for lib, delete route config, filter, pagination, sidebar, and dashboard-shell.
- Dev docs: Hermes dashboard page mentions Search Query management and `/dashboard/search-queries`.
- Trivial `next-env.d.ts` touch in `apps/user-registration`.

## How to test

1. Sign in to Hermes and open **Dashboard → Search Query** (or go to `/dashboard/search-queries`).
2. Confirm the table loads with pagination; change page size and page and confirm totals behave as expected.
3. Enter a ticker name fragment in the filter and submit; confirm only matching rows appear and pagination keeps the `ticker` query param.
4. Delete a search query that is **not** used by any `data_source`; confirm it disappears after refresh.
5. Try deleting a query that **is** referenced by a data source (if you have fixture data); confirm deletion is blocked or errors as designed.