### PR TITLE
Fix Hermes dashboard login redirect on Fly

### DIFF
--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -6,7 +6,6 @@ LABEL fly_launch_runtime="Next.js"
 WORKDIR /app
 
 ENV NODE_ENV="production"
-ENV HOSTNAME="0.0.0.0"
 ENV CI=true
 
 RUN npm install -g pnpm
@@ -41,7 +40,6 @@ FROM node:${NODE_VERSION}-slim AS runner
 WORKDIR /app
 
 ENV NODE_ENV="production"
-ENV HOSTNAME="0.0.0.0"
 ENV PORT=3001
 
 RUN addgroup --system --gid 1001 nodejs && \

--- a/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.test.ts
+++ b/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.test.ts
@@ -13,4 +13,18 @@ describe("clear-hermes-dashboard-session GET", () => {
     expect(raw).toContain("auth-user=");
     expect(raw).toContain("Max-Age=0");
   });
+
+  it("uses x-forwarded-host when request URL is the internal bind address", () => {
+    const res = GET(
+      new Request("http://0.0.0.0:3001/clear-hermes-dashboard-session", {
+        headers: {
+          "x-forwarded-host": "mediapulse-hermes.fly.dev",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+    expect(res.headers.get("location")).toBe(
+      "https://mediapulse-hermes.fly.dev/login",
+    );
+  });
 });

--- a/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.ts
+++ b/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.ts
@@ -3,11 +3,31 @@ import { NextResponse } from "next/server";
 import { applyClearHermesDashboardAuthCookies } from "@/lib/auth-dashboard";
 
 /**
+ * Origin for absolute redirects when `request.url` reflects the container (e.g. `0.0.0.0:3001`)
+ * instead of the public host (Fly and other proxies set `x-forwarded-*`).
+ *
+ * @param request - Incoming request.
+ * @returns Base URL origin (`https://…`) suitable for `new URL(path, origin)`.
+ */
+const resolvePublicOrigin = (request: Request): string => {
+  const forwardedHost = request.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  if (!forwardedHost) {
+    return new URL(request.url).origin;
+  }
+  const forwardedProto =
+    request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? "https";
+  return `${forwardedProto}://${forwardedHost}`;
+};
+
+/**
  * Clears dashboard session cookies and redirects to the login page.
  * Invoked from the dashboard layout when the session is invalid or the user is not an active admin.
  */
 export const GET = (request: Request) => {
-  const loginUrl = new URL("/login", request.url);
+  const loginUrl = new URL("/login", resolvePublicOrigin(request));
   const response = NextResponse.redirect(loginUrl);
   applyClearHermesDashboardAuthCookies(response);
   return response;


### PR DESCRIPTION
## Summary

Fixes incorrect `Location` headers that sent users to `https://0.0.0.0:3001/login` when opening the Hermes dashboard on Fly. The clear-session route now builds the login URL from proxy `x-forwarded-*` headers when present, and the Dockerfile no longer sets `HOSTNAME=0.0.0.0`, which can confuse URL generation.

## Important changes

- **Dockerfile** — Removed `ENV HOSTNAME="0.0.0.0"` from build and run stages; standalone still listens on all interfaces with `PORT=3001` only.
- **Clear-session redirect** — `GET /clear-hermes-dashboard-session` resolves the public origin via `x-forwarded-host` and `x-forwarded-proto` before `new URL("/login", …)`.

## Other changes

- Added a Vitest case covering internal `request.url` with Fly-style forwarded headers.

## Key files to review

- `apps/hermes/dashboard/Dockerfile` — confirm dropping `HOSTNAME` is acceptable for your Fly/internal networking.
- `apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.ts` — forwarded-header parsing and HTTPS default when proto is omitted.
- `apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.test.ts` — regression for `0.0.0.0:3001` + forwarded host.

## How to test

1. From repo root: `pnpm code-quality` (passes on this branch).
2. Deploy the dashboard image to Fly (or run behind a proxy that sets `x-forwarded-host` / `x-forwarded-proto`), visit `/dashboard` unauthenticated, and confirm redirect goes to `https://<your-app>.fly.dev/login` (not `0.0.0.0:3001`).
