### PR TITLE
Document GitHub issue linking in open-github-pr skill

### DIFF
--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: open-github-pr
-description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, and a reviewer-friendly PR body. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure.
+description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and GitHub issue links (Closes/Fixes/Refs) so PRs connect to tickets. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (plus Related issues when applicable).
 ---
 
 # Open GitHub Pull Request
 
-Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body.
+Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body. When work maps to GitHub issues, include **`## Related issues`** with `Closes`/`Fixes`/`Refs` (see **Link PRs to GitHub issues**) so the PR appears under each issue’s Development section.
 
 ## When to use this skill
 
@@ -34,6 +34,33 @@ Then:
 - Create: `gh pr create ... --base <base> --head <head>` when `<base>` is not the default branch, or pass `--base` whenever you want to be explicit.
 
 See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for stack ordering, sync, and merge order. After a lower PR merges, **retarget** the next PR to `main` (or run Git Town sync) per your workflow—do not assume the base stays the old parent forever.
+
+## Link PRs to GitHub issues (tickets)
+
+GitHub connects a PR to issues when the **body or commits** contain recognized references. PRs opened with this skill must **actively include** those references—otherwise the Development panel stays empty and nothing links “ticket → PR.”
+
+### Resolve issue numbers before drafting the body
+
+1. **From the work** — branch name (`…/mp-142-…`), ticket filename from `prd-to-tickets` / Linear export, or the user’s stated IDs.
+2. **From the repo** — `gh issue list --repo "<owner>/<repo>" --limit 20` (or search: `gh issue list --search "title text"`).
+3. **Same repo** — use `#123`. **Other repo** — use `owner/other-repo#123` or a full issue URL (GitHub still links and tracks development when the keyword is present).
+
+### Keywords (pick intentionally)
+
+| Intent                                                                                   | In the PR body (example)                                   | Effect                                                                                                                                                                   |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| This PR **finishes** the ticket when merged (usual single PR or **final** stack layer)   | `Closes #123`, `Fixes #123`, or `Resolves #123`            | Issue auto-closes when the PR is merged (per [repo merge settings](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)) |
+| Link the PR to the ticket **without** closing yet (common for **non-final** stacked PRs) | `Refs #123` or `Ref #123`                                  | Linked in Development; does not close on merge                                                                                                                           |
+| Multiple tickets                                                                         | One line each or bullets, e.g. `Closes #10` and `Refs #11` | Same rules per line                                                                                                                                                      |
+
+Place keywords in **`## Related issues`** (recommended) or in **`## Summary`** so they are easy to find. **Do not** rely on the title alone—titles do not create the same development linkage as body/commit keywords.
+
+### Stacked PRs + tickets
+
+- **One ticket, multiple PRs in a stack:** Use **`Refs #N`** on every layer that is not the last merge to the default branch; use **`Closes #N`** (or **`Fixes`**) only on the PR that should complete the ticket when merged (often the **top** of the stack once it targets `main`, or the single PR that delivers the remaining work—align with your team). If every layer used `Closes #N`, the issue could close too early when an intermediate PR merges.
+- **One ticket per PR in the stack:** Each PR body should **`Closes`** (or **`Fixes`**) **its** issue only.
+
+If unsure whether intermediate merges close issues in your org, prefer **`Refs`** until the final PR, then **`Closes`** there.
 
 ## PR body: prefer `--body-file`
 
@@ -96,8 +123,10 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
    - Push with upstream tracking: `git push -u origin HEAD`.
 5. Draft PR content using `/pr-title-description`:
    - Title: short, imperative, verb-first.
+   - **Resolve GitHub issue numbers** for this PR (see **Link PRs to GitHub issues** above). If the work came from tickets, the body must include `Refs`/`Closes`/`Fixes` lines so GitHub links the PR.
    - Description sections:
      - `## Summary`
+     - `## Related issues` (when any ticket/issue applies — include `Closes`/`Fixes`/`Refs` lines; omit the section only if there is truly no tracking issue)
      - `## Important changes`
      - `## Other changes`
      - `## Key files to review`
@@ -120,6 +149,10 @@ cat <<'EOF' >"$BODY_FILE"
 ## Summary
 
 1-3 sentences on what changed and why.
+
+## Related issues
+
+Closes #123
 
 ## Important changes
 
@@ -150,13 +183,14 @@ Set `BASE` before this command so it matches the three-dot range in step 3: **st
 7. Verify body after create (read-only check only):
    - Fetch body: `gh pr view --repo "<owner>/<repo>" --json number,body --jq '.body'`
    - Confirm it does **not** contain `Made with [Cursor](https://cursor.com)` or `Made with Cursor`.
+   - If tickets apply, confirm the body still contains the intended `Closes`/`Fixes`/`Refs` lines (GitHub parses these from the merged body text).
    - Do **not** run `gh pr edit` for footer cleanup; if cleanup is needed, close/recreate so final PR is not marked edited.
 8. Return the PR URL and a short test note (mention `<base>` → `<head>` if useful for reviewers).
 
 ## Quality checklist
 
 - PR title starts with a verb and has no trailing period.
-- Description follows `/pr-title-description` sections exactly.
+- Description follows `/pr-title-description` sections, with **`## Related issues`** inserted after **Summary** when work is tracked in GitHub issues.
 - Do not include any signature/footer such as `Made with Cursor` in the PR title or body.
 - Body is supplied via **`--body-file`** so automated footers are not injected into `--body`.
 - After creation, run a read-only body verification check (no `gh pr edit` footer cleanup).
@@ -164,3 +198,4 @@ Set `BASE` before this command so it matches the three-dot range in step 3: **st
 - Test steps are concrete and include expected outcomes.
 - The command uses `--repo <owner>/<repo>` and a verified account context (`gh auth switch -h <host> -u <account>` + `gh api` access check).
 - **Stacked PRs:** `--base` matches the real parent branch (`git town config get-parent` or equivalent); `git diff <base>...HEAD` matches what GitHub will show.
+- **Tickets:** Body includes **`## Related issues`** with at least one `Closes`/`Fixes`/`Refs` line (or cross-repo `owner/repo#N`) when work is tracked in GitHub; stacked layers use `Refs` until the appropriate final PR uses `Closes`/`Fixes` so issues are not closed prematurely.


### PR DESCRIPTION
## Summary

Expands the `open-github-pr` Cursor skill so agents consistently link PRs to GitHub issues: when to use `Closes` / `Fixes` / `Refs`, how to resolve issue numbers, and how stacked PRs interact with closing issues. Updates the skill metadata, workflow steps, template snippet, verification checklist, and quality gate.

## Important changes

- New **Link PRs to GitHub issues** section with keyword table, resolution steps, and stacked-PR guidance.
- Workflow and `gh pr create` example now include `## Related issues` in the body template; post-create verification checks issue keywords remain in the published body.

## Other changes

- Skill frontmatter `description` updated to mention ticket linking.

## Key files to review

- `.cursor/skills/open-github-pr/SKILL.md` — full issue-linking guidance and checklist updates; confirm wording matches how your team uses stacks and `gh`.

## How to test

1. Open `.cursor/skills/open-github-pr/SKILL.md` and skim the new **Link PRs to GitHub issues** section for clarity and internal consistency with **Stacked branches** and `--body-file`.
2. Confirm the embedded PR body example lists `## Related issues` in the right order (after Summary).
3. No runtime or automated tests apply (documentation-only change).
