### PR TITLE
Add HTTP trigger request snapshots with secret redaction

### DIFF
--- a/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/invoke/route.test.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/invoke/route.test.ts
@@ -1,6 +1,8 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { HTTP_TRIGGER_REQUEST_HEADER_REDACTED } from "@/lib/collect-http-trigger-request-snapshot";
+
 vi.mock("@/lib/hermes-job-queue", () => ({
   getHermesJobQueue: vi.fn(),
 }));
@@ -134,6 +136,21 @@ describe("http trigger invoke route", () => {
         payload: { httpTriggerExecutionId: "e1" },
       }),
     );
+    expect(prisma.httpTriggerExecution.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            requestSnapshotVersion: 1,
+            request: expect.objectContaining({
+              method: "POST",
+            }),
+            headers: expect.objectContaining({
+              authorization: HTTP_TRIGGER_REQUEST_HEADER_REDACTED,
+            }),
+          }),
+        }),
+      }),
+    );
   });
 
   it("supports configured GET method", async () => {
@@ -165,5 +182,17 @@ describe("http trigger invoke route", () => {
     // Assert
     expect(response.status).toBe(202);
     expect(addJob).toHaveBeenCalledTimes(1);
+    expect(prisma.httpTriggerExecution.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            requestSnapshotVersion: 1,
+            request: expect.objectContaining({
+              method: "GET",
+            }),
+          }),
+        }),
+      }),
+    );
   });
 });

--- a/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/invoke/route.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/invoke/route.ts
@@ -1,6 +1,14 @@
 import { NextResponse } from "next/server";
-import { prisma, ScheduleEnqueueStatus } from "@hermes/orchestration-database";
+import {
+  prisma,
+  type Prisma,
+  ScheduleEnqueueStatus,
+} from "@hermes/orchestration-database";
 
+import {
+  collectHttpTriggerRequestSnapshot,
+  toHttpTriggerExecutionMetadata,
+} from "@/lib/collect-http-trigger-request-snapshot";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 import { verifyHttpTriggerToken } from "@/lib/http-trigger-auth";
 
