### PR TITLE
Disable Fly auto_stop for Hermes worker HTTP service

### DIFF
--- a/apps/hermes/worker/fly.toml
+++ b/apps/hermes/worker/fly.toml
@@ -7,7 +7,7 @@ primary_region = 'sin'
 [http_service]
   internal_port = 3001
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 1
   processes = ['app']


### PR DESCRIPTION
## Summary

Disables Fly `http_service.auto_stop_machines` for the Hermes worker so machines are not automatically stopped, which helps avoid scheduler or DataQueue gaps tied to scale-to-zero behavior.

## Important changes

- `apps/hermes/worker/fly.toml`: `auto_stop_machines` changes from `'stop'` to `false`.

## Other changes

- None.

## Key files to review

- `apps/hermes/worker/fly.toml` — confirm this matches desired Fly runtime policy (`min_machines_running` remains 1).

## How to test

1. Merge and deploy the worker app on Fly (`fly deploy` from `apps/hermes/worker` or your CI path).
2. In the Fly dashboard or with `fly machine list`, confirm worker machines behave as expected for auto-stop after deploy (policy disabled).
3. Optionally verify schedules and DataQueue processing continue without long gaps after idle periods.

