### PR TITLE
Redirect Hermes dashboard root via Next.js proxy

### DIFF
--- a/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.ts
+++ b/apps/hermes/dashboard/app/clear-hermes-dashboard-session/route.ts
@@ -1,26 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { applyClearHermesDashboardAuthCookies } from "@/lib/auth-dashboard";
-
-/**
- * Origin for absolute redirects when `request.url` reflects the container (e.g. `0.0.0.0:3001`)
- * instead of the public host (Fly and other proxies set `x-forwarded-*`).
- *
- * @param request - Incoming request.
- * @returns Base URL origin (`https://…`) suitable for `new URL(path, origin)`.
- */
-const resolvePublicOrigin = (request: Request): string => {
-  const forwardedHost = request.headers
-    .get("x-forwarded-host")
-    ?.split(",")[0]
-    ?.trim();
-  if (!forwardedHost) {
-    return new URL(request.url).origin;
-  }
-  const forwardedProto =
-    request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? "https";
-  return `${forwardedProto}://${forwardedHost}`;
-};
+import { resolvePublicOrigin } from "@/lib/resolve-public-origin";
 
 /**
  * Clears dashboard session cookies and redirects to the login page.

--- a/apps/hermes/dashboard/app/page.test.tsx
+++ b/apps/hermes/dashboard/app/page.test.tsx
@@ -1,38 +1,64 @@
-import React from "react";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import Page from "./page";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-describe("Page (Root)", () => {
-  it("renders the Hermes heading", () => {
-    // Act
-    render(<Page />);
+const cookiesMock = vi.fn();
+const redirectMock = vi.fn();
 
-    // Assert
-    expect(
-      screen.getByRole("heading", { name: "Hermes", level: 1 }),
-    ).toBeInTheDocument();
+vi.mock("next/headers", () => ({
+  cookies: () => cookiesMock(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (...args: [string]) => redirectMock(...args),
+}));
+
+describe("Page (root)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cookiesMock.mockReset();
+    redirectMock.mockReset();
   });
 
-  it("renders centered container", () => {
-    // Act
-    const { container } = render(<Page />);
+  it("redirects to /login when auth-token cookie is missing", async () => {
+    cookiesMock.mockResolvedValue({
+      get: () => undefined,
+    });
+    redirectMock.mockImplementation(() => {
+      throw new Error("REDIRECT");
+    });
 
-    // Assert
-    const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper).toHaveClass("flex");
-    expect(wrapper).toHaveClass("items-center");
-    expect(wrapper).toHaveClass("justify-center");
-    expect(wrapper).toHaveClass("min-h-svh");
+    const Page = (await import("./page")).default;
+
+    await expect(Page()).rejects.toThrow("REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/login");
   });
 
-  it("renders heading with correct styling", () => {
-    // Act
-    render(<Page />);
+  it("redirects to /dashboard when auth-token cookie is non-empty", async () => {
+    cookiesMock.mockResolvedValue({
+      get: (name: string) =>
+        name === "auth-token" ? { value: "session-token" } : undefined,
+    });
+    redirectMock.mockImplementation(() => {
+      throw new Error("REDIRECT");
+    });
 
-    // Assert
-    const heading = screen.getByRole("heading", { name: "Hermes" });
-    expect(heading).toHaveClass("text-2xl");
-    expect(heading).toHaveClass("font-bold");
+    const Page = (await import("./page")).default;
+
+    await expect(Page()).rejects.toThrow("REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/dashboard");
+  });
+
+  it("redirects to /login when auth-token is whitespace only", async () => {
+    cookiesMock.mockResolvedValue({
+      get: (name: string) =>
+        name === "auth-token" ? { value: "   " } : undefined,
+    });
+    redirectMock.mockImplementation(() => {
+      throw new Error("REDIRECT");
+    });
+
+    const Page = (await import("./page")).default;
+
+    await expect(Page()).rejects.toThrow("REDIRECT");
+    expect(redirectMock).toHaveBeenCalledWith("/login");
   });
 });

--- a/apps/hermes/dashboard/app/page.tsx
+++ b/apps/hermes/dashboard/app/page.tsx
@@ -1,9 +1,12 @@
-export default function Page() {
-  return (
-    <div className="flex items-center justify-center min-h-svh">
-      <div className="flex flex-col items-center justify-center gap-4">
-        <h1 className="text-2xl font-bold">Hermes</h1>
-      </div>
-    </div>
-  );
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+/**
+ * Root URL has no Hermes landing page. Unauthenticated users go to login;
+ * users with a session cookie go to the dashboard (layout still enforces admin).
+ */
+export default async function Page() {
+  const jar = await cookies();
+  const token = jar.get("auth-token")?.value?.trim();
+  redirect(token ? "/dashboard" : "/login");
 }