@@ -74,6 +82,8 @@ const handleInvoke = async (
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const requestSnapshot = await collectHttpTriggerRequestSnapshot(request);
+
   const execution = await prisma.httpTriggerExecution.create({
     data: {
       httpTriggerId: trigger.id,
@@ -85,9 +95,9 @@ const handleInvoke = async (
         trigger.pipeline.executionConfig != null
           ? trigger.pipeline.executionConfig
           : undefined,
-      metadata: {
-        requestedMethod: request.method,
-      },
+      metadata: toHttpTriggerExecutionMetadata(
+        requestSnapshot,
+      ) as Prisma.InputJsonValue,
     },
     select: { id: true },
   });

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
@@ -83,6 +83,19 @@ export default async function HttpTriggerExecutionDetailPage({
         </p>
       </section>
 
+      {detail.execution.metadata != null ? (
+        <section>
+          <h2 className="mb-2 text-lg font-medium">Request snapshot</h2>
+          <pre className="max-h-[32rem] overflow-auto rounded-md border bg-muted p-4 font-mono text-xs">
+            {JSON.stringify(
+              maskSecretsInJson(detail.execution.metadata),
+              null,
+              2,
+            )}
+          </pre>
+        </section>
+      ) : null}
+
       <section>
         <h2 className="mb-2 text-lg font-medium">Pipeline steps</h2>
         <div className="rounded-md border">

--- a/apps/hermes/dashboard/lib/collect-http-trigger-request-snapshot.test.ts
+++ b/apps/hermes/dashboard/lib/collect-http-trigger-request-snapshot.test.ts
@@ -1,0 +1,430 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  HTTP_TRIGGER_REQUEST_HEADER_REDACTED,
+  buildRequestBodySnapshot,
+  collectHttpTriggerRequestSnapshot,
+  collectRedactedHeaderRecord,
+  DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES,
+  isSensitiveHttpHeaderName,
+  searchParamsToRecord,
+  shouldOmitBodyForContentType,
+  toHttpTriggerExecutionMetadata,
+  truncateUtf8String,
+} from "./collect-http-trigger-request-snapshot";
+
+describe("isSensitiveHttpHeaderName", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns true for authorization", () => {
+    // Act
+    const a = isSensitiveHttpHeaderName("Authorization");
+    const b = isSensitiveHttpHeaderName("authorization");
+
+    // Assert
+    expect(a).toBe(true);
+    expect(b).toBe(true);
+  });
+
+  it("returns true for cookie and proxy-authorization", () => {
+    // Act & Assert
+    expect(isSensitiveHttpHeaderName("Cookie")).toBe(true);
+    expect(isSensitiveHttpHeaderName("Set-Cookie")).toBe(true);
+    expect(isSensitiveHttpHeaderName("Proxy-Authorization")).toBe(true);
+  });
+
+  it("returns true for api key style headers", () => {
+    // Act & Assert
+    expect(isSensitiveHttpHeaderName("X-Api-Key")).toBe(true);
+    expect(isSensitiveHttpHeaderName("x-auth-token")).toBe(true);
+  });
+
+  it("returns false for safe headers", () => {
+    // Act & Assert
+    expect(isSensitiveHttpHeaderName("Accept")).toBe(false);
+    expect(isSensitiveHttpHeaderName("Content-Type")).toBe(false);
+  });
+});
+
+describe("searchParamsToRecord", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("maps single values to strings", () => {
+    // Setup
+    const params = new URLSearchParams("a=1&b=two");
+
+    // Act
+    const rec = searchParamsToRecord(params);
+
+    // Assert
+    expect(rec).toEqual({ a: "1", b: "two" });
+  });
+
+  it("maps duplicate keys to string arrays", () => {
+    // Setup
+    const params = new URLSearchParams("a=1&a=2");
+
+    // Act
+    const rec = searchParamsToRecord(params);
+
+    // Assert
+    expect(rec).toEqual({ a: ["1", "2"] });
+  });
+});
+
+describe("shouldOmitBodyForContentType", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false for null and text types", () => {
+    // Act & Assert
+    expect(shouldOmitBodyForContentType(null)).toBe(false);
+    expect(shouldOmitBodyForContentType("")).toBe(false);
+    expect(shouldOmitBodyForContentType("application/json")).toBe(false);
+    expect(shouldOmitBodyForContentType("text/plain; charset=utf-8")).toBe(
+      false,
+    );
+  });
+
+  it("returns true for multipart and octet-stream", () => {
+    // Act & Assert
+    expect(
+      shouldOmitBodyForContentType("multipart/form-data; boundary=x"),
+    ).toBe(true);
+    expect(shouldOmitBodyForContentType("application/octet-stream")).toBe(true);
+  });
+
+  it("returns true for image video audio", () => {
+    // Act & Assert
+    expect(shouldOmitBodyForContentType("image/png")).toBe(true);
+    expect(shouldOmitBodyForContentType("video/mp4")).toBe(true);
+    expect(shouldOmitBodyForContentType("audio/wav")).toBe(true);
+  });
+});
+
+describe("truncateUtf8String", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns unchanged when under byte limit", () => {
+    // Act
+    const r = truncateUtf8String("hello", 100);
+
+    // Assert
+    expect(r.text).toBe("hello");
+    expect(r.truncated).toBe(false);
+    expect(r.originalByteLength).toBe(5);
+  });
+
+  it("truncates to max bytes without splitting codepoints", () => {
+    // Setup — euro is 3 UTF-8 bytes
+    const input = "a€b";
+
+    // Act
+    const r = truncateUtf8String(input, 2);
+
+    // Assert
+    expect(r.truncated).toBe(true);
+    expect(r.originalByteLength).toBeGreaterThan(2);
+    expect(r.text).toBe("a");
+  });
+});
+
+describe("collectRedactedHeaderRecord", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("redacts authorization and keeps other headers", () => {
+    // Setup
+    const headers = new Headers();
+    headers.set("Authorization", "Bearer secret");
+    headers.set("X-Custom", "ok");
+
+    // Act
+    const rec = collectRedactedHeaderRecord(headers);
+
+    // Assert
+    expect(rec.authorization).toBe(HTTP_TRIGGER_REQUEST_HEADER_REDACTED);
+    expect(rec["x-custom"]).toBe("ok");
+  });
+});
+
+describe("buildRequestBodySnapshot", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("omits body for multipart content type", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "multipart/form-data; boundary=abc" },
+      body: "ignored",
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(
+      request,
+      "multipart/form-data; boundary=abc",
+      1024,
+    );
+
+    // Assert
+    expect(body.omittedReason).toBe("non_text_or_large_binary_content_type");
+    expect(body.contentType).toBe("multipart/form-data; boundary=abc");
+  });
+
+  it("returns parseError for invalid JSON when type is application/json", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not-json",
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(
+      request,
+      "application/json",
+      1024,
+    );
+
+    // Assert
+    expect(body.parseError).toBeDefined();
+    expect(body.text).toContain("{not-json");
+  });
+
+  it("masks secrets in parsed JSON body", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "x", apiKey: "secret" }),
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(
+      request,
+      "application/json",
+      1024,
+    );
+
+    // Assert
+    expect(body.json).toEqual({
+      name: "x",
+      apiKey: expect.any(String),
+    });
+    expect((body.json as { apiKey: string }).apiKey).not.toBe("secret");
+  });
+
+  it("stores plain text body for text/plain", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "hello",
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(request, "text/plain", 1024);
+
+    // Assert
+    expect(body.text).toBe("hello");
+    expect(body.truncated).toBe(false);
+  });
+
+  it("truncates body when over maxBodyBytes", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "abcdefghij",
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(request, "text/plain", 4);
+
+    // Assert
+    expect(body.truncated).toBe(true);
+    expect(body.text).toBe("abcd");
+    expect(body.originalByteLength).toBe(10);
+  });
+
+  it("returns omittedReason when body read throws", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "x",
+    });
+    vi.spyOn(request, "text").mockRejectedValue(new Error("boom"));
+
+    // Act
+    const body = await buildRequestBodySnapshot(request, "text/plain", 1024);
+
+    // Assert
+    expect(body.omittedReason).toBe("body_read_failed");
+  });
+
+  it("parses application/vnd.api+json as JSON", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/vnd.api+json" },
+      body: '{"a":1}',
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(
+      request,
+      "application/vnd.api+json",
+      1024,
+    );
+
+    // Assert
+    expect(body.json).toEqual({ a: 1 });
+  });
+
+  it("returns empty text for application/json with empty body", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "",
+    });
+
+    // Act
+    const body = await buildRequestBodySnapshot(
+      request,
+      "application/json",
+      1024,
+    );
+
+    // Assert
+    expect(body.text).toBe("");
+    expect(body.truncated).toBe(false);
+    expect(body.originalByteLength).toBe(0);
+  });
+});
+
+describe("collectHttpTriggerRequestSnapshot", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("collects url method search params headers client and body", async () => {
+    // Setup
+    const request = new Request(
+      "http://example.com/api/http-triggers/t1/invoke?q=1&q=2",
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer x",
+          "User-Agent": "vitest",
+          "X-Forwarded-For": "203.0.113.1",
+          "Content-Type": "application/json",
+        },
+        body: "{}",
+      },
+    );
+
+    // Act
+    const snap = await collectHttpTriggerRequestSnapshot(request);
+
+    // Assert
+    expect(snap.requestSnapshotVersion).toBe(1);
+    expect(snap.request.method).toBe("POST");
+    expect(snap.request.pathname).toBe("/api/http-triggers/t1/invoke");
+    expect(snap.request.searchParams).toEqual({ q: ["1", "2"] });
+    expect(snap.headers.authorization).toBe(
+      HTTP_TRIGGER_REQUEST_HEADER_REDACTED,
+    );
+    expect(snap.client.userAgent).toBe("vitest");
+    expect(snap.client.forwardedFor).toBe("203.0.113.1");
+    expect(snap.body.json).toEqual({});
+  });
+
+  it("respects maxBodyBytes option", async () => {
+    // Setup
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: "abcdef",
+    });
+
+    // Act
+    const snap = await collectHttpTriggerRequestSnapshot(request, {
+      maxBodyBytes: 3,
+    });
+
+    // Assert
+    expect(snap.body.truncated).toBe(true);
+    expect(snap.body.text).toBe("abc");
+  });
+
+  it("uses default max body bytes from constant", async () => {
+    // Setup
+    const longBody = "x".repeat(
+      DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES + 1,
+    );
+    const request = new Request("http://localhost", {
+      method: "POST",
+      headers: { "Content-Type": "text/plain" },
+      body: longBody,
+    });
+
+    // Act
+    const snap = await collectHttpTriggerRequestSnapshot(request);
+
+    // Assert
+    expect(snap.body.truncated).toBe(true);
+    expect(snap.body.originalByteLength).toBe(
+      DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES + 1,
+    );
+  });
+});
+
+describe("toHttpTriggerExecutionMetadata", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("serializes snapshot fields for Prisma Json", () => {
+    // Setup
+    const snapshot = {
+      requestSnapshotVersion: 1 as const,
+      request: {
+        method: "GET",
+        url: "http://x",
+        pathname: "/",
+        searchParams: {},
+      },
+      headers: {},
+      body: { contentType: null },
+      client: {
+        userAgent: null,
+        forwardedFor: null,
+        realIp: null,
+        cfConnectingIp: null,
+      },
+    };
+
+    // Act
+    const meta = toHttpTriggerExecutionMetadata(snapshot);
+
+    // Assert
+    expect(meta.requestSnapshotVersion).toBe(1);
+    expect(meta.request).toEqual(snapshot.request);
+    expect(meta.headers).toEqual({});
+    expect(meta.body).toEqual({ contentType: null });
+    expect(meta.client).toEqual(snapshot.client);
+  });
+});

