### PR TITLE
Add elapsed time for pipeline and schedule executions

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
@@ -11,6 +11,10 @@ import {
   TableRow,
 } from "@workspace/ui/components/table";
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
+import {
+  computePipelineWallElapsed,
+  formatPipelineElapsedLabel,
+} from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
 import { getHttpTriggerExecutionDetail } from "@/lib/http-triggers";
 import { maskSecretsInJson } from "@/lib/mask-json-secrets";
@@ -26,6 +30,16 @@ export default async function HttpTriggerExecutionDetailPage({
   const { id: triggerId, executionId } = await params;
   const rawDetail = await getHttpTriggerExecutionDetail(triggerId, executionId);
   if (!rawDetail) notFound();
+
+  const pipelineElapsed = computePipelineWallElapsed(
+    rawDetail.invocations.map((job) => ({
+      enqueuedAt: job.enqueuedAt,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+    })),
+    rawDetail.execution.runStatus,
+  );
+
   const detail = {
     ...rawDetail,
     invocations: rawDetail.invocations.map((invocation) => ({
@@ -78,6 +92,10 @@ export default async function HttpTriggerExecutionDetailPage({
         <p>
           <span className="text-muted-foreground">Run status:</span>{" "}
           {detail.execution.runStatus}
+        </p>
+        <p>
+          <span className="text-muted-foreground">Elapsed:</span>{" "}
+          {formatPipelineElapsedLabel(pipelineElapsed)}
         </p>
         <p>
           <span className="text-muted-foreground">

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
@@ -12,6 +12,10 @@ import {
 } from "@workspace/ui/components/table";
 
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
+import {
+  computePipelineWallElapsed,
+  formatPipelineElapsedLabel,
+} from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
 import { maskSecretsInJson } from "@/lib/mask-json-secrets";
 import { getManualPipelineExecutionDetail } from "@/lib/pipeline-executions";
@@ -30,6 +34,15 @@ export default async function PipelineExecutionDetailPage({
     executionId,
   );
   if (!rawDetail) notFound();
+
+  const pipelineElapsed = computePipelineWallElapsed(
+    rawDetail.invocations.map((job) => ({
+      enqueuedAt: job.enqueuedAt,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+    })),
+    rawDetail.execution.runStatus,
+  );
 
   const detail = {
     ...rawDetail,
@@ -69,6 +82,10 @@ export default async function PipelineExecutionDetailPage({
         <p>
           <span className="text-muted-foreground">Run status:</span>{" "}
           {detail.execution.runStatus}
+        </p>
+        <p>
+          <span className="text-muted-foreground">Elapsed:</span>{" "}
+          {formatPipelineElapsedLabel(pipelineElapsed)}
         </p>
         <p>
           <span className="text-muted-foreground">

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/pipeline-executions-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/pipeline-executions-table.tsx
@@ -59,6 +59,7 @@ export const PipelineExecutionsTable = ({
             <TableHead className="min-w-[140px] whitespace-normal">
               Invocations (success / fail)
             </TableHead>
+            <TableHead className="w-[120px]">Elapsed</TableHead>
             <TableHead className="w-[90px]">Detail</TableHead>
           </TableRow>
         </TableHeader>
@@ -66,7 +67,7 @@ export const PipelineExecutionsTable = ({
           {executions.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={7}
+                colSpan={8}
                 className="text-center text-muted-foreground"
               >
                 No executions yet.
@@ -102,6 +103,9 @@ export const PipelineExecutionsTable = ({
                   <TableCell className="text-sm">
                     {execution.succeededInvocationCount} /{" "}
                     {execution.failedInvocationCount}
+                  </TableCell>
+                  <TableCell className="text-sm tabular-nums text-muted-foreground">
+                    {execution.elapsedLabel}
                   </TableCell>
                   <TableCell>
                     <Link

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
@@ -12,6 +12,10 @@ import {
 } from "@workspace/ui/components/table";
 
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
+import {
+  computePipelineWallElapsed,
+  formatPipelineElapsedLabel,
+} from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
 import { maskScheduleExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 import { getScheduleExecutionDetail } from "@/lib/schedules";
@@ -31,6 +35,14 @@ export default async function ScheduleExecutionDetailPage({
   if (!rawDetail) {
     notFound();
   }
+  const pipelineElapsed = computePipelineWallElapsed(
+    rawDetail.invocations.map((job) => ({
+      enqueuedAt: job.enqueuedAt,
+      startedAt: job.startedAt,
+      completedAt: job.completedAt,
+    })),
+    rawDetail.execution.runStatus,
+  );
   const detail = maskScheduleExecutionDetailForDisplay(rawDetail);
 
   return (
@@ -73,6 +85,10 @@ export default async function ScheduleExecutionDetailPage({
         <p>
           <span className="text-muted-foreground">Run status:</span>{" "}
           {detail.execution.runStatus}
+        </p>
+        <p>
+          <span className="text-muted-foreground">Elapsed:</span>{" "}
+          {formatPipelineElapsedLabel(pipelineElapsed)}
         </p>
         <p>
           <span className="text-muted-foreground">

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
@@ -19,6 +19,10 @@ import {
 } from "@workspace/ui/components/table";
 import { Button } from "@workspace/ui/components/button";
 
+import {
+  computeJobElapsedDisplay,
+  formatJobElapsedCell,
+} from "@/lib/compute-execution-elapsed";
 import { formatQueueAttemptsDisplay } from "@/lib/format-queue-attempts-display";
 import { resolveInvocationOutcomeLabel } from "@/lib/invocation-display-status";
 
@@ -145,13 +149,14 @@ export const ScheduleExecutionInvocationsTable = ({
                   onToggle={toggleSort}
                 />
               </TableHead>
+              <TableHead>Duration</TableHead>
               <TableHead>Reason</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {invocations.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} className="text-muted-foreground">
+                <TableCell colSpan={8} className="text-muted-foreground">
                   No invocations.
                 </TableCell>
               </TableRow>
@@ -163,6 +168,13 @@ export const ScheduleExecutionInvocationsTable = ({
                 );
                 const isTerminalOutcome =
                   outcome === "success" || outcome === "failure";
+                const startedAt =
+                  j.startedAtIso != null ? new Date(j.startedAtIso) : null;
+                const completedAt =
+                  j.completedAtIso != null ? new Date(j.completedAtIso) : null;
+                const durationLabel = formatJobElapsedCell(
+                  computeJobElapsedDisplay(startedAt, completedAt),
+                );
 
                 return (
                   <TableRow key={j.jobId}>
@@ -204,6 +216,9 @@ export const ScheduleExecutionInvocationsTable = ({
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
                       {formatOptionalIso(j.completedAtIso)}
+                    </TableCell>
+                    <TableCell className="text-sm tabular-nums text-muted-foreground">
+                      {durationLabel}
                     </TableCell>
                     <TableCell className="max-w-md whitespace-normal wrap-break-word text-sm text-muted-foreground">
                       {j.errorSummary ?? "—"}

--- a/apps/hermes/dashboard/lib/compute-execution-elapsed.test.ts
+++ b/apps/hermes/dashboard/lib/compute-execution-elapsed.test.ts
@@ -1,0 +1,262 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  computeJobElapsedDisplay,
+  computeJobElapsedMs,
+  computePipelineWallElapsed,
+  formatElapsedMs,
+  formatJobElapsedCell,
+  formatPipelineElapsedLabel,
+} from "./compute-execution-elapsed";
+
+describe("formatElapsedMs", () => {
+  it("formats sub-second as less than one second", () => {
+    expect(formatElapsedMs(0)).toBe("<1s");
+    expect(formatElapsedMs(500)).toBe("<1s");
+    expect(formatElapsedMs(999)).toBe("<1s");
+  });
+
+  it("formats seconds under one minute", () => {
+    expect(formatElapsedMs(1000)).toBe("1s");
+    expect(formatElapsedMs(45_000)).toBe("45s");
+    expect(formatElapsedMs(59_999)).toBe("59s");
+  });
+
+  it("formats minutes under one hour", () => {
+    expect(formatElapsedMs(60_000)).toBe("1m");
+    expect(formatElapsedMs(125_000)).toBe("2m 5s");
+    expect(formatElapsedMs(3_599_000)).toBe("59m 59s");
+  });
+
+  it("formats hours", () => {
+    expect(formatElapsedMs(3_600_000)).toBe("1h");
+    expect(formatElapsedMs(3_660_000)).toBe("1h 1m");
+  });
+
+  it("treats negative ms as zero", () => {
+    expect(formatElapsedMs(-100)).toBe("0s");
+  });
+});
+
+describe("computeJobElapsedMs", () => {
+  it("returns null when either timestamp is missing", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-01-01T00:00:05.000Z");
+    expect(computeJobElapsedMs(null, b)).toBeNull();
+    expect(computeJobElapsedMs(a, null)).toBeNull();
+    expect(computeJobElapsedMs(null, null)).toBeNull();
+  });
+
+  it("returns difference in ms when valid", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-01-01T00:00:05.000Z");
+    expect(computeJobElapsedMs(a, b)).toBe(5000);
+  });
+
+  it("returns null when completed is before started", () => {
+    const a = new Date("2026-01-01T00:00:05.000Z");
+    const b = new Date("2026-01-01T00:00:00.000Z");
+    expect(computeJobElapsedMs(a, b)).toBeNull();
+  });
+});
+
+describe("computeJobElapsedDisplay", () => {
+  it("returns final when both timestamps exist", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const b = new Date("2026-01-01T00:00:03.000Z");
+    const r = computeJobElapsedDisplay(a, b);
+    expect(r).toEqual({ kind: "final", ms: 3000 });
+  });
+
+  it("returns in_progress when only started is set", () => {
+    const a = new Date("2026-01-01T00:00:00.000Z");
+    const now = new Date("2026-01-01T00:01:00.000Z");
+    const r = computeJobElapsedDisplay(a, null, now);
+    expect(r).toEqual({ kind: "in_progress", ms: 60_000 });
+  });
+
+  it("returns unknown when no started and no completed", () => {
+    expect(computeJobElapsedDisplay(null, null)).toEqual({ kind: "unknown" });
+  });
+
+  it("returns unknown when started is in the future relative to now", () => {
+    const future = new Date("2099-01-01T00:00:00.000Z");
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    expect(computeJobElapsedDisplay(future, null, now)).toEqual({
+      kind: "unknown",
+    });
+  });
+});
+
+describe("formatJobElapsedCell", () => {
+  it("formats unknown as em dash", () => {
+    expect(formatJobElapsedCell({ kind: "unknown" })).toBe("—");
+  });
+
+  it("formats final with formatElapsedMs", () => {
+    expect(formatJobElapsedCell({ kind: "final", ms: 5000 })).toBe("5s");
+  });
+
+  it("formats in_progress with suffix", () => {
+    expect(formatJobElapsedCell({ kind: "in_progress", ms: 60_000 })).toBe(
+      "1m (so far)",
+    );
+  });
+});
+
+describe("computePipelineWallElapsed", () => {
+  const t0 = new Date("2026-01-01T00:00:00.000Z");
+  const t1 = new Date("2026-01-01T00:00:10.000Z");
+  const t2 = new Date("2026-01-01T00:01:00.000Z");
+
+  it("returns unknown for empty invocations", () => {
+    expect(computePipelineWallElapsed([], "succeeded")).toEqual({
+      kind: "unknown",
+    });
+  });
+
+  it("computes final wall time for terminal status", () => {
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: t0,
+          startedAt: new Date("2026-01-01T00:00:05.000Z"),
+          completedAt: t1,
+        },
+        {
+          enqueuedAt: t0,
+          startedAt: null,
+          completedAt: t2,
+        },
+      ],
+      "succeeded",
+    );
+    expect(r).toEqual({ kind: "final", ms: 60_000 });
+  });
+
+  it("uses enqueuedAt when startedAt is null for min start", () => {
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: t0,
+          startedAt: null,
+          completedAt: t1,
+        },
+      ],
+      "failed",
+    );
+    expect(r).toEqual({ kind: "final", ms: 10_000 });
+  });
+
+  it("returns unknown for terminal when no job completed", () => {
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: t0,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+      "failed",
+    );
+    expect(r).toEqual({ kind: "unknown" });
+  });
+
+  it("returns unknown for terminal when max completed is before min start", () => {
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: t0,
+          startedAt: new Date("2026-01-01T00:01:00.000Z"),
+          completedAt: new Date("2026-01-01T00:00:30.000Z"),
+        },
+      ],
+      "succeeded",
+    );
+    expect(r).toEqual({ kind: "unknown" });
+  });
+
+  it("returns in_progress snapshot for running", () => {
+    const start = new Date("2026-01-01T00:00:00.000Z");
+    const now = new Date("2026-01-01T00:05:00.000Z");
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: start,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+      "running",
+      now,
+    );
+    expect(r).toEqual({ kind: "in_progress", ms: 5 * 60_000 });
+  });
+
+  it("returns in_progress snapshot for pending", () => {
+    const start = new Date("2026-01-01T00:00:00.000Z");
+    const now = new Date("2026-01-01T00:00:30.000Z");
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: start,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+      "pending",
+      now,
+    );
+    expect(r).toEqual({ kind: "in_progress", ms: 30_000 });
+  });
+
+  it("returns unknown for non-terminal non-running status", () => {
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: t0,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+      "unexpected",
+    );
+    expect(r).toEqual({ kind: "unknown" });
+  });
+
+  it("returns unknown for running when now is before min start", () => {
+    const start = new Date("2026-01-01T12:00:00.000Z");
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const r = computePipelineWallElapsed(
+      [
+        {
+          enqueuedAt: start,
+          startedAt: null,
+          completedAt: null,
+        },
+      ],
+      "running",
+      now,
+    );
+    expect(r).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("formatPipelineElapsedLabel", () => {
+  it("formats unknown as em dash", () => {
+    expect(formatPipelineElapsedLabel({ kind: "unknown" })).toBe("—");
+  });
+
+  it("formats final", () => {
+    expect(formatPipelineElapsedLabel({ kind: "final", ms: 90_000 })).toBe(
+      "1m 30s",
+    );
+  });
+
+  it("formats in_progress with prefix", () => {
+    expect(formatPipelineElapsedLabel({ kind: "in_progress", ms: 5000 })).toBe(
+      "In progress (5s)",
+    );
+  });
+});

--- a/apps/hermes/dashboard/lib/compute-execution-elapsed.ts
+++ b/apps/hermes/dashboard/lib/compute-execution-elapsed.ts
@@ -1,0 +1,196 @@
+/** Terminal pipeline run statuses: wall duration is meaningful when job bounds exist. */
+const TERMINAL_RUN_STATUSES = new Set(["succeeded", "partial", "failed"]);
+
+export type PipelineWallElapsedResult =
+  | { kind: "unknown" }
+  | { kind: "final"; ms: number }
+  | { kind: "in_progress"; ms: number };
+
+export type JobElapsedDisplayResult =
+  | { kind: "unknown" }
+  | { kind: "final"; ms: number }
+  | { kind: "in_progress"; ms: number };
+
+/**
+ * Formats a non-negative duration in milliseconds for admin UI (compact, tabular-friendly).
+ *
+ * @param ms - Elapsed milliseconds (must be >= 0).
+ * @returns Human-readable string (e.g. seconds, minutes, hours).
+ */
+export const formatElapsedMs = (ms: number): string => {
+  if (ms < 0) {
+    return "0s";
+  }
+  if (ms < 1000) {
+    return "<1s";
+  }
+  const secTotal = Math.floor(ms / 1000);
+  if (secTotal < 60) {
+    return `${secTotal}s`;
+  }
+  const minTotal = Math.floor(secTotal / 60);
+  const sec = secTotal % 60;
+  if (minTotal < 60) {
+    return sec > 0 ? `${minTotal}m ${sec}s` : `${minTotal}m`;
+  }
+  const h = Math.floor(minTotal / 60);
+  const min = minTotal % 60;
+  return min > 0 ? `${h}h ${min}m` : `${h}h`;
+};
+
+/**
+ * Worker run time for one job when both start and completion timestamps exist.
+ *
+ * @param startedAt - When the worker started processing, if recorded.
+ * @param completedAt - When the job finished, if recorded.
+ * @returns Elapsed ms, or null if either timestamp is missing.
+ */
+export const computeJobElapsedMs = (
+  startedAt: Date | null,
+  completedAt: Date | null,
+): number | null => {
+  if (startedAt == null || completedAt == null) {
+    return null;
+  }
+  const ms = completedAt.getTime() - startedAt.getTime();
+  if (ms < 0) {
+    return null;
+  }
+  return ms;
+};
+
+/**
+ * Display string for one job row: finished duration, snapshot while running, or em dash.
+ *
+ * @param startedAt - Worker start time.
+ * @param completedAt - Worker completion time.
+ * @param now - Current time (injectable for tests).
+ * @returns Final duration, in-progress snapshot, or unknown.
+ */
+export const computeJobElapsedDisplay = (
+  startedAt: Date | null,
+  completedAt: Date | null,
+  now: Date = new Date(),
+): JobElapsedDisplayResult => {
+  const finalMs = computeJobElapsedMs(startedAt, completedAt);
+  if (finalMs != null) {
+    return { kind: "final", ms: finalMs };
+  }
+  if (startedAt != null && completedAt == null) {
+    const ms = now.getTime() - startedAt.getTime();
+    if (ms >= 0) {
+      return { kind: "in_progress", ms };
+    }
+  }
+  return { kind: "unknown" };
+};
+
+/**
+ * Formats a job elapsed result for the invocations table.
+ *
+ * @param result - Output from {@link computeJobElapsedDisplay}.
+ * @returns Plain text cell value.
+ */
+export const formatJobElapsedCell = (
+  result: JobElapsedDisplayResult,
+): string => {
+  if (result.kind === "unknown") {
+    return "—";
+  }
+  if (result.kind === "final") {
+    return formatElapsedMs(result.ms);
+  }
+  return `${formatElapsedMs(result.ms)} (so far)`;
+};
+
+/**
+ * Earliest meaningful start for a job: worker start, else enqueue time.
+ *
+ * @param enqueuedAt - When the job was enqueued (required).
+ * @param startedAt - When processing started, if known.
+ */
+const effectiveJobStart = (enqueuedAt: Date, startedAt: Date | null): Date => {
+  return startedAt ?? enqueuedAt;
+};
+
+/**
+ * Wall-clock span across all jobs in one pipeline execution.
+ *
+ * - **Terminal runs** (`succeeded` | `partial` | `failed`): `min(startedAt ?? enqueuedAt)` to `max(completedAt)` when both bounds exist.
+ * - **Pending / running:** snapshot from earliest start to `now` (updates on refresh).
+ * - **No jobs or insufficient timestamps:** unknown.
+ *
+ * @param invocations - Agent job rows for this execution.
+ * @param runStatus - Execution-level run status.
+ * @param now - Current time for in-progress snapshots (injectable for tests).
+ */
+export const computePipelineWallElapsed = (
+  invocations: Array<{
+    enqueuedAt: Date;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }>,
+  runStatus: string,
+  now: Date = new Date(),
+): PipelineWallElapsedResult => {
+  if (invocations.length === 0) {
+    return { kind: "unknown" };
+  }
+
+  let minStart: number | null = null;
+  let maxCompleted: number | null = null;
+  for (const job of invocations) {
+    const start = effectiveJobStart(job.enqueuedAt, job.startedAt);
+    const t0 = start.getTime();
+    if (minStart == null || t0 < minStart) {
+      minStart = t0;
+    }
+    if (job.completedAt != null) {
+      const tc = job.completedAt.getTime();
+      if (maxCompleted == null || tc > maxCompleted) {
+        maxCompleted = tc;
+      }
+    }
+  }
+
+  if (minStart == null) {
+    return { kind: "unknown" };
+  }
+
+  const isTerminal = TERMINAL_RUN_STATUSES.has(runStatus);
+
+  if (isTerminal) {
+    if (maxCompleted != null && maxCompleted >= minStart) {
+      return { kind: "final", ms: maxCompleted - minStart };
+    }
+    return { kind: "unknown" };
+  }
+
+  if (runStatus === "running" || runStatus === "pending") {
+    const ms = now.getTime() - minStart;
+    if (ms >= 0) {
+      return { kind: "in_progress", ms };
+    }
+    return { kind: "unknown" };
+  }
+
+  return { kind: "unknown" };
+};
+
+/**
+ * Single-line label for pipeline execution summary (detail page / list).
+ *
+ * @param result - Output from {@link computePipelineWallElapsed}.
+ * @returns Display string for admins.
+ */
+export const formatPipelineElapsedLabel = (
+  result: PipelineWallElapsedResult,
+): string => {
+  if (result.kind === "unknown") {
+    return "—";
+  }
+  if (result.kind === "final") {
+    return formatElapsedMs(result.ms);
+  }
+  return `In progress (${formatElapsedMs(result.ms)})`;
+};

--- a/apps/hermes/dashboard/lib/http-triggers.ts
+++ b/apps/hermes/dashboard/lib/http-triggers.ts
@@ -197,6 +197,7 @@ export type HttpTriggerExecutionDetail = {
     error: unknown;
     agentResponse: unknown;
     semanticStatus: string | null;
+    enqueuedAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
     dataQueueAttempts: number | null;
@@ -246,6 +247,7 @@ export const getHttpTriggerExecutionDetail = async (
           error: true,
           agentResponse: true,
           semanticStatus: true,
+          enqueuedAt: true,
           startedAt: true,
           completedAt: true,
           dataQueueAttempts: true,
@@ -301,6 +303,7 @@ export const getHttpTriggerExecutionDetail = async (
       error: job.error,
       agentResponse: job.agentResponse,
       semanticStatus: job.semanticStatus,
+      enqueuedAt: job.enqueuedAt,
       startedAt: job.startedAt,
       completedAt: job.completedAt,
       dataQueueAttempts: job.dataQueueAttempts,

--- a/apps/hermes/dashboard/lib/mask-json-secrets.test.ts
+++ b/apps/hermes/dashboard/lib/mask-json-secrets.test.ts
@@ -102,6 +102,7 @@ describe("maskScheduleExecutionDetailForDisplay", () => {
           error: null,
           agentResponse: null,
           semanticStatus: null,
+          enqueuedAt: new Date("2026-01-01T00:00:00.000Z"),
           startedAt: null,
           completedAt: null,
           dataQueueAttempts: null,

--- a/apps/hermes/dashboard/lib/pipeline-executions.test.ts
+++ b/apps/hermes/dashboard/lib/pipeline-executions.test.ts
@@ -6,6 +6,7 @@ import { getPipelineExecutionsPage } from "./pipeline-executions";
 const scheduleExecutionFindManyMock = vi.fn();
 const httpTriggerExecutionFindManyMock = vi.fn();
 const manualPipelineExecutionFindManyMock = vi.fn();
+const agentJobExecutionFindManyMock = vi.fn();
 
 vi.mock("@hermes/orchestration-database", () => ({
   prisma: {
@@ -20,6 +21,9 @@ vi.mock("@hermes/orchestration-database", () => ({
       findMany: (...args: unknown[]) =>
         manualPipelineExecutionFindManyMock(...args),
     },
+    agentJobExecution: {
+      findMany: (...args: unknown[]) => agentJobExecutionFindManyMock(...args),
+    },
   },
 }));
 
@@ -29,6 +33,7 @@ describe("getPipelineExecutionsPage", () => {
     scheduleExecutionFindManyMock.mockReset();
     httpTriggerExecutionFindManyMock.mockReset();
     manualPipelineExecutionFindManyMock.mockReset();
+    agentJobExecutionFindManyMock.mockReset();
   });
 
   it("merges rows across sources and sorts by execution time desc", async () => {
@@ -78,6 +83,7 @@ describe("getPipelineExecutionsPage", () => {
         createdAt: new Date("2026-03-20T12:00:00.000Z"),
       },
     ]);
+    agentJobExecutionFindManyMock.mockResolvedValue([]);
 
     // Act
     const result = await getPipelineExecutionsPage("pipe-1", 1, 10);
@@ -93,6 +99,11 @@ describe("getPipelineExecutionsPage", () => {
       "manual",
       "http-trigger",
       "schedule",
+    ]);
+    expect(result.executions.map((item) => item.elapsedLabel)).toEqual([
+      "—",
+      "—",
+      "—",
     ]);
   });
 
@@ -142,6 +153,16 @@ describe("getPipelineExecutionsPage", () => {
         createdAt: new Date("2026-03-20T11:00:00.000Z"),
       },
     ]);
+    agentJobExecutionFindManyMock.mockResolvedValue([
+      {
+        scheduleExecutionId: "sch-exec-1",
+        httpTriggerExecutionId: null,
+        manualExecutionId: null,
+        enqueuedAt: new Date("2026-03-20T10:00:00.000Z"),
+        startedAt: new Date("2026-03-20T10:00:05.000Z"),
+        completedAt: new Date("2026-03-20T10:01:00.000Z"),
+      },
+    ]);
 
     // Act
     const result = await getPipelineExecutionsPage("pipe-1", 2, 2);
@@ -150,5 +171,6 @@ describe("getPipelineExecutionsPage", () => {
     expect(result.total).toBe(3);
     expect(result.executions).toHaveLength(1);
     expect(result.executions[0]?.id).toBe("sch-exec-1");
+    expect(result.executions[0]?.elapsedLabel).toBe("55s");
   });
 });

--- a/apps/hermes/dashboard/lib/pipeline-executions.ts
+++ b/apps/hermes/dashboard/lib/pipeline-executions.ts
@@ -1,6 +1,11 @@
 import type { Prisma } from "@hermes/orchestration-database";
 import { prisma } from "@hermes/orchestration-database";
 
+import {
+  computePipelineWallElapsed,
+  formatPipelineElapsedLabel,
+} from "./compute-execution-elapsed";
+
 type Db = typeof prisma;
 
 export type PipelineExecutionSource = "manual" | "schedule" | "http-trigger";
@@ -18,6 +23,8 @@ export type PipelineExecutionRow = {
   failedInvocationCount: number;
   errors: unknown;
   createdAt: Date;
+  /** Wall-clock elapsed label for this execution (derived from job rows). */
+  elapsedLabel: string;
 };
 
 export type PipelineExecutionsPageResult = {
@@ -100,7 +107,7 @@ export const getPipelineExecutionsPage = async (
     db.manualPipelineExecution.findMany(manualArgs),
   ]);
 
-  const merged: PipelineExecutionRow[] = [
+  const merged: Array<Omit<PipelineExecutionRow, "elapsedLabel">> = [
     ...scheduleRows.map((row) => ({
       id: row.id,
       source: "schedule" as const,
@@ -150,12 +157,144 @@ export const getPipelineExecutionsPage = async (
 
   const start = Math.max(0, (page - 1) * pageSize);
   const end = start + pageSize;
+  const slice = merged.slice(start, end);
+  const executionsWithElapsed = await attachPipelineExecutionElapsedLabels(
+    slice,
+    db,
+  );
+
   return {
-    executions: merged.slice(start, end),
+    executions: executionsWithElapsed,
     total: merged.length,
     page,
     pageSize,
   };
+};
+
+/**
+ * Groups agent jobs by execution id for pipeline execution list rows.
+ *
+ * @param rows - One page of merged execution rows (no id collisions across sources).
+ * @param jobs - Job rows from Prisma for those executions only.
+ * @returns Map from `source:id` to invocation inputs for {@link computePipelineWallElapsed}.
+ */
+const groupJobsByPipelineExecutionRow = (
+  rows: Array<Pick<PipelineExecutionRow, "id" | "source" | "runStatus">>,
+  jobs: Array<{
+    scheduleExecutionId: string | null;
+    httpTriggerExecutionId: string | null;
+    manualExecutionId: string | null;
+    enqueuedAt: Date;
+    startedAt: Date | null;
+    completedAt: Date | null;
+  }>,
+): Map<
+  string,
+  Array<{ enqueuedAt: Date; startedAt: Date | null; completedAt: Date | null }>
+> => {
+  const map = new Map<
+    string,
+    Array<{
+      enqueuedAt: Date;
+      startedAt: Date | null;
+      completedAt: Date | null;
+    }>
+  >();
+  const keyForRow = (source: PipelineExecutionSource, id: string) =>
+    `${source}:${id}`;
+
+  for (const row of rows) {
+    map.set(keyForRow(row.source, row.id), []);
+  }
+
+  for (const job of jobs) {
+    let key: string | null = null;
+    if (job.scheduleExecutionId != null) {
+      key = keyForRow("schedule", job.scheduleExecutionId);
+    } else if (job.httpTriggerExecutionId != null) {
+      key = keyForRow("http-trigger", job.httpTriggerExecutionId);
+    } else if (job.manualExecutionId != null) {
+      key = keyForRow("manual", job.manualExecutionId);
+    }
+    if (key == null || !map.has(key)) {
+      continue;
+    }
+    const list = map.get(key);
+    if (list) {
+      list.push({
+        enqueuedAt: job.enqueuedAt,
+        startedAt: job.startedAt,
+        completedAt: job.completedAt,
+      });
+    }
+  }
+
+  return map;
+};
+
+/**
+ * Fetches job timestamps for the current page and attaches formatted elapsed labels.
+ *
+ * @param slice - Paginated execution rows (still without elapsed).
+ * @param db - Prisma client.
+ * @returns Rows including {@link PipelineExecutionRow.elapsedLabel}.
+ */
+const attachPipelineExecutionElapsedLabels = async (
+  slice: Array<Omit<PipelineExecutionRow, "elapsedLabel">>,
+  db: Db,
+): Promise<PipelineExecutionRow[]> => {
+  const now = new Date();
+  if (slice.length === 0) {
+    return [];
+  }
+
+  const scheduleIds = slice
+    .filter((row) => row.source === "schedule")
+    .map((row) => row.id);
+  const httpIds = slice
+    .filter((row) => row.source === "http-trigger")
+    .map((row) => row.id);
+  const manualIds = slice
+    .filter((row) => row.source === "manual")
+    .map((row) => row.id);
+
+  const or: Prisma.AgentJobExecutionWhereInput[] = [];
+  if (scheduleIds.length > 0) {
+    or.push({ scheduleExecutionId: { in: scheduleIds } });
+  }
+  if (httpIds.length > 0) {
+    or.push({ httpTriggerExecutionId: { in: httpIds } });
+  }
+  if (manualIds.length > 0) {
+    or.push({ manualExecutionId: { in: manualIds } });
+  }
+
+  const jobs =
+    or.length === 0
+      ? []
+      : await db.agentJobExecution.findMany({
+          where: { OR: or },
+          select: {
+            scheduleExecutionId: true,
+            httpTriggerExecutionId: true,
+            manualExecutionId: true,
+            enqueuedAt: true,
+            startedAt: true,
+            completedAt: true,
+          },
+        });
+
+  const grouped = groupJobsByPipelineExecutionRow(slice, jobs);
+
+  return slice.map((row) => {
+    const key = `${row.source}:${row.id}`;
+    const invocations = grouped.get(key) ?? [];
+    const elapsed = computePipelineWallElapsed(invocations, row.runStatus, now);
+    return {
+      ...row,
+      elapsedLabel: formatPipelineElapsedLabel(elapsed),
+    };
+  });
 };
 
 export type ManualPipelineExecutionDetail = {
@@ -193,6 +332,7 @@ export type ManualPipelineExecutionDetail = {
     error: unknown;
     agentResponse: unknown;
     semanticStatus: string | null;
+    enqueuedAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
     dataQueueAttempts: number | null;
@@ -241,6 +381,7 @@ export const getManualPipelineExecutionDetail = async (
           error: true,
           agentResponse: true,
           semanticStatus: true,
+          enqueuedAt: true,
           startedAt: true,
           completedAt: true,
           dataQueueAttempts: true,
@@ -288,6 +429,7 @@ export const getManualPipelineExecutionDetail = async (
       error: job.error,
       agentResponse: job.agentResponse,
       semanticStatus: job.semanticStatus,
+      enqueuedAt: job.enqueuedAt,
       startedAt: job.startedAt,
       completedAt: job.completedAt,
       dataQueueAttempts: job.dataQueueAttempts,

--- a/apps/hermes/dashboard/lib/schedules.ts
+++ b/apps/hermes/dashboard/lib/schedules.ts
@@ -243,6 +243,7 @@ export type ScheduleExecutionDetail = {
     error: unknown;
     agentResponse: unknown;
     semanticStatus: string | null;
+    enqueuedAt: Date;
     startedAt: Date | null;
     completedAt: Date | null;
     /** DataQueue `attempts` when the worker last claimed this job; null for legacy rows. */
@@ -292,6 +293,7 @@ export const getScheduleExecutionDetail = async (
           error: true,
           agentResponse: true,
           semanticStatus: true,
+          enqueuedAt: true,
           startedAt: true,
           completedAt: true,
           dataQueueAttempts: true,
@@ -347,6 +349,7 @@ export const getScheduleExecutionDetail = async (
       error: j.error,
       agentResponse: j.agentResponse,
       semanticStatus: j.semanticStatus,
+      enqueuedAt: j.enqueuedAt,
       startedAt: j.startedAt,
       completedAt: j.completedAt,
       dataQueueAttempts: j.dataQueueAttempts,


### PR DESCRIPTION
## Summary

Adds wall-clock elapsed time for Hermes pipeline runs (list and detail) and per-job duration on schedule execution invocations, using shared helpers for formatting and terminal vs in-progress states.

## Important changes

- Pipeline execution history table shows an **Elapsed** column derived from job start/completion bounds.
- Pipeline execution detail pages (manual, schedule, HTTP trigger) show a summary **Elapsed** line for the run.
- Schedule invocation table shows per-invocation duration when worker timestamps exist, with sensible labels for running and unknown cases.

## Other changes

- Unit tests for `compute-execution-elapsed` and extended coverage in `pipeline-executions` and related libs.
- Minor test fixture adjustment in `mask-json-secrets.test.ts`.

## Key files to review

- `apps/hermes/dashboard/lib/compute-execution-elapsed.ts` — core duration math, formatting, and terminal run handling.
- `apps/hermes/dashboard/lib/compute-execution-elapsed.test.ts` — edge cases and label behavior.
- `apps/hermes/dashboard/lib/pipeline-executions.ts` — how `elapsedLabel` is attached to merged execution rows.
- `apps/hermes/dashboard/app/dashboard/pipelines/[id]/pipeline-executions-table.tsx` — new column wiring.
- `apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx` and parallel schedule/HTTP trigger execution pages — detail UI.

## How to test

1. From repo root: `pnpm code-quality` (or `pnpm --filter hermes-dashboard test` if scoping).
2. In Hermes dashboard, open a pipeline with execution history: confirm **Elapsed** appears on the executions table and matches expectations for finished vs active runs.
3. Open a pipeline execution detail (schedule or HTTP trigger path as applicable): confirm **Elapsed** matches the run.
4. Open a schedule execution detail with invocations: confirm per-row duration labels and running/unknown states.
