### PR TITLE
Add DataQueue retries and attempt tracking for agent invocations

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
@@ -132,6 +132,8 @@ export default async function ScheduleExecutionDetailPage({
             agentId: j.agentId,
             startedAtIso: j.startedAt?.toISOString() ?? null,
             completedAtIso: j.completedAt?.toISOString() ?? null,
+            dataQueueAttempts: j.dataQueueAttempts,
+            dataQueueMaxAttempts: j.dataQueueMaxAttempts,
           }))}
         />
       </section>

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.test.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.test.tsx
@@ -41,6 +41,8 @@ describe("ScheduleExecutionInvocationsTable", () => {
         agentId: "my-agent",
         startedAtIso: "2025-03-20T10:00:00.000Z",
         completedAtIso: "2025-03-20T10:00:05.000Z",
+        dataQueueAttempts: null,
+        dataQueueMaxAttempts: null,
       },
     ];
 
@@ -76,6 +78,8 @@ describe("ScheduleExecutionInvocationsTable", () => {
         agentId: "alpha",
         startedAtIso: "2025-01-02T00:00:00.000Z",
         completedAtIso: "2025-01-02T00:01:00.000Z",
+        dataQueueAttempts: 2,
+        dataQueueMaxAttempts: 5,
       },
     ];
 
@@ -91,5 +95,6 @@ describe("ScheduleExecutionInvocationsTable", () => {
     ).toBeInTheDocument();
     expect(screen.getByText("success")).toBeInTheDocument();
     expect(screen.queryByText("Semantic")).not.toBeInTheDocument();
+    expect(screen.getByText("2 / 5")).toBeInTheDocument();
   });
 });

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
@@ -19,6 +19,7 @@ import {
 } from "@workspace/ui/components/table";
 import { Button } from "@workspace/ui/components/button";
 
