### PR TITLE
Document stacked-branch PR bases in open-github-pr skill

### DIFF
--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -13,6 +13,27 @@ Create pull requests for this repo with `gh pr create`, and use the `/pr-title-d
 - User asks to draft or publish a pull request from current changes.
 - User asks for PR title/description generation for the current branch.
 - User asks to land skill-only or docs-only changes via a **separate worktree** (branch, push, PR, then remove the worktree).
+- The branch is part of a **stack** ([Git Town](https://www.git-town.com/) or another stacked workflow) where the PR must target the **parent branch**, not the repo default.
+
+## Stacked branches: set `--base` to the parent (not always `main`)
+
+For **stacked changes**, GitHub must compare the head branch to the **correct base**. If you omit `--base`, `gh pr create` uses the repository **default branch** (often `main`), which is wrong for every layer above the bottom of the stack: reviewers see unrelated commits, and the diff is misleading.
+
+**Resolve the PR base before** `git diff …` and `gh pr create`:
+
+1. **Git Town** — parent of the current branch is the PR base:
+   - `git town config get-parent`  
+     (optional: `git town config get-parent <branch>`).  
+     If Git Town is not installed or the command fails, infer the parent another way.
+2. **Repo default** — only the **root** of a stack usually targets the default branch. Confirm with `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name` when you need the name explicitly.
+3. **Manual / non–Git-Town stacks** — use the branch you actually branched from (the dependency), or `git merge-base` / `git log --first-parent` against candidates until the diff matches what should be reviewed.
+
+Then:
+
+- Review range: `git diff <base>...HEAD` (three-dot), not `git diff main...HEAD` unless `<base>` **is** `main`.
+- Create: `gh pr create ... --base <base> --head <head>` when `<base>` is not the default branch, or pass `--base` whenever you want to be explicit.
+
+See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for stack ordering, sync, and merge order. After a lower PR merges, **retarget** the next PR to `main` (or run Git Town sync) per your workflow—do not assume the base stays the old parent forever.
 
 ## PR body: prefer `--body-file`
 
@@ -64,15 +85,16 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
      - `gh auth switch -h <host> -u <account>`
    - Verify access before continuing:
      - `gh api --hostname <host> repos/<owner>/<repo>`
-2. Confirm branch status and pending changes:
+2. **Resolve the PR base branch** `<base>` (see **Stacked branches** above if this is a stacked branch). Do not assume `main`.
+3. Confirm branch status and pending changes:
    - `git status`
    - `git diff`
    - `git log --oneline -n 10`
-   - `git diff main...HEAD` (or the intended base branch)
-3. Ensure the branch exists and is pushed:
+   - `git diff <base>...HEAD` (three-dot diff against the **same** base you will pass to `gh pr create --base`)
+4. Ensure the branch exists and is pushed:
    - If needed, create/switch to feature branch.
    - Push with upstream tracking: `git push -u origin HEAD`.
-4. Draft PR content using `/pr-title-description`:
+5. Draft PR content using `/pr-title-description`:
    - Title: short, imperative, verb-first.
    - Description sections:
      - `## Summary`
@@ -80,12 +102,17 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
      - `## Other changes`
      - `## Key files to review`
      - `## How to test`
-5. Create PR in one shot with a **body file** (no post-create edits for footer cleanup):
+6. Create PR in one shot with a **body file** (no post-create edits for footer cleanup):
    - Write the full markdown to a file; use the template below.
    - Remove any accidental signature lines from the file if they appear (for example lines matching `Made with [Cursor](https://cursor.com)` or `Made with Cursor`).
    - `gh pr create --repo "<owner>/<repo>" --title "..." --body-file /path/to/body.md`
+   - Add `--base <base>` when the PR must not target the repo default (stacked branches). Add `--head <head>` if the head branch name is not inferred correctly (e.g. fork or multiple remotes).
 
 ```bash
+# Set BASE to the parent branch for stacked PRs, or the repo default for the root of the stack.
+# Example (Git Town): BASE="$(git town config get-parent)"
+# Example (single PR off main): BASE="main"  # or output of gh repo view --json defaultBranchRef ...
+
 BODY_FILE="$(mktemp -t gh-pr-body)"
 trap 'rm -f "$BODY_FILE"' EXIT
 
@@ -115,14 +142,16 @@ cat <<'EOF' >"$BODY_FILE"
 3. Confirm expected result and edge case behavior.
 EOF
 
-gh pr create --repo "<owner>/<repo>" --title "Add concise verb-first title" --body-file "$BODY_FILE"
+gh pr create --repo "<owner>/<repo>" --base "$BASE" --title "Add concise verb-first title" --body-file "$BODY_FILE"
 ```
 
-6. Verify body after create (read-only check only):
+Set `BASE` before this command so it matches the three-dot range in step 3: **stacked PRs** → parent from `git town config get-parent` (or equivalent); **root of stack or single PR** → repo default branch name (same as `gh repo view --json defaultBranchRef`). Passing `--base "$BASE"` when `BASE` is the default branch is equivalent to omitting `--base` but keeps diff and PR creation in sync.
+
+7. Verify body after create (read-only check only):
    - Fetch body: `gh pr view --repo "<owner>/<repo>" --json number,body --jq '.body'`
    - Confirm it does **not** contain `Made with [Cursor](https://cursor.com)` or `Made with Cursor`.
    - Do **not** run `gh pr edit` for footer cleanup; if cleanup is needed, close/recreate so final PR is not marked edited.
-7. Return the PR URL and a short test note.
+8. Return the PR URL and a short test note (mention `<base>` → `<head>` if useful for reviewers).
 
 ## Quality checklist
 
@@ -134,3 +163,4 @@ gh pr create --repo "<owner>/<repo>" --title "Add concise verb-first title" --bo
 - High-risk behavior and reviewer-critical files are explicitly called out.
 - Test steps are concrete and include expected outcomes.
 - The command uses `--repo <owner>/<repo>` and a verified account context (`gh auth switch -h <host> -u <account>` + `gh api` access check).
+- **Stacked PRs:** `--base` matches the real parent branch (`git town config get-parent` or equivalent); `git diff <base>...HEAD` matches what GitHub will show.


### PR DESCRIPTION
## Summary

This change extends the **open-github-pr** Cursor skill so agents resolve the correct GitHub **compare base** for stacked branches (especially Git Town), avoiding misleading diffs when `gh pr create` would otherwise default to the repo default branch.

## Important changes

- New **Stacked branches** section: when to use `--base`, how to resolve the parent via `git town config get-parent`, repo default, or manual merge-base checks, and using `git diff <base>...HEAD` consistently with `gh pr create --base`.
- Cross-link to **git-town-stacked-changes** and a short note on retargeting after a lower PR merges.

## Other changes

- Workflow step 2 now explicitly points to stacked-base resolution instead of assuming a single default branch name.

## Key files to review

- `.cursor/skills/open-github-pr/SKILL.md` — stacked PR base rules, three-dot diff alignment, and workflow checklist updates.

## How to test

1. Read the updated skill and confirm the stacked-branch steps match your Git Town workflow (`git town config get-parent`, `gh pr create --base <parent>`).
2. On a non-root stack branch, verify the documented review range `git diff <base>...HEAD` matches what you expect before opening a PR.
