### PR TITLE
Group Hermes dashboard sidebar navigation by area

### DIFF
--- a/apps/hermes/dashboard/components/app-sidebar.test.tsx
+++ b/apps/hermes/dashboard/components/app-sidebar.test.tsx
@@ -139,17 +139,31 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Hermes")).toBeInTheDocument();
   });
 
-  it("renders Hermes main nav and integration-grouped domain links", () => {
+  it("renders Hermes grouped main nav and integration-grouped domain links", () => {
     usePathnameMock.mockReturnValue("/dashboard");
 
     render(<AppSidebar domainIntegrations={domainIntegrations} />);
 
+    const groupLabels = screen
+      .getAllByTestId("sidebar-group-label")
+      .map((el) => el.textContent);
+    expect(groupLabels).toEqual([
+      "Overview",
+      "Orchestration",
+      "Agents",
+      "Platform",
+      "Mediapulse",
+    ]);
     expect(screen.getByText("Dashboard")).toBeInTheDocument();
     expect(screen.getByText("Pipelines")).toBeInTheDocument();
     expect(screen.getByText("Mediapulse")).toBeInTheDocument();
     expect(screen.getByText("Tickers")).toBeInTheDocument();
     expect(screen.getByText("Search Query")).toBeInTheDocument();
-    expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Agents" })).toBeInTheDocument();
+    expect(screen.getByText("Agent configs")).toBeInTheDocument();
+    expect(screen.getByText("Variables")).toBeInTheDocument();
+    expect(screen.getByText("HTTP triggers")).toBeInTheDocument();
+    expect(screen.getByText("Admins")).toBeInTheDocument();
     expect(screen.getByText("Domain integrations")).toBeInTheDocument();
     expect(screen.getByText("Schedules")).toBeInTheDocument();
     expect(screen.getByText("Entity Types")).toBeInTheDocument();

--- a/apps/hermes/dashboard/components/app-sidebar.tsx
+++ b/apps/hermes/dashboard/components/app-sidebar.tsx
@@ -43,7 +43,8 @@ type AppSidebarProps = React.ComponentProps<typeof Sidebar> & {
 };
 
 /**
- * Hermes app sidebar matching dashboard-01. Main nav (Dashboard, Pipelines) and footer with user and logout.
+ * Hermes app sidebar matching dashboard-01. Primary nav is grouped by area (overview, orchestration,
+ * agent catalog, platform); domain integration pages follow; footer has user and logout.
  */
 export const AppSidebar = ({
   user,
@@ -76,7 +77,7 @@ export const AppSidebar = ({
       </div>
       <SidebarContent>
         <SidebarGroup>
-          <SidebarGroupLabel>Main</SidebarGroupLabel>
+          <SidebarGroupLabel>Overview</SidebarGroupLabel>
           <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={isDashboard}>
@@ -86,6 +87,11 @@ export const AppSidebar = ({
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Orchestration</SidebarGroupLabel>
+          <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={isPipelines}>
                 <Link href="/dashboard/pipelines">
@@ -94,6 +100,27 @@ export const AppSidebar = ({
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={isSchedules}>
+                <Link href="/dashboard/schedules">
+                  <Calendar className="size-4" />
+                  <span>Schedules</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild isActive={isHttpTriggers}>
+                <Link href="/dashboard/http-triggers">
+                  <Radio className="size-4" />
+                  <span>HTTP triggers</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Agents</SidebarGroupLabel>
+          <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={isAgents}>
                 <Link href="/dashboard/agents">
@@ -118,27 +145,16 @@ export const AppSidebar = ({
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarGroup>
+          <SidebarGroupLabel>Platform</SidebarGroupLabel>
+          <SidebarMenu>
             <SidebarMenuItem>
               <SidebarMenuButton asChild isActive={isDomainIntegrations}>
                 <Link href="/dashboard/domain-integrations">
                   <Plug className="size-4" />
                   <span>Domain integrations</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={isSchedules}>
-                <Link href="/dashboard/schedules">
-                  <Calendar className="size-4" />
-                  <span>Schedules</span>
-                </Link>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-            <SidebarMenuItem>
-              <SidebarMenuButton asChild isActive={isHttpTriggers}>
-                <Link href="/dashboard/http-triggers">
-                  <Radio className="size-4" />
-                  <span>HTTP triggers</span>
                 </Link>
               </SidebarMenuButton>
             </SidebarMenuItem>


### PR DESCRIPTION
## Summary

Reorganizes the Hermes dashboard sidebar from a single "Main" list into labeled groups (Overview, Orchestration, Agents, Platform) so related routes sit together. Schedules and HTTP triggers move under Orchestration with pipelines; agent-related links stay under Agents; domain integrations and admins sit under Platform.

## Important changes

- Split primary navigation into four `SidebarGroup` sections with new labels and ordering.
- Moved Schedules and HTTP triggers from the old flat list into the Orchestration group (same routes and active states, different placement).

## Other changes

- Updated `AppSidebar` JSDoc to describe the new grouping.
- Extended unit tests to assert group label order, disambiguate the Agents link, and cover key items per group.

## Key files to review

- `apps/hermes/dashboard/components/app-sidebar.tsx` — group structure, link placement, and active-state wiring.
- `apps/hermes/dashboard/components/app-sidebar.test.tsx` — group label expectations and nav coverage.

## How to test

1. Run `pnpm code-quality` from the repo root (or `pnpm vitest run apps/hermes/dashboard/components/app-sidebar.test.tsx`).
2. Open the Hermes dashboard and expand the sidebar: confirm labels Overview, Orchestration, Agents, Platform (plus Mediapulse integration group when applicable) and that each link navigates correctly and shows active styling on the matching route.
3. Visit schedules and HTTP triggers URLs and confirm those items still highlight as active under Orchestration.

Made with [Cursor](https://cursor.com)