+import { formatQueueAttemptsDisplay } from "@/lib/format-queue-attempts-display";
 import { resolveInvocationOutcomeLabel } from "@/lib/invocation-display-status";
 
 import {
@@ -124,6 +125,7 @@ export const ScheduleExecutionInvocationsTable = ({
             <TableRow>
               <TableHead>Job</TableHead>
               <TableHead>Agent</TableHead>
+              <TableHead>Attempts</TableHead>
               <TableHead>Status</TableHead>
               <TableHead>
                 <TimestampSortHeader
@@ -149,7 +151,7 @@ export const ScheduleExecutionInvocationsTable = ({
           <TableBody>
             {invocations.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={6} className="text-muted-foreground">
+                <TableCell colSpan={7} className="text-muted-foreground">
                   No invocations.
                 </TableCell>
               </TableRow>
@@ -178,6 +180,15 @@ export const ScheduleExecutionInvocationsTable = ({
                     </TableCell>
                     <TableCell className="font-mono text-xs">
                       {j.agentId}
+                    </TableCell>
+                    <TableCell
+                      className="text-sm text-muted-foreground tabular-nums"
+                      title="DataQueue processing attempts (current / max)"
+                    >
+                      {formatQueueAttemptsDisplay(
+                        j.dataQueueAttempts,
+                        j.dataQueueMaxAttempts,
+                      )}
                     </TableCell>
                     <TableCell
                       className={

--- a/apps/hermes/dashboard/components/use-schedule-execution-invocations-modal.test.ts
+++ b/apps/hermes/dashboard/components/use-schedule-execution-invocations-modal.test.ts
@@ -16,6 +16,8 @@ const sampleRow: ScheduleExecutionInvocationRow = {
   agentId: "ticker-echo",
   startedAtIso: "2025-03-20T10:00:00.000Z",
   completedAtIso: "2025-03-20T10:00:01.000Z",
+  dataQueueAttempts: null,
+  dataQueueMaxAttempts: null,
 };
 
 describe("useScheduleExecutionInvocationsModal", () => {

--- a/apps/hermes/dashboard/components/use-schedule-execution-invocations-modal.ts
+++ b/apps/hermes/dashboard/components/use-schedule-execution-invocations-modal.ts
@@ -16,6 +16,10 @@ export type ScheduleExecutionInvocationRow = {
   startedAtIso: string | null;
   /** ISO-8601 timestamp when the job finished, or null if not terminal yet. */
   completedAtIso: string | null;
+  /** DataQueue `attempts` when the worker last synced; null if unknown (legacy). */
+  dataQueueAttempts: number | null;
+  /** DataQueue `max_attempts` when last synced; null if unknown. */
+  dataQueueMaxAttempts: number | null;
 };
 
 /**

--- a/apps/hermes/dashboard/components/use-schedule-execution-invocations-sort.test.ts
+++ b/apps/hermes/dashboard/components/use-schedule-execution-invocations-sort.test.ts
@@ -22,6 +22,8 @@ const baseRow = (
   agentId: "agent-a",
   startedAtIso,
   completedAtIso,
+  dataQueueAttempts: null,
+  dataQueueMaxAttempts: null,
 });
 
 describe("compareOptionalIsoDates", () => {

--- a/apps/hermes/dashboard/lib/format-queue-attempts-display.test.ts
+++ b/apps/hermes/dashboard/lib/format-queue-attempts-display.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatQueueAttemptsDisplay } from "./format-queue-attempts-display";
+
+describe("formatQueueAttemptsDisplay", () => {
+  it("returns em dash when both are missing", () => {
+    expect(formatQueueAttemptsDisplay(null, null)).toBe("—");
+    expect(formatQueueAttemptsDisplay(undefined, undefined)).toBe("—");
+  });
+
+  it("returns fraction when both are present", () => {
+    expect(formatQueueAttemptsDisplay(2, 5)).toBe("2 / 5");
+  });
+
+  it("returns attempts only when max is missing", () => {
+    expect(formatQueueAttemptsDisplay(3, null)).toBe("3");
+  });
+
+  it("returns placeholder max when attempts missing", () => {
+    expect(formatQueueAttemptsDisplay(null, 5)).toBe("— / 5");
+  });
+});

--- a/apps/hermes/dashboard/lib/format-queue-attempts-display.ts
+++ b/apps/hermes/dashboard/lib/format-queue-attempts-display.ts
@@ -1,0 +1,23 @@
+/**
+ * Human-readable DataQueue attempt label for schedule execution invocations.
+ *
+ * @param attempts - Synced `dataQueueAttempts`, or null/undefined when unknown (legacy jobs).
+ * @param maxAttempts - Synced `dataQueueMaxAttempts`, or null/undefined when unknown.
+ */
+export const formatQueueAttemptsDisplay = (
+  attempts: number | null | undefined,
+  maxAttempts: number | null | undefined,
+): string => {
+  const a = attempts ?? null;
+  const m = maxAttempts ?? null;
+  if (a == null && m == null) {
+    return "—";
+  }
+  if (a != null && m != null) {
+    return `${a} / ${m}`;
+  }
+  if (a != null) {
+    return String(a);
+  }
+  return `— / ${m}`;
+};

--- a/apps/hermes/dashboard/lib/mask-json-secrets.test.ts
+++ b/apps/hermes/dashboard/lib/mask-json-secrets.test.ts
@@ -104,6 +104,8 @@ describe("maskScheduleExecutionDetailForDisplay", () => {
           semanticStatus: null,
           startedAt: null,
           completedAt: null,
+          dataQueueAttempts: null,
+          dataQueueMaxAttempts: null,
         },
       ],
     } satisfies ScheduleExecutionDetail;

--- a/apps/hermes/dashboard/lib/schedules.ts
+++ b/apps/hermes/dashboard/lib/schedules.ts
@@ -238,6 +238,10 @@ export type ScheduleExecutionDetail = {
     semanticStatus: string | null;
     startedAt: Date | null;
     completedAt: Date | null;
+    /** DataQueue `attempts` when the worker last claimed this job; null for legacy rows. */
+    dataQueueAttempts: number | null;
+    /** DataQueue `max_attempts` when last synced; null for legacy rows. */
+    dataQueueMaxAttempts: number | null;
   }>;
 };
 
@@ -283,6 +287,8 @@ export const getScheduleExecutionDetail = async (
           semanticStatus: true,
           startedAt: true,
           completedAt: true,
+          dataQueueAttempts: true,
+          dataQueueMaxAttempts: true,
         },
       },
     },
@@ -336,6 +342,8 @@ export const getScheduleExecutionDetail = async (
       semanticStatus: j.semanticStatus,
       startedAt: j.startedAt,
       completedAt: j.completedAt,
+      dataQueueAttempts: j.dataQueueAttempts,
+      dataQueueMaxAttempts: j.dataQueueMaxAttempts,
     })),
   };
 };

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import type { JobContext } from "@nicnocquee/dataqueue";
 import { AgentJobExecutionStatus } from "@hermes/orchestration-database";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -47,6 +48,9 @@ vi.mock("@hermes/env/hermes-worker", () => ({
     HERMES_INTERNAL_API_KEY: "test-internal-hermes-key",
     AGENT_AUTH_API_URL: "https://auth.example.com",
     REQUIRE_HTTPS_AGENT_ENDPOINTS: undefined as string | undefined,
+    HERMES_INVOKE_AGENT_RETRY_DELAY: undefined as string | undefined,
+    HERMES_INVOKE_AGENT_RETRY_BACKOFF: undefined as string | undefined,
+    HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: undefined as string | undefined,
   },
 }));
 
@@ -77,10 +81,14 @@ vi.mock("@hermes/scheduler", async (importOriginal) => {
 });
 
 const mockAddJobs = vi.fn().mockResolvedValue([1]);
+const mockEditJob = vi.fn().mockResolvedValue(undefined);
+const mockGetJob = vi.fn();
 
 vi.mock("./queue", () => ({
   getJobQueue: () => ({
     addJobs: mockAddJobs,
+    editJob: mockEditJob,
+    getJob: mockGetJob,
   }),
 }));
 
@@ -90,6 +98,9 @@ describe("jobHandlers", () => {
     vi.mocked(executeSchedule).mockClear();
     vi.mocked(logger.error).mockClear();
     mockAddJobs.mockClear();
+    mockEditJob.mockClear();
+    mockGetJob.mockClear();
+    mockAddJobs.mockResolvedValue([1]);
   });
 
   afterEach(() => {
@@ -193,6 +204,13 @@ describe("jobHandlers", () => {
         payload: expect.objectContaining({ jobId: "j1" }),
         priority: 0,
         idempotencyKey: "j1",
+      });
+      expect(mockEditJob).toHaveBeenCalledTimes(1);
+      expect(mockEditJob).toHaveBeenCalledWith(1, {
+        payload: expect.objectContaining({
+          jobId: "j1",
+          hermesDataQueueJobId: 1,
+        }),
       });
     });
 
@@ -367,7 +385,7 @@ describe("jobHandlers", () => {
     };
 
     const signal = new AbortController().signal;
-    const ctx = {} as Parameters<typeof jobHandlers.invoke_agent>[2];
+    const jobCtx = {} as JobContext;
 
     beforeEach(() => {
       vi.mocked(invokeAgentPost).mockClear();
@@ -396,7 +414,7 @@ describe("jobHandlers", () => {
         },
       });
 
-      await jobHandlers.invoke_agent(payload, signal, ctx);
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
 
       expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledWith({
         where: {
@@ -433,17 +451,56 @@ describe("jobHandlers", () => {
       );
     });
 
-    it("updates to failed and rethrows on transport error from invokeAgentPost", async () => {
+    it("syncs DataQueue attempts after claim when hermesDataQueueJobId is set", async () => {
+      mockGetJob.mockResolvedValueOnce({
+        attempts: 2,
+        maxAttempts: 5,
+      });
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "http",
+        response: {
+          statusCode: 200,
+          rawBody: '{"schemaVersion":1,"status":"success"}',
+          isEmptyBody: false,
+        },
+      });
+      vi.mocked(parseAgentResponseEnvelope).mockReturnValue({
+        ok: true,
+        envelope: {
+          schemaVersion: 1,
+          status: "success",
+          truncated: {},
+        },
+      });
+
+      await jobHandlers.invoke_agent(
+        { ...payload, hermesDataQueueJobId: 42 },
+        signal,
+        jobCtx,
+      );
+
+      expect(mockGetJob).toHaveBeenCalledWith(42);
+      expect(mockPrisma.agentJobExecution.update).toHaveBeenCalledWith({
+        where: { jobId: payload.jobId },
+        data: {
+          dataQueueAttempts: 2,
+          dataQueueMaxAttempts: 5,
+        },
+      });
+    });
+
+    it("updates to failed and rethrows on transport error when hermesDataQueueJobId is absent (legacy)", async () => {
       vi.mocked(invokeAgentPost).mockResolvedValue({
         kind: "transport_error",
         error: new Error("Network error"),
       });
 
       await expect(
-        jobHandlers.invoke_agent(payload, signal, ctx),
+        jobHandlers.invoke_agent(payload, signal, jobCtx),
       ).rejects.toThrow("Network error");
 
       expect(invokeAgentPost).toHaveBeenCalledTimes(1);
+      expect(mockGetJob).not.toHaveBeenCalled();
       expect(mockPrisma.agentJobExecution.update).toHaveBeenCalledWith({
         where: { jobId: payload.jobId },
         data: {
@@ -454,10 +511,111 @@ describe("jobHandlers", () => {
       });
     });
 
+    it("resets to pending on transport error when DataQueue will retry", async () => {
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "transport_error",
+        error: new Error("Network error"),
+      });
+      mockGetJob.mockResolvedValue({
+        attempts: 1,
+        maxAttempts: 3,
+      });
+
+      await expect(
+        jobHandlers.invoke_agent(
+          { ...payload, hermesDataQueueJobId: 42 },
+          signal,
+          jobCtx,
+        ),
+      ).rejects.toThrow("Network error");
+
+      expect(mockGetJob).toHaveBeenCalledWith(42);
+      expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledWith({
+        where: {
+          jobId: payload.jobId,
+          status: AgentJobExecutionStatus.running,
+        },
+        data: {
+          status: AgentJobExecutionStatus.pending,
+          completedAt: null,
+          error: {
+            message: "Network error",
+            retryable: true,
+            transient: true,
+          },
+        },
+      });
+      expect(applyInvocationCompletion).not.toHaveBeenCalled();
+    });
+
+    it("applies completion and rethrows on transport error when queue attempts are exhausted", async () => {
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "transport_error",
+        error: new Error("Network error"),
+      });
+      mockGetJob.mockResolvedValue({
+        attempts: 3,
+        maxAttempts: 3,
+      });
+
+      await expect(
+        jobHandlers.invoke_agent(
+          { ...payload, hermesDataQueueJobId: 99 },
+          signal,
+          jobCtx,
+        ),
+      ).rejects.toThrow("Network error");
+
+      expect(applyInvocationCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: payload.jobId,
+          scheduleExecutionId: payload.scheduleExecutionId,
+          terminal: {
+            status: AgentJobExecutionStatus.failed,
+            error: { message: "Network error", retryable: true },
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("applies completion on 5xx when queue attempts are exhausted", async () => {
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "http",
+        response: {
+          statusCode: 503,
+          rawBody: "",
+          isEmptyBody: true,
+        },
+      });
+      mockGetJob.mockResolvedValue({
+        attempts: 2,
+        maxAttempts: 2,
+      });
+
+      await expect(
+        jobHandlers.invoke_agent(
+          { ...payload, hermesDataQueueJobId: 7 },
+          signal,
+          jobCtx,
+        ),
+      ).rejects.toThrow("Agent returned HTTP 503");
+
+      expect(applyInvocationCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          terminal: {
+            status: AgentJobExecutionStatus.failed,
+            error: { message: "Agent HTTP 503", retryable: true },
+          },
+        }),
+        expect.any(Object),
+      );
+    });
+
     it("skips HTTP call when claim returns count 0 (idempotent)", async () => {
       mockPrisma.agentJobExecution.updateMany.mockResolvedValue({ count: 0 });
 
-      await jobHandlers.invoke_agent(payload, signal, ctx);
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
 
       expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledTimes(1);
       expect(invokeAgentPost).not.toHaveBeenCalled();
@@ -478,7 +636,7 @@ describe("jobHandlers", () => {
         },
       });
 
-      await jobHandlers.invoke_agent(payload, signal, ctx);
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
 
       expect(applyInvocationCompletion).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -9,7 +9,7 @@ import { decryptDomainIntegrationApiKey } from "@hermes/domain-integration-crypt
 import { createDomainIntegrationClient } from "@hermes/domain-contract";
 import { env } from "@hermes/env/hermes-worker";
 import { logger } from "@workspace/logger";
-import type { JobHandlers } from "@nicnocquee/dataqueue";
+import type { JobContext, JobHandlers } from "@nicnocquee/dataqueue";
 import { batchDepRef } from "@nicnocquee/dataqueue";
 import type { JobPayloadMap } from "./job-payload-map";
 import { createAgentTokenClient } from "@workspace/agent-auth-client";
@@ -21,10 +21,26 @@ import {
   invokeAgentPost,
   parseAgentResponseEnvelope,
   parseHttpErrorBodyMessage,
+  willRetryAfterTransientFailure,
   type ExpandStepInputs,
   type InvokeAgentHttpClient,
+  type InvokeAgentJobPayload,
 } from "@hermes/scheduler";
 import { getJobQueue } from "./queue";
+
+/**
+ * Parses optional positive integer env strings (DataQueue retry delay fields are in seconds).
+ *
+ * @param raw - Env value from `@hermes/env/hermes-worker`.
+ * @returns Integer >= 1, or undefined when unset/invalid.
+ */
+const parsePositiveIntEnv = (raw: string | undefined): number | undefined => {
+  if (raw == null || raw.trim() === "") {
+    return undefined;
+  }
+  const n = Number.parseInt(raw.trim(), 10);
+  return Number.isFinite(n) && n >= 1 ? n : undefined;
+};
 
 /**
  * Creates an HTTP client that forwards the optional AbortSignal to got for request cancellation.
@@ -119,6 +135,70 @@ const completionDeps = {
 };
 
 /**
+ * Transport or 5xx: reset `AgentJobExecution` to `pending` when DataQueue will retry; otherwise
+ * terminal failure via `applyInvocationCompletion`, then rethrow for the queue.
+ *
+ * @param params - Payload, user-facing message, and error to propagate to DataQueue.
+ */
+const handleTransientInvokeFailure = async (params: {
+  payload: InvokeAgentJobPayload;
+  message: string;
+  errorToThrow: Error;
+}): Promise<never> => {
+  const { payload, message, errorToThrow } = params;
+  const jobQueue = getJobQueue();
+
+  if (payload.hermesDataQueueJobId == null) {
+    await orchestrationPrisma.agentJobExecution.update({
+      where: { jobId: payload.jobId },
+      data: {
+        status: AgentJobExecutionStatus.failed,
+        error: { message, retryable: true },
+        completedAt: new Date(),
+      },
+    });
+    throw errorToThrow;
+  }
+
+  const dqJob = await jobQueue.getJob(payload.hermesDataQueueJobId);
+  if (
+    dqJob == null ||
+    !willRetryAfterTransientFailure(dqJob.attempts, dqJob.maxAttempts)
+  ) {
+    await applyInvocationCompletion(
+      {
+        jobId: payload.jobId,
+        scheduleExecutionId: payload.scheduleExecutionId,
+        pipelineStepId: payload.pipelineStepId,
+        terminal: {
+          status: AgentJobExecutionStatus.failed,
+          error: { message, retryable: true },
+        },
+      },
+      completionDeps,
+    );
+    throw errorToThrow;
+  }
+
+  await orchestrationPrisma.agentJobExecution.updateMany({
+    where: {
+      jobId: payload.jobId,
+      status: AgentJobExecutionStatus.running,
+    },
+    data: {
+      status: AgentJobExecutionStatus.pending,
+      completedAt: null,
+      error: {
+        message,
+        retryable: true,
+        transient: true,
+      },
+    },
+  });
+  throw errorToThrow;
+};
+
+/**
  * DataQueue job handlers for Hermes.
  * check_schedules: polls due schedules and enqueues invoke_agent jobs.
  * invoke_agent: performs the HTTP call to the agent and updates AgentJobExecution.
@@ -142,31 +222,63 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
               : undefined;
             const deadLetterJobType =
               env.HERMES_INVOKE_AGENT_DLQ_JOB_TYPE?.trim() || undefined;
-            await jobQueue.addJobs(
-              items.map((item) => ({
-                jobType: "invoke_agent" as const,
-                payload: item.payload,
-                priority: item.payload.priority,
-                idempotencyKey: item.payload.jobId,
-                maxAttempts,
-                deadLetterJobType,
-                dependsOn:
-                  item.dependsOnBatchIndices?.length &&
-                  item.dependsOnBatchIndices.length > 0
-                    ? {
-                        jobIds: item.dependsOnBatchIndices.map((i) =>
-                          batchDepRef(i),
-                        ),
-                      }
-                    : undefined,
-                tags: [
-                  `scheduleExecution:${item.payload.scheduleExecutionId}`,
-                  `schedule:${item.payload.scheduleId}`,
-                  `pipeline:${item.payload.pipelineId}`,
-                  `pipelineStep:${item.payload.pipelineStepId}`,
-                ],
-              })),
+            const retryDelaySec = parsePositiveIntEnv(
+              env.HERMES_INVOKE_AGENT_RETRY_DELAY,
             );
+            const retryDelayMaxSec = parsePositiveIntEnv(
+              env.HERMES_INVOKE_AGENT_RETRY_DELAY_MAX,
+            );
+            const backoffRaw = env.HERMES_INVOKE_AGENT_RETRY_BACKOFF?.trim();
+            const retryBackoff =
+              backoffRaw === "true"
+                ? true
+                : backoffRaw === "false"
+                  ? false
+                  : undefined;
+            const jobDefs = items.map((item) => ({
+              jobType: "invoke_agent" as const,
+              payload: item.payload,
+              priority: item.payload.priority,
+              idempotencyKey: item.payload.jobId,
+              maxAttempts,
+              deadLetterJobType,
+              ...(retryDelaySec !== undefined
+                ? { retryDelay: retryDelaySec }
+                : {}),
+              ...(retryBackoff !== undefined ? { retryBackoff } : {}),
+              ...(retryDelayMaxSec !== undefined
+                ? { retryDelayMax: retryDelayMaxSec }
+                : {}),
+              dependsOn:
+                item.dependsOnBatchIndices?.length &&
+                item.dependsOnBatchIndices.length > 0
+                  ? {
+                      jobIds: item.dependsOnBatchIndices.map((i) =>
+                        batchDepRef(i),
+                      ),
+                    }
+                  : undefined,
+              tags: [
+                `scheduleExecution:${item.payload.scheduleExecutionId}`,
+                `schedule:${item.payload.scheduleId}`,
+                `pipeline:${item.payload.pipelineId}`,
+                `pipelineStep:${item.payload.pipelineStepId}`,
+              ],
+            }));
+            const insertedIds = await jobQueue.addJobs(jobDefs);
+            for (let i = 0; i < insertedIds.length; i++) {
+              const queueJobId = insertedIds[i];
+              const item = items[i];
+              if (item === undefined || queueJobId === undefined) {
+                continue;
+              }
+              await jobQueue.editJob(queueJobId, {
+                payload: {
+                  ...item.payload,
+                  hermesDataQueueJobId: queueJobId,
+                },
+              });
+            }
           },
           expandStepInputs,
           defaultTimeoutMs: 300_000,
@@ -182,7 +294,8 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
     }
   },
 
-  invoke_agent: async (payload, signal) => {
+  invoke_agent: async (payload, signal, _ctx: JobContext) => {
+    void _ctx;
     logger.info(
       {
         jobId: payload.jobId,
@@ -201,6 +314,26 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
     });
     if (claimed.count === 0) {
       return;
+    }
+
+    if (payload.hermesDataQueueJobId != null) {
+      try {
+        const dqJob = await getJobQueue().getJob(payload.hermesDataQueueJobId);
+        if (dqJob != null) {
+          await orchestrationPrisma.agentJobExecution.update({
+            where: { jobId: payload.jobId },
+            data: {
+              dataQueueAttempts: dqJob.attempts,
+              dataQueueMaxAttempts: dqJob.maxAttempts,
+            },
+          });
+        }
+      } catch (err) {
+        logger.warn(
+          { err, jobId: payload.jobId },
+          "invoke_agent: failed to sync DataQueue attempts to agent_job_execution",
+        );
+      }
     }
 
     if (!payload.scheduleExecutionId) {
@@ -253,40 +386,105 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
         },
         "invoke_agent transport failure",
       );
-      await orchestrationPrisma.agentJobExecution.update({
-        where: { jobId: payload.jobId },
-        data: {
-          status: AgentJobExecutionStatus.failed,
-          error: {
-            message: postResult.error.message,
-            retryable: true,
-          },
-          completedAt: new Date(),
-        },
+      await handleTransientInvokeFailure({
+        payload,
+        message: postResult.error.message,
+        errorToThrow: postResult.error,
       });
-      throw postResult.error;
-    }
+    } else {
+      const { statusCode, rawBody, isEmptyBody } = postResult.response;
 
-    const { statusCode, rawBody, isEmptyBody } = postResult.response;
+      if (statusCode >= 500) {
+        const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+        const message = bodyMessage ?? `Agent HTTP ${statusCode}`;
+        const err = new Error(`Agent returned HTTP ${statusCode}`);
+        await handleTransientInvokeFailure({
+          payload,
+          message,
+          errorToThrow: err,
+        });
+      }
 
-    if (statusCode >= 500) {
-      const bodyMessage = parseHttpErrorBodyMessage(rawBody);
-      await orchestrationPrisma.agentJobExecution.update({
-        where: { jobId: payload.jobId },
-        data: {
-          status: AgentJobExecutionStatus.failed,
-          error: {
-            message: bodyMessage ?? `Agent HTTP ${statusCode}`,
-            retryable: true,
+      if (statusCode >= 400) {
+        const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+        await applyInvocationCompletion(
+          {
+            jobId: payload.jobId,
+            scheduleExecutionId: payload.scheduleExecutionId,
+            pipelineStepId: payload.pipelineStepId,
+            terminal: {
+              status: AgentJobExecutionStatus.failed,
+              error: {
+                message: bodyMessage ?? `HTTP ${statusCode}`,
+                retryable: false,
+              },
+            },
           },
-          completedAt: new Date(),
-        },
-      });
-      throw new Error(`Agent returned HTTP ${statusCode}`);
-    }
+          completionDeps,
+        );
+        return;
+      }
 
-    if (statusCode >= 400) {
-      const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+      if (statusCode >= 200 && statusCode < 300) {
+        const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
+        if (!parsed.ok) {
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.failed,
+                error: {
+                  message: parsed.error.message,
+                  code: parsed.error.code,
+                  retryable: false,
+                },
+              },
+            },
+            completionDeps,
+          );
+          return;
+        }
+        if (parsed.envelope.status === "failure") {
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.failed,
+                error: {
+                  message:
+                    parsed.envelope.message ??
+                    "Agent reported semantic failure",
+                  retryable: false,
+                  semantic: true,
+                },
+                agentResponse:
+                  parsed.envelope as unknown as Prisma.InputJsonValue,
+                semanticStatus: "failure",
+              },
+            },
+            completionDeps,
+          );
+          return;
+        }
+        await applyInvocationCompletion(
+          {
+            jobId: payload.jobId,
+            scheduleExecutionId: payload.scheduleExecutionId,
+            pipelineStepId: payload.pipelineStepId,
+            terminal: {
+              status: AgentJobExecutionStatus.completed,
+              envelope: parsed.envelope,
+            },
+          },
+          completionDeps,
+        );
+        return;
+      }
+
       await applyInvocationCompletion(
         {
           jobId: payload.jobId,
@@ -295,89 +493,13 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           terminal: {
             status: AgentJobExecutionStatus.failed,
             error: {
-              message: bodyMessage ?? `HTTP ${statusCode}`,
+              message: `Unexpected HTTP status ${statusCode}`,
               retryable: false,
             },
           },
         },
         completionDeps,
       );
-      return;
     }
-
-    if (statusCode >= 200 && statusCode < 300) {
-      const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
-      if (!parsed.ok) {
-        await applyInvocationCompletion(
-          {
-            jobId: payload.jobId,
-            scheduleExecutionId: payload.scheduleExecutionId,
-            pipelineStepId: payload.pipelineStepId,
-            terminal: {
-              status: AgentJobExecutionStatus.failed,
-              error: {
-                message: parsed.error.message,
-                code: parsed.error.code,
-                retryable: false,
-              },
-            },
-          },
-          completionDeps,
-        );
-        return;
-      }
-      if (parsed.envelope.status === "failure") {
-        await applyInvocationCompletion(
-          {
-            jobId: payload.jobId,
-            scheduleExecutionId: payload.scheduleExecutionId,
-            pipelineStepId: payload.pipelineStepId,
-            terminal: {
-              status: AgentJobExecutionStatus.failed,
-              error: {
-                message:
-                  parsed.envelope.message ?? "Agent reported semantic failure",
-                retryable: false,
-                semantic: true,
-              },
-              agentResponse:
-                parsed.envelope as unknown as Prisma.InputJsonValue,
-              semanticStatus: "failure",
-            },
-          },
-          completionDeps,
-        );
-        return;
-      }
-      await applyInvocationCompletion(
-        {
-          jobId: payload.jobId,
-          scheduleExecutionId: payload.scheduleExecutionId,
-          pipelineStepId: payload.pipelineStepId,
-          terminal: {
-            status: AgentJobExecutionStatus.completed,
-            envelope: parsed.envelope,
-          },
-        },
-        completionDeps,
-      );
-      return;
-    }
-
-    await applyInvocationCompletion(
-      {
-        jobId: payload.jobId,
-        scheduleExecutionId: payload.scheduleExecutionId,
-        pipelineStepId: payload.pipelineStepId,
-        terminal: {
-          status: AgentJobExecutionStatus.failed,
-          error: {
-            message: `Unexpected HTTP status ${statusCode}`,
-            retryable: false,
-          },
-        },
-      },
-      completionDeps,
-    );
   },
 };

--- a/dev-docs/docs/hermes/apps/hermes-worker.mdx
+++ b/dev-docs/docs/hermes/apps/hermes-worker.mdx
@@ -12,7 +12,7 @@ icon: ServerCog
 
 - **Queue init** — Connects to DataQueue using `PG_DATAQUEUE_DATABASE`.
 - **Cron registration** — Ensures `hermes-check-schedules` (every minute) exists.
-- **Processor** — Runs job handlers: `check_schedules` (get due schedules, enqueue one `invoke_agent` job per expanded input); `invoke_agent` (get JWT, POST to agent, update `AgentJobExecution`). Concurrency and batch size are configurable via env so multiple agent invocations run in parallel.
+- **Processor** — Runs job handlers: `check_schedules` (get due schedules, enqueue one `invoke_agent` job per expanded input); `invoke_agent` (get JWT, POST to agent, update `AgentJobExecution`). Concurrency and batch size are configurable via env so multiple agent invocations run in parallel. Transient failures (network errors, HTTP 5xx) can be retried by DataQueue with optional exponential backoff env vars; orchestration rows are reset to `pending` between retries so the agent is called again.
 - **Supervisor** — Reclaims stuck jobs, cleans old jobs/events.
 - **JWT-only invocation** — The worker **requires** `AGENT_AUTH_API_URL` and **`HERMES_INTERNAL_API_KEY`** (same preset as the Hermes dashboard and agent-auth-api, not a dashboard API key). The worker uses it only to fetch short-lived JWTs from `POST /api/token` and sends only JWTs to agents; the preset is never sent to agents. Rotate the preset in env if it is compromised.
 - **HTTPS enforcement** — When `REQUIRE_HTTPS_AGENT_ENDPOINTS=true`, agent endpoint URLs must use HTTPS (or `http://localhost` / `http://127.0.0.1` for local dev).
@@ -42,16 +42,27 @@ If you see an error like `relation "cron_schedules" does not exist` when startin
 
 Variables are defined in **`packages/hermes/env/env.hermes-worker.example`**. Copy values into **`apps/hermes/worker/.env.local`** (or set in your deployment).
 
-| Variable                          | Required | Description                                                                                                        |
-| --------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| **DATABASE_URL**                  | Yes      | Main app database (Prisma).                                                                                        |
-| **PG_DATAQUEUE_DATABASE**         | Yes      | DataQueue connection (`?schema=dataqueue&search_path=dataqueue`). Run migrate-dataqueue before first start.        |
-| **AGENT_AUTH_API_URL**            | Yes      | **Required.** Base URL of agent-auth-api. Worker mints JWTs via POST /api/token.                                   |
-| **HERMES_INTERNAL_API_KEY**       | Yes      | Preset shared with Hermes dashboard and agent-auth-api. Used only to call `POST /api/token`; never sent to agents. |
-| **REQUIRE_HTTPS_AGENT_ENDPOINTS** | No       | Set to `true` in production to reject non-HTTPS agent endpoints (except localhost).                                |
-| **PROCESSOR_BATCH_SIZE**          | No       | Max jobs fetched per poll (default `10`). Tune for agent invocation throughput.                                    |
-| **PROCESSOR_CONCURRENCY**         | No       | Max concurrent job executions, e.g. agent HTTP calls (default `3`). Increase for more parallelism.                 |
-| **HERMES_DATA_SOURCE_MAX_TAKE**   | No       | Cap for `db:` expansion (default matches Hermes validation).                                                       |
+| Variable                                | Required | Description                                                                                                        |
+| --------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| **DATABASE_URL**                        | Yes      | Main app database (Prisma).                                                                                        |
+| **PG_DATAQUEUE_DATABASE**               | Yes      | DataQueue connection (`?schema=dataqueue&search_path=dataqueue`). Run migrate-dataqueue before first start.        |
+| **AGENT_AUTH_API_URL**                  | Yes      | **Required.** Base URL of agent-auth-api. Worker mints JWTs via POST /api/token.                                   |
+| **HERMES_INTERNAL_API_KEY**             | Yes      | Preset shared with Hermes dashboard and agent-auth-api. Used only to call `POST /api/token`; never sent to agents. |
+| **REQUIRE_HTTPS_AGENT_ENDPOINTS**       | No       | Set to `true` in production to reject non-HTTPS agent endpoints (except localhost).                                |
+| **PROCESSOR_BATCH_SIZE**                | No       | Max jobs fetched per poll (default `10`). Tune for agent invocation throughput.                                    |
+| **PROCESSOR_CONCURRENCY**               | No       | Max concurrent job executions, e.g. agent HTTP calls (default `3`). Increase for more parallelism.                 |
+| **HERMES_DATA_SOURCE_MAX_TAKE**         | No       | Cap for `db:` expansion (default matches Hermes validation).                                                       |
+| **HERMES_INVOKE_AGENT_MAX_ATTEMPTS**    | No       | DataQueue `maxAttempts` for `invoke_agent` jobs. Omit for library default.                                         |
+| **HERMES_INVOKE_AGENT_DLQ_JOB_TYPE**    | No       | When set, exhausted `invoke_agent` failures enqueue a dead-letter job of this type.                                |
+| **HERMES_INVOKE_AGENT_RETRY_DELAY**     | No       | Base delay **in seconds** between retries (`retryDelay`). Enables second-based backoff when set.                   |
+| **HERMES_INVOKE_AGENT_RETRY_BACKOFF**   | No       | `"false"` for fixed delay; omit or `"true"` for exponential backoff when `HERMES_INVOKE_AGENT_RETRY_DELAY` is set. |
+| **HERMES_INVOKE_AGENT_RETRY_DELAY_MAX** | No       | Optional cap on retry delay **in seconds** (`retryDelayMax`).                                                      |
+
+### Transient invocation retries
+
+Transport failures and **HTTP 5xx** responses are treated as transient: the worker throws so DataQueue schedules another attempt (with backoff when configured). So that a retry actually runs the HTTP call again, the worker resets the corresponding `AgentJobExecution` row from **running** back to **pending** while attempts remain; after the last attempt it applies normal terminal failure (including schedule rollups) via `applyInvocationCompletion`. Each enqueued job gets `hermesDataQueueJobId` on the payload after `addJobs` so the handler can read the queue row’s `attempts` / `maxAttempts`. Jobs enqueued before this behavior (no queue id on payload) keep the previous semantics: a single terminal `failed` row when the handler throws.
+
+After each successful claim, the worker copies DataQueue **`attempts`** and **`max_attempts`** into `agent_job_execution.data_queue_attempts` and `data_queue_max_attempts` so the Hermes dashboard execution detail page can show **Attempts** (current / max) per invocation.
 
 ## Workspace dependencies
 

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -32,7 +32,13 @@ PROCESSOR_BATCH_SIZE=10 # optional
 # Max concurrent job executions (e.g. agent HTTP calls). Default 3; increase for more parallelism.
 PROCESSOR_CONCURRENCY=3 # optional
 
-# Optional: DataQueue max attempts for invoke_agent (transport retries). Omit for library default.
+# Optional: DataQueue max attempts for invoke_agent (transport / 5xx retries). Omit for library default (3).
 HERMES_INVOKE_AGENT_MAX_ATTEMPTS= # optional
 # Optional: dead-letter job type when invoke_agent exhausts retries.
 HERMES_INVOKE_AGENT_DLQ_JOB_TYPE= # optional
+# Optional: base delay between invoke_agent retries in seconds (DataQueue retryDelay). When set with default backoff, delay grows as base * 2^attempts with jitter.
+HERMES_INVOKE_AGENT_RETRY_DELAY= # optional #number
+# Optional: set to "false" for fixed delay; omit or "true" for exponential backoff when HERMES_INVOKE_AGENT_RETRY_DELAY is set.
+HERMES_INVOKE_AGENT_RETRY_BACKOFF= # optional
+# Optional: cap retry delay in seconds (DataQueue retryDelayMax).
+HERMES_INVOKE_AGENT_RETRY_DELAY_MAX= # optional #number

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -17,6 +17,9 @@ export const env = createEnv({
     PROCESSOR_CONCURRENCY: z.string().optional(),
     HERMES_INVOKE_AGENT_MAX_ATTEMPTS: z.string().optional(),
     HERMES_INVOKE_AGENT_DLQ_JOB_TYPE: z.string().optional(),
+    HERMES_INVOKE_AGENT_RETRY_DELAY: z.string().optional(),
+    HERMES_INVOKE_AGENT_RETRY_BACKOFF: z.string().optional(),
+    HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: z.string().optional(),
   },
   client: {
   },

--- a/packages/hermes/orchestration-database/prisma/migrations/20260322230157_agent_job_execution_data_queue_attempts/migration.sql
+++ b/packages/hermes/orchestration-database/prisma/migrations/20260322230157_agent_job_execution_data_queue_attempts/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "agent_job_execution" ADD COLUMN     "data_queue_attempts" INTEGER,
+ADD COLUMN     "data_queue_max_attempts" INTEGER;

--- a/packages/hermes/orchestration-database/prisma/schema.prisma
+++ b/packages/hermes/orchestration-database/prisma/schema.prisma
@@ -229,28 +229,32 @@ model ScheduleExecution {
 }
 
 model AgentJobExecution {
-  id                  String                  @id @default(uuid())
-  jobId               String                  @unique @map("job_id")
-  agentId             String                  @map("agent_id")
-  scheduleId          String?                 @map("schedule_id")
-  scheduleExecutionId String?                 @map("schedule_execution_id")
-  pipelineId          String?                 @map("pipeline_id")
-  pipelineStepId      String?                 @map("pipeline_step_id")
-  status              AgentJobExecutionStatus
-  priority            Int                     @default(0)
-  enqueuedAt          DateTime                @map("enqueued_at")
-  dependencies        Json?
-  params              Json                    @default("{}")
+  id                   String                  @id @default(uuid())
+  jobId                String                  @unique @map("job_id")
+  agentId              String                  @map("agent_id")
+  scheduleId           String?                 @map("schedule_id")
+  scheduleExecutionId  String?                 @map("schedule_execution_id")
+  pipelineId           String?                 @map("pipeline_id")
+  pipelineStepId       String?                 @map("pipeline_step_id")
+  status               AgentJobExecutionStatus
+  priority             Int                     @default(0)
+  enqueuedAt           DateTime                @map("enqueued_at")
+  dependencies         Json?
+  params               Json                    @default("{}")
   /// Resolved step `config` sent with the agent body (stored for execution debugging).
-  invocationConfig    Json?                   @map("invocation_config")
-  error               Json?
+  invocationConfig     Json?                   @map("invocation_config")
+  error                Json?
   /// Parsed agent response envelope (success path or semantic failure): message, details, logs, schemaVersion.
-  agentResponse       Json?                   @map("agent_response")
+  agentResponse        Json?                   @map("agent_response")
   /// Agent envelope `status` when body was valid: "success" | "failure".
-  semanticStatus      String?                 @map("semantic_status")
-  startedAt           DateTime?               @map("started_at")
-  completedAt         DateTime?               @map("completed_at")
-  createdAt           DateTime                @default(now()) @map("created_at")
+  semanticStatus       String?                 @map("semantic_status")
+  startedAt            DateTime?               @map("started_at")
+  completedAt          DateTime?               @map("completed_at")
+  /// DataQueue `attempts` after the worker claimed this job (refreshed each processing attempt).
+  dataQueueAttempts    Int?                    @map("data_queue_attempts")
+  /// DataQueue `max_attempts` when last synced (for display, e.g. `3 / 5`).
+  dataQueueMaxAttempts Int?                    @map("data_queue_max_attempts")
+  createdAt            DateTime                @default(now()) @map("created_at")
 
   schedule          Schedule?          @relation(fields: [scheduleId], references: [id], onDelete: SetNull)
   scheduleExecution ScheduleExecution? @relation(fields: [scheduleExecutionId], references: [id], onDelete: SetNull)

--- a/packages/hermes/scheduler/src/execute-schedule.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.ts
@@ -34,6 +34,8 @@ export type InvokeAgentJobPayload = {
   body: { input: Record<string, unknown>; config: Record<string, unknown> };
   timeoutMs: number;
   priority: number;
+  /** Set by hermes-worker after `addJobs` (DataQueue numeric id) for transient retry orchestration. */
+  hermesDataQueueJobId?: number;
 };
 
 /**

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -37,6 +37,7 @@ export {
   type GetDueSchedulesDb,
 } from "./get-due-schedules";
 export { computeNextRunAt, type ScheduleForNextRun } from "./next-run-at";
+export { willRetryAfterTransientFailure } from "./will-retry-after-transient-failure";
 export {
   applyHermesInvokeCorrelationHeaders,
   invokeAgent,

--- a/packages/hermes/scheduler/src/will-retry-after-transient-failure.test.ts
+++ b/packages/hermes/scheduler/src/will-retry-after-transient-failure.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { willRetryAfterTransientFailure } from "./will-retry-after-transient-failure";
+
+describe("willRetryAfterTransientFailure", () => {
+  it("returns true when attempts are below maxAttempts", () => {
+    expect(willRetryAfterTransientFailure(1, 3)).toBe(true);
+    expect(willRetryAfterTransientFailure(2, 3)).toBe(true);
+  });
+
+  it("returns false when attempts equal maxAttempts (last attempt exhausted)", () => {
+    expect(willRetryAfterTransientFailure(3, 3)).toBe(false);
+  });
+
+  it("returns false when attempts exceed maxAttempts", () => {
+    expect(willRetryAfterTransientFailure(4, 3)).toBe(false);
+  });
+});

--- a/packages/hermes/scheduler/src/will-retry-after-transient-failure.ts
+++ b/packages/hermes/scheduler/src/will-retry-after-transient-failure.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether DataQueue will schedule another attempt after the current handler failure.
+ * Compare `JobRecord.attempts` (after the lock increment) with `JobRecord.maxAttempts`.
+ *
+ * @param attempts - Current `attempts` on the queue job row while processing.
+ * @param maxAttempts - Configured maximum attempts for the job.
+ * @returns True if another try remains after this failure is recorded.
+ */
+export const willRetryAfterTransientFailure = (
+  attempts: number,
+  maxAttempts: number,
+): boolean => attempts < maxAttempts;


### PR DESCRIPTION
## Summary

Aligns Hermes `invoke_agent` with DataQueue retries for transient failures (network errors, HTTP 5xx), resets orchestration rows to `pending` when another attempt is scheduled, and persists queue `attempts` / `max_attempts` on `AgentJobExecution` for dashboard visibility. Legacy jobs without a queue id keep the previous single-shot failure behavior.

## Important changes

- **Migration:** `agent_job_execution` gains nullable `data_queue_attempts` and `data_queue_max_attempts` (run orchestration DB migrate before deploy).
- **Worker:** After enqueue, payload is updated with `hermesDataQueueJobId`; handler syncs attempt counts, and on retryable transport/5xx failures resets running executions to `pending` (with error metadata) when `willRetryAfterTransientFailure` is true; otherwise applies terminal failure as before.
- **HTTP handling:** `invoke_agent` response path refactored so non-success status codes are classified explicitly (e.g. 4xx vs 2xx envelope parsing).
- **Env:** Optional `HERMES_INVOKE_AGENT_RETRY_DELAY`, `HERMES_INVOKE_AGENT_RETRY_BACKOFF`, `HERMES_INVOKE_AGENT_RETRY_DELAY_MAX` for DataQueue retry timing (documented in dev-docs and `env.hermes-worker.example`).

## Other changes

- Dashboard schedule execution invocations table: new **Attempts** column via `formatQueueAttemptsDisplay` (shows `—` for legacy/null).
- Scheduler package: `InvokeAgentJobPayload` documents optional `hermesDataQueueJobId`; exports `willRetryAfterTransientFailure` with unit tests.

## How to test

1. Apply the new Prisma migration for `@hermes/orchestration-database` and restart the Hermes worker with a known `PG_DATAQUEUE_DATABASE` and optional retry env vars.
2. Trigger a scheduled agent run; open the execution detail page and confirm invocations show **Attempts** (e.g. `1 / 3`) after the worker processes the job.
3. Simulate a transport failure or 5xx with retries remaining: confirm `AgentJobExecution` returns to `pending` and the agent is invoked again; after the final failed attempt, confirm the row ends in terminal `failed` and schedule rollups behave as before.
4. For a payload without `hermesDataQueueJobId` (or pre-migration data), confirm a transport error still marks the execution failed in one shot and the UI shows `—` for attempts when counts are null.