### PR TITLE
Filter AI PR review findings for concrete product paths

### DIFF
--- a/scripts/ai-pr-review.mjs
+++ b/scripts/ai-pr-review.mjs
@@ -5,6 +5,7 @@ import process from "node:process";
 
 import {
   buildAiReviewPrompt,
+  filterAiReviewMarkdownFindings,
   selectSkillRelativePaths,
   truncateMiddle,
 } from "./lib/ai-pr-review.mjs";
@@ -207,7 +208,7 @@ const main = async () => {
           {
             role: "system",
             content:
-              "You are an automated PR reviewer for this monorepo. Check the diff against the pasted rules and skills honestly. Keep output minimal, but do not be overly conservative: if there is any reasonably supported rules/skills violation in the diff, you must include a Finding row. Never invent findings or generic follow-up advice. Findings must be tied to an observable diff issue and mapped to a specific rule/skill id; exact quotes and exact line numbers are not required. Prefer should-fix over nice-to-have when a real process gap exists. Use the Findings table with exactly the five columns from the user prompt when and only when you have at least one such row; do not add or rename columns.",
+              'You are an automated PR reviewer for this monorepo. Check the diff against the pasted rules and skills honestly. Keep output minimal, but do not be overly conservative: if there is any reasonably supported rules/skills violation in apps/ or packages/ code, include a Finding row. Every Finding must anchor to a concrete repo-relative file path from the diff (never "—" for File), and never target repo-root scripts/ paths. Do not emit vague workflow-only compliance rows (for example "did not read rules first" / "did not run code-quality") unless tied to a specific product-file diff violation. Never invent findings or generic follow-up advice. Prefer should-fix over nice-to-have when a real process gap exists. Use the Findings table with exactly the five columns from the user prompt when and only when you have at least one such row; do not add or rename columns.',
           },
           { role: "user", content: prompt },
         ],
