### PR TITLE
Add Fly deployment for ticker-echo agent

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -108,3 +108,36 @@ jobs:
         run: flyctl deploy --remote-only -c apps/mediapulse/agents/delivery/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  ticker-echo:
+    runs-on: ubuntu-latest
+    env:
+      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
+      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Set up build environment
+        run: |
+          ./dev-bootstrap.sh
+          pnpm install
+          pnpm generate
+
+      - name: Build
+        run: pnpm exec turbo build --filter=@mediapulse/ticker-echo --only
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to fly.io
+        run: flyctl deploy --remote-only -c apps/mediapulse/agents/ticker-echo/fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/mediapulse/agents/ticker-echo/.dockerignore
+++ b/apps/mediapulse/agents/ticker-echo/.dockerignore
@@ -1,0 +1,4 @@
+# flyctl launch added from .gitignore
+# deps
+**/node_modules
+fly.toml

--- a/apps/mediapulse/agents/ticker-echo/Dockerfile
+++ b/apps/mediapulse/agents/ticker-echo/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: install and build (monorepo context from repo root)
+FROM node:24-bookworm-slim AS builder
+WORKDIR /app
+COPY . .
+
+# pnpm for workspace install; bun for the app build
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g bun
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm exec turbo build --filter=@mediapulse/ticker-echo --only --env-mode=loose
+
+# Stage 2: run the built bundle only
+FROM oven/bun:1
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=4010
+EXPOSE 4010
+
+COPY --from=builder /app/apps/mediapulse/agents/ticker-echo/dist/server.js ./server.js
+CMD ["bun", "server.js"]

--- a/apps/mediapulse/agents/ticker-echo/fly.toml
+++ b/apps/mediapulse/agents/ticker-echo/fly.toml
@@ -1,0 +1,24 @@
+# fly.toml app configuration file generated for mediapulse-ticker-echo-agent on 2026-03-30T19:17:40+07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'mediapulse-ticker-echo-agent'
+primary_region = 'sin'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 4010
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256


### PR DESCRIPTION
## Summary

Adds Fly.io deployment for the **ticker-echo** Mediapulse agent using the same pattern as data-collection, content-generation, and delivery: two-stage Dockerfile from repo root, `http_service` on port **4010** (aligned with env defaults and dev-docs), and a **ticker-echo** job in the agent deploy workflow.

## Important changes

- New Fly app name: `mediapulse-ticker-echo-agent` (`sin`, 256MB VM, auto stop/start).
- CI builds `@mediapulse/ticker-echo` and deploys with `flyctl deploy` when `main` would merge; operators must create the Fly app and set secrets (e.g. `AGENT_PUBLIC_URL`, auth/registry) before the job succeeds in production.

## Other changes

- `.dockerignore` matches other agents (`node_modules`, `fly.toml`).

## Key files to review

- `apps/mediapulse/agents/ticker-echo/fly.toml` — `internal_port` and app name.
- `apps/mediapulse/agents/ticker-echo/Dockerfile` — build filters and runtime `PORT`.
- `.github/workflows/agent-deploy.yml` — new job mirrors existing agent jobs.

## How to test

1. From repo root after merge (or locally): `pnpm exec turbo build --filter=@mediapulse/ticker-echo --only` and confirm `dist/server.js` exists.
2. Optional: `flyctl deploy --remote-only -c apps/mediapulse/agents/ticker-echo/fly.toml` with a test app and secrets; hit the public HTTPS URL with a valid agent invoke request.
3. Confirm workflow syntax: validate the YAML in GitHub Actions or `actionlint` if used in the repo.