--- a/apps/hermes/dashboard/lib/collect-http-trigger-request-snapshot.ts
+++ b/apps/hermes/dashboard/lib/collect-http-trigger-request-snapshot.ts
@@ -1,0 +1,283 @@
+import { maskSecretsInJson } from "@/lib/json-secret-mask";
+
+/** Default cap for stored request body UTF-8 bytes (256 KiB). */
+export const DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES = 256 * 1024;
+
+/** Placeholder stored instead of raw credential header values. */
+export const HTTP_TRIGGER_REQUEST_HEADER_REDACTED = "[REDACTED]";
+
+const SENSITIVE_HEADER_NAMES = new Set(
+  [
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+    "x-api-key",
+    "x-auth-token",
+  ].map((h) => h.toLowerCase()),
+);
+
+/**
+ * Header names whose values must not be persisted on HTTP trigger executions.
+ *
+ * @param name - Raw header name from the incoming request.
+ */
+export const isSensitiveHttpHeaderName = (name: string): boolean =>
+  SENSITIVE_HEADER_NAMES.has(name.trim().toLowerCase());
+
+/**
+ * Builds a plain record of URL query parameters. Duplicate keys become string arrays;
+ * single values stay strings (JSDoc: last duplicate alone would lose data, so we use arrays when repeated).
+ *
+ * @param searchParams - `URLSearchParams` from the request URL.
+ */
+export const searchParamsToRecord = (
+  searchParams: URLSearchParams,
+): Record<string, string | string[]> => {
+  const out: Record<string, string | string[]> = {};
+  for (const key of searchParams.keys()) {
+    const all = searchParams.getAll(key);
+    out[key] = all.length <= 1 ? (all[0] ?? "") : all;
+  }
+  return out;
+};
+
+/**
+ * Returns true when the Content-Type indicates we should not load the full body into memory as text
+ * (binary or multipart payloads).
+ *
+ * @param contentType - Raw `Content-Type` header value, may include charset etc.
+ */
+export const shouldOmitBodyForContentType = (
+  contentType: string | null,
+): boolean => {
+  if (contentType == null || contentType === "") return false;
+  const primary = contentType.split(";")[0]?.trim().toLowerCase() ?? "";
+  if (primary.startsWith("multipart/")) return true;
+  if (primary === "application/octet-stream") return true;
+  if (primary.startsWith("image/")) return true;
+  if (primary.startsWith("video/")) return true;
+  if (primary.startsWith("audio/")) return true;
+  return false;
+};
+
+type TruncateUtf8Result = {
+  text: string;
+  truncated: boolean;
+  originalByteLength: number;
+};
+
+/**
+ * Truncates a string to a maximum UTF-8 byte length without splitting a codepoint.
+ *
+ * @param input - Full body text.
+ * @param maxBytes - Maximum UTF-8 bytes to keep.
+ */
+export const truncateUtf8String = (
+  input: string,
+  maxBytes: number,
+): TruncateUtf8Result => {
+  const encoder = new TextEncoder();
+  const decoder = new TextDecoder();
+  const full = encoder.encode(input);
+  const originalByteLength = full.length;
+  if (full.length <= maxBytes) {
+    return { text: input, truncated: false, originalByteLength };
+  }
+  let end = Math.min(maxBytes, full.length);
+  const fatalDecoder = new TextDecoder("utf-8", { fatal: true });
+  while (end > 0) {
+    try {
+      fatalDecoder.decode(full.slice(0, end));
+      break;
+    } catch {
+      end -= 1;
+    }
+  }
+  return {
+    text: decoder.decode(full.slice(0, end)),
+    truncated: true,
+    originalByteLength,
+  };
+};
+
+/**
+ * Collects all header names and values, redacting known credential headers.
+ *
+ * @param headers - The incoming `Request` headers.
+ */
+export const collectRedactedHeaderRecord = (
+  headers: Headers,
+): Record<string, string> => {
+  const out: Record<string, string> = {};
+  headers.forEach((value, name) => {
+    const key = name.toLowerCase();
+    out[key] = isSensitiveHttpHeaderName(name)
+      ? HTTP_TRIGGER_REQUEST_HEADER_REDACTED
+      : value;
+  });
+  return out;
+};
+
+/** Version 1 snapshot stored on `HttpTriggerExecution.metadata`. */
+export type HttpTriggerRequestSnapshotV1 = {
+  requestSnapshotVersion: 1;
+  request: {
+    method: string;
+    url: string;
+    pathname: string;
+    searchParams: Record<string, string | string[]>;
+  };
+  headers: Record<string, string>;
+  body: {
+    contentType: string | null;
+    originalByteLength?: number;
+    truncated?: boolean;
+    text?: string;
+    json?: unknown;
+    parseError?: string;
+    omittedReason?: string;
+  };
+  client: {
+    userAgent: string | null;
+    forwardedFor: string | null;
+    realIp: string | null;
+    cfConnectingIp: string | null;
+  };
+};
+
+export type CollectHttpTriggerRequestSnapshotOptions = {
+  /** Maximum UTF-8 bytes to store from the body; defaults to {@link DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES}. */
+  maxBodyBytes?: number;
+};
+
+/**
+ * Reads the request body and builds the `body` field of the snapshot (omit, text, or JSON).
+ *
+ * @param request - Incoming HTTP request.
+ * @param contentType - Normalized primary content type or null.
+ * @param maxBodyBytes - Max UTF-8 bytes to persist.
+ */
+export const buildRequestBodySnapshot = async (
+  request: Request,
+  contentType: string | null,
+  maxBodyBytes: number,
+): Promise<HttpTriggerRequestSnapshotV1["body"]> => {
+  if (shouldOmitBodyForContentType(contentType)) {
+    return {
+      contentType,
+      omittedReason: "non_text_or_large_binary_content_type",
+    };
+  }
+
+  let rawText: string;
+  try {
+    rawText = await request.text();
+  } catch {
+    return {
+      contentType,
+      omittedReason: "body_read_failed",
+    };
+  }
+
+  const { text, truncated, originalByteLength } = truncateUtf8String(
+    rawText,
+    maxBodyBytes,
+  );
+
+  const primaryType = contentType?.split(";")[0]?.trim().toLowerCase() ?? "";
+
+  if (primaryType === "application/json" || primaryType.endsWith("+json")) {
+    if (text === "") {
+      return {
+        contentType,
+        originalByteLength: 0,
+        truncated: false,
+        text: "",
+      };
+    }
+    try {
+      const parsed = JSON.parse(text) as unknown;
+      return {
+        contentType,
+        originalByteLength,
+        truncated,
+        text: truncated ? text : undefined,
+        json: maskSecretsInJson(parsed),
+      };
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "invalid_json";
+      return {
+        contentType,
+        originalByteLength,
+        truncated,
+        text,
+        parseError: message,
+      };
+    }
+  }
+
+  return {
+    contentType,
+    originalByteLength,
+    truncated,
+    text: text === "" ? "" : text,
+  };
+};
+
+/**
+ * Captures URL, headers (redacted), optional body, and common client headers for persistence on an HTTP trigger execution.
+ *
+ * @param request - The invoke `Request` after auth has succeeded (body is only read once).
+ * @param options - Optional `maxBodyBytes` override for tests or policy.
+ */
+export const collectHttpTriggerRequestSnapshot = async (
+  request: Request,
+  options: CollectHttpTriggerRequestSnapshotOptions = {},
+): Promise<HttpTriggerRequestSnapshotV1> => {
+  const maxBodyBytes =
+    options.maxBodyBytes ?? DEFAULT_HTTP_TRIGGER_REQUEST_BODY_MAX_BYTES;
+  const url = new URL(request.url);
+  const contentType = request.headers.get("content-type");
+
+  const headers = collectRedactedHeaderRecord(request.headers);
+
+  const body = await buildRequestBodySnapshot(
+    request,
+    contentType,
+    maxBodyBytes,
+  );
+
+  return {
+    requestSnapshotVersion: 1,
+    request: {
+      method: request.method,
+      url: request.url,
+      pathname: url.pathname,
+      searchParams: searchParamsToRecord(url.searchParams),
+    },
+    headers,
+    body,
+    client: {
+      userAgent: request.headers.get("user-agent"),
+      forwardedFor: request.headers.get("x-forwarded-for"),
+      realIp: request.headers.get("x-real-ip"),
+      cfConnectingIp: request.headers.get("cf-connecting-ip"),
+    },
+  };
+};
+
+/**
+ * Wraps a version-1 request snapshot as `HttpTriggerExecution.metadata` JSON.
+ *
+ * @param snapshot - Snapshot from {@link collectHttpTriggerRequestSnapshot}.
+ */
+export const toHttpTriggerExecutionMetadata = (
+  snapshot: HttpTriggerRequestSnapshotV1,
+): Record<string, unknown> => ({
+  requestSnapshotVersion: snapshot.requestSnapshotVersion,
+  request: snapshot.request,
+  headers: snapshot.headers,
+  body: snapshot.body,
+  client: snapshot.client,
+});

