### PR TITLE
Expand step inputs for manual pipeline runs via domain-api

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -143,6 +143,7 @@ describe("createRunPipelineHandler", () => {
     });
     const handler = createRunPipelineHandler({
       getToken: async () => "jwt",
+      expandStepInputs: async (ctx) => [ctx.input],
       post: postMock as never,
       db: {
         ...createExecutionPersistenceStubs(),
@@ -201,6 +202,7 @@ describe("createRunPipelineHandler", () => {
     });
     const handler = createRunPipelineHandler({
       getToken: async () => "jwt",
+      expandStepInputs: async (ctx) => [ctx.input],
       post: postMock as never,
       db: {
         ...createExecutionPersistenceStubs(),

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -25,6 +25,7 @@ import {
 import { z } from "zod";
 
 import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-inputs-for-manual-pipeline";
 import { validatePipeline } from "@/lib/validate-pipeline";
 
 const bodyValidator = z.object({
@@ -114,7 +115,7 @@ export const createRunPipelineHandler = ({
     }),
   post = got.post,
   now = () => new Date(),
-  expandStepInputs = async (context) => [context.input],
+  expandStepInputs = createExpandStepInputsForManualPipelineRun(),
 }: RunPipelineHandlerDependencies = {}): RunPipelineHandler => {
   return async (data) => {
     const session = data.user;

--- a/apps/hermes/dashboard/lib/domain-integration-auth-token.test.ts
+++ b/apps/hermes/dashboard/lib/domain-integration-auth-token.test.ts
@@ -87,4 +87,24 @@ describe("getBearerJwtForDomainIntegrationId", () => {
       credential: "decrypted-api-key",
     });
   });
+
+  it("uses injected db when provided", async () => {
+    envState.AGENT_AUTH_API_URL = "http://auth";
+    const customFindFirst = vi.fn().mockResolvedValue({
+      encryptedApiKey: '{"v":1}',
+    });
+    mockGetToken.mockResolvedValue("jwt-from-custom-db");
+
+    const { getBearerJwtForDomainIntegrationId } =
+      await import("./domain-integration-auth-token");
+
+    await expect(
+      getBearerJwtForDomainIntegrationId("int-1", {
+        db: { domainIntegration: { findFirst: customFindFirst } },
+      }),
+    ).resolves.toBe("jwt-from-custom-db");
+
+    expect(customFindFirst).toHaveBeenCalled();
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
 });

--- a/apps/hermes/dashboard/lib/domain-integration-auth-token.ts
+++ b/apps/hermes/dashboard/lib/domain-integration-auth-token.ts
@@ -2,9 +2,15 @@ import { createAgentTokenClient } from "@workspace/agent-auth-client";
 import {
   DomainIntegrationStatus,
   prisma,
+  type PrismaClient,
 } from "@hermes/orchestration-database";
 import { decryptDomainIntegrationApiKey } from "@hermes/domain-integration-crypto";
 import { env } from "@hermes/env";
+
+/** Orchestration DB slice needed for JWT minting (injectable for tests and `orchDb` from expansion context). */
+export type DomainIntegrationAuthDb = {
+  domainIntegration: Pick<PrismaClient["domainIntegration"], "findFirst">;
+};
 
 /**
  * Returns a short-lived JWT for Hermes → registered domain integration HTTP APIs
@@ -14,17 +20,22 @@ import { env } from "@hermes/env";
  * domain-api should allow that only in local dev).
  *
  * @param domainIntegrationId - Orchestration `domain_integration.id`.
+ * @param options - Optional `db` (defaults to shared orchestration `prisma`).
  * @returns Bearer JWT string, or `undefined` when token issuance is not configured or no ciphertext exists.
  */
 export async function getBearerJwtForDomainIntegrationId(
   domainIntegrationId: string,
+  options?: { db?: DomainIntegrationAuthDb },
 ): Promise<string | undefined> {
   const authApiUrl = env.AGENT_AUTH_API_URL?.trim();
   if (!authApiUrl) {
     return undefined;
   }
 
-  const row = await prisma.domainIntegration.findFirst({
+  const db: DomainIntegrationAuthDb = options?.db ?? {
+    domainIntegration: prisma.domainIntegration,
+  };
+  const row = await db.domainIntegration.findFirst({
     where: {
       id: domainIntegrationId,
       status: DomainIntegrationStatus.active,

--- a/apps/hermes/dashboard/lib/expand-step-inputs-for-manual-pipeline.test.ts
+++ b/apps/hermes/dashboard/lib/expand-step-inputs-for-manual-pipeline.test.ts
@@ -1,0 +1,70 @@
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const expandStepInputsHttp = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    expandedInputs: [{ id: "a" }, { id: "b" }],
+  }),
+);
+
+vi.mock("@hermes/domain-contract", () => ({
+  createDomainIntegrationClient: vi.fn(() => ({
+    expandStepInputs: expandStepInputsHttp,
+  })),
+}));
+
+vi.mock("./domain-integration-auth-token", () => ({
+  getBearerJwtForDomainIntegrationId: vi.fn().mockResolvedValue("jwt"),
+}));
+
+describe("createExpandStepInputsForManualPipelineRun", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws when domain integration has no base URL", async () => {
+    const { createExpandStepInputsForManualPipelineRun } =
+      await import("./expand-step-inputs-for-manual-pipeline");
+    const expand = createExpandStepInputsForManualPipelineRun();
+    await expect(
+      expand({
+        input: {},
+        scheduleId: "s",
+        pipelineId: "p",
+        pipelineStepId: "st",
+        domainIntegrationId: "di-1",
+        orchDb: {
+          domainIntegration: {
+            findFirst: vi.fn().mockResolvedValue(null),
+          },
+        } as never,
+      }),
+    ).rejects.toThrow(/no base URL/);
+  });
+
+  it("returns expanded inputs from domain-api", async () => {
+    const { createExpandStepInputsForManualPipelineRun } =
+      await import("./expand-step-inputs-for-manual-pipeline");
+    const expand = createExpandStepInputsForManualPipelineRun();
+    const result = await expand({
+      input: { tickerId: "db:ticker:id" },
+      scheduleId: "s",
+      pipelineId: "p",
+      pipelineStepId: "st",
+      domainIntegrationId: "di-1",
+      orchDb: {
+        domainIntegration: {
+          findFirst: vi.fn().mockResolvedValue({
+            baseUrl: "https://domain.example",
+          }),
+        },
+      } as never,
+    });
+    expect(result).toEqual([{ id: "a" }, { id: "b" }]);
+    expect(expandStepInputsHttp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        input: { tickerId: "db:ticker:id" },
+      }),
+    );
+  });
+});

--- a/apps/hermes/dashboard/lib/expand-step-inputs-for-manual-pipeline.ts
+++ b/apps/hermes/dashboard/lib/expand-step-inputs-for-manual-pipeline.ts
@@ -1,0 +1,52 @@
+import { createDomainIntegrationClient } from "@hermes/domain-contract";
+import { DomainIntegrationStatus } from "@hermes/orchestration-database";
+import { env } from "@hermes/env";
+import { DEFAULT_TAKE, MAX_TAKE } from "@hermes/step-input-syntax";
+import type { ExpandStepInputs } from "@hermes/scheduler";
+
+import { getBearerJwtForDomainIntegrationId } from "./domain-integration-auth-token";
+
+/**
+ * Builds {@link ExpandStepInputs} for dashboard “Run pipeline”: resolves `db:` data-source expansion
+ * and aliases via domain-api, matching scheduled runs in hermes-worker.
+ *
+ * Uses {@link ExpandStepInputsContext.orchDb} for domain lookups and JWT minting so injected DBs in tests behave correctly.
+ *
+ * @returns Expansion callback for {@link planPipelineInvocations}.
+ */
+export const createExpandStepInputsForManualPipelineRun =
+  (): ExpandStepInputs => {
+    const defaultTake = DEFAULT_TAKE;
+    const maxTake = env.HERMES_DATA_SOURCE_MAX_TAKE ?? MAX_TAKE;
+
+    return async (context) => {
+      const db = context.orchDb;
+      const integration = await db.domainIntegration.findFirst({
+        where: {
+          id: context.domainIntegrationId,
+          status: DomainIntegrationStatus.active,
+        },
+        select: { baseUrl: true },
+      });
+      const baseUrl = integration?.baseUrl?.trim();
+      if (!baseUrl) {
+        throw new Error(
+          "Domain integration has no base URL; register domain-api with Hermes before running pipelines that need step-input expansion.",
+        );
+      }
+      const authToken = await getBearerJwtForDomainIntegrationId(
+        context.domainIntegrationId,
+        { db },
+      );
+      const domainClient = createDomainIntegrationClient({
+        baseUrl,
+        ...(authToken !== undefined ? { authToken } : {}),
+      });
+      const response = await domainClient.expandStepInputs({
+        input: context.input,
+        defaultTake,
+        maxTake,
+      });
+      return response.expandedInputs;
+    };
+  };


### PR DESCRIPTION
## Summary

Manual “Run pipeline” in the Hermes dashboard now expands step inputs through domain-api (`expandStepInputs`), matching scheduled runs in hermes-worker so `db:` data-source resolution and aliases behave the same. JWT minting for domain integration calls can use the same orchestration DB slice as the expansion context via optional injection.

## Important changes

- Default `expandStepInputs` for the run-pipeline action uses `createExpandStepInputsForManualPipelineRun` (domain client + base URL lookup + optional bearer JWT).
- `getBearerJwtForDomainIntegrationId` accepts an optional injected `db` (`DomainIntegrationAuthDb`) so tests and callers can pass `orchDb` consistently.

## Other changes

- Unit tests for expansion (missing base URL, successful expansion), JWT injection, and run-pipeline handler wiring.

## Key files to review

- `apps/hermes/dashboard/lib/expand-step-inputs-for-manual-pipeline.ts` — domain integration lookup, JWT, and `expandStepInputs` call with take limits.
- `apps/hermes/dashboard/lib/domain-integration-auth-token.ts` — injectable DB for `findFirst` on domain integration.
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — default dependency switched to the new factory.

## How to test

1. Run `pnpm code-quality` from the repo root (typecheck, lint, tests).
2. Manually run a pipeline in the dashboard that relies on `db:` / expanded step inputs; confirm executions match behavior of a scheduled run for the same pipeline.
3. If domain integration has no base URL, confirm the run fails with a clear error about registering domain-api.