--- a/apps/hermes/dashboard/lib/resolve-public-origin.test.ts
+++ b/apps/hermes/dashboard/lib/resolve-public-origin.test.ts
@@ -1,0 +1,52 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { resolvePublicOrigin } from "./resolve-public-origin";
+
+describe("resolvePublicOrigin", () => {
+  it("uses request.url origin when forwarded host is absent", () => {
+    expect(
+      resolvePublicOrigin(
+        new Request("https://app.test/clear-hermes-dashboard-session"),
+      ),
+    ).toBe("https://app.test");
+  });
+
+  it("prefers x-forwarded-host and x-forwarded-proto when set", () => {
+    expect(
+      resolvePublicOrigin(
+        new Request("http://0.0.0.0:3001/path", {
+          headers: {
+            "x-forwarded-host": "mediapulse-hermes.fly.dev",
+            "x-forwarded-proto": "https",
+          },
+        }),
+      ),
+    ).toBe("https://mediapulse-hermes.fly.dev");
+  });
+
+  it("defaults proto to https when forwarded host is set but proto is missing", () => {
+    expect(
+      resolvePublicOrigin(
+        new Request("http://127.0.0.1:3001/", {
+          headers: {
+            "x-forwarded-host": "example.com",
+          },
+        }),
+      ),
+    ).toBe("https://example.com");
+  });
+
+  it("uses first value when forwarded headers are comma-separated", () => {
+    expect(
+      resolvePublicOrigin(
+        new Request("http://localhost/", {
+          headers: {
+            "x-forwarded-host": "a.example.com, b.example.com",
+            "x-forwarded-proto": "https, http",
+          },
+        }),
+      ),
+    ).toBe("https://a.example.com");
+  });
+});

--- a/apps/hermes/dashboard/lib/resolve-public-origin.ts
+++ b/apps/hermes/dashboard/lib/resolve-public-origin.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolves the public origin for redirects when `request.url` reflects the
+ * container bind address (e.g. `0.0.0.0:3001`) instead of the browser host.
+ * Reverse proxies (Fly, etc.) send `x-forwarded-host` and `x-forwarded-proto`.
+ *
+ * @param request - Incoming request.
+ * @returns Base URL origin (`https://…`) suitable for `new URL(path, origin)`.
+ */
+export const resolvePublicOrigin = (request: Request): string => {
+  const forwardedHost = request.headers
+    .get("x-forwarded-host")
+    ?.split(",")[0]
+    ?.trim();
+  if (!forwardedHost) {
+    return new URL(request.url).origin;
+  }
+  const forwardedProto =
+    request.headers.get("x-forwarded-proto")?.split(",")[0]?.trim() ?? "https";
+  return `${forwardedProto}://${forwardedHost}`;
+};

