### PR TITLE
Refresh Hermes login UI with branded split layout

### DIFF
--- a/apps/hermes/dashboard/app/login/login-form.test.tsx
+++ b/apps/hermes/dashboard/app/login/login-form.test.tsx
@@ -89,7 +89,22 @@ describe("LoginForm", () => {
     render(<LoginForm />);
 
     // Assert
-    expect(screen.getByRole("button", { name: "Sign in" })).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Login" })).toBeEnabled();
+  });
+
+  it("renders remember me checkbox", async () => {
+    // Setup
+    const mock = await getUseFormActionMock();
+    mock.mockReturnValue(createMockUseFormAction());
+
+    // Act
+    render(<LoginForm />);
+
+    // Assert
+    expect(screen.getByLabelText("Remember me")).toHaveAttribute(
+      "type",
+      "checkbox",
+    );
   });
 
   it("shows an error message when action state fails", async () => {

--- a/apps/hermes/dashboard/app/login/login-form.tsx
+++ b/apps/hermes/dashboard/app/login/login-form.tsx
@@ -4,13 +4,6 @@ import React, { useEffect, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { useFormAction } from "./action/.generated/use-form-action";
 import { Button } from "@workspace/ui/components/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@workspace/ui/components/card";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 
@@ -65,47 +58,62 @@ export const LoginForm = () => {
   const { FormWithAction, pending, errorMessage } = useLoginFormState();
 
   return (
-    <Card className="w-full max-w-sm">
-      <CardHeader>
-        <CardTitle>Admin login</CardTitle>
-        <CardDescription>
-          Sign in with your admin email and password.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <FormWithAction className="flex flex-col gap-4">
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="body.email">Email</Label>
-            <Input
-              id="body.email"
-              name="body.email"
-              type="email"
-              placeholder="admin@example.com"
-              required
-              autoComplete="email"
-            />
-          </div>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="body.password">Password</Label>
-            <Input
-              id="body.password"
-              name="body.password"
-              type="password"
-              placeholder="Your password"
-              required
-              autoComplete="current-password"
-            />
-          </div>
-          {errorMessage ? (
-            <p className="text-sm text-destructive" role="alert">
-              {errorMessage}
-            </p>
-          ) : null}
-          <Button type="submit" disabled={pending} className="w-full">
-            {pending ? "Signing in..." : "Sign in"}
-          </Button>
-        </FormWithAction>
-      </CardContent>
-    </Card>
+    <FormWithAction className="flex flex-col gap-6">
+      <div className="flex flex-col gap-2 text-center">
+        <h1 className="text-2xl font-bold">Welcome to Hermes</h1>
+        <p className="text-sm text-muted-foreground text-balance">
+          Enter your admin email and password to log in.
+        </p>
+      </div>
+      <div className="flex flex-col gap-4">
+        {errorMessage ? (
+          <p className="text-sm text-destructive" role="alert">
+            {errorMessage}
+          </p>
+        ) : null}
+        <div className="grid gap-2">
+          <Label htmlFor="body.email">Email</Label>
+          <Input
+            id="body.email"
+            name="body.email"
+            type="email"
+            placeholder="admin@example.com"
+            required
+            autoComplete="email"
+          />
+        </div>
+        <div className="grid gap-2">
+          <Label htmlFor="body.password">Password</Label>
+          <Input
+            id="body.password"
+            name="body.password"
+            type="password"
+            placeholder="********"
+            required
+            autoComplete="current-password"
+          />
+        </div>
+        <div className="flex items-center gap-2">
+          <input
+            id="rememberMe"
+            name="rememberMe"
+            type="checkbox"
+            value="on"
+            aria-describedby="rememberMe-description"
+            className="size-4 rounded border border-input"
+          />
+          <Label
+            id="rememberMe-description"
+            htmlFor="rememberMe"
+            className="cursor-pointer text-sm font-normal"
+          >
+            Remember me
+          </Label>
+        </div>
+        <Button type="submit" disabled={pending} className="w-full">
+          {pending ? "Signing in..." : "Login"}
+        </Button>
+      </div>
+    </FormWithAction>
   );
 };

--- a/apps/hermes/dashboard/app/login/page.test.tsx
+++ b/apps/hermes/dashboard/app/login/page.test.tsx
@@ -16,15 +16,25 @@ describe("LoginPage", () => {
     expect(screen.getByTestId("login-form")).toBeInTheDocument();
   });
 
-  it("centers the login form on the page", () => {
+  it("renders split layout with two columns on large screens", () => {
     // Act
     const { container } = render(<Page />);
 
     // Assert
     const wrapper = container.firstChild as HTMLElement;
-    expect(wrapper).toHaveClass("flex");
+    expect(wrapper).toHaveClass("grid");
     expect(wrapper).toHaveClass("min-h-svh");
-    expect(wrapper).toHaveClass("items-center");
-    expect(wrapper).toHaveClass("justify-center");
+    expect(wrapper).toHaveClass("lg:grid-cols-2");
+  });
+
+  it("renders Hermes branding copy", () => {
+    // Act
+    render(<Page />);
+
+    // Assert
+    expect(screen.getAllByText("Hermes").length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/Swiftly carrying messages between worlds\./),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/hermes/dashboard/app/login/page.tsx
+++ b/apps/hermes/dashboard/app/login/page.tsx
@@ -2,8 +2,26 @@ import { LoginForm } from "./login-form";
 
 const Page = () => {
   return (
-    <div className="flex min-h-svh items-center justify-center">
-      <LoginForm />
+    <div className="grid min-h-svh lg:grid-cols-2">
+      <div className="relative hidden flex-col bg-muted p-10 lg:flex">
+        <div className="absolute inset-0 bg-gradient-to-br from-primary/20 via-muted to-muted-foreground/10" />
+        <div className="relative z-20 flex items-center gap-2 font-semibold">
+          <span>Hermes</span>
+        </div>
+        <div className="relative z-20 mt-auto">
+          <blockquote className="space-y-2">
+            <p className="text-lg">
+              &ldquo;Swiftly carrying messages between worlds.&rdquo;
+            </p>
+            <footer className="text-sm text-muted-foreground">Hermes</footer>
+          </blockquote>
+        </div>
+      </div>
+      <div className="flex items-center justify-center p-6 md:p-10">
+        <div className="w-full max-w-xs">
+          <LoginForm />
+        </div>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Improve the Hermes dashboard login experience by adopting a Space-style split-screen layout and cleaner form presentation. This keeps authentication behavior unchanged while making first-use UX more polished and project-branded.

## Important changes

- Replaced the centered single-card login page with a split layout (`lg:grid-cols-2`) featuring a branded left panel and right-side login form.
- Refined login form content hierarchy with a welcome headline, helper text, remember-me checkbox, and updated primary button label (`Login`).

## Other changes

- Added a Hermes-relevant quote in the left panel: “Swiftly carrying messages between worlds.”
- Updated login page/form tests to validate the new layout and UI elements.

## Key files to review

- `apps/hermes/dashboard/app/login/page.tsx` - split-screen structure and Hermes quote/branding panel.
- `apps/hermes/dashboard/app/login/login-form.tsx` - updated login form composition and controls.
- `apps/hermes/dashboard/app/login/page.test.tsx` - assertions for split layout and branding copy.
- `apps/hermes/dashboard/app/login/login-form.test.tsx` - assertions for submit label and remember-me checkbox.

## How to test

1. Run `pnpm code-quality` from repo root.
2. Start dashboard and open `/login`.
3. Confirm split layout on large screens, Hermes quote panel, and updated login form UI.
4. Submit invalid and valid credentials to verify error display and redirect behavior remain unchanged.
