### PR TITLE
Add delete action for domain integrations

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.test.ts
@@ -1,0 +1,67 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeleteDomainIntegrationHandler } from "./route.post.config";
+
+const mockDashboardUser = {
+  id: "user-1",
+  name: "A",
+  email: "a@b.com",
+} as const;
+
+const integrationId = "00000000-0000-4000-8000-000000000001";
+
+const baseData = {
+  body: { id: integrationId },
+  params: {},
+  headers: new Headers(),
+  searchParams: {},
+  user: mockDashboardUser,
+};
+
+describe("createDeleteDomainIntegrationHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("deletes domain integration and returns ok", async () => {
+    // Setup
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      pipeline: { count: vi.fn().mockResolvedValue(0) },
+      domainIntegration: { delete: deleteMock },
+    };
+    const handler = createDeleteDomainIntegrationHandler({
+      db: db as never,
+    });
+
+    // Act
+    const result = await handler(baseData as never);
+
+    // Assert
+    expect(result.status).toBe(true);
+    expect((result as { data?: { ok: boolean } }).data?.ok).toBe(true);
+    expect(deleteMock).toHaveBeenCalledWith({
+      where: { id: integrationId },
+    });
+  });
+
+  it("returns error when pipelines still reference the integration", async () => {
+    // Setup
+    const deleteMock = vi.fn();
+    const db = {
+      pipeline: { count: vi.fn().mockResolvedValue(1) },
+      domainIntegration: { delete: deleteMock },
+    };
+    const handler = createDeleteDomainIntegrationHandler({
+      db: db as never,
+    });
+
+    // Act
+    const result = await handler(baseData as never);
+
+    // Assert
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toContain("pipelines");
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
@@ -1,0 +1,68 @@
+import { prisma } from "@hermes/orchestration-database";
+import {
+  createRequestValidator,
+  errorResponse,
+  HandlerFunc,
+  successResponse,
+} from "route-action-gen/lib";
+import { z } from "zod";
+
+import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+
+const bodyValidator = z.object({
+  id: z.string().uuid(),
+});
+
+export const requestValidator = createRequestValidator({
+  body: bodyValidator,
+  user: requireDashboardSessionForRoute,
+});
+
+export const responseValidator = z.object({
+  ok: z.literal(true),
+});
+
+type DeleteDomainIntegrationHandlerDependencies = {
+  db?: typeof prisma;
+};
+
+type DeleteDomainIntegrationHandler = HandlerFunc<
+  typeof requestValidator,
+  typeof responseValidator,
+  undefined
+>;
+
+/**
+ * Creates the delete-domain-integration handler with injectable dependencies.
+ *
+ * @param dependencies - Optional db client for tests.
+ * @returns Handler that deletes a domain integration by id.
+ */
+export const createDeleteDomainIntegrationHandler = ({
+  db = prisma,
+}: DeleteDomainIntegrationHandlerDependencies = {}): DeleteDomainIntegrationHandler => {
+  return async (data) => {
+    const { id } = data.body;
+
+    const pipelineCount = await db.pipeline.count({
+      where: { domainIntegrationId: id },
+    });
+    if (pipelineCount > 0) {
+      return errorResponse(
+        "Cannot delete: one or more pipelines still use this domain integration. Reassign or remove those pipelines first.",
+      );
+    }
+
+    await db.domainIntegration.delete({
+      where: { id },
+    });
+
+    return successResponse({ ok: true as const });
+  };
+};
+
+/**
+ * Handles delete domain integration: validates session and deletes by id.
+ */
+export const handler: DeleteDomainIntegrationHandler =
+  createDeleteDomainIntegrationHandler();

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.ts
@@ -1,0 +1,1 @@
+export * from "./.generated/route";

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/domain-integration-row-actions.tsx
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/domain-integration-row-actions.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@workspace/ui/components/dropdown-menu";
+import { Button } from "@workspace/ui/components/button";
+import { MoreHorizontal } from "lucide-react";
+
+import { DeleteConfirmForm } from "@/components/delete-confirm-form";
+import { useFormAction } from "@/app/dashboard/domain-integrations/actions/delete/.generated/use-form-action";
+
+export type DomainIntegrationRow = {
+  id: string;
+  key: string;
+  name: string;
+};
+
+type DomainIntegrationRowActionsProps = {
+  row: DomainIntegrationRow;
+};
+
+/**
+ * Dropdown with delete for a domain integration row; refreshes the page on success.
+ */
+export const DomainIntegrationRowActions = ({
+  row,
+}: DomainIntegrationRowActionsProps) => {
+  const router = useRouter();
+  const { FormWithAction, state, pending } = useFormAction();
+
+  useEffect(() => {
+    if (state && state.status === true) {
+      router.refresh();
+    }
+  }, [state, router]);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          aria-label={`Actions for integration ${row.key}`}
+        >
+          <MoreHorizontal className="size-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-48">
+        <DropdownMenuItem variant="destructive" disabled={pending} asChild>
+          <DeleteConfirmForm
+            FormWithAction={FormWithAction}
+            confirmMessage={`Delete domain integration "${row.key}" (${row.name})? You cannot delete it while pipelines still reference it.`}
+            bodyField={{ name: "body.id", value: row.id }}
+            pending={pending}
+          />
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/page.tsx
@@ -14,6 +14,7 @@ import {
 } from "@workspace/ui/components/table";
 import { prisma } from "@hermes/orchestration-database";
 import { formatCreatedBy } from "@/lib/format-created-by";
+import { DomainIntegrationRowActions } from "./domain-integration-row-actions";
 
 /**
  * Lists domain integrations (pending and active) with links to create new.
@@ -60,13 +61,14 @@ const DomainIntegrationsPage = async () => {
               <TableHead className="w-[120px]">Status</TableHead>
               <TableHead>Base URL</TableHead>
               <TableHead>Created by</TableHead>
+              <TableHead className="w-[56px] text-right">Actions</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {rows.length === 0 ? (
               <TableRow>
                 <TableCell
-                  colSpan={5}
+                  colSpan={6}
                   className="text-center text-muted-foreground"
                 >
                   No integrations yet. Create one to get an API key.
@@ -94,6 +96,11 @@ const DomainIntegrationsPage = async () => {
                   </TableCell>
                   <TableCell className="text-sm text-muted-foreground">
                     {formatCreatedBy(row.createdBy, row.createdById)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <DomainIntegrationRowActions
+                      row={{ id: row.id, key: row.key, name: row.name }}
+                    />
                   </TableCell>
                 </TableRow>
               ))


### PR DESCRIPTION
## Summary

Adds a server action and UI to delete domain integrations from the Hermes dashboard list. Deletion is blocked when any pipeline still references the integration.

## Important changes

- Delete handler validates dashboard session, checks `pipeline.count` for the integration id, and returns a clear error if pipelines still reference it before calling `domainIntegration.delete`.
- Each table row gets a row-actions menu with `DeleteConfirmForm` and generated `useFormAction`; successful delete triggers `router.refresh()`.

## Other changes

- Co-located Vitest coverage for the delete handler config (`route.post.config.test.ts`).

## Key files to review

- `apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts` — pipeline guard and delete logic.
- `apps/hermes/dashboard/app/dashboard/domain-integrations/domain-integration-row-actions.tsx` — dropdown + confirm + refresh on success.
- `apps/hermes/dashboard/app/dashboard/domain-integrations/page.tsx` — Actions column wiring.

## How to test

1. From repo root: `pnpm code-quality` (should pass).
2. Run the dashboard locally, open Domain integrations, use the row ⋮ menu → delete on an integration with no pipelines; confirm it disappears after confirm.
3. Create or point a pipeline at an integration and try delete; confirm the error message explains pipelines must be reassigned or removed first.
