### PR TITLE
Add Fly deployment for user-registration agent

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -141,3 +141,36 @@ jobs:
         run: flyctl deploy --remote-only -c apps/mediapulse/agents/ticker-echo/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+
+  user-registration:
+    runs-on: ubuntu-latest
+    env:
+      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
+      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Set up build environment
+        run: |
+          ./dev-bootstrap.sh
+          pnpm install
+          pnpm generate
+
+      - name: Build
+        run: pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only
+
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Deploy to fly.io
+        run: flyctl deploy --remote-only -c apps/mediapulse/agents/user-registration/fly.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/mediapulse/agents/user-registration/.dockerignore
+++ b/apps/mediapulse/agents/user-registration/.dockerignore
@@ -1,0 +1,4 @@
+# flyctl launch added from .gitignore
+# deps
+**/node_modules
+fly.toml

--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -1,0 +1,21 @@
+# Stage 1: install and build (monorepo context from repo root)
+FROM node:24-bookworm-slim AS builder
+WORKDIR /app
+COPY . .
+
+# pnpm for workspace install; bun for the app build
+RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN npm install -g bun
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose
+
+# Stage 2: run the built bundle only
+FROM oven/bun:1
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=4004
+EXPOSE 4004
+
+COPY --from=builder /app/apps/mediapulse/agents/user-registration/dist/server.js ./server.js
+CMD ["bun", "server.js"]

--- a/apps/mediapulse/agents/user-registration/fly.toml
+++ b/apps/mediapulse/agents/user-registration/fly.toml
@@ -1,0 +1,24 @@
+# fly.toml app configuration file generated for mediapulse-user-registration-agent on 2026-03-30T19:33:01+07:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'mediapulse-user-registration-agent'
+primary_region = 'sin'
+
+[build]
+  dockerfile = 'Dockerfile'
+
+[http_service]
+  internal_port = 4004
+  force_https = true
+  auto_stop_machines = 'stop'
+  auto_start_machines = true
+  min_machines_running = 0
+  processes = ['app']
+
+[[vm]]
+  memory = '256mb'
+  cpu_kind = 'shared'
+  cpus = 1
+  memory_mb = 256


### PR DESCRIPTION
## Summary

Adds Fly.io deployment for the **user-registration** Mediapulse **agent** (`@mediapulse/user-registration-agent` under `apps/mediapulse/agents/user-registration`), using the same Dockerfile + `fly.toml` + CI pattern as the other agents. Fly app **`mediapulse-user-registration-agent`** and internal port **4004** align with `env.agents.user-registration.example` and keep naming distinct from the Next.js app **`mediapulse-user-registration`**.

## Important changes

- New **user-registration** job in **Agent Deployment** workflow: build filter `@mediapulse/user-registration-agent`, deploy with `apps/mediapulse/agents/user-registration/fly.toml`.
- Operators must create the Fly app and set secrets (agent-data-api, auth, registry, Resend, Outlook, etc.) before production deploys succeed.

## Other changes

- `.dockerignore` follows other agents.

## Key files to review

- `apps/mediapulse/agents/user-registration/fly.toml` — app name vs Next `mediapulse-user-registration`, port `4004`.
- `apps/mediapulse/agents/user-registration/Dockerfile` — `agent-auth-client` pre-build and turbo filter.
- `.github/workflows/agent-deploy.yml` — new job block.

## How to test

1. `pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only` and confirm `dist/server.js` exists.
2. Optionally `pnpm code-quality` from repo root (already expected to pass before merge).
3. After creating the Fly app, `flyctl deploy --remote-only -c apps/mediapulse/agents/user-registration/fly.toml` with real secrets to smoke-test.
