### PR TITLE
Relax AI PR review prompts so Findings surface

### DIFF
--- a/scripts/ai-pr-review.mjs
+++ b/scripts/ai-pr-review.mjs
@@ -207,7 +207,7 @@ const main = async () => {
           {
             role: "system",
             content:
-              "You are an automated PR reviewer for this monorepo. Check the diff against the pasted rules and skills honestly. If nothing substantive applies, output a short Summary only—omit Findings, Possible false positives, and Suggested follow-ups entirely. Never invent findings or generic follow-up advice. Every Finding row must cite a concrete rule/skill clause or an observable diff issue. Prefer should-fix over nice-to-have when a real process gap exists. Use the Findings table with exactly the five columns from the user prompt when and only when you have at least one such row; do not add or rename columns.",
+              "You are an automated PR reviewer for this monorepo. Check the diff against the pasted rules and skills honestly. Keep output minimal, but do not be overly conservative: if there is any reasonably supported rules/skills violation in the diff, you must include a Finding row. Never invent findings or generic follow-up advice. Findings must be tied to an observable diff issue and mapped to a specific rule/skill id; exact quotes and exact line numbers are not required. Prefer should-fix over nice-to-have when a real process gap exists. Use the Findings table with exactly the five columns from the user prompt when and only when you have at least one such row; do not add or rename columns.",
           },
           { role: "user", content: prompt },
         ],

--- a/scripts/lib/ai-pr-review.mjs
+++ b/scripts/lib/ai-pr-review.mjs
@@ -236,7 +236,7 @@ export const buildAiReviewPrompt = (args) => {
   const diff = truncateMiddle(args.diffText, args.maxDiffChars);
 
   return `
-You are a senior reviewer for a TypeScript monorepo. Internally check the PR diff against **Context: rules** and **Context: skills** below. **Output must be minimal:** do not invent problems, generic advice, or “educational” follow-ups. If the diff does not violate the pasted standards in a concrete way, say so briefly and stop—leave optional sections out entirely.
+You are a senior reviewer for a TypeScript monorepo. Check the PR diff against **Context: rules** and **Context: skills** below. **Output must be minimal:** do not invent problems, generic advice, or “educational” follow-ups. However, if you see a rules/skills violation that is reasonably supported by the diff (even without exact line numbers), you must include it as a Finding.
 
 Return **GitHub-flavored markdown** using **only** the sections below, in order. **Omit a section completely** (no heading, no placeholder text) when you have nothing real to put there.
 
@@ -245,7 +245,7 @@ Return **GitHub-flavored markdown** using **only** the sections below, in order.
 - If there **are** findings: 1–3 short bullets **tied to those findings only**. No tables here.
 
 ## Findings
-Include this section **only if** there is at least **one** substantive, evidence-backed row. If none, **omit this entire section** (do not output an empty table, no placeholder row, no “no findings” row).
+Include this section **only if** there is at least **one** rules/skills-grounded row. If none, **omit this entire section** (do not output an empty table, no placeholder row, no “no findings” row).
 
 When present, output **only** a single markdown table under this heading—no extra prose. Use **exactly** these five columns and header row **verbatim** (including capitalization):
 
@@ -266,7 +266,7 @@ Include **only if** you already listed at least one finding **and** there is **s
 Include **only if** there is a **concrete**, diff- or rules-grounded action **not** already covered by a Finding row (e.g. a named follow-up ticket tied to a gap you cited). Otherwise **omit this section entirely**. **Forbidden:** generic team advice (“ensure contributors know…”, “monitor effectiveness…”, “consider documenting…”) that does not reference a specific rule line and diff hunk.
 
 ### Reviewer discipline (follow strictly)
-- Every Finding row must be grounded in **quoted or paraphrased** rule/skill text **or** a clear diff issue. If you cannot tie it that way, **do not output a Finding** for it.
+- Every Finding row must be grounded in a clear diff observation and mapped to a specific rule/skill. Do not require verbatim quotes; paraphrase is fine.
 - **No hollow praise** and no PR recap unless it directly supports a finding.
 - **Test location (this monorepo)**: Default expectation is \`*.test.ts\` / \`*.test.tsx\` **next to the module under test**. A top-level \`tests/\` tree separate from \`src/\` is not the default—flag only when the diff actually adds such a mismatch per neighboring patterns.
 - **Nice-to-have** rows: only when a real, minor improvement is rules-grounded; no filler.


### PR DESCRIPTION
## Summary

The AI PR review (`pnpm ai:review`) often returned **Summary-only** because the system and user prompts were overly conservative (models treated “cite a concrete clause” as a bar too high). This updates both prompts so **obvious rules/skills violations in the diff still produce a Findings table**, without requiring exact quotes or line numbers.

## Important changes

- System message in `scripts/ai-pr-review.mjs`: instruct the model not to be overly conservative; require Finding rows when violations are reasonably supported; map to specific rule/skill ids.
- User prompt in `scripts/lib/ai-pr-review.mjs`: align wording—Finding rows need diff + rule mapping; paraphrase is fine.

## Other changes

- None.

## Key files to review

- `scripts/ai-pr-review.mjs` — system instructions sent with each completion.
- `scripts/lib/ai-pr-review.mjs` — markdown template the model receives as user content.

## How to test

1. Set `CURSOR_REVIEW_BASE_SHA`, `CURSOR_REVIEW_HEAD_SHA`, and `OPENAI_API_KEY`, then run `pnpm ai:review` on a PR that previously only showed Summary despite clear rule gaps.
2. Confirm the response includes a `## Findings` section with table rows when expectations (e.g. agent-data-api manifest sync) are violated.
