### PR TITLE
Update open-github-pr skill to sanitize PR body before create

### DIFF
--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -17,7 +17,7 @@ Create pull requests for this repo with `gh pr create`, and use the `/pr-title-d
 
 1. Resolve repository slug, host, and account context first:
    - Parse `origin` remote to get `host`, `owner`, and `repo`.
-   - If the remote uses an SSH alias host (example: `github.com-swift`), map it to the real API host (`github.com`) before calling `gh`.
+   - If the remote uses an SSH alias host (example: `github.com-somealias`), map it to the real API host (`github.com`) before calling `gh`.
    - Determine target account from owner mapping (for example from shell mapping like `GH_OWNER_ACCOUNT`), then switch explicitly:
      - `gh auth switch -h <host> -u <account>`
    - Verify access before continuing:


### PR DESCRIPTION
## Summary

Updates the open-github-pr Cursor skill so the PR description is stripped of Cursor footer lines **before** `gh pr create`, avoiding a follow-up `gh pr edit` that marks the pull request as edited.

## Important changes

- Post-create step is verification only; agents must not use `gh pr edit` for footer cleanup (close/recreate if the footer still appears).

## Other changes

- Aligns SSH alias example wording with the global skill (`github.com-swift`).

## Key files to review

- `.cursor/skills/open-github-pr/SKILL.md` — full workflow, bash snippet, and checklist.

## How to test

1. Open `.cursor/skills/open-github-pr/SKILL.md` and confirm step 5 uses pre-create sanitization and step 6 forbids `gh pr edit` for footers.