--- a/apps/hermes/dashboard/lib/http-triggers.ts
+++ b/apps/hermes/dashboard/lib/http-triggers.ts
@@ -164,6 +164,7 @@ export type HttpTriggerExecutionDetail = {
       succeededInvocationCount: true;
       failedInvocationCount: true;
       errors: true;
+      metadata: true;
       createdAt: true;
     };
   }>;
@@ -263,6 +264,7 @@ export const getHttpTriggerExecutionDetail = async (
       succeededInvocationCount: row.succeededInvocationCount,
       failedInvocationCount: row.failedInvocationCount,
       errors: row.errors,
+      metadata: row.metadata,
       createdAt: row.createdAt,
     },
     pipeline,

--- a/apps/hermes/dashboard/lib/json-secret-mask.test.ts
+++ b/apps/hermes/dashboard/lib/json-secret-mask.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  isSensitiveJsonKey,
+  maskSecretsInJson,
+  SECRET_MASK,
+} from "./json-secret-mask";
+
+describe("json-secret-mask", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("isSensitiveJsonKey matches credential-like names", () => {
+    // Assert
+    expect(isSensitiveJsonKey("password")).toBe(true);
+    expect(isSensitiveJsonKey("apiKey")).toBe(true);
+    expect(isSensitiveJsonKey("session")).toBe(true);
+    expect(isSensitiveJsonKey("bearer")).toBe(true);
+    expect(isSensitiveJsonKey("title")).toBe(false);
+  });
+
+  it("maskSecretsInJson masks sensitive leaves and handles bigint and Date", () => {
+    // Setup
+    const input = {
+      ok: 1n,
+      when: new Date("2020-01-01T00:00:00.000Z"),
+      nested: { token: "hide-me" },
+    };
+
+    // Act
+    const out = maskSecretsInJson(input) as Record<string, unknown>;
+
+    // Assert
+    expect(out.ok).toBe("1");
+    expect(out.when).toBe("2020-01-01T00:00:00.000Z");
+    expect((out.nested as Record<string, unknown>).token).toBe(SECRET_MASK);
+  });
+
+  it("maskSecretsInJson returns SECRET_MASK for unsupported types", () => {
+    // Act
+    const out = maskSecretsInJson(() => {});
+
+    // Assert
+    expect(out).toBe(SECRET_MASK);
+  });
+
+  it("maskSecretsInJson passes null through under sensitive key", () => {
+    // Act
+    const out = maskSecretsInJson({ token: null }) as Record<string, unknown>;
+
+    // Assert
+    expect(out.token).toBeNull();
+  });
+});

