### PR TITLE
Add run-pipeline logging and ajv-formats in Hermes scheduler

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -78,6 +78,7 @@ describe("createRunPipelineHandler", () => {
   });
 
   it("returns error when pipeline is missing", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const handler = createRunPipelineHandler({
       getToken: async () => "jwt",
       db: {
@@ -88,6 +89,43 @@ describe("createRunPipelineHandler", () => {
     const result = await handler(request({ pipelineId: "missing" }));
     expect(result.status).toBe(false);
     expect((result as { message?: string }).message).toBe("Pipeline not found");
+    expect(logSpy).toHaveBeenCalledWith(
+      "[hermes-dashboard:run-pipeline]",
+      "Pipeline not found",
+      expect.objectContaining({
+        phase: "load-pipeline",
+        pipelineId: "missing",
+      }),
+    );
+    logSpy.mockRestore();
+  });
+
+  it("returns error and logs when an unexpected error is thrown", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = createRunPipelineHandler({
+      getToken: async () => "jwt",
+      db: {
+        ...createExecutionPersistenceStubs(),
+        pipeline: {
+          findUnique: vi.fn().mockRejectedValue(new Error("db down")),
+        },
+      } as never,
+    });
+    const result = await handler(request({ pipelineId: "p-1" }));
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Run pipeline failed: db down",
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      "[hermes-dashboard:run-pipeline]",
+      "Unexpected error while running pipeline",
+      expect.objectContaining({
+        phase: "unhandled",
+        pipelineId: "p-1",
+      }),
+      expect.any(Error),
+    );
+    logSpy.mockRestore();
   });
 
   it("returns failed run with 0 invocations when planning yields no jobs", async () => {
@@ -195,6 +233,7 @@ describe("createRunPipelineHandler", () => {
   });
 
   it("returns success with failedInvocationCount when invocation fails", async () => {
+    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const postMock = vi.fn().mockResolvedValue({
       ok: false,
       statusCode: 400,
@@ -244,5 +283,16 @@ describe("createRunPipelineHandler", () => {
         failedInvocationCount: 1,
       },
     });
+    expect(logSpy).toHaveBeenCalledWith(
+      "[hermes-dashboard:run-pipeline]",
+      "Agent HTTP response was not OK",
+      expect.objectContaining({
+        phase: "agent-http",
+        pipelineId: "p-1",
+        detail: "bad input",
+        statusCode: 400,
+      }),
+    );
+    logSpy.mockRestore();
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -32,6 +32,37 @@ const bodyValidator = z.object({
   pipelineId: z.string().uuid(),
 });
 
+/** Prefix for server logs when debugging Run pipeline in Docker or `pnpm dev` output. */
+const RUN_PIPELINE_LOG_PREFIX = "[hermes-dashboard:run-pipeline]";
+
+/**
+ * Logs run-pipeline diagnostics to stderr (visible in dashboard server logs).
+ *
+ * @param phase - Stage that failed or produced a warning (e.g. token, planning, agent-http).
+ * @param pipelineId - Pipeline id when known; use undefined before load.
+ * @param message - Short summary.
+ * @param extra - Optional structured fields (job id, status code, planning errors).
+ * @param err - Optional thrown value for stack/details.
+ */
+const logRunPipelineIssue = (
+  phase: string,
+  pipelineId: string | undefined,
+  message: string,
+  extra?: Record<string, unknown>,
+  err?: unknown,
+): void => {
+  const base = {
+    phase,
+    pipelineId: pipelineId ?? null,
+    ...extra,
+  };
+  if (err !== undefined) {
+    console.error(RUN_PIPELINE_LOG_PREFIX, message, base, err);
+  } else {
+    console.error(RUN_PIPELINE_LOG_PREFIX, message, base);
+  }
+};
+
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
   user: requireDashboardSessionForRoute,
@@ -118,323 +149,419 @@ export const createRunPipelineHandler = ({
   expandStepInputs = createExpandStepInputsForManualPipelineRun(),
 }: RunPipelineHandlerDependencies = {}): RunPipelineHandler => {
   return async (data) => {
-    const session = data.user;
+    const pipelineIdRequest = data.body.pipelineId;
 
-    let jwt: string;
     try {
-      jwt = await getToken();
-    } catch (err) {
-      console.error("--> error getting token", err);
-      return errorResponse(
-        "AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY are required to run pipelines (JWT-only invocation)",
-      );
-    }
+      const session = data.user;
 
-    const pipelineFindArgs = {
-      where: { id: data.body.pipelineId },
-      include: {
-        steps: {
-          include: { agentConfig: true },
-          orderBy: { order: "asc" },
-        },
-      },
-    } satisfies Prisma.PipelineFindUniqueArgs;
-    const pipeline = await db.pipeline.findUnique(pipelineFindArgs);
-    if (!pipeline) {
-      return errorResponse("Pipeline not found");
-    }
-
-    const pipelineValidation = await validatePipeline(
-      {
-        id: pipeline.id,
-        name: pipeline.name,
-        domainIntegrationId: pipeline.domainIntegrationId,
-        steps: pipeline.steps.map((step) => ({
-          id: step.id,
-          order: step.order,
-          agentId: step.agentId,
-          agentVersion: step.agentVersion,
-          agentConfigId: step.agentConfigId,
-          input: step.input,
-          config: step.config,
-        })),
-      },
-      db,
-    );
-    if (!pipelineValidation.valid) {
-      return errorResponse(
-        `Pipeline is invalid: ${pipelineValidation.warnings.join("; ")}`,
-      );
-    }
-
-    const effectiveExecutionConfig = mergeExecutionConfig(
-      pipeline.executionConfig,
-      null,
-    );
-    const planning = await planPipelineInvocations({
-      db,
-      pipeline: {
-        id: pipeline.id,
-        domainIntegrationId: pipeline.domainIntegrationId,
-        steps: pipeline.steps,
-      },
-      sourceId: pipeline.id,
-      expandStepInputs,
-      variableSecretMasterKey: env.HERMES_INTERNAL_API_KEY,
-      requireHttpsAgentEndpoints: false,
-    });
-    const executionTime = now();
-    const waveList = planning.waveList.map((wave) =>
-      wave.map((planned) => ({
-        ...planned,
-        jobId: randomUUID(),
-      })),
-    );
-    const plannedJobs = waveList.flat();
-    const jobsCreated = plannedJobs.length;
-
-    const enqueueStatus =
-      jobsCreated === 0
-        ? ScheduleEnqueueStatus.failed
-        : planning.errors.length > 0
-          ? ScheduleEnqueueStatus.partial
-          : ScheduleEnqueueStatus.success;
-    const execution = await db.manualPipelineExecution.create({
-      data: {
-        pipelineId: pipeline.id,
-        executionTime,
-        enqueueStatus,
-        runStatus: jobsCreated === 0 ? ScheduleRunStatus.failed : "running",
-        effectiveExecutionConfig:
-          effectiveExecutionConfig as Prisma.InputJsonValue,
-        jobsCreated,
-        jobsEnqueued: jobsCreated,
-        metadata: {
-          source: "dashboard",
-          initiatedByUserId: session.id,
-          initiatedByUserEmail: session.email,
-        },
-      },
-      select: { id: true },
-    });
-
-    const stepExpected = new Map<string, number>();
-    for (const job of plannedJobs) {
-      stepExpected.set(
-        job.pipelineStepId,
-        (stepExpected.get(job.pipelineStepId) ?? 0) + 1,
-      );
-    }
-
-    const stepStats = new Map<
-      string,
-      {
-        succeededCount: number;
-        failedCount: number;
-        expectedInvocationCount: number;
-      }
-    >();
-    for (const step of pipeline.steps) {
-      const expectedInvocationCount = stepExpected.get(step.id) ?? 0;
-      await db.manualPipelineStepExecution.create({
-        data: {
-          manualExecutionId: execution.id,
-          pipelineStepId: step.id,
-          expectedInvocationCount,
-          rollupStatus:
-            expectedInvocationCount > 0
-              ? ScheduleStepRollupStatus.running
-              : ScheduleStepRollupStatus.pending,
-        },
-      });
-      stepStats.set(step.id, {
-        succeededCount: 0,
-        failedCount: 0,
-        expectedInvocationCount,
-      });
-    }
-
-    const errors: Array<{
-      step: string;
-      detail: string;
-      code: number | "unknown";
-      jobId: string;
-    }> = planning.errors.map((error) => ({
-      step: "planning",
-      detail: error.message,
-      code: "unknown",
-      jobId: "planning",
-    }));
-
-    for (const wave of waveList) {
-      for (const job of wave) {
-        const step = pipeline.steps.find(
-          (item) => item.id === job.pipelineStepId,
+      let jwt: string;
+      try {
+        jwt = await getToken();
+      } catch (err) {
+        logRunPipelineIssue(
+          "token",
+          pipelineIdRequest,
+          "Failed to obtain JWT for agent invocation (check AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY)",
+          {},
+          err,
         );
-        if (!step) {
-          errors.push({
-            step: "unknown",
-            detail: `Missing pipeline step ${job.pipelineStepId}`,
-            code: "unknown",
-            jobId: job.jobId,
-          });
-          continue;
-        }
+        return errorResponse(
+          "AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY are required to run pipelines (JWT-only invocation)",
+        );
+      }
 
-        await db.agentJobExecution.create({
+      const pipelineFindArgs = {
+        where: { id: data.body.pipelineId },
+        include: {
+          steps: {
+            include: { agentConfig: true },
+            orderBy: { order: "asc" },
+          },
+        },
+      } satisfies Prisma.PipelineFindUniqueArgs;
+      const pipeline = await db.pipeline.findUnique(pipelineFindArgs);
+      if (!pipeline) {
+        logRunPipelineIssue(
+          "load-pipeline",
+          pipelineIdRequest,
+          "Pipeline not found",
+        );
+        return errorResponse("Pipeline not found");
+      }
+
+      const pipelineValidation = await validatePipeline(
+        {
+          id: pipeline.id,
+          name: pipeline.name,
+          domainIntegrationId: pipeline.domainIntegrationId,
+          steps: pipeline.steps.map((step) => ({
+            id: step.id,
+            order: step.order,
+            agentId: step.agentId,
+            agentVersion: step.agentVersion,
+            agentConfigId: step.agentConfigId,
+            input: step.input,
+            config: step.config,
+          })),
+        },
+        db,
+      );
+      if (!pipelineValidation.valid) {
+        const warningText = pipelineValidation.warnings.join("; ");
+        logRunPipelineIssue(
+          "validate-pipeline",
+          pipeline.id,
+          "Pipeline invalid",
+          {
+            warnings: pipelineValidation.warnings,
+          },
+        );
+        return errorResponse(`Pipeline is invalid: ${warningText}`);
+      }
+
+      const effectiveExecutionConfig = mergeExecutionConfig(
+        pipeline.executionConfig,
+        null,
+      );
+      const planning = await planPipelineInvocations({
+        db,
+        pipeline: {
+          id: pipeline.id,
+          domainIntegrationId: pipeline.domainIntegrationId,
+          steps: pipeline.steps,
+        },
+        sourceId: pipeline.id,
+        expandStepInputs,
+        variableSecretMasterKey: env.HERMES_INTERNAL_API_KEY,
+        requireHttpsAgentEndpoints: false,
+      });
+      const executionTime = now();
+      const waveList = planning.waveList.map((wave) =>
+        wave.map((planned) => ({
+          ...planned,
+          jobId: randomUUID(),
+        })),
+      );
+      const plannedJobs = waveList.flat();
+      const jobsCreated = plannedJobs.length;
+
+      if (planning.errors.length > 0) {
+        logRunPipelineIssue(
+          "planning",
+          pipeline.id,
+          "Planning reported errors (run may be partial or empty)",
+          {
+            planningErrors: planning.errors,
+            jobsPlanned: jobsCreated,
+            stepCount: pipeline.steps.length,
+          },
+        );
+      }
+      if (jobsCreated === 0) {
+        logRunPipelineIssue(
+          "planning",
+          pipeline.id,
+          "No invocations planned - expandStepInputs yielded no jobs (check step inputs / agent expansion)",
+          {
+            planningErrorCount: planning.errors.length,
+            stepCount: pipeline.steps.length,
+          },
+        );
+      }
+
+      const enqueueStatus =
+        jobsCreated === 0
+          ? ScheduleEnqueueStatus.failed
+          : planning.errors.length > 0
+            ? ScheduleEnqueueStatus.partial
+            : ScheduleEnqueueStatus.success;
+      const execution = await db.manualPipelineExecution.create({
+        data: {
+          pipelineId: pipeline.id,
+          executionTime,
+          enqueueStatus,
+          runStatus: jobsCreated === 0 ? ScheduleRunStatus.failed : "running",
+          effectiveExecutionConfig:
+            effectiveExecutionConfig as Prisma.InputJsonValue,
+          jobsCreated,
+          jobsEnqueued: jobsCreated,
+          metadata: {
+            source: "dashboard",
+            initiatedByUserId: session.id,
+            initiatedByUserEmail: session.email,
+          },
+        },
+        select: { id: true },
+      });
+
+      const stepExpected = new Map<string, number>();
+      for (const job of plannedJobs) {
+        stepExpected.set(
+          job.pipelineStepId,
+          (stepExpected.get(job.pipelineStepId) ?? 0) + 1,
+        );
+      }
+
+      const stepStats = new Map<
+        string,
+        {
+          succeededCount: number;
+          failedCount: number;
+          expectedInvocationCount: number;
+        }
+      >();
+      for (const step of pipeline.steps) {
+        const expectedInvocationCount = stepExpected.get(step.id) ?? 0;
+        await db.manualPipelineStepExecution.create({
           data: {
-            jobId: job.jobId,
-            agentId: job.agentId,
             manualExecutionId: execution.id,
-            pipelineId: pipeline.id,
             pipelineStepId: step.id,
-            status: "running",
-            enqueuedAt: executionTime,
-            startedAt: now(),
-            params: job.input as Prisma.InputJsonValue,
-            invocationConfig: job.config as Prisma.InputJsonValue,
+            expectedInvocationCount,
+            rollupStatus:
+              expectedInvocationCount > 0
+                ? ScheduleStepRollupStatus.running
+                : ScheduleStepRollupStatus.pending,
           },
         });
+        stepStats.set(step.id, {
+          succeededCount: 0,
+          failedCount: 0,
+          expectedInvocationCount,
+        });
+      }
 
-        try {
-          const agentResponse = await post(job.endpointUrl, {
-            json: { input: job.input, config: job.config },
-            headers: {
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${jwt}`,
-            },
-            throwHttpErrors: false,
-          });
-          const response = agentResponse as {
-            ok?: boolean;
-            statusCode?: number;
-            body?: unknown;
-          };
-          if (response.ok === true) {
-            const stats = stepStats.get(step.id);
-            if (stats) stats.succeededCount += 1;
-            await db.agentJobExecution.update({
-              where: { jobId: job.jobId },
-              data: {
-                status: "completed",
-                completedAt: now(),
-                error: Prisma.DbNull,
-                agentResponse:
-                  (response.body as Prisma.InputJsonValue | undefined) ??
-                  Prisma.DbNull,
-                semanticStatus: "success",
+      const errors: Array<{
+        step: string;
+        detail: string;
+        code: number | "unknown";
+        jobId: string;
+      }> = planning.errors.map((error) => ({
+        step: "planning",
+        detail: error.message,
+        code: "unknown",
+        jobId: "planning",
+      }));
+
+      for (const wave of waveList) {
+        for (const job of wave) {
+          const step = pipeline.steps.find(
+            (item) => item.id === job.pipelineStepId,
+          );
+          if (!step) {
+            logRunPipelineIssue(
+              "agent-invoke",
+              pipeline.id,
+              "Planned job references missing pipeline step",
+              {
+                jobId: job.jobId,
+                pipelineStepId: job.pipelineStepId,
+                agentId: job.agentId,
               },
+            );
+            errors.push({
+              step: "unknown",
+              detail: `Missing pipeline step ${job.pipelineStepId}`,
+              code: "unknown",
+              jobId: job.jobId,
             });
             continue;
           }
 
-          const detail = detailFromAgentErrorBody(response.body);
-          const code = response.statusCode ?? "unknown";
-          const stats = stepStats.get(step.id);
-          if (stats) stats.failedCount += 1;
-          errors.push({
-            step: `${step.agentId}@${step.agentVersion}`,
-            detail,
-            code,
-            jobId: job.jobId,
-          });
-          await db.agentJobExecution.update({
-            where: { jobId: job.jobId },
+          await db.agentJobExecution.create({
             data: {
-              status: "failed",
-              completedAt: now(),
-              error: {
-                detail,
-                code,
-                jobId: job.jobId,
-              },
-              agentResponse:
-                (response.body as Prisma.InputJsonValue | undefined) ??
-                Prisma.DbNull,
-              semanticStatus: "failure",
+              jobId: job.jobId,
+              agentId: job.agentId,
+              manualExecutionId: execution.id,
+              pipelineId: pipeline.id,
+              pipelineStepId: step.id,
+              status: "running",
+              enqueuedAt: executionTime,
+              startedAt: now(),
+              params: job.input as Prisma.InputJsonValue,
+              invocationConfig: job.config as Prisma.InputJsonValue,
             },
           });
-        } catch (err) {
-          const detail = err instanceof Error ? err.message : String(err);
-          const stats = stepStats.get(step.id);
-          if (stats) stats.failedCount += 1;
-          errors.push({
-            step: `${step.agentId}@${step.agentVersion}`,
-            detail,
-            code: "unknown",
-            jobId: job.jobId,
-          });
-          await db.agentJobExecution.update({
-            where: { jobId: job.jobId },
-            data: {
-              status: "failed",
-              completedAt: now(),
-              error: {
-                detail,
-                code: "unknown",
-                jobId: job.jobId,
+
+          try {
+            const agentResponse = await post(job.endpointUrl, {
+              json: { input: job.input, config: job.config },
+              headers: {
+                "Content-Type": "application/json",
+                Authorization: `Bearer ${jwt}`,
               },
-              semanticStatus: "failure",
-            },
-          });
+              throwHttpErrors: false,
+            });
+            const response = agentResponse as {
+              ok?: boolean;
+              statusCode?: number;
+              body?: unknown;
+            };
+            if (response.ok === true) {
+              const stats = stepStats.get(step.id);
+              if (stats) stats.succeededCount += 1;
+              await db.agentJobExecution.update({
+                where: { jobId: job.jobId },
+                data: {
+                  status: "completed",
+                  completedAt: now(),
+                  error: Prisma.DbNull,
+                  agentResponse:
+                    (response.body as Prisma.InputJsonValue | undefined) ??
+                    Prisma.DbNull,
+                  semanticStatus: "success",
+                },
+              });
+              continue;
+            }
+
+            const detail = detailFromAgentErrorBody(response.body);
+            const code = response.statusCode ?? "unknown";
+            logRunPipelineIssue(
+              "agent-http",
+              pipeline.id,
+              "Agent HTTP response was not OK",
+              {
+                jobId: job.jobId,
+                pipelineStepId: step.id,
+                agentId: step.agentId,
+                agentVersion: step.agentVersion,
+                endpointUrl: job.endpointUrl,
+                statusCode: code,
+                detail,
+              },
+            );
+            const stats = stepStats.get(step.id);
+            if (stats) stats.failedCount += 1;
+            errors.push({
+              step: `${step.agentId}@${step.agentVersion}`,
+              detail,
+              code,
+              jobId: job.jobId,
+            });
+            await db.agentJobExecution.update({
+              where: { jobId: job.jobId },
+              data: {
+                status: "failed",
+                completedAt: now(),
+                error: {
+                  detail,
+                  code,
+                  jobId: job.jobId,
+                },
+                agentResponse:
+                  (response.body as Prisma.InputJsonValue | undefined) ??
+                  Prisma.DbNull,
+                semanticStatus: "failure",
+              },
+            });
+          } catch (err) {
+            const detail = err instanceof Error ? err.message : String(err);
+            logRunPipelineIssue(
+              "agent-http",
+              pipeline.id,
+              "Agent HTTP request threw (network/DNS/TLS/timeout)",
+              {
+                jobId: job.jobId,
+                pipelineStepId: step.id,
+                agentId: step.agentId,
+                agentVersion: step.agentVersion,
+                endpointUrl: job.endpointUrl,
+                detail,
+              },
+              err,
+            );
+            const stats = stepStats.get(step.id);
+            if (stats) stats.failedCount += 1;
+            errors.push({
+              step: `${step.agentId}@${step.agentVersion}`,
+              detail,
+              code: "unknown",
+              jobId: job.jobId,
+            });
+            await db.agentJobExecution.update({
+              where: { jobId: job.jobId },
+              data: {
+                status: "failed",
+                completedAt: now(),
+                error: {
+                  detail,
+                  code: "unknown",
+                  jobId: job.jobId,
+                },
+                semanticStatus: "failure",
+              },
+            });
+          }
         }
       }
-    }
 
-    const stepRollups: StepRollupTerminal[] = [];
-    for (const step of pipeline.steps) {
-      const stats = stepStats.get(step.id);
-      if (!stats) continue;
-      const rollup = computeStepRollupFromCounts(
-        stats.succeededCount,
-        stats.failedCount,
-        effectiveExecutionConfig.stepRollupPolicy,
-      );
-      stepRollups.push(rollup);
-      await db.manualPipelineStepExecution.update({
-        where: {
-          manualExecutionId_pipelineStepId: {
-            manualExecutionId: execution.id,
-            pipelineStepId: step.id,
+      const stepRollups: StepRollupTerminal[] = [];
+      for (const step of pipeline.steps) {
+        const stats = stepStats.get(step.id);
+        if (!stats) continue;
+        const rollup = computeStepRollupFromCounts(
+          stats.succeededCount,
+          stats.failedCount,
+          effectiveExecutionConfig.stepRollupPolicy,
+        );
+        stepRollups.push(rollup);
+        await db.manualPipelineStepExecution.update({
+          where: {
+            manualExecutionId_pipelineStepId: {
+              manualExecutionId: execution.id,
+              pipelineStepId: step.id,
+            },
           },
-        },
+          data: {
+            succeededCount: stats.succeededCount,
+            failedCount: stats.failedCount,
+            rollupStatus: stepTerminalToPrismaRollup(rollup),
+          },
+        });
+      }
+
+      const finalRunStatus =
+        jobsCreated === 0
+          ? "failed"
+          : computeExecutionRunStatusFromStepRollups(
+              stepRollups,
+              effectiveExecutionConfig.stepRollupPolicy,
+            );
+      const failedInvocationCount = Array.from(stepStats.values()).reduce(
+        (sum, item) => sum + item.failedCount,
+        0,
+      );
+      await db.manualPipelineExecution.update({
+        where: { id: execution.id },
         data: {
-          succeededCount: stats.succeededCount,
-          failedCount: stats.failedCount,
-          rollupStatus: stepTerminalToPrismaRollup(rollup),
+          runStatus: runStatusTerminalToPrisma(finalRunStatus),
+          succeededInvocationCount: jobsCreated - failedInvocationCount,
+          failedInvocationCount,
+          errors:
+            errors.length > 0
+              ? (errors as Prisma.InputJsonValue)
+              : Prisma.DbNull,
         },
       });
-    }
 
-    const finalRunStatus =
-      jobsCreated === 0
-        ? "failed"
-        : computeExecutionRunStatusFromStepRollups(
-            stepRollups,
-            effectiveExecutionConfig.stepRollupPolicy,
-          );
-    const failedInvocationCount = Array.from(stepStats.values()).reduce(
-      (sum, item) => sum + item.failedCount,
-      0,
-    );
-    await db.manualPipelineExecution.update({
-      where: { id: execution.id },
-      data: {
-        runStatus: runStatusTerminalToPrisma(finalRunStatus),
-        succeededInvocationCount: jobsCreated - failedInvocationCount,
+      return successResponse({
+        ok: true as const,
+        invocationsRun: jobsCreated,
+        executionId: execution.id,
+        runStatus: finalRunStatus,
         failedInvocationCount,
-        errors:
-          errors.length > 0 ? (errors as Prisma.InputJsonValue) : Prisma.DbNull,
-      },
-    });
-
-    return successResponse({
-      ok: true as const,
-      invocationsRun: jobsCreated,
-      executionId: execution.id,
-      runStatus: finalRunStatus,
-      failedInvocationCount,
-    });
+      });
+    } catch (err) {
+      logRunPipelineIssue(
+        "unhandled",
+        pipelineIdRequest,
+        "Unexpected error while running pipeline",
+        {},
+        err,
+      );
+      const message = err instanceof Error ? err.message : String(err);
+      return errorResponse(`Run pipeline failed: ${message}`);
+    }
   };
 };
 

--- a/packages/hermes/scheduler/package.json
+++ b/packages/hermes/scheduler/package.json
@@ -19,6 +19,7 @@
     "@hermes/domain-integration-crypto": "workspace:*",
     "@hermes/orchestration-database": "workspace:*",
     "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "cron-parser": "^5.0.0",
     "zod": "catalog:"
   },

--- a/packages/hermes/scheduler/src/validate-json-schema.test.ts
+++ b/packages/hermes/scheduler/src/validate-json-schema.test.ts
@@ -57,4 +57,19 @@ describe("validateWithJsonSchema", () => {
       ).toBe(true);
     }
   });
+
+  it("accepts date-time format when ajv-formats is registered", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        watermark: { type: "string", format: "date-time" },
+      },
+      required: ["watermark"],
+    };
+    expect(
+      validateWithJsonSchema(schema, { watermark: "2025-03-13T12:00:00Z" }),
+    ).toEqual({ valid: true });
+    const invalid = validateWithJsonSchema(schema, { watermark: "not-a-date" });
+    expect(invalid.valid).toBe(false);
+  });
 });

--- a/packages/hermes/scheduler/src/validate-json-schema.ts
+++ b/packages/hermes/scheduler/src/validate-json-schema.ts
@@ -1,6 +1,8 @@
 import Ajv, { type JSONSchemaType } from "ajv";
+import addFormats from "ajv-formats";
 
 const ajv = new Ajv({ allErrors: true });
+addFormats(ajv);
 
 type JsonSchemaLike = {
   type?: string | string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1001,6 +1001,9 @@ importers:
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       cron-parser:
         specifier: ^5.0.0
         version: 5.5.0


### PR DESCRIPTION
## Summary

Improves observability when Hermes dashboard **Run pipeline** fails, and fixes JSON Schema validation in the scheduler so standard `format` keywords (for example `date-time` on agent input schemas) work with Ajv instead of surfacing "unknown format" errors.

## Important changes

- **Dashboard run-pipeline:** Structured `console.error` logs with prefix `[hermes-dashboard:run-pipeline]` for token, validation, planning, agent HTTP, and unexpected failures; unexpected errors also return a clear form error message.
- **Scheduler:** Register `ajv-formats` on the shared Ajv instance so pipeline planning validates schemas that use `format: "date-time"` (and other registered formats). **Deploy both dashboard and worker** so they pick up the updated scheduler package.

## Other changes

- Unit tests for logging expectations and `date-time` validation in `@hermes/scheduler`.

## Key files to review

- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — logging phases and outer try/catch.
- `packages/hermes/scheduler/src/validate-json-schema.ts` — `addFormats(ajv)` wiring.
- `packages/hermes/scheduler/src/validate-json-schema.test.ts` — `date-time` acceptance test.

## How to test

1. From repo root: `pnpm code-quality` (passes locally).
2. Dashboard: run a pipeline that previously failed opaquely; confirm server logs include `[hermes-dashboard:run-pipeline]` with useful context.
3. Scheduler: run planning/validation for an agent whose input schema uses `format: "date-time"` with a valid ISO-8601 string; confirm it no longer fails with unknown format for `watermark` / similar fields.
