### PR TITLE
Add Hermes correlation headers for scheduled agent invocations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ scripts/deploy-all.sh
 data
 
 docs-output
+
+tmp

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -409,6 +409,18 @@ describe("jobHandlers", () => {
         },
       });
       expect(invokeAgentPost).toHaveBeenCalledTimes(1);
+      expect(invokeAgentPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          jobId: payload.jobId,
+          executionId: payload.executionId,
+          scheduleId: payload.scheduleId,
+          scheduleExecutionId: payload.scheduleExecutionId,
+          pipelineStepId: payload.pipelineStepId,
+        }),
+        expect.anything(),
+      );
       expect(applyInvocationCompletion).toHaveBeenCalledWith(
         expect.objectContaining({
           jobId: payload.jobId,

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -233,6 +233,9 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       {
         jobId: payload.jobId,
         executionId: payload.executionId,
+        scheduleId: payload.scheduleId,
+        scheduleExecutionId: payload.scheduleExecutionId,
+        pipelineStepId: payload.pipelineStepId,
         authToken,
         timeoutMs: payload.timeoutMs,
         signal,

--- a/dev-docs/docs/architecture/communication.mdx
+++ b/dev-docs/docs/architecture/communication.mdx
@@ -47,6 +47,7 @@ Agent->>HermesOrWorker: 200 response
 2. **agent-auth-api** matches the bearer token to the preset or a **domain_integration** key hash, signs a JWT with `AGENT_AUTH_JWT_SECRET`, and returns `{ token, expiresIn }` (e.g. 15 minutes).
 3. Hermes/hermes-worker **caches** the JWT and uses it for all agent requests until close to expiry, then fetches a new one.
 4. For each pipeline step, the caller sends `POST` to the agent URL with `Authorization: Bearer <jwt>` and the step input/config.
+   - **hermes-worker** (scheduled runs) also sends correlation headers: `X-Job-Id`, `X-Execution-Id`, and schedule context `X-Schedule-Id`, `X-Schedule-Execution-Id`, `X-Pipeline-Step-Id` (see `invokeAgentPost` in `@hermes/scheduler`). Agents built with `@workspace/agent-runtime` receive those schedule/step ids on `run` as optional `context.hermesCorrelation` when those headers are present. Manual dashboard pipeline runs do not send the schedule headers unless extended later.
 5. The **agent** (via `@workspace/agent-runtime` bearer middleware) receives the request, extracts the Bearer token, and calls **agent-auth-api** `POST /api/verify` with that token.
 6. **agent-auth-api** `POST /api/verify` is **JWT-only**: it verifies signature and expiry. If the token is not a JWT or is invalid, it returns 401. The agent rejects the request unless it gets 200.
 7. The agent runs its logic and returns the result.

--- a/dev-docs/docs/hermes/packages/agent-runtime.mdx
+++ b/dev-docs/docs/hermes/packages/agent-runtime.mdx
@@ -10,14 +10,14 @@ icon: Cpu
 
 ## Main exports
 
-- **`createAgentApp<TInput, TSchema, TConfig?, TConfigSchema?>(config, options)`** — Creates the agent app (fetch handler + port). Config: `agentId`, `agentVersion`, `inputSchema` (Zod), optional `configSchema` (Zod), `run({ input, config, token })`. Exposes **GET /schemas** (no auth) returning input and config as JSON Schema. Option **`autoRegister`** triggers self-registration with the agent-registry-api on startup when set.
+- **`createAgentApp<TInput, TSchema, TConfig?, TConfigSchema?>(config, options)`** — Creates the agent app (fetch handler + port). Config: `agentId`, `agentVersion`, `inputSchema` (Zod), optional `configSchema` (Zod), `run({ input, config, token, hermesCorrelation? })`. Exposes **GET /schemas** (no auth) returning input and config as JSON Schema. Option **`autoRegister`** triggers self-registration with the agent-registry-api on startup when set.
 - **`registerWithRegistry(params)`** — Registers the agent with the registry (POST with schemas and endpoint). Used internally when `autoRegister` is set; can be called explicitly if needed.
 - **`verifyTokenViaAuthApi`** — Re-exported from `@workspace/agent-auth-client`; used when `authApiUrl` is set.
-- **Types:** `AgentRunResult` (`{ success: true }` \| `{ success: false; message }`), `HermesInvokeEnvelopeV1`, `AgentRunContext<TInput, TConfig>`, `AgentConfig`, `CreateAgentAppOptions`, `AutoRegisterOptions`, `LoggerLike`.
+- **Types:** `AgentRunResult` (`{ success: true }` \| `{ success: false; message }`), `HermesInvokeEnvelopeV1`, `HermesInvokeCorrelation`, `AgentRunContext<TInput, TConfig>`, `AgentConfig`, `CreateAgentAppOptions`, `AutoRegisterOptions`, `LoggerLike`.
 
 ## Request body and how Hermes invokes agents
 
-Hermes sends **POST** with body `{ input: <params>, config: <stepConfig> }` and header `Authorization: Bearer <jwt>` (short-lived JWT from agent-auth-api). The agent validates `input` with `inputSchema` and `config` with `configSchema` (default empty object), then runs `run({ input, config, token })` and returns a consistent JSON result (success/failure/skipped). See [Agent–Hermes contract](/guide/agent-hermes-contract) for the full contract.
+Hermes sends **POST** with body `{ input: <params>, config: <stepConfig> }` and header `Authorization: Bearer <jwt>` (short-lived JWT from agent-auth-api). The agent validates `input` with `inputSchema` and `config` with `configSchema` (default empty object), then runs `run({ input, config, token, hermesCorrelation? })` and returns a consistent JSON result (success/failure/skipped). When **hermes-worker** invokes the agent, optional schedule/step ids are passed as `hermesCorrelation` (see [Communication](/architecture/communication)). See [Agent–Hermes contract](/guide/agent-hermes-contract) for the full contract.
 
 ## Options (DI)
 

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -38,11 +38,13 @@ export {
 } from "./get-due-schedules";
 export { computeNextRunAt, type ScheduleForNextRun } from "./next-run-at";
 export {
+  applyHermesInvokeCorrelationHeaders,
   invokeAgent,
   invokeAgentPost,
   AgentEndpointSchema,
   type AgentEndpoint,
   type InvokeAgentHttpClient,
   type InvokeAgentHttpResponse,
+  type InvokeAgentPostOptions,
   type InvokeAgentPostResult,
 } from "./invoke-agent";

--- a/packages/hermes/scheduler/src/invoke-agent.test.ts
+++ b/packages/hermes/scheduler/src/invoke-agent.test.ts
@@ -1,0 +1,80 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyHermesInvokeCorrelationHeaders,
+  invokeAgentPost,
+} from "./invoke-agent";
+
+describe("applyHermesInvokeCorrelationHeaders", () => {
+  it("adds X-Schedule-Id, X-Schedule-Execution-Id, X-Pipeline-Step-Id when options are non-empty after trim", () => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    applyHermesInvokeCorrelationHeaders(headers, {
+      scheduleId: "  sched-1  ",
+      scheduleExecutionId: "se-1",
+      pipelineStepId: "step-1",
+    });
+    expect(headers).toMatchObject({
+      "X-Schedule-Id": "sched-1",
+      "X-Schedule-Execution-Id": "se-1",
+      "X-Pipeline-Step-Id": "step-1",
+    });
+  });
+
+  it("omits headers when values are missing or whitespace-only", () => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    applyHermesInvokeCorrelationHeaders(headers, {
+      scheduleId: "   ",
+      scheduleExecutionId: undefined,
+      pipelineStepId: "",
+    });
+    expect(headers["X-Schedule-Id"]).toBeUndefined();
+    expect(headers["X-Schedule-Execution-Id"]).toBeUndefined();
+    expect(headers["X-Pipeline-Step-Id"]).toBeUndefined();
+  });
+});
+
+describe("invokeAgentPost", () => {
+  it("sends correlation headers and JSON body via http client", async () => {
+    const post = vi.fn().mockResolvedValue({
+      statusCode: 200,
+      rawBody: "{}",
+      isEmptyBody: false,
+    });
+
+    const result = await invokeAgentPost(
+      { url: "https://agent.example/run", method: "POST" },
+      { input: { x: 1 }, config: {} },
+      {
+        jobId: "job-1",
+        executionId: "exec-1",
+        scheduleId: "sched-1",
+        scheduleExecutionId: "se-1",
+        pipelineStepId: "ps-1",
+        authToken: "jwt",
+        timeoutMs: 5000,
+      },
+      { post },
+    );
+
+    expect(result.kind).toBe("http");
+    expect(post).toHaveBeenCalledWith("https://agent.example/run", {
+      json: { input: { x: 1 }, config: {} },
+      headers: {
+        "Content-Type": "application/json",
+        "X-Job-Id": "job-1",
+        "X-Execution-Id": "exec-1",
+        "X-Schedule-Id": "sched-1",
+        "X-Schedule-Execution-Id": "se-1",
+        "X-Pipeline-Step-Id": "ps-1",
+        Authorization: "Bearer jwt",
+      },
+      timeout: { request: 5000 },
+      signal: undefined,
+    });
+  });
+});

--- a/packages/hermes/scheduler/src/invoke-agent.ts
+++ b/packages/hermes/scheduler/src/invoke-agent.ts
@@ -39,25 +39,61 @@ export type InvokeAgentPostResult =
   | { kind: "transport_error"; error: Error }
   | { kind: "http"; response: InvokeAgentHttpResponse };
 
+/** Options shared by {@link invokeAgentPost} and {@link invokeAgent} (Hermes correlation headers). */
+export type InvokeAgentPostOptions = {
+  jobId: string;
+  executionId: string;
+  /** When set, sent as `X-Schedule-Id` (e.g. hermes-worker scheduled runs). */
+  scheduleId?: string;
+  /** When set, sent as `X-Schedule-Execution-Id`. */
+  scheduleExecutionId?: string;
+  /** When set, sent as `X-Pipeline-Step-Id`. */
+  pipelineStepId?: string;
+  authToken?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+};
+
+/**
+ * Adds Hermes schedule / step correlation headers when the corresponding option is a non-empty string.
+ *
+ * @param headers - Outgoing request headers (mutated).
+ * @param options - Invoke options; only defined string ids are added.
+ */
+export function applyHermesInvokeCorrelationHeaders(
+  headers: Record<string, string>,
+  options: Pick<
+    InvokeAgentPostOptions,
+    "scheduleId" | "scheduleExecutionId" | "pipelineStepId"
+  >,
+): void {
+  const scheduleId = options.scheduleId?.trim();
+  if (scheduleId) {
+    headers["X-Schedule-Id"] = scheduleId;
+  }
+  const scheduleExecutionId = options.scheduleExecutionId?.trim();
+  if (scheduleExecutionId) {
+    headers["X-Schedule-Execution-Id"] = scheduleExecutionId;
+  }
+  const pipelineStepId = options.pipelineStepId?.trim();
+  if (pipelineStepId) {
+    headers["X-Pipeline-Step-Id"] = pipelineStepId;
+  }
+}
+
 /**
  * Sends JSON to the agent endpoint and returns status + raw body (no semantic parsing).
  * Transport failures (network, DNS) are returned as `transport_error` (do not throw).
  *
  * @param endpoint - Parsed agent endpoint (url, method).
  * @param params - JSON body for the request.
- * @param options - Job IDs for headers, auth token, timeout, optional abort signal.
+ * @param options - Job and execution headers (`X-Job-Id`, `X-Execution-Id`), optional schedule/step headers, auth token, timeout, optional abort signal.
  * @param httpClient - HTTP client (e.g. got with `throwHttpErrors: false`).
  */
 export const invokeAgentPost = async (
   endpoint: AgentEndpoint,
   params: Record<string, unknown>,
-  options: {
-    jobId: string;
-    executionId: string;
-    authToken?: string;
-    timeoutMs?: number;
-    signal?: AbortSignal;
-  },
+  options: InvokeAgentPostOptions,
   httpClient: InvokeAgentHttpClient,
 ): Promise<InvokeAgentPostResult> => {
   const headers: Record<string, string> = {
@@ -65,6 +101,7 @@ export const invokeAgentPost = async (
     "X-Job-Id": options.jobId,
     "X-Execution-Id": options.executionId,
   };
+  applyHermesInvokeCorrelationHeaders(headers, options);
   if (options.authToken) {
     headers.Authorization = `Bearer ${options.authToken}`;
   }
@@ -88,13 +125,7 @@ export const invokeAgentPost = async (
 export const invokeAgent = async (
   endpoint: AgentEndpoint,
   params: Record<string, unknown>,
-  options: {
-    jobId: string;
-    executionId: string;
-    authToken?: string;
-    timeoutMs?: number;
-    signal?: AbortSignal;
-  },
+  options: InvokeAgentPostOptions,
   httpClient: InvokeAgentHttpClient,
 ): Promise<void> => {
   const result = await invokeAgentPost(endpoint, params, options, httpClient);

--- a/packages/shared/agent-runtime/src/create-agent-app.test.ts
+++ b/packages/shared/agent-runtime/src/create-agent-app.test.ts
@@ -13,6 +13,11 @@ vi.mock("@workspace/agent-auth-client", async (importOriginal) => {
 });
 
 import { createAgentApp } from "./create-agent-app.js";
+import {
+  HERMES_HEADER_PIPELINE_STEP_ID,
+  HERMES_HEADER_SCHEDULE_EXECUTION_ID,
+  HERMES_HEADER_SCHEDULE_ID,
+} from "./hermes-invoke-correlation.js";
 import type { AgentRunResult } from "./types.js";
 
 const schema = z.object({ tickerId: z.string().uuid() });
@@ -269,6 +274,42 @@ describe("createAgentApp", () => {
       input: validInput,
       config: { limit: 10 },
       token: "Bearer test-token",
+    });
+  });
+
+  it("passes Hermes schedule headers from request into run when present", async () => {
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<Input, typeof schema>(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: {
+        ...authHeaders,
+        [HERMES_HEADER_SCHEDULE_ID]: "sched-a",
+        [HERMES_HEADER_SCHEDULE_EXECUTION_ID]: "exec-b",
+        [HERMES_HEADER_PIPELINE_STEP_ID]: "step-c",
+      },
+      body: JSON.stringify(validBody),
+    });
+
+    expect(res.status).toBe(200);
+    expect(run).toHaveBeenCalledWith({
+      input: validInput,
+      config: {},
+      token: "Bearer test-token",
+      hermesCorrelation: {
+        scheduleId: "sched-a",
+        scheduleExecutionId: "exec-b",
+        pipelineStepId: "step-c",
+      },
     });
   });
 

--- a/packages/shared/agent-runtime/src/create-agent-app.ts
+++ b/packages/shared/agent-runtime/src/create-agent-app.ts
@@ -10,6 +10,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 
 import { registerWithRegistry } from "./register-with-registry.js";
 import type { HermesInvokeEnvelopeV1 } from "./invoke-envelope.js";
+import { hermesInvokeCorrelationFromGetHeader } from "./hermes-invoke-correlation.js";
 import type { AgentConfig, CreateAgentAppOptions } from "./types.js";
 
 const emptyConfigSchema = z.object({});
@@ -20,6 +21,9 @@ const emptyConfigSchema = z.object({});
  *
  * **200:** `run` result is mapped to the Hermes PRD envelope (`schemaVersion`, `status`, optional `message`).
  * **Throw** from `run` → 500 (or validation errors → 400).
+ *
+ * When **hermes-worker** invokes the agent, it may send `X-Schedule-Id`, `X-Schedule-Execution-Id`, and
+ * `X-Pipeline-Step-Id`; those are passed to `run` on `context.hermesCorrelation` when present.
  *
  * @param config - Agent id, version, Zod input/config schemas, and run function.
  * @param options - Optional authApiUrl, verifyToken, and logger (DI for tests).
@@ -172,8 +176,16 @@ export function createAgentApp<
           ? ({} as TConfig)
           : ((await configSchema.parseAsync(requestBody.config)) as TConfig);
       const token = context.req.header("Authorization");
+      const hermesCorrelation = hermesInvokeCorrelationFromGetHeader((name) =>
+        context.req.header(name),
+      );
 
-      const result = await config.run({ input, config: configParsed, token });
+      const result = await config.run({
+        input,
+        config: configParsed,
+        token,
+        ...(hermesCorrelation !== undefined ? { hermesCorrelation } : {}),
+      });
 
       if (result.success) {
         const envelope: HermesInvokeEnvelopeV1 = {

--- a/packages/shared/agent-runtime/src/hermes-invoke-correlation.test.ts
+++ b/packages/shared/agent-runtime/src/hermes-invoke-correlation.test.ts
@@ -1,0 +1,37 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  HERMES_HEADER_PIPELINE_STEP_ID,
+  HERMES_HEADER_SCHEDULE_EXECUTION_ID,
+  HERMES_HEADER_SCHEDULE_ID,
+  hermesInvokeCorrelationFromGetHeader,
+} from "./hermes-invoke-correlation.js";
+
+describe("hermesInvokeCorrelationFromGetHeader", () => {
+  it("returns spreadable keys only for non-empty trimmed header values", () => {
+    const getHeader = (name: string): string | undefined => {
+      if (name === HERMES_HEADER_SCHEDULE_ID) return "  s1  ";
+      if (name === HERMES_HEADER_SCHEDULE_EXECUTION_ID) return "se1";
+      if (name === HERMES_HEADER_PIPELINE_STEP_ID) return "p1";
+      return undefined;
+    };
+
+    const result = hermesInvokeCorrelationFromGetHeader(getHeader);
+
+    expect(result).toEqual({
+      scheduleId: "s1",
+      scheduleExecutionId: "se1",
+      pipelineStepId: "p1",
+    });
+  });
+
+  it("returns undefined when no usable header values remain", () => {
+    const getHeader = (name: string): string | undefined => {
+      if (name === HERMES_HEADER_SCHEDULE_ID) return "   ";
+      return undefined;
+    };
+
+    expect(hermesInvokeCorrelationFromGetHeader(getHeader)).toBeUndefined();
+  });
+});

--- a/packages/shared/agent-runtime/src/hermes-invoke-correlation.ts
+++ b/packages/shared/agent-runtime/src/hermes-invoke-correlation.ts
@@ -1,0 +1,42 @@
+import type { HermesInvokeCorrelation } from "./types.js";
+
+/**
+ * HTTP header names set by `invokeAgentPost` in `@hermes/scheduler` for scheduled runs.
+ */
+export const HERMES_HEADER_SCHEDULE_ID = "X-Schedule-Id";
+
+/** Hermes schedule execution row id (header name). */
+export const HERMES_HEADER_SCHEDULE_EXECUTION_ID = "X-Schedule-Execution-Id";
+
+/** Hermes pipeline step id (header name). */
+export const HERMES_HEADER_PIPELINE_STEP_ID = "X-Pipeline-Step-Id";
+
+/**
+ * Reads Hermes schedule / step correlation from HTTP headers (e.g. Hono `req.header` lookup).
+ * Returns only keys with non-empty trimmed values, or `undefined` when none are present.
+ *
+ * @param getHeader - Returns a header value or undefined (case-insensitive lookup).
+ * @returns Correlation object for `AgentRunContext.hermesCorrelation`, or `undefined` if no headers.
+ */
+export function hermesInvokeCorrelationFromGetHeader(
+  getHeader: (name: string) => string | undefined,
+): HermesInvokeCorrelation | undefined {
+  const scheduleId = getHeader(HERMES_HEADER_SCHEDULE_ID)?.trim();
+  const scheduleExecutionId = getHeader(
+    HERMES_HEADER_SCHEDULE_EXECUTION_ID,
+  )?.trim();
+  const pipelineStepId = getHeader(HERMES_HEADER_PIPELINE_STEP_ID)?.trim();
+  const correlation: HermesInvokeCorrelation = {
+    ...(scheduleId ? { scheduleId } : {}),
+    ...(scheduleExecutionId ? { scheduleExecutionId } : {}),
+    ...(pipelineStepId ? { pipelineStepId } : {}),
+  };
+  if (
+    correlation.scheduleId === undefined &&
+    correlation.scheduleExecutionId === undefined &&
+    correlation.pipelineStepId === undefined
+  ) {
+    return undefined;
+  }
+  return correlation;
+}

--- a/packages/shared/agent-runtime/src/index.ts
+++ b/packages/shared/agent-runtime/src/index.ts
@@ -1,5 +1,11 @@
 export { createAgentApp } from "./create-agent-app.js";
 export {
+  hermesInvokeCorrelationFromGetHeader,
+  HERMES_HEADER_PIPELINE_STEP_ID,
+  HERMES_HEADER_SCHEDULE_EXECUTION_ID,
+  HERMES_HEADER_SCHEDULE_ID,
+} from "./hermes-invoke-correlation.js";
+export {
   HermesInvokeEnvelopeSchemaV1,
   type HermesInvokeEnvelopeV1,
 } from "./invoke-envelope.js";
@@ -10,5 +16,6 @@ export type {
   AutoRegisterOptions,
   AgentRunContext,
   CreateAgentAppOptions,
+  HermesInvokeCorrelation,
   LoggerLike,
 } from "./types.js";

--- a/packages/shared/agent-runtime/src/types.ts
+++ b/packages/shared/agent-runtime/src/types.ts
@@ -18,6 +18,19 @@ export type AgentRunResult =
   | { success: true; message?: string }
   | { success: false; message: string };
 
+/**
+ * Hermes orchestration ids from invoke headers (`X-Schedule-Id`, etc.), grouped for `run` context.
+ * Present when hermes-worker invokes the agent; omitted for e.g. dashboard "Run now".
+ */
+export type HermesInvokeCorrelation = {
+  /** Hermes `Schedule.id` when `X-Schedule-Id` was sent. */
+  scheduleId?: string;
+  /** Hermes `ScheduleExecution.id` when `X-Schedule-Execution-Id` was sent. */
+  scheduleExecutionId?: string;
+  /** Hermes `PipelineStep.id` when `X-Pipeline-Step-Id` was sent. */
+  pipelineStepId?: string;
+};
+
 /** Context passed to the agent run function. */
 export type AgentRunContext<TInput, TConfig = Record<string, never>> = {
   /** Parsed and validated input (per-run payload). */
@@ -26,6 +39,11 @@ export type AgentRunContext<TInput, TConfig = Record<string, never>> = {
   config: TConfig;
   /** Authorization header value (e.g. "Bearer <token>"). */
   token: string | undefined;
+  /**
+   * Hermes schedule / execution / step correlation when the caller sent the corresponding headers.
+   * Omitted when no such headers are present (e.g. "Run now" in the dashboard).
+   */
+  hermesCorrelation?: HermesInvokeCorrelation;
 };
 
 /** Options for auto-registering with the agent-registry-api on startup. */


### PR DESCRIPTION
## Summary

Sends schedule and pipeline step identifiers on Hermes `invoke_agent` HTTP calls so agents can correlate runs with orchestration data, and exposes them on `AgentRunContext` when those headers are present.

## Important changes

- `invokeAgentPost` accepts optional `scheduleId`, `scheduleExecutionId`, and `pipelineStepId` and sets `X-Schedule-Id`, `X-Schedule-Execution-Id`, and `X-Pipeline-Step-Id` when non-empty
- Hermes worker passes those ids from the `invoke_agent` job payload into `invokeAgentPost`
- Agent runtime adds `hermesCorrelation` on `AgentRunContext`, populated via `hermesInvokeCorrelationFromGetHeader` from incoming request headers
- Exported header name constants and `applyHermesInvokeCorrelationHeaders` from `@hermes/scheduler` for reuse/tests

## Other changes

- Unit tests for scheduler invoke, correlation parsing, and `create-agent-app`
- Dev docs updates (`agent-runtime`, architecture communication) and `.gitignore` tweak

## How to test

1. Run `pnpm code-quality` from the repo root; confirm it passes.
2. Trigger a scheduled agent run (or exercise the worker path that enqueues `invoke_agent` with schedule/execution/step ids) and inspect the outbound POST: expect the three `X-*` headers when payload fields are set.
3. Hit an agent’s run endpoint with those headers manually (or via a test) and confirm `context.hermesCorrelation` in `run` matches the header values; omit headers and confirm `hermesCorrelation` is undefined (e.g. dashboard “run now” behavior).