--- a/apps/hermes/dashboard/lib/json-secret-mask.ts
+++ b/apps/hermes/dashboard/lib/json-secret-mask.ts
@@ -1,0 +1,85 @@
+/**
+ * JSON key masking for credentials — no database or env imports (safe for lightweight callers).
+ */
+
+/** Mask shown in UI and stored snapshots for secret values (never expose real value). */
+export const SECRET_MASK = "••••••••";
+
+/**
+ * Returns true when a JSON object key likely holds a credential or secret.
+ * Matching is conservative: values under these keys are masked in the dashboard.
+ *
+ * @param key - Object property name (leaf segment for nested paths).
+ */
+export const isSensitiveJsonKey = (key: string): boolean => {
+  const leaf = key.includes(".") ? (key.split(".").pop() ?? key) : key;
+  const normalized = leaf.replace(/[-_]/g, "").toLowerCase();
+
+  if (
+    normalized === "authorization" ||
+    normalized === "cookie" ||
+    normalized === "session" ||
+    normalized === "bearer"
+  ) {
+    return true;
+  }
+  if (normalized.includes("password") || normalized.includes("secret")) {
+    return true;
+  }
+  if (normalized.includes("token")) {
+    return true;
+  }
+  if (normalized.includes("apikey")) {
+    return true;
+  }
+  if (normalized.includes("privatekey")) {
+    return true;
+  }
+  return false;
+};
+
+/**
+ * Deep-clones JSON-like data and replaces values under sensitive keys with a fixed mask.
+ *
+ * @param value - Any JSON-serializable value.
+ * @param keyHint - Parent key when recursing into object properties (used for masking).
+ */
+export const maskSecretsInJson = (
+  value: unknown,
+  keyHint?: string,
+): unknown => {
+  if (keyHint !== undefined && isSensitiveJsonKey(keyHint)) {
+    if (value === null || value === undefined) {
+      return value;
+    }
+    return SECRET_MASK;
+  }
+
+  if (value === null || value === undefined) {
+    return value;
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => maskSecretsInJson(item));
+  }
+  if (typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = maskSecretsInJson(v, k);
+    }
+    return out;
+  }
+  return SECRET_MASK;
+};

