### PR TITLE
Add next-run summary to schedule detail and replace error log column with detail links

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.test.tsx
@@ -1,12 +1,20 @@
 import React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ExecutionsTable } from "./executions-table";
 import type { ScheduleExecutionRow } from "@/lib/schedules";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href }: React.PropsWithChildren<{ href: string }>) => (
-    <a href={href}>{children}</a>
+  default: ({
+    children,
+    href,
+    ...rest
+  }: React.PropsWithChildren<
+    { href: string } & React.AnchorHTMLAttributes<HTMLAnchorElement>
+  >) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
   ),
 }));
 
@@ -27,39 +35,6 @@ vi.mock("@workspace/ui/components/table", () => ({
     colSpan,
   }: React.PropsWithChildren<{ colSpan?: number }>) => (
     <td colSpan={colSpan}>{children}</td>
-  ),
-}));
-
-vi.mock("@workspace/ui/components/button", () => ({
-  Button: ({
-    children,
-    onClick,
-  }: React.PropsWithChildren<{ onClick?: () => void }>) => (
-    <button type="button" onClick={onClick}>
-      {children}
-    </button>
-  ),
-}));
-
-vi.mock("./error-log-modal", () => ({
-  ErrorLogModal: ({
-    open,
-    onOpenChange,
-    errors,
-  }: {
-    open: boolean;
-    onOpenChange: (open: boolean) => void;
-    errors: unknown;
-  }) => (
-    <div
-      data-testid="error-log-modal"
-      data-open={open}
-      data-errors={JSON.stringify(errors)}
-    >
-      <button type="button" onClick={() => onOpenChange(false)}>
-        Close
-      </button>
-    </div>
   ),
 }));
 
