### PR TITLE
Add React custom-hooks detection to Cursor PR review

### DIFF
--- a/scripts/lib/cursor-pr-review.mjs
+++ b/scripts/lib/cursor-pr-review.mjs
@@ -138,6 +138,209 @@ const firstLineWhere = (text, predicate) => {
   return undefined;
 };
 
+/** Max characters before `{` to inspect for hook vs component (handles a few wrapped lines). */
+const REACT_HOOK_PRELUDE_MAX_CHARS = 1200;
+
+/**
+ * Classifies `{` at `openBraceIdx`: custom hook body, component (or PascalCase) body, or inherits parent scope.
+ *
+ * @param {string} s
+ * @param {number} openBraceIdx
+ * @returns {"hook"|"component"|"inherit"}
+ */
+const classifyReactOpeningBrace = (s, openBraceIdx) => {
+  const preludeStart = Math.max(0, openBraceIdx - REACT_HOOK_PRELUDE_MAX_CHARS);
+  const prelude = s
+    .slice(preludeStart, openBraceIdx)
+    .replace(/[\s\uFEFF]+$/g, "");
+
+  const arrowHook = prelude.match(
+    /(?:export\s+)?(?:const|let|var)\s+(use[A-Z][\w$]*)\s*=\s*(?:async\s*)?\([^)]*\)\s*=>\s*$/s,
+  );
+  if (arrowHook) return "hook";
+
+  const arrowComp = prelude.match(
+    /(?:export\s+)?(?:const|let|var)\s+([A-Z][\w$]*)\s*=\s*(?:async\s*)?\([^)]*\)\s*=>\s*$/s,
+  );
+  if (arrowComp && !arrowComp[1].startsWith("use")) return "component";
+
+  const funcHook = prelude.match(
+    /(?:export\s+)?function\s+(use[A-Z][\w$]*)\s*\([^)]*\)\s*$/s,
+  );
+  if (funcHook) return "hook";
+
+  const funcComp = prelude.match(
+    /(?:export\s+)?function\s+([A-Z][\w$]*)\s*\([^)]*\)\s*$/s,
+  );
+  if (funcComp && !funcComp[1].startsWith("use")) return "component";
+
+  return "inherit";
+};
+
+/**
+ * 1-based line numbers where `useState(` / `useEffect(` appear in a non–custom-hook scope (heuristic).
+ *
+ * @param {string} text
+ * @returns {readonly number[]}
+ */
+const collectReactCustomHooksViolationLines = (text) => {
+  /** @type {number[]} */
+  const violations = [];
+  /** @type {{ inHook: boolean }[]} */
+  const stack = [{ inHook: false }];
+
+  let i = 0;
+  let line = 1;
+  let state = "code";
+
+  const atIdentifierBoundary = (idx) =>
+    idx === 0 || !/[\w$]/.test(text[idx - 1] ?? "");
+
+  const tryRecordHookCall = (idx) => {
+    if (!atIdentifierBoundary(idx)) return;
+    const slice = text.slice(idx);
+    const m = slice.match(/^use(State|Effect)\s*\(/i);
+    if (!m) return;
+    if (!stack[stack.length - 1].inHook) {
+      violations.push(line);
+    }
+  };
+
+  while (i < text.length) {
+    const c = text[i] ?? "";
+    const next = text[i + 1] ?? "";
+
+    if (state === "code") {
+      if (c === "/" && next === "/") {
+        i += 2;
+        while (i < text.length && text[i] !== "\n") i++;
+        continue;
+      }
+      if (c === "/" && next === "*") {
+        i += 2;
+        state = "block_comment";
+        continue;
+      }
+      if (c === '"') {
+        i++;
+        state = "string_dq";
+        continue;
+      }
+      if (c === "'") {
+        i++;
+        state = "string_sq";
+        continue;
+      }
+      if (c === "`") {
+        i++;
+        state = "template";
+        continue;
+      }
+
+      if (c === "\n") {
+        line++;
+        i++;
+        continue;
+      }
+
+      if (c === "{") {
+        const kind = classifyReactOpeningBrace(text, i);
+        const parent = stack[stack.length - 1].inHook;
+        const inHook =
+          kind === "hook" ? true : kind === "component" ? false : parent;
+        stack.push({ inHook });
+        i++;
+        continue;
+      }
+
+      if (c === "}") {
+        if (stack.length > 1) stack.pop();
+        i++;
+        continue;
+      }
+
+      if (c === "u" || c === "U") {
+        tryRecordHookCall(i);
+      }
+
+      i++;
+      continue;
+    }
+
+    if (state === "block_comment") {
+      if (c === "\n") line++;
+      if (c === "*" && next === "/") {
+        i += 2;
+        state = "code";
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (state === "string_dq") {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "\n") line++;
+      if (c === '"') {
+        i++;
+        state = "code";
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (state === "string_sq") {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "\n") line++;
+      if (c === "'") {
+        i++;
+        state = "code";
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    if (state === "template") {
+      if (c === "\\") {
+        i += 2;
+        continue;
+      }
+      if (c === "\n") line++;
+      if (c === "`") {
+        i++;
+        state = "code";
+        continue;
+      }
+      if (c === "$" && next === "{") {
+        i += 2;
+        let depth = 1;
+        while (i < text.length && depth > 0) {
+          const ch = text[i] ?? "";
+          if (ch === "\n") line++;
+          if (ch === "{") depth++;
+          else if (ch === "}") depth--;
+          i++;
+        }
+        continue;
+      }
+      i++;
+      continue;
+    }
+
+    i++;
+  }
+
+  return violations;
+};
+
 const CURSOR_PR_REVIEW_DIRECTIVE_MAX_LINES = 40;
 
 /**
@@ -414,16 +617,14 @@ export const runCursorPrReview = async (collaborators, options) => {
     if (!isTsx(f.filePath)) continue;
     const text = await collaborators.readTextFile(f.filePath);
     if (isRuleDisabledInFile(text, "react-custom-hooks", f.filePath)) continue;
-    if (/\buseState\s*\(/.test(text) || /\buseEffect\s*\(/.test(text)) {
-      const line = firstLineWhere(
-        text,
-        (ln) => /\buseState\s*\(/.test(ln) || /\buseEffect\s*\(/.test(ln),
-      );
+    const violationLines = collectReactCustomHooksViolationLines(text);
+    const uniqueLines = [...new Set(violationLines)].sort((a, b) => a - b);
+    for (const line of uniqueLines) {
       findings.push({
         ruleId: "react-custom-hooks",
         severity: "error",
         filePath: f.filePath,
-        ...(line !== undefined ? { line } : {}),
+        line,
         message:
           "React components must not use useState/useEffect directly; move state/effects into custom hooks.",
       });

--- a/scripts/lib/cursor-pr-review.test.ts
+++ b/scripts/lib/cursor-pr-review.test.ts
@@ -357,7 +357,47 @@ const x = process.env.ALLOWED_HERE;
         filePath: "apps/x/src/component.tsx",
         line: 4,
       }),
+      expect.objectContaining({
+        ruleId: "react-custom-hooks",
+        severity: "error",
+        filePath: "apps/x/src/component.tsx",
+        line: 5,
+      }),
     ]);
+  });
+
+  it("does not flag useState/useEffect when they only appear inside a custom hook in the same TSX file", async () => {
+    // Setup
+    const listChangedFiles = async () => [
+      { status: "M", filePath: "apps/x/src/component.tsx" },
+    ];
+    const readTextFile = async () => `
+      import { useEffect, useState } from "react";
+
+      const useThing = () => {
+        const [x, setX] = useState(0);
+        useEffect(() => {
+          setX(1);
+        }, []);
+        return x;
+      };
+
+      export const Component = () => {
+        const x = useThing();
+        return <div>{x}</div>;
+      };
+    `;
+
+    // Act
+    const result = await runCursorPrReview(
+      { listChangedFiles, readTextFile },
+      { baseRef: "origin/main", headRef: "HEAD" },
+    );
+
+    // Assert
+    expect(
+      result.findings.filter((f) => f.ruleId === "react-custom-hooks"),
+    ).toEqual([]);
   });
 
   it("adds a prisma-migrations error when schema.prisma is touched and an existing migration.sql is modified", async () => {


### PR DESCRIPTION
## Summary

Extends the Cursor PR review script with a `react-custom-hooks` rule that flags direct `useState` / `useEffect` usage in `.tsx` files when those calls sit outside a `use*` custom hook body (heuristic brace/scope analysis). Aligns automated review with the workspace rule that components should push state and effects into custom hooks.

## Important changes

- New findings use rule id `react-custom-hooks` with severity `error`, skippable via existing `cursor-pr-review-disable` directives.
- Scope detection distinguishes custom hook bodies (`useFoo` arrow/function) from PascalCase components so hooks used inside `useX` are not falsely reported.

## Other changes

- Unit tests cover the positive case (violations in a component) and the negative case (same hooks only inside a custom hook in the same file).

## Key files to review

- `scripts/lib/cursor-pr-review.mjs` — `classifyReactOpeningBrace`, `collectReactCustomHooksViolationLines`, and integration with the review loop.
- `scripts/lib/cursor-pr-review.test.ts` — assertions for `react-custom-hooks` findings and the custom-hook exemption.

## How to test

1. From repo root: `pnpm vitest run scripts/lib/cursor-pr-review.test.ts` (or `pnpm code-quality` if that is your usual gate).
2. Optionally run the Cursor PR review script against a branch that adds a `.tsx` component with top-level `useState` and confirm a `react-custom-hooks` finding is emitted; repeat with hooks only inside `useSomething` and confirm no finding.