--- a/apps/hermes/dashboard/proxy.test.ts
+++ b/apps/hermes/dashboard/proxy.test.ts
@@ -1,0 +1,60 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { config, proxy } from "./proxy";
+
+describe("proxy", () => {
+  it("exports a root-only matcher", () => {
+    expect(config.matcher).toBe("/");
+  });
+
+  it("redirects to /login when auth-token cookie is missing", () => {
+    const res = proxy(new Request("https://app.test/"));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://app.test/login");
+  });
+
+  it("redirects to /dashboard when auth-token cookie is non-empty", () => {
+    const res = proxy(
+      new Request("https://app.test/", {
+        headers: {
+          cookie: "auth-token=abc; other=1",
+        },
+      }),
+    );
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toBe("https://app.test/dashboard");
+  });
+
+  it("treats whitespace-only auth-token as logged out", () => {
+    const res = proxy(
+      new Request("https://app.test/", {
+        headers: {
+          cookie: "auth-token=   ",
+        },
+      }),
+    );
+    expect(res.headers.get("location")).toBe("https://app.test/login");
+  });
+
+  it("uses x-forwarded-host for redirect origin on internal request URL", () => {
+    const res = proxy(
+      new Request("http://0.0.0.0:3001/", {
+        headers: {
+          cookie: "auth-token=x",
+          "x-forwarded-host": "mediapulse-hermes.fly.dev",
+          "x-forwarded-proto": "https",
+        },
+      }),
+    );
+    expect(res.headers.get("location")).toBe(
+      "https://mediapulse-hermes.fly.dev/dashboard",
+    );
+  });
+
+  it("returns next() when pathname is not root", () => {
+    const res = proxy(new Request("https://app.test/login"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("location")).toBeNull();
+  });
+});

--- a/apps/hermes/dashboard/proxy.ts
+++ b/apps/hermes/dashboard/proxy.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+import { getCookieFromHeader } from "@/lib/auth-dashboard";
+import { resolvePublicOrigin } from "@/lib/resolve-public-origin";
+
+/**
+ * Hermes dashboard proxy: `/` has no public landing page. Send visitors to
+ * `/dashboard` when the session cookie is present, otherwise `/login`.
+ * Uses forwarded headers so redirects stay on the public host behind Fly, etc.
+ *
+ * @param request - Incoming request (matched to `/` only via `config.matcher`).
+ * @returns Redirect or passthrough (defensive if pathname is not `/`).
+ */
+export function proxy(request: Request) {
+  const url = new URL(request.url);
+  if (url.pathname !== "/") {
+    return NextResponse.next();
+  }
+
+  const token = getCookieFromHeader(
+    request.headers.get("cookie"),
+    "auth-token",
+  );
+  const path =
+    token !== null && token.trim().length > 0 ? "/dashboard" : "/login";
+
+  return NextResponse.redirect(new URL(path, resolvePublicOrigin(request)));
+}
+
+export const config = {
+  matcher: "/",
+};


### PR DESCRIPTION
## Summary

Hermes dashboard no longer serves a public home page at `/`. Next.js 16 `proxy.ts` redirects `/` immediately to `/dashboard` when the `auth-token` cookie is present, otherwise to `/login`, using the same forwarded-host logic as other Fly-safe redirects. The root `page.tsx` mirrors that behavior as a server fallback.

## Important changes

- **Root routing** — New `proxy.ts` with `matcher: "/"` issues 307 redirects; cookie detection reuses `getCookieFromHeader` from auth helpers (aligned with `withAuthProtection`).
- **Shared origin helper** — `resolvePublicOrigin` lives in `lib/` and is used by the proxy and `clear-hermes-dashboard-session` so redirect `Location` stays on the public host behind proxies.

## Other changes

- Root `page.test.tsx` updated to assert redirect targets with mocked `cookies` / `redirect`.
- Vitest coverage for `proxy` and `resolve-public-origin`.

## Key files to review

- `apps/hermes/dashboard/proxy.ts` — matcher scope, redirect paths, cookie heuristic (token present vs empty/whitespace).
- `apps/hermes/dashboard/lib/resolve-public-origin.ts` — forwarded header parsing and HTTPS default.
- `apps/hermes/dashboard/app/page.tsx` — fallback redirect when the proxy does not run.

## How to test

1. `pnpm code-quality` (passes on this branch).
2. Local: visit `http://localhost:3001/` with no cookies → `/login`; after login (or with `auth-token` set) → `/dashboard`.
3. Deployed: confirm `/` on Fly resolves to the public app host, not an internal bind URL.