@@ -223,7 +224,9 @@ const main = async () => {
 
   /** @type {{ choices?: ReadonlyArray<{ message?: { content?: string } }> }} */
   const completionJson = await completionRes.json();
-  const reviewMd = completionJson.choices?.[0]?.message?.content ?? "";
+  const reviewMd = filterAiReviewMarkdownFindings(
+    completionJson.choices?.[0]?.message?.content ?? "",
+  );
 
   const body = `${MARKER}\n## Cursor AI Review\n\n${reviewMd}`;
 

--- a/scripts/lib/ai-pr-review.mjs
+++ b/scripts/lib/ai-pr-review.mjs
@@ -17,6 +17,144 @@ const DEFAULT_SKILL_CONTEXT_RESERVE_RATIO = 0.38;
 /** @param {string} relPath */
 const normalizeRelPath = (relPath) => relPath.replaceAll("\\", "/");
 
+/** Repo-root `scripts/` only (not e.g. `packages/foo/scripts/`). */
+const isRepoRootScriptsPath = (filePath) => {
+  const n = normalizeRelPath(filePath).trim();
+  return n === "scripts" || n.startsWith("scripts/");
+};
+
+/**
+ * True when a Findings **File** or **Line** cell is an em/en dash, hyphen stub, empty, or "N/A".
+ *
+ * @param {string} value
+ * @returns {boolean}
+ */
+const isFindingsTablePlaceholderCell = (value) => {
+  const t = value.replaceAll("`", "").trim();
+  if (t.length === 0) return true;
+  if (/^n\/a$/iu.test(t)) return true;
+  return /^[\u2014\u2013\-—]+$/u.test(t);
+};
+
+/**
+ * Parses a single GFM table row into cells (excluding leading/trailing pipes).
+ *
+ * @param {string} line
+ * @returns {readonly string[] | null}
+ */
+const parseGfmTableRowCells = (line) => {
+  const raw = line.trim();
+  if (!raw.startsWith("|")) return null;
+  const parts = raw.split("|");
+  if (parts.length < 3) return null;
+  return parts.slice(1, -1).map((c) => c.trim());
+};
+
+/**
+ * Drops low-signal AI review Finding rows: missing a concrete **File** path, placeholder **File**,
+ * or repo-root `scripts/` paths (tooling; not product code under review).
+ *
+ * Removes the entire `## Findings` section when the findings table has zero data rows left.
+ *
+ * @param {string} markdown
+ * @returns {string}
+ */
+export const filterAiReviewMarkdownFindings = (markdown) => {
+  const findingsHeading = /^## Findings(\s*\r?\n)/m;
+  const m = findingsHeading.exec(markdown);
+  if (m === null || m.index === undefined) return markdown;
+
+  const before = markdown.slice(0, m.index);
+  const afterHeading = markdown.slice(m.index + m[0].length);
+  const nextHeadingIdx = afterHeading.search(/^## /m);
+  const findingsBody =
+    nextHeadingIdx === -1
+      ? afterHeading
+      : afterHeading.slice(0, nextHeadingIdx);
+  const afterSection =
+    nextHeadingIdx === -1 ? "" : afterHeading.slice(nextHeadingIdx);
+
+  const lines = findingsBody.split(/\r?\n/);
+  /** @type {string[]} */
+  const prefix = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i] ?? "";
+    const nextLine = lines[i + 1] ?? "";
+    const cells = parseGfmTableRowCells(line);
+    const nextCells = parseGfmTableRowCells(nextLine);
+    const isHeader =
+      cells !== null &&
+      cells.length >= 5 &&
+      /\bTier\b/u.test(cells[0] ?? "") &&
+      /\bRule\b/u.test(cells[1] ?? "") &&
+      /\bFile\b/u.test(cells[2] ?? "") &&
+      /\bLine\b/u.test(cells[3] ?? "") &&
+      /\bFinding\b/u.test(cells[4] ?? "");
+    const isSeparator =
+      nextCells !== null &&
+      nextCells.length >= 5 &&
+      nextCells.every((c) => /^:?-{3,}:?$/.test((c ?? "").trim()));
+
+    if (!(isHeader && isSeparator)) {
+      prefix.push(line);
+      i += 1;
+      continue;
+    }
+
+    let modified = false;
+    i += 2;
+    /** @type {string[]} */
+    const kept = [];
+    while (i < lines.length) {
+      const rowLine = lines[i] ?? "";
+      const rowCells = parseGfmTableRowCells(rowLine);
+      if (rowCells === null || rowCells.length < 5) break;
+      const fileRaw = rowCells[2] ?? "";
+      const filePh = isFindingsTablePlaceholderCell(fileRaw);
+      const dropForMissingAnchors = filePh;
+      const dropForScripts = !filePh && isRepoRootScriptsPath(fileRaw);
+
+      if (dropForMissingAnchors || dropForScripts) {
+        modified = true;
+        i += 1;
+        continue;
+      }
+
+      kept.push(rowLine);
+      i += 1;
+    }
+
+    const suffix = lines.slice(i);
+    if (kept.length === 0) {
+      const joinBetween = (a, b) => {
+        if (a.length === 0) return b;
+        if (b.length === 0) return a;
+        return `${a.replace(/\s+$/, "")}\n\n${b.replace(/^\s+/, "")}`;
+      };
+      const trimmedPrefix = prefix.join("\n").trimEnd();
+      const rest = suffix.join("\n").trimEnd();
+      return joinBetween(
+        joinBetween(before.trimEnd(), trimmedPrefix),
+        afterSection,
+      );
+    }
+
+    const rebuiltFindings = [
+      ...prefix,
+      line,
+      nextLine,
+      ...kept,
+      ...suffix,
+    ].join("\n");
+    const out = `${before}## Findings\n${rebuiltFindings}${afterSection}`;
+    return modified ? out : markdown;
+  }
+
+  return markdown;
+};
+
 /**
  * Selects relevant skill markdown files based on changed paths (best-effort).
  *
@@ -255,8 +393,8 @@ When present, output **only** a single markdown table under this heading—no ex
 **Row rules (fixed layout):**
 - **Tier** must be exactly one of: \`must-fix\` | \`should-fix\` | \`nice-to-have\`.
 - **Rule** is a short id (e.g. \`env-variables\`, \`prisma-strong-typing\`, or the rule filename like \`typescript-javascript-standards.mdc\`).
-- **File** is a repo-relative path from the diff, or \`—\` if not file-specific.
-- **Line** is a single line number, or \`—\` if unknown or N/A.
+- **File** must be a **concrete** repo-relative path present in the PR diff. **Never** use \`—\`. **Never** use repo-root \`scripts/**\` paths (tooling); findings must target product code under \`apps/**\` / \`packages/**\` (or other non-\`scripts/\` roots if the diff touches them).
+- **Line** is a single line number when you can tie the issue to a specific changed line; use \`—\` **only** for genuinely file-scoped issues (still requires a real **File** path).
 - **Finding** is plain text in a single table cell: **one or two short sentences**, no pipe characters, no newlines. Be specific (what to change and why).
 
 ## Possible false positives
@@ -267,6 +405,7 @@ Include **only if** there is a **concrete**, diff- or rules-grounded action **no
 
 ### Reviewer discipline (follow strictly)
 - Every Finding row must be grounded in a clear diff observation and mapped to a specific rule/skill. Do not require verbatim quotes; paraphrase is fine.
+- **Do not** emit vague "process compliance" rows tied only to workflow rules like \`read-rules-and-skills-first.mdc\`, \`run-code-quality-after-changes.mdc\`, or \`planning-ts-js-standards.mdc\` unless you can cite a concrete non-\`scripts/\` file path from the diff that demonstrates the violation.
 - **No hollow praise** and no PR recap unless it directly supports a finding.
 - **Test location (this monorepo)**: Default expectation is \`*.test.ts\` / \`*.test.tsx\` **next to the module under test**. A top-level \`tests/\` tree separate from \`src/\` is not the default—flag only when the diff actually adds such a mismatch per neighboring patterns.
 - **Nice-to-have** rows: only when a real, minor improvement is rules-grounded; no filler.

--- a/scripts/lib/ai-pr-review.test.ts
+++ b/scripts/lib/ai-pr-review.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   buildAiReviewPrompt,
+  filterAiReviewMarkdownFindings,
   selectSkillRelativePaths,
   truncateContextChunks,
   truncateMiddle,
@@ -171,5 +172,42 @@ describe("buildAiReviewPrompt", () => {
     expect(prompt).toContain("Prisma migrations");
     expect(prompt.toLowerCase()).toContain("omit this entire section");
     expect(prompt).toContain("Forbidden:");
+  });
+});
+
+describe("filterAiReviewMarkdownFindings", () => {
+  const tableHeader =
+    "| Tier | Rule | File | Line | Finding |\n| :--- | :--- | :--- | :--- | :--- |";
+
+  it("removes rows with placeholder File and removes repo-root scripts paths", () => {
+    // Act
+    const out = filterAiReviewMarkdownFindings(
+      `## Summary\n\nok\n\n## Findings\n\n${tableHeader}\n| must-fix | read-rules | — | — | vague |\n| should-fix | run-code-quality | scripts/lib/x.mjs | 12 | vague |\n| must-fix | env-variables | apps/a.ts | 3 | real |\n`,
+    );
+
+    // Assert
+    expect(out).toContain("apps/a.ts");
+    expect(out).not.toContain("read-rules");
+    expect(out).not.toContain("scripts/lib/x.mjs");
+    expect(out).not.toContain("| — | — |");
+  });
+
+  it("removes the entire Findings section when no rows remain", () => {
+    // Act
+    const out = filterAiReviewMarkdownFindings(
+      `## Summary\n\nok\n\n## Findings\n\n${tableHeader}\n| must-fix | x | — | — | vague |\n`,
+    );
+
+    // Assert
+    expect(out).not.toContain("## Findings");
+  });
+
+  it("does not touch markdown when there is no Findings heading", () => {
+    // Act
+    const md = "## Summary\n\nOnly summary.";
+    const out = filterAiReviewMarkdownFindings(md);
+
+    // Assert
+    expect(out).toBe(md);
   });
 });


### PR DESCRIPTION
## Summary

Tightens automated AI PR review so Findings stay anchored to concrete paths in `apps/` and `packages/`, drops placeholder table rows and repo-root `scripts/` targets, and post-processes model output to strip rows that slip through. The system prompt and user-facing prompt rules are aligned with the same constraints.

## Important changes

- Adds `filterAiReviewMarkdownFindings` to strip Finding rows with placeholder **File** cells, rows pointing at repo-root `scripts/`, and removes the whole `## Findings` section when no data rows remain.
- Updates the reviewer system prompt: focus violations on `apps/` / `packages/` code, require a real **File** path from the diff, and discourage vague workflow-only compliance rows unless tied to a specific product file.
- Refines **File** / **Line** instructions in the built prompt (no `—` for File; no repo-root `scripts/**` findings).

## Other changes

- Vitest coverage for filtering behavior (placeholder rows, empty section removal, no-op when no Findings heading).

## Key files to review

- `scripts/lib/ai-pr-review.mjs` — table parsing, filtering rules, and prompt text updates.
- `scripts/ai-pr-review.mjs` — system prompt change and wiring `filterAiReviewMarkdownFindings` on completion output.
- `scripts/lib/ai-pr-review.test.ts` — assertions for kept/dropped rows and section removal.

## How to test

1. From repo root: `pnpm exec vitest run scripts/lib/ai-pr-review.test.ts` (or the package/script that runs these tests if different).
2. Optionally run the AI review script against a small diff and confirm the posted comment has no `scripts/` file paths in Findings and no placeholder **File** rows.
