### PR TITLE
Add orchestration schema for credential version and admin password reset tokens

### DIFF
--- a/packages/hermes/orchestration-database/prisma/migrations/20260406120000_add_credential_version_and_hermes_admin_password_reset_token/migration.sql
+++ b/packages/hermes/orchestration-database/prisma/migrations/20260406120000_add_credential_version_and_hermes_admin_password_reset_token/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN "credential_version" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "hermes_admin_password_reset_token" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token_hash" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "used_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "hermes_admin_password_reset_token_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "hermes_admin_password_reset_token_token_hash_key" ON "hermes_admin_password_reset_token"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "hermes_admin_password_reset_token_user_id_idx" ON "hermes_admin_password_reset_token"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "hermes_admin_password_reset_token" ADD CONSTRAINT "hermes_admin_password_reset_token_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/hermes/orchestration-database/prisma/schema.prisma
+++ b/packages/hermes/orchestration-database/prisma/schema.prisma
@@ -8,14 +8,16 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(uuid())
-  name      String
-  email     String   @unique
-  password  String
-  role      UserRole @default(USER)
-  isActive  Boolean  @default(true) @map("is_active")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  id                 String   @id @default(uuid())
+  name               String
+  email              String   @unique
+  password           String
+  role               UserRole @default(USER)
+  isActive           Boolean  @default(true) @map("is_active")
+  /// Bumped on password change to invalidate dashboard cookies that embed this version.
+  credentialVersion  Int      @default(0) @map("credential_version")
+  createdAt          DateTime @default(now()) @map("created_at")
+  updatedAt          DateTime @updatedAt @map("updated_at")
 
   variables                           Variable[]
   domainIntegrationsCreated           DomainIntegration[]           @relation("DomainIntegrationCreatedBy")
@@ -25,8 +27,25 @@ model User {
   httpTriggersCreated                 HttpTrigger[]                 @relation("HttpTriggerCreatedBy")
   pipelineStepsCreated                PipelineStep[]                @relation("PipelineStepCreatedBy")
   dataSourceExpansionTemplatesCreated DataSourceExpansionTemplate[] @relation("DataSourceExpansionTemplateCreatedBy")
+  hermesAdminPasswordResetTokens      HermesAdminPasswordResetToken[]
 
   @@map("user")
+}
+
+/// Single-use token for Hermes dashboard admin self-service password reset (secret stored hashed only).
+model HermesAdminPasswordResetToken {
+  id        String    @id @default(uuid())
+  userId    String    @map("user_id")
+  /// SHA-256 hex digest of the raw token from the email link.
+  tokenHash String    @unique @map("token_hash")
+  expiresAt DateTime  @map("expires_at")
+  usedAt    DateTime? @map("used_at")
+  createdAt DateTime  @default(now()) @map("created_at")
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("hermes_admin_password_reset_token")
 }
 
 enum UserRole {


### PR DESCRIPTION
## Summary

Adds `User.credentialVersion` and a `HermesAdminPasswordResetToken` model to the orchestration database so sessions and reset links can be invalidated consistently.

## Important changes

- New migration applies `credentialVersion` on `User` and the reset-token table with hashed token storage and expiry.

## Other changes

- Prisma schema updates only; no application code in this layer.

## Key files to review

- `packages/hermes/orchestration-database/prisma/schema.prisma` — model fields, relations, indexes.
- `packages/hermes/orchestration-database/prisma/migrations/20260406120000_add_credential_version_and_hermes_admin_password_reset_token/migration.sql` — matches schema.

## How to test

1. With Postgres running (`docker compose up -d postgres`), from repo root: `pnpm --filter @hermes/orchestration-database db:migrate:deploy` (or full `pnpm code-quality`).
2. Confirm migration applies cleanly against a dev DB.