--- a/apps/hermes/dashboard/lib/mask-json-secrets.ts
+++ b/apps/hermes/dashboard/lib/mask-json-secrets.ts
@@ -1,85 +1,12 @@
 import type { ScheduleExecutionDetail } from "@/lib/schedules";
 
-import { SECRET_MASK } from "@/lib/variables";
+export {
+  isSensitiveJsonKey,
+  maskSecretsInJson,
+  SECRET_MASK,
+} from "./json-secret-mask";
 
-/**
- * Returns true when a JSON object key likely holds a credential or secret.
- * Matching is conservative: values under these keys are masked in the dashboard.
- *
- * @param key - Object property name (leaf segment for nested paths).
- */
-export const isSensitiveJsonKey = (key: string): boolean => {
-  const leaf = key.includes(".") ? (key.split(".").pop() ?? key) : key;
-  const normalized = leaf.replace(/[-_]/g, "").toLowerCase();
-
-  if (
-    normalized === "authorization" ||
-    normalized === "cookie" ||
-    normalized === "session" ||
-    normalized === "bearer"
-  ) {
-    return true;
-  }
-  if (normalized.includes("password") || normalized.includes("secret")) {
-    return true;
-  }
-  if (normalized.includes("token")) {
-    return true;
-  }
-  if (normalized.includes("apikey")) {
-    return true;
-  }
-  if (normalized.includes("privatekey")) {
-    return true;
-  }
-  return false;
-};
-
-/**
- * Deep-clones JSON-like data and replaces values under sensitive keys with a fixed mask.
- *
- * @param value - Any JSON-serializable value.
- * @param keyHint - Parent key when recursing into object properties (used for masking).
- */
-export const maskSecretsInJson = (
-  value: unknown,
-  keyHint?: string,
-): unknown => {
-  if (keyHint !== undefined && isSensitiveJsonKey(keyHint)) {
-    if (value === null || value === undefined) {
-      return value;
-    }
-    return SECRET_MASK;
-  }
-
-  if (value === null || value === undefined) {
-    return value;
-  }
-  if (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean"
-  ) {
-    return value;
-  }
-  if (typeof value === "bigint") {
-    return value.toString();
-  }
-  if (value instanceof Date) {
-    return value.toISOString();
-  }
-  if (Array.isArray(value)) {
-    return value.map((item) => maskSecretsInJson(item));
-  }
-  if (typeof value === "object") {
-    const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      out[k] = maskSecretsInJson(v, k);
-    }
-    return out;
-  }
-  return SECRET_MASK;
-};
+import { maskSecretsInJson } from "./json-secret-mask";
 
 /**
  * Returns a copy of schedule execution detail with invocation `params` and `invocationConfig`

--- a/apps/hermes/dashboard/lib/variables.ts
+++ b/apps/hermes/dashboard/lib/variables.ts
@@ -5,10 +5,11 @@ import {
   isEncryptedSecretVariablePayload,
 } from "@hermes/domain-integration-crypto";
 
+import { SECRET_MASK } from "./json-secret-mask";
+
 type Db = typeof prisma;
 
-/** Mask shown in UI for secret variable values (never expose real value). */
-export const SECRET_MASK = "••••••••";
+export { SECRET_MASK };
 
 export type VariableRow = {
   id: string;

--- a/dev-docs/docs/hermes/orchestration/http-triggers.mdx
+++ b/dev-docs/docs/hermes/orchestration/http-triggers.mdx
@@ -22,8 +22,9 @@ Multiple HTTP triggers can point to the same pipeline.
    - trigger exists and is enabled
    - request method matches trigger config
    - `Authorization: Bearer <token>` matches configured token hash
-3. Hermes creates an execution row and returns **`202 Accepted`** with JSON `{ status: "accepted", executionId }` (wrong method → **405**, disabled trigger → **409**, bad/missing token → **401**, unknown id → **404**).
-4. Worker picks up the `execute_http_trigger` DataQueue job and runs the pipeline asynchronously (same planning and variable substitution as schedules).
+3. Hermes captures a **request snapshot** (method, full URL, path, query string, all headers with known credential headers redacted, body when safe to read, and common client/proxy headers such as `User-Agent` and `X-Forwarded-For`) and stores it on the new execution row’s `metadata` JSON field (`requestSnapshotVersion: 1`). JSON bodies are parsed and sensitive keys are masked before storage. Bodies are capped at **256 KiB** UTF-8 (truncation is recorded in metadata). Bodies with `multipart/*`, `application/octet-stream`, or major `image`/`video`/`audio` types are not inlined; metadata records the content type and an omit reason instead. TLS version, HTTP protocol version, and the true TCP client address are **not** available from the standard `Request` object in the App Router—only what the request URL and headers provide.
+4. Hermes returns **`202 Accepted`** with JSON `{ status: "accepted", executionId }` (wrong method → **405**, disabled trigger → **409**, bad/missing token → **401**, unknown id → **404**).
+5. Worker picks up the `execute_http_trigger` DataQueue job and runs the pipeline asynchronously (same planning and variable substitution as schedules).
 
 ## Execution history
 
@@ -31,6 +32,6 @@ The dashboard includes:
 
 - `HTTP Triggers` list page for CRUD
 - trigger detail page with executions table
-- execution detail page with step rollups and invocation-level status/errors
+- execution detail page with step rollups, invocation-level status/errors, and a **Request snapshot** panel (JSON, with an extra masking pass for display)
 
 This mirrors the schedules execution experience, but is on-demand instead of periodic.


### PR DESCRIPTION
## Summary

Persists a bounded, redacted snapshot of each incoming HTTP trigger request (method, URL, query, headers, and JSON body when safe) on the execution record so operators can debug invocations without storing credentials. Refactors JSON secret masking into a shared helper used by both variable previews and trigger snapshots.

## Important changes

- Invoke route collects a request snapshot and stores it on HTTP trigger execution metadata after auth succeeds.
- Sensitive header names (e.g. `Authorization`, cookies, common API key headers) are replaced with a fixed placeholder; JSON bodies are masked using Hermes secret variable paths.
- Binary and multipart content types skip full body capture; oversized bodies are truncated to a configurable byte cap.
- Execution detail page surfaces the stored request snapshot for review.

## Other changes

- `mask-json-secrets` delegates to `json-secret-mask` to avoid duplicated masking logic.
- HTTP triggers dev-docs updated to describe snapshot behavior and limits.

## Key files to review

- `apps/hermes/dashboard/lib/collect-http-trigger-request-snapshot.ts` — snapshot shape, redaction rules, body limits, and metadata wiring.
- `apps/hermes/dashboard/app/api/http-triggers/[triggerId]/invoke/route.ts` — where the snapshot is built and attached to the execution.
- `apps/hermes/dashboard/lib/json-secret-mask.ts` — shared JSON traversal and masking used by snapshots and variables.
- `apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx` — UI for viewing the snapshot.

## How to test

1. From the repo root, run `pnpm code-quality` and confirm it exits 0.
2. Enable an HTTP trigger, send a `POST` with JSON body and `Authorization: Bearer <token>`; open the execution in the dashboard.
3. Confirm the snapshot shows method, URL, query, non-sensitive headers, and masked JSON (no raw bearer token or secret values).
4. Send `multipart/form-data` or a large body and confirm behavior matches docs (no full binary body / truncation as implemented).
