### PR TITLE
Format date-time cells in domain table

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/domain-table-page.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-table-page.test.ts
@@ -1,0 +1,56 @@
+/** @vitest-environment node */
+import { format } from "date-fns";
+import { describe, expect, it } from "vitest";
+import {
+  formatDomainTableCellValue,
+  type DomainTableColumnForDisplay,
+} from "./domain-table-page";
+
+const dateTimeColumn: DomainTableColumnForDisplay = {
+  key: "createdAt",
+  label: "Created",
+  type: "date-time",
+};
+
+const textColumn: DomainTableColumnForDisplay = {
+  key: "name",
+  label: "Name",
+  type: "text",
+};
+
+describe("formatDomainTableCellValue", () => {
+  it("formats ISO values for date-time columns", () => {
+    // Setup
+    const iso = "2025-01-01T12:00:00.000Z";
+    const expected = format(new Date(iso), "LLL d, yyyy");
+
+    // Act
+    const result = formatDomainTableCellValue(dateTimeColumn, iso);
+
+    // Assert
+    expect(result).toBe(expected);
+    expect(result).not.toBe(iso);
+  });
+
+  it("keeps non-date columns as plain string values", () => {
+    // Setup
+    const value = "alpha";
+
+    // Act
+    const result = formatDomainTableCellValue(textColumn, value);
+
+    // Assert
+    expect(result).toBe("alpha");
+  });
+
+  it("falls back safely for unparseable date-time values", () => {
+    // Setup
+    const badDate = "not-a-date";
+
+    // Act
+    const result = formatDomainTableCellValue(dateTimeColumn, badDate);
+
+    // Assert
+    expect(result).toBe("not-a-date");
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/domain-table-page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/domain-table-page.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns";
 import { revalidatePath } from "next/cache";
 import Link from "next/link";
 import { redirect } from "next/navigation";
@@ -50,6 +51,47 @@ type DomainTablePageProps = {
         sort?: string;
         dir?: string;
       };
+};
+
+/** Column shape from table-v1 meta (`text` or `date-time`). */
+export type DomainTableColumnForDisplay = {
+  key: string;
+  label: string;
+  type: "text" | "date-time";
+};
+
+/**
+ * Formats a raw domain table cell value for display based on column type.
+ *
+ * `date-time` columns render like other dashboard lists (e.g. `LLL d, yyyy` via date-fns).
+ * Unparseable dates fall back to the original string representation.
+ *
+ * @param column - Column descriptor from domain table meta.
+ * @param rawValue - Cell value from the list row.
+ * @returns String safe to render in a table cell.
+ */
+export const formatDomainTableCellValue = (
+  column: DomainTableColumnForDisplay,
+  rawValue: unknown,
+): string => {
+  if (column.type !== "date-time") {
+    return String(rawValue ?? "");
+  }
+  if (rawValue == null || rawValue === "") {
+    return "";
+  }
+  if (rawValue instanceof Date) {
+    return Number.isNaN(rawValue.getTime())
+      ? ""
+      : format(rawValue, "LLL d, yyyy");
+  }
+  if (typeof rawValue === "string" || typeof rawValue === "number") {
+    const parsed = new Date(rawValue);
+    return Number.isNaN(parsed.getTime())
+      ? String(rawValue)
+      : format(parsed, "LLL d, yyyy");
+  }
+  return String(rawValue);
 };
 
 /**
@@ -246,7 +288,7 @@ export const DomainTablePage = async ({
                   <TableRow key={rowId}>
                     {meta.columns.map((column) => (
                       <TableCell key={`${rowId}-${column.key}`}>
-                        {String(row[column.key] ?? "")}
+                        {formatDomainTableCellValue(column, row[column.key])}
                       </TableCell>
                     ))}
                     {hasRowActions ? (


### PR DESCRIPTION
## Summary

Format `date-time` domain table cells into a readable date string and add targeted unit tests for the formatter behavior. This keeps dashboard table output consistent with existing list date formatting.

## Important changes

- Add `formatDomainTableCellValue` to render `date-time` columns as `LLL d, yyyy` and keep safe fallbacks for empty and unparseable values.
- Update `DomainTablePage` cell rendering to use the shared formatter for each row/column value.

## Other changes

- Add `domain-table-page.test.ts` coverage for ISO date formatting, non-date passthrough, and invalid date fallback.
- Export `DomainTableColumnForDisplay` to type formatter inputs consistently.

## Key files to review

- `apps/hermes/dashboard/app/dashboard/domain-table-page.tsx` - date display formatter logic and table cell integration.
- `apps/hermes/dashboard/app/dashboard/domain-table-page.test.ts` - formatter behavior and edge-case assertions.

## How to test

1. Run `pnpm code-quality` from the repo root and confirm it exits with code 0.
2. Open the Hermes dashboard domain table and verify `date-time` columns render as human-readable dates.
3. Confirm non-date columns still render unchanged and invalid date values still display their original text.