@@ -90,7 +65,10 @@ describe("ExecutionsTable", () => {
     expect(screen.getByText("Enqueue")).toBeInTheDocument();
     expect(screen.getByText("Run")).toBeInTheDocument();
     expect(screen.getByText("Jobs")).toBeInTheDocument();
-    expect(screen.getByText("Error log")).toBeInTheDocument();
+    expect(
+      screen.getByText("Invocations (success / fail)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Detail")).toBeInTheDocument();
   });
 
   it("renders empty state when no executions", () => {
@@ -113,42 +91,21 @@ describe("ExecutionsTable", () => {
     expect(screen.getByText("running")).toBeInTheDocument();
   });
 
-  it("shows View log button when execution has errors", () => {
-    const executions = [
-      createMockExecution({
-        id: "ex-1",
-        errors: [
-          { message: "Something failed", timestamp: "2025-01-15T10:00:00Z" },
-        ],
-      }),
-    ];
+  it("links execution time and detail to the execution page", () => {
+    const executions = [createMockExecution({ id: "ex-99" })];
     render(<ExecutionsTable scheduleId="sched-1" executions={executions} />);
-    const viewLogBtn = screen.getByRole("button", { name: "View log" });
-    expect(viewLogBtn).toBeInTheDocument();
-  });
-
-  it("shows dash when execution has no errors", () => {
-    render(
-      <ExecutionsTable
-        scheduleId="sched-1"
-        executions={[createMockExecution()]}
-      />,
+    const links = screen.getAllByRole("link", {
+      name: /open execution detail/i,
+    });
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute(
+      "href",
+      "/dashboard/schedules/sched-1/executions/ex-99",
     );
-    expect(screen.getByText("—")).toBeInTheDocument();
-  });
-
-  it("opens error log modal when View log is clicked", () => {
-    const errors = [{ message: "Error", timestamp: "2025-01-15" }];
-    const executions = [createMockExecution({ id: "ex-1", errors })];
-    render(<ExecutionsTable scheduleId="sched-1" executions={executions} />);
-    expect(screen.getByTestId("error-log-modal")).toHaveAttribute(
-      "data-open",
-      "false",
-    );
-    fireEvent.click(screen.getByRole("button", { name: "View log" }));
-    expect(screen.getByTestId("error-log-modal")).toHaveAttribute(
-      "data-open",
-      "true",
+    const viewLink = screen.getByRole("link", { name: "View" });
+    expect(viewLink).toHaveAttribute(
+      "href",
+      "/dashboard/schedules/sched-1/executions/ex-99",
     );
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { useCallback, useState } from "react";
-
 import Link from "next/link";
 
-import { Button } from "@workspace/ui/components/button";
 import {
   Table,
   TableBody,
@@ -17,81 +14,70 @@ import { format } from "date-fns";
 
 import type { ScheduleExecutionRow } from "@/lib/schedules";
 
-import { ErrorLogModal } from "./error-log-modal";
-
 type ExecutionsTableProps = {
   scheduleId: string;
   executions: ScheduleExecutionRow[];
 };
 
-const hasErrors = (errors: unknown): boolean =>
-  Array.isArray(errors) ? errors.length > 0 : errors != null;
-
 /**
- * Encapsulates executions table error log modal state.
+ * Builds the dashboard path for a single schedule execution detail view.
+ *
+ * @param scheduleId - Owning schedule id.
+ * @param executionId - Schedule execution row id.
+ * @returns Absolute app path for the execution detail page.
  */
-const useExecutionsTableState = () => {
-  const [errorLogOpen, setErrorLogOpen] = useState(false);
-  const [selectedErrors, setSelectedErrors] = useState<unknown>(null);
-
-  const openErrorLog = useCallback((errors: unknown) => {
-    setSelectedErrors(errors);
-    setErrorLogOpen(true);
-  }, []);
-
-  const closeErrorLog = useCallback(() => {
-    setErrorLogOpen(false);
-    setSelectedErrors(null);
-  }, []);
-
-  return {
-    errorLogOpen,
-    selectedErrors,
-    openErrorLog,
-    closeErrorLog,
-  };
-};
+const executionDetailHref = (scheduleId: string, executionId: string) =>
+  `/dashboard/schedules/${scheduleId}/executions/${executionId}`;
 
 /**
- * Renders the schedule executions list: enqueue/run status, job counts, link to execution detail.
+ * Renders the schedule executions list: enqueue/run status, job counts, and links to execution detail.
  */
 export const ExecutionsTable = ({
   scheduleId,
   executions,
 }: ExecutionsTableProps) => {
-  const { errorLogOpen, selectedErrors, openErrorLog, closeErrorLog } =
-    useExecutionsTableState();
-
   return (
-    <>
-      <div className="rounded-md border">
-        <Table>
-          <TableHeader className="bg-muted/50">
-            <TableRow className="border-muted hover:bg-transparent">
-              <TableHead className="w-[180px]">Execution time</TableHead>
-              <TableHead className="w-[100px]">Enqueue</TableHead>
-              <TableHead className="w-[100px]">Run</TableHead>
-              <TableHead className="w-[90px]">Jobs</TableHead>
-              <TableHead className="w-[110px]">Invocations ✓ / ✗</TableHead>
-              <TableHead>Error log</TableHead>
-              <TableHead className="w-[90px]">Detail</TableHead>
+    <div className="rounded-md border">
+      <Table>
+        <TableHeader className="bg-muted/50">
+          <TableRow className="border-muted hover:bg-transparent">
+            <TableHead className="w-[180px]">Execution time</TableHead>
+            <TableHead className="w-[100px]">Enqueue</TableHead>
+            <TableHead className="w-[100px]">Run</TableHead>
+            <TableHead className="w-[90px]">Jobs</TableHead>
+            <TableHead className="min-w-[140px] whitespace-normal">
+              Invocations (success / fail)
+            </TableHead>
+            <TableHead className="w-[90px]">Detail</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {executions.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={6}
+                className="text-center text-muted-foreground"
+              >
+                No executions yet.
+              </TableCell>
             </TableRow>
-          </TableHeader>
-          <TableBody>
-            {executions.length === 0 ? (
-              <TableRow>
-                <TableCell
-                  colSpan={7}
-                  className="text-center text-muted-foreground"
-                >
-                  No executions yet.
-                </TableCell>
-              </TableRow>
-            ) : (
-              executions.map((execution) => (
+          ) : (
+            executions.map((execution) => {
+              const detailHref = executionDetailHref(scheduleId, execution.id);
+              const timeLabel = format(
+                execution.executionTime,
+                "LLL d, yyyy HH:mm:ss",
+              );
+              return (
                 <TableRow key={execution.id}>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {format(execution.executionTime, "LLL d, yyyy HH:mm:ss")}
+                  <TableCell className="text-sm">
+                    <Link
+                      href={detailHref}
+                      className="text-primary underline-offset-4 hover:underline"
+                      aria-label={`Open execution detail for ${timeLabel}`}
+                    >
+                      {timeLabel}
+                    </Link>
                   </TableCell>
                   <TableCell className="text-sm capitalize">
                     {execution.enqueueStatus}
@@ -107,38 +93,19 @@ export const ExecutionsTable = ({
                     {execution.failedInvocationCount}
                   </TableCell>
                   <TableCell>
-                    {hasErrors(execution.errors) ? (
-                      <Button
-                        type="button"
-                        variant="link"
-                        className="h-auto p-0 text-primary"
-                        onClick={() => openErrorLog(execution.errors)}
-                      >
-                        View log
-                      </Button>
-                    ) : (
-                      <span className="text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell>
                     <Link
-                      href={`/dashboard/schedules/${scheduleId}/executions/${execution.id}`}
+                      href={detailHref}
                       className="text-sm text-primary underline-offset-4 hover:underline"
                     >
                       View
                     </Link>
                   </TableCell>
                 </TableRow>
-              ))
-            )}
-          </TableBody>
-        </Table>
-      </div>
-      <ErrorLogModal
-        open={errorLogOpen}
-        onOpenChange={(open) => !open && closeErrorLog()}
-        errors={selectedErrors}
-      />
-    </>
+              );
+            })
+          )}
+        </TableBody>
+      </Table>
+    </div>
   );
 };

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/page.tsx
@@ -12,7 +12,7 @@ const DEFAULT_PAGE_SIZE = 15;
 
 /**
  * Schedule detail page. Loads schedule by id, paginated executions (newest first), and pipelines for the edit modal.
- * Renders schedule header with Edit button and executions table with error-log modal.
+ * Renders schedule header with Edit button, next-run summary, and executions table.
  */
 const ScheduleDetailPage = async ({
   params,

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/schedule-detail-content.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/schedule-detail-content.test.tsx
@@ -72,6 +72,10 @@ vi.mock("@/components/list-pagination", () => ({
   ),
 }));
 
+vi.mock("date-fns", () => ({
+  format: () => "FORMATTED_DATE",
+}));
+
 const createMockSchedule = (
   overrides?: Partial<ScheduleDetailContentProps["schedule"]>,
 ): ScheduleDetailContentProps["schedule"] =>
@@ -180,6 +184,65 @@ describe("ScheduleDetailContent", () => {
     expect(
       screen.getByLabelText("This schedule is disabled"),
     ).toBeInTheDocument();
+  });
+
+  it("shows next run time when enabled and nextRunAt is set", () => {
+    const nextRunAt = new Date("2026-03-22T12:00:00.000Z");
+    render(
+      <ScheduleDetailContent
+        schedule={createMockSchedule({
+          enabled: true,
+          nextRunAt,
+          timezone: "UTC",
+        })}
+        executions={[]}
+        totalExecutions={0}
+        currentPage={1}
+        pageSize={15}
+        pipelines={[]}
+        pipelineValidationById={{}}
+      />,
+    );
+    const timeEl = screen.getByRole("time");
+    expect(timeEl).toHaveAttribute("dateTime", nextRunAt.toISOString());
+    expect(timeEl).toHaveTextContent("FORMATTED_DATE (UTC)");
+    expect(screen.getByText("Next run:")).toBeInTheDocument();
+  });
+
+  it("shows none scheduled when enabled but nextRunAt is null", () => {
+    render(
+      <ScheduleDetailContent
+        schedule={createMockSchedule({
+          enabled: true,
+          nextRunAt: null,
+        })}
+        executions={[]}
+        totalExecutions={0}
+        currentPage={1}
+        pageSize={15}
+        pipelines={[]}
+        pipelineValidationById={{}}
+      />,
+    );
+    expect(screen.getByText("None scheduled")).toBeInTheDocument();
+  });
+
+  it("shows disabled next-run copy when schedule is disabled", () => {
+    render(
+      <ScheduleDetailContent
+        schedule={createMockSchedule({
+          enabled: false,
+          nextRunAt: new Date(),
+        })}
+        executions={[]}
+        totalExecutions={0}
+        currentPage={1}
+        pageSize={15}
+        pipelines={[]}
+        pipelineValidationById={{}}
+      />,
+    );
+    expect(screen.getByText("Not while disabled")).toBeInTheDocument();
   });
 
   it("renders Edit schedule button", () => {

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/schedule-detail-content.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/schedule-detail-content.tsx
@@ -6,6 +6,7 @@ import { useState } from "react";
 
 import { Badge } from "@workspace/ui/components/badge";
 import { Button } from "@workspace/ui/components/button";
+import { format } from "date-fns";
 import { ChevronLeft } from "lucide-react";
 
 import type { getScheduleById, ScheduleExecutionRow } from "@/lib/schedules";
@@ -37,6 +38,16 @@ const useScheduleDetailContentState = () => {
   const [editModalOpen, setEditModalOpen] = useState(false);
   return { editModalOpen, setEditModalOpen };
 };
+
+/**
+ * Formats `nextRunAt` for display in the schedule header (local time string + IANA timezone label).
+ *
+ * @param nextRunAt - Upcoming run instant from the schedule row.
+ * @param timezone - Schedule timezone name (e.g. `America/New_York`).
+ * @returns Formatted date/time and timezone for screen readers and UI.
+ */
+const formatNextRunAt = (nextRunAt: Date, timezone: string): string =>
+  `${format(nextRunAt, "LLL d, yyyy HH:mm:ss")} (${timezone})`;
 
 /**
  * Client wrapper for schedule detail: back link, header with Edit schedule button, executions table, and pagination.
@@ -81,6 +92,20 @@ export const ScheduleDetailContent = ({
                 {schedule.enabled ? "Enabled" : "Disabled"}
               </Badge>
             </div>
+            <p className="mt-1 text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">Next run: </span>
+              {schedule.enabled ? (
+                schedule.nextRunAt ? (
+                  <time dateTime={schedule.nextRunAt.toISOString()}>
+                    {formatNextRunAt(schedule.nextRunAt, schedule.timezone)}
+                  </time>
+                ) : (
+                  <span>None scheduled</span>
+                )
+              ) : (
+                <span>Not while disabled</span>
+              )}
+            </p>
             <p className="text-muted-foreground">
               {schedule.description ??
                 "View executions and edit schedule settings."}


### PR DESCRIPTION
## Summary

Surfaces the schedule’s next run in the detail header (with clear copy when disabled or unscheduled) and simplifies the executions table by dropping the inline error-log modal in favor of linking execution time and the View action to the execution detail page.

## Important changes

- Schedule header shows **Next run** with a semantic `<time>` element when enabled and `nextRunAt` is set; **None scheduled** or **Not while disabled** when appropriate
- Executions table removes the **Error log** column, **View log** button, and **ErrorLogModal** usage; execution time is a link to the same URL as **View**
- Invocations column label updated from symbols to **Invocations (success / fail)** for clarity

## Other changes

- Shared `executionDetailHref` helper and JSDoc on `ScheduleDetailContent`’s `formatNextRunAt`
- `page.tsx` JSDoc updated to mention next-run summary
- Tests updated for new table columns/links; new cases for next-run display in `schedule-detail-content.test.tsx`
- Next.js `Link` test mock forwards extra anchor props

## How to test

1. Open **Dashboard → Schedules → [a schedule]**; confirm **Next run** shows formatted time and timezone when the schedule is enabled and has `nextRunAt`, **None scheduled** when enabled with no next run, and **Not while disabled** when disabled.
2. On the same page, confirm the executions table has **Invocations (success / fail)** and **Detail** but no **Error log** column.
3. Click an execution’s timestamp and the **View** link; both should go to `/dashboard/schedules/{scheduleId}/executions/{executionId}` and load the execution detail as before.
4. Run `pnpm code-quality` (or the app’s test target for these files) and confirm all tests pass.