### PR TITLE
Validate agent config against schema before run

### DIFF
--- a/apps/mediapulse/agents/user-registration/src/index.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.ts
@@ -47,11 +47,6 @@ const app = createAgentApp<
     inputSchema: BodySchema,
     configSchema: ConfigSchema,
     run: async ({ input, token, config }) => {
-      const configValidation = ConfigSchema.safeParse(config);
-      if (!configValidation.success) {
-        throw configValidation.error;
-      }
-
       logger.info(
         `Running user-registration agent. Max messages: ${input.maxMessagesPerRun}`,
       );

--- a/packages/shared/agent-runtime/src/create-agent-app.test.ts
+++ b/packages/shared/agent-runtime/src/create-agent-app.test.ts
@@ -313,8 +313,7 @@ describe("createAgentApp", () => {
     });
   });
 
-  it("accepts missing config even when configSchema has required fields", async () => {
-    // Setup
+  it("returns 400 when config is omitted and configSchema has required fields", async () => {
     const requiredConfigSchema = z.object({ limit: z.number() });
     type RequiredConfig = z.infer<typeof requiredConfigSchema>;
     const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
@@ -334,19 +333,285 @@ describe("createAgentApp", () => {
       { verifyToken: async () => true },
     );
 
-    // Act
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ input: validInput }),
+    });
+    const body = (await res.json()) as {
+      message: string;
+      requiredFields: string[];
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.message).toContain("missing required field(s): limit");
+    expect(body.requiredFields).toContain("limit");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("parses omitted config as {} when configSchema allows an empty object", async () => {
+    const optionalFieldsConfigSchema = z.object({
+      limit: z.number().optional(),
+    });
+    type OptionalFieldsConfig = z.infer<typeof optionalFieldsConfigSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      OptionalFieldsConfig,
+      typeof optionalFieldsConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: optionalFieldsConfigSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
     const res = await app.request("http://localhost/", {
       method: "POST",
       headers: authHeaders,
       body: JSON.stringify({ input: validInput }),
     });
 
-    // Assert
     expect(res.status).toBe(200);
     expect(run).toHaveBeenCalledWith({
       input: validInput,
       config: {},
       token: "Bearer test-token",
+    });
+  });
+
+  it("returns 400 when config is JSON null and configSchema has required fields", async () => {
+    const requiredConfigSchema = z.object({ limit: z.number() });
+    type RequiredConfig = z.infer<typeof requiredConfigSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      RequiredConfig,
+      typeof requiredConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: requiredConfigSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ input: validInput, config: null }),
+    });
+    const body = (await res.json()) as {
+      message: string;
+      requiredFields: string[];
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.message).toContain("missing required field(s): limit");
+    expect(body.requiredFields).toContain("limit");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when config is an empty object and configSchema has required fields", async () => {
+    const requiredConfigSchema = z.object({ limit: z.number() });
+    type RequiredConfig = z.infer<typeof requiredConfigSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      RequiredConfig,
+      typeof requiredConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: requiredConfigSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ input: validInput, config: {} }),
+    });
+    const body = (await res.json()) as {
+      message: string;
+      requiredFields: string[];
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.message).toContain("missing required field(s): limit");
+    expect(body.requiredFields).toContain("limit");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when config has wrong types for configSchema", async () => {
+    const requiredConfigSchema = z.object({ limit: z.number() });
+    type RequiredConfig = z.infer<typeof requiredConfigSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      RequiredConfig,
+      typeof requiredConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: requiredConfigSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({
+        input: validInput,
+        config: { limit: "not-a-number" },
+      }),
+    });
+    const body = (await res.json()) as {
+      message: string;
+      requiredFields: string[];
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.message).toBe("Validation failed");
+    expect(body.requiredFields).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 with nested required path when nested config field is missing", async () => {
+    const nestedConfigSchema = z.object({
+      api: z.object({ key: z.string().min(1) }),
+    });
+    type NestedConfig = z.infer<typeof nestedConfigSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      NestedConfig,
+      typeof nestedConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: nestedConfigSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: authHeaders,
+      body: JSON.stringify({ input: validInput, config: {} }),
+    });
+    const body = (await res.json()) as {
+      message: string;
+      requiredFields: string[];
+    };
+
+    expect(res.status).toBe(400);
+    expect(body.requiredFields).toContain("api");
+    expect(body.message).toContain("api");
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("passes parsed config and Hermes correlation together when both are present", async () => {
+    const configSchema = z.object({ limit: z.number() });
+    type Config = z.infer<typeof configSchema>;
+    const run = vi.fn().mockResolvedValue({ success: true } as AgentRunResult);
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      Config,
+      typeof configSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema,
+        run,
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/", {
+      method: "POST",
+      headers: {
+        ...authHeaders,
+        [HERMES_HEADER_SCHEDULE_ID]: "sched-z",
+        [HERMES_HEADER_SCHEDULE_EXECUTION_ID]: "exec-z",
+        [HERMES_HEADER_PIPELINE_STEP_ID]: "step-z",
+      },
+      body: JSON.stringify({
+        input: validInput,
+        config: { limit: 42 },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(run).toHaveBeenCalledWith({
+      input: validInput,
+      config: { limit: 42 },
+      token: "Bearer test-token",
+      hermesCorrelation: {
+        scheduleId: "sched-z",
+        scheduleExecutionId: "exec-z",
+        pipelineStepId: "step-z",
+      },
+    });
+  });
+
+  it("GET /schemas includes custom configSchema JSON when configSchema is provided", async () => {
+    const customConfigSchema = z.object({
+      feature: z.boolean(),
+    });
+    type CustomConfig = z.infer<typeof customConfigSchema>;
+    const app = createAgentApp<
+      Input,
+      typeof schema,
+      CustomConfig,
+      typeof customConfigSchema
+    >(
+      {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        inputSchema: schema,
+        configSchema: customConfigSchema,
+        run: async () => ({ success: true }),
+      },
+      { verifyToken: async () => true },
+    );
+
+    const res = await app.request("http://localhost/schemas", {
+      method: "GET",
+    });
+    const body = (await res.json()) as {
+      configSchema: { properties?: Record<string, unknown> };
+    };
+
+    expect(res.status).toBe(200);
+    expect(body.configSchema.properties).toMatchObject({
+      feature: expect.objectContaining({ type: "boolean" }),
     });
   });
 

--- a/packages/shared/agent-runtime/src/create-agent-app.ts
+++ b/packages/shared/agent-runtime/src/create-agent-app.ts
@@ -17,7 +17,11 @@ const emptyConfigSchema = z.object({});
 
 /**
  * Creates a Hono app that handles GET /schemas (no auth), POST "/" with bearer auth,
- * body validation ({ input, config }), and the agent run function.
+ * body validation (`input` and `config`), and the agent run function.
+ *
+ * When a `configSchema` is provided, the posted `config` object is validated on every request.
+ * If the JSON body omits `config`, it is treated as `{}` — so required fields in the schema
+ * fail validation before `run` is called (400).
  *
  * **200:** `run` result is mapped to the Hermes PRD envelope (`schemaVersion`, `status`, optional `message`).
  * **Throw** from `run` → 500 (or validation errors → 400).
@@ -171,10 +175,9 @@ export function createAgentApp<
       };
       const rawInput = requestBody?.input;
       const input = (await config.inputSchema.parseAsync(rawInput)) as TInput;
-      const configParsed =
-        requestBody?.config === undefined
-          ? ({} as TConfig)
-          : ((await configSchema.parseAsync(requestBody.config)) as TConfig);
+      const configParsed = (await configSchema.parseAsync(
+        requestBody?.config ?? {},
+      )) as TConfig;
       const token = context.req.header("Authorization");
       const hermesCorrelation = hermesInvokeCorrelationFromGetHeader((name) =>
         context.req.header(name),
@@ -232,7 +235,7 @@ export function createAgentApp<
             errors: flattenedErrors,
             requiredFields,
           },
-          "Agent input validation failed",
+          "Agent request validation failed",
         );
         return context.json(
           {


### PR DESCRIPTION
## Summary

Centralizes agent `config` validation in `createAgentApp`: omitted `config` is parsed as `{}`, so Zod `configSchema` required fields are enforced before `run` (HTTP 400). Removes redundant per-agent `safeParse` in the user-registration agent.

## Important changes

- `createAgentApp` always validates posted `config` (including `{}` when the field is omitted) against the provided `configSchema` before invoking `run`.
- Requests with missing required config, `config: null`, empty object where fields are required, or wrong types return 400 without calling `run`.
- Validation error envelope message updated from "Agent input validation failed" to "Agent request validation failed" when input/config validation fails.

## Other changes

- Extended `create-agent-app` unit tests for omitted config, null, empty object, type errors, nested required paths, Hermes correlation + config, and GET `/schemas` config schema exposure.
- Removed duplicate `ConfigSchema.safeParse` block from the user-registration agent `run` handler (runtime handles it).
- JSDoc on `createAgentApp` documents omitted-`config` behavior.

## Key files to review

- `packages/shared/agent-runtime/src/create-agent-app.ts` — `configParsed` uses `parseAsync(requestBody?.config ?? {})` and updated validation message.
- `packages/shared/agent-runtime/src/create-agent-app.test.ts` — new/updated cases for config validation and schemas endpoint.
- `apps/mediapulse/agents/user-registration/src/index.ts` — redundant config validation removed.

## How to test

1. From repo root: `pnpm code-quality` (or `pnpm --filter @mediapulse/agent-runtime test` if scoped).
2. POST to an agent with a `configSchema` that requires fields: omit `config` or send `{}` / `null` / invalid types and confirm 400 JSON with `requiredFields` / message as expected; valid `config` returns 200 and `run` receives parsed config.
3. GET `/schemas` on such an agent and confirm `configSchema` reflects the Zod schema (e.g. property types).
