### PR TITLE
Document feature-flag guidance for Git Town stacked PRs

### DIFF
--- a/.cursor/skills/git-town-stacked-changes/SKILL.md
+++ b/.cursor/skills/git-town-stacked-changes/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-town-stacked-changes
-description: Implements features as Git Town stacked branches so each layer ships as a small, reviewable PR. Maps PRD ticket batches (from prd-to-tickets) to branch stacks, dependency order, and PR bases. Use when the user asks for stacked PRs, stacked branches, Git Town, smaller PRs, incremental merge order, or when following up after /prd-to-tickets output.
+description: Implements features as Git Town stacked branches so each layer ships as a small, reviewable PR. Maps PRD ticket batches (from prd-to-tickets) to branch stacks, dependency order, and PR bases. Covers when and how to gate user-visible work with feature flags so early merged layers stay safe until later tickets land, and requires removing those gates (code + env + tests) once the feature is fully on main unless the flag is intentionally permanent. Use when the user asks for stacked PRs, stacked branches, Git Town, smaller PRs, incremental merge order, partial merge order (UI before API), or when following up after /prd-to-tickets output.
 ---
 
 # Git Town stacked changes (small PRs)
@@ -36,6 +36,7 @@ If two tickets are **independent**, do **not** stack them: use separate top-leve
 2. **Stack only real dependencies** — child branch contains work that truly requires the parent’s commits.
 3. **Merge / ship oldest first** — the branch whose base is `main` (or the stack’s root) ships before branches that sit on top of it.
 4. **Sync often** — run `git town sync --stack` or `git town sync --all` regularly to reduce drift and [phantom conflicts](https://www.git-town.com/stacked-changes.html) (especially with squash-merge workflows).
+5. **Temporary flags are debt** — flags introduced only to survive partial stack merges must be **removed** (see [Remove the flag when it is no longer needed](#remove-the-flag-when-it-is-no-longer-needed)) after all related tickets are on `main`, unless the PRD calls for a **long-lived** kill switch or gradual rollout.
 
 ## Typical Git Town commands
 
@@ -104,8 +105,64 @@ When moving from tickets to code:
 1. Read the ticket batch directory and list **ids** and **Depends on** edges.
 2. Topologically order tickets (dependencies first).
 3. For each ticket in order: ensure a **dedicated branch**; use `hack` for the first independent slice, `append` for dependent slices.
-4. Keep commits scoped; run **`pnpm code-quality`** (or project equivalent) before pushing each layer if the repo requires it.
-5. Open PRs from **leaf to root** is wrong — **ship/merge from root of stack toward tip** (oldest / closest to `main` first).
+4. **Assess feature-flag need** (see next section): if an earlier ticket would expose UI, routes, or product behavior that depends on a **later** ticket (API, schema, worker, permissions), gate that behavior behind a flag defaulting **off** until the stack is complete—or reorder tickets so vertical slices merge safely without dead ends.
+5. **Plan flag removal**: if you add a **temporary** merge-order flag, record in the **last** integrating ticket (or a dedicated cleanup ticket) that the gate must be **deleted** and env/docs updated—do not leave the feature forever behind `if (env.FLAG)`.
+6. Keep commits scoped; run **`pnpm code-quality`** (or project equivalent) before pushing each layer if the repo requires it.
+7. Open PRs from **leaf to root** is wrong — **ship/merge from root of stack toward tip** (oldest / closest to `main` first).
+
+## Feature flags when the stack splits UI and backend (or any unsafe partial ship)
+
+Stacked PRs often split work **horizontally**: e.g. `main → ticket1 (types) → ticket2 (UI only) → ticket3 (API + persistence)`. If **ticket2** merges before **ticket3**, users must not see broken navigation, empty states that imply missing backend, or actions that always fail.
+
+### When the agent should introduce a flag
+
+Use a **single, initiative-level gate** (not one flag per tiny commit) when **any** of these hold:
+
+- **User-visible surface** ships in an earlier PR than the **behavior or data** it requires.
+- **Server and client** are split across tickets and the UI is not meaningfully useful—or is misleading—without the rest.
+- **Risky or irreversible** behavior would run if half the stack is on `main` (writes, billing, notifications) even if “the button exists.”
+
+**Prefer avoiding flags** when you can: merge a **vertical slice** per ticket (minimal API + minimal UI together), or put **ticket2** behind **ticket3** in the stack so backend merges first. Use flags when ordering or slice shape makes horizontal layers unavoidable.
+
+### Naming and ownership
+
+- **One flag per initiative** when multiple tickets belong to the same `group_slug` / product feature: e.g. `HERMES_FEATURE_X_ENABLED` or `NEXT_PUBLIC_HERMES_FEATURE_X` only if the surface must be known on the client (prefer **server-evaluated** flags for sensitive or SSR’d UI so defaults stay server-controlled).
+- Reuse the **same** flag and check in **every** stacked PR that touches the feature until the final ticket **enables** it, then **removes** the gate entirely when safe (see below)—unless the initiative needs a **permanent** operational flag.
+- Document in **ticket Notes** and **PR bodies**: flag name, default (`false` / off in prod), **which ticket enables the feature for users**, and **which ticket removes** the flag after the stack is complete.
+
+### Default and rollout semantics
+
+- **Default off** in production-shaped configs until the **last** slice that completes the feature is merged (or until AC explicitly allows a phased rollout).
+- **Enabling for users** belongs in the PR that makes the feature **correct end-to-end** (often the backend / integration ticket): you may flip default to **on** in that PR **or** remove branching and ship the feature unconditionally in the same change—prefer **removing the flag** once nothing on `main` depends on “off” anymore.
+- **Cleanup** belongs in that same final PR or immediately after: do not stop at “flag defaults to true”; **delete** the temporary gate unless the product needs an ongoing switch (see [Remove the flag…](#remove-the-flag-when-it-is-no-longer-needed)).
+- If the repo uses typed env (`@hermes/env`, `@mediapulse/env`), add or reuse an env key following [env-variables](../env-variables/SKILL.md); do not read `process.env` ad hoc. When removing the flag, **remove the env key** from schema and `env.example` per that skill and rebuild the env package.
+
+### Implementation discipline
+
+- **Gate the entry point**, not scattered `if` fragments: hide nav items, routes, server actions, or job triggers in one place where possible so reviewers see the flag clearly.
+- **Server components and loaders**: evaluate the flag on the server so disabled features do not flash on the client.
+- **APIs introduced early**: return **404** or **501** when the flag is off, or omit routes until the implementing ticket registers them—avoid ambiguous empty success responses.
+- **Tests**: cover both flag-off (no leakage of UI or side effects) and flag-on behavior while the flag exists. When the flag is **removed**, update or delete tests that only asserted the old branchy behavior; keep coverage for the feature’s real behavior without the gate.
+
+### Remove the flag when it is no longer needed
+
+Treat stack-only flags as **short-lived**. Once **every** ticket in the initiative is merged to `main` and the feature is correct end-to-end, **remove** the gate in a deliberate PR (same as “enable” or immediately after—never leave it as optional tech debt).
+
+**Do in the cleanup PR:**
+
+1. **Delete** conditional checks and wire the feature **unconditionally** (nav, routes, handlers, jobs).
+2. **Remove** the env variable (or config key) from the typed env package, `env.example`, and any deployment docs; run the env package **build** so generated types stay correct ([env-variables](../env-variables/SKILL.md)).
+3. **Search** the repo for the flag symbol/name and **delete stragglers** (comments, stale TODOs, duplicate helpers).
+4. **Adjust tests** so they no longer depend on toggling the removed flag; keep regression coverage for the shipped feature.
+
+**When _not_ to remove:** the PRD or team explicitly wants a **long-term** flag (gradual rollout, entitlement, per-tenant switch, emergency kill switch). Then document that the flag is **permanent** in ticket Notes and skip mandatory removal—but still avoid duplicate or confusing names.
+
+### Agent mini-checklist (per stacked initiative)
+
+1. After ordering tickets, ask: “If PR _k_ merges alone, is anything **broken or misleading**?” If yes → flag or reorder.
+2. Introduce the flag in the **first** PR that would otherwise expose incomplete behavior (often the same PR as the UI), unless the repo pattern is “define flag in first PR, consume in later PRs”—either way, keep **one** name stable across the stack.
+3. Mention in each PR description: **stack position**, **flag name**, whether this PR **adds**, **wires**, **enables**, or **removes** the gate.
+4. **Final integrating PR (or dedicated follow-up):** remove the temporary flag per **Remove the flag when it is no longer needed**—do not leave `FEATURE_X_ENABLED` in the codebase once the stack is done unless it is explicitly a permanent control.
 
 ## Optional deep dive
 

--- a/.cursor/skills/prd-to-tickets/SKILL.md
+++ b/.cursor/skills/prd-to-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-to-tickets
-description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
+description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. When work will ship as stacked PRs with horizontal splits (UI before API), tickets should document feature-flag gating and enabling order. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
 ---
 
 # PRD → Tickets
@@ -58,7 +58,8 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 4. **Do not** merge unrelated requirements into one ticket; **do** merge duplicate or overlapping bullets from the PRD into a single ticket with a clear combined AC.
 5. **Traceability:** Each ticket must reference the PRD (`prd_source:` with file path or `"inline PRD"`) and **requirement IDs** when present (`prd_refs: [REQ-001, …]`).
 6. **Dependencies:** If the PRD orders work, add a **Depends on:** section using **same-batch ids** (`HERMES-ADM-PWRESET-001`) or REQ ids where tickets are not yet numbered.
-7. **Non-goals:** Do not create tickets for items explicitly out of scope unless the user asks to “include deferred items” as a separate backlog file.
+7. **Stacked / horizontal splits:** If the user plans **Git Town stacked PRs** and separates layers (e.g. UI ticket before API ticket), add the optional **Stacked delivery** section to affected tickets and specify **feature-flag** expectations so merged-but-incomplete work does not surface to users ([git-town-stacked-changes](../git-town-stacked-changes/SKILL.md)).
+8. **Non-goals:** Do not create tickets for items explicitly out of scope unless the user asks to “include deferred items” as a separate backlog file.
 
 ## File naming
 
@@ -105,6 +106,16 @@ status: draft
 - Depends on: [none | HERMES-ADM-PWRESET-xxx | REQ-xxx]
 - Blocks: …
 
+## Stacked delivery (optional)
+
+Use when tickets will ship as **Git Town stacked PRs** and work is split so an **earlier** ticket is incomplete without a **later** one (e.g. UI in `…-002`, API in `…-003`):
+
+- In **Acceptance criteria**, state that user-visible behavior stays **hidden or non-functional until enabled** (feature flag or equivalent), and name the **enabling** ticket (e.g. “Feature hidden behind `FEATURE_X_ENABLED` until `…-003` merges.”).
+- Add AC that the **temporary** flag (and env key, if any) is **removed** after the initiative is fully merged—either in the **last** ticket of the stack or a small follow-up ticket—unless the PRD requires a **permanent** flag.
+- In **Notes**, record the **flag/env key** (if known) or “TBD—see …-003,” and call out **merge order** risks for reviewers.
+
+See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for implementation guidance.
+
 ## Notes
 
 [APIs, flags, analytics, migration, rollout — only if PRD calls for it.]
@@ -117,6 +128,7 @@ Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_pre
 - Every **P0 / must-have** requirement maps to at least one ticket **or** is explicitly listed under a parent ticket’s AC with PRD ref.
 - No ticket without **testable** acceptance criteria (mirror the PRD’s given/when/then or checklist).
 - **`ticket_prefix`, `group_slug`, and `group_label` are consistent** across all files in the batch.
+- If **Stacked delivery** and a **merge-order-only** flag are documented, at least one ticket’s AC covers **flag removal** (or states the flag is intentionally permanent).
 - Filenames sort in execution order when the PRD implies an order; otherwise sort by **priority** then **id**.
 
 ## After writing


### PR DESCRIPTION
## Summary

Expands Cursor skills for Git Town stacked delivery and PRD→tickets so horizontal stacks (e.g. UI before API) document when to use temporary feature flags, how to name and gate behavior, and how to remove merge-order flags once the initiative is complete.

## Important changes

- **git-town-stacked-changes:** New section on feature flags for unsafe partial ships (when to flag, naming, defaults, implementation discipline, cleanup checklist, agent mini-checklist). Front matter description updated; new principle that temporary flags are debt to remove after the stack lands unless intentionally permanent.
- **prd-to-tickets:** Front matter and ticket-writing rules now call out stacked/horizontal splits; optional **Stacked delivery** template block for AC/notes on gating and flag removal; quality gate that merge-order flags must have removal (or permanence) called out in AC.

## Other changes

- Cross-links between skills (`git-town-stacked-changes` ↔ `prd-to-tickets`, env-variables where relevant).

## Key files to review

- `.cursor/skills/git-town-stacked-changes/SKILL.md` — full feature-flag guidance for stacked PRs.
- `.cursor/skills/prd-to-tickets/SKILL.md` — optional stacked-delivery section and checklist updates.

## How to test

1. Open both SKILL files in the editor and skim for broken relative links (`../env-variables/`, `../git-town-stacked-changes/`).
2. No runtime or `pnpm` steps required (documentation-only change).
