### PR TITLE
Add optional createdAt window to analysis GET

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -246,6 +246,39 @@ describe("agent-data-api", () => {
         unanalyzed: true,
       });
     });
+
+    it("forwards start and end query params to loadAnalysisContext", async () => {
+      const mod = await getAnalysisService();
+      vi.mocked(mod.loadAnalysisContext).mockResolvedValue({
+        dataSources: [],
+        entityTypes: [],
+        relationTypes: [],
+        existingEntities: [],
+      });
+
+      const start = "2026-01-01T00:00:00.000Z";
+      const end = "2026-01-31T00:00:00.000Z";
+      const qs = new URLSearchParams({
+        tickerId: TICKER_ID,
+        unanalyzed: "true",
+        start,
+        end,
+      });
+
+      const { app } = await import("./index.js");
+      const res = await app.request(
+        `http://localhost${analysisPath}?${qs.toString()}`,
+        { headers: AUTH_HEADERS },
+      );
+
+      expect(res.status).toBe(200);
+      expect(mod.loadAnalysisContext).toHaveBeenCalledWith({
+        tickerId: TICKER_ID,
+        unanalyzed: true,
+        start,
+        end,
+      });
+    });
   });
 
   describe(`POST ${analysisPath}`, () => {

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -1,4 +1,5 @@
 /** @vitest-environment node */
+import { getAnalysisQuerySchema } from "@workspace/agent-data-api-contract";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mediapulse/database", () => ({
@@ -21,6 +22,38 @@ beforeAll(async () => {
 describe("normalizeAnalysisName", () => {
   it("trims and lowercases", () => {
     expect(normalizeAnalysisName("  Acme Corp  ")).toBe("acme corp");
+  });
+});
+
+describe("getAnalysisQuerySchema", () => {
+  it("rejects when start is after end", () => {
+    const result = getAnalysisQuerySchema.safeParse({
+      tickerId: "ticker-1",
+      unanalyzed: "true",
+      start: "2026-02-01T00:00:00.000Z",
+      end: "2026-01-01T00:00:00.000Z",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("treats empty string bounds as omitted", () => {
+    const parsed = getAnalysisQuerySchema.parse({
+      tickerId: "ticker-1",
+      start: "",
+      end: "",
+    });
+    expect(parsed.start).toBeUndefined();
+    expect(parsed.end).toBeUndefined();
+  });
+
+  it("accepts start without end", () => {
+    const parsed = getAnalysisQuerySchema.parse({
+      tickerId: "ticker-1",
+      start: "2026-01-01T00:00:00.000Z",
+    });
+    expect(parsed.start).toBe("2026-01-01T00:00:00.000Z");
+    expect(parsed.end).toBeUndefined();
+    expect(parsed.unanalyzed).toBe(true);
   });
 });
 
@@ -90,6 +123,121 @@ describe("loadAnalysisContext", () => {
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { tickerId: "ticker-2" },
+      }),
+    );
+  });
+
+  it("filters by createdAt gte when start is set", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      entityType: { findMany: vi.fn().mockResolvedValue([]) },
+      relationType: { findMany: vi.fn().mockResolvedValue([]) },
+      entity: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+      },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn() },
+      $transaction: vi.fn(),
+    };
+
+    await loadAnalysisContext(
+      {
+        tickerId: "ticker-w",
+        unanalyzed: true,
+        start: "2026-01-01T00:00:00.000Z",
+      },
+      { db: db as never },
+    );
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: { gte: new Date("2026-01-01T00:00:00.000Z") },
+        }),
+      }),
+    );
+  });
+
+  it("filters by createdAt lte when end is set", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      entityType: { findMany: vi.fn().mockResolvedValue([]) },
+      relationType: { findMany: vi.fn().mockResolvedValue([]) },
+      entity: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+      },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn() },
+      $transaction: vi.fn(),
+    };
+
+    await loadAnalysisContext(
+      {
+        tickerId: "ticker-w",
+        unanalyzed: false,
+        end: "2026-12-31T23:59:59.999Z",
+      },
+      { db: db as never },
+    );
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: { lte: new Date("2026-12-31T23:59:59.999Z") },
+        }),
+      }),
+    );
+  });
+
+  it("filters by createdAt gte and lte when both bounds are set", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+    const db = {
+      dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      entityType: { findMany: vi.fn().mockResolvedValue([]) },
+      relationType: { findMany: vi.fn().mockResolvedValue([]) },
+      entity: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+      },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn() },
+      $transaction: vi.fn(),
+    };
+
+    await loadAnalysisContext(
+      {
+        tickerId: "ticker-w",
+        unanalyzed: true,
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2026-01-15T00:00:00.000Z",
+      },
+      { db: db as never },
+    );
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: {
+            gte: new Date("2026-01-01T00:00:00.000Z"),
+            lte: new Date("2026-01-15T00:00:00.000Z"),
+          },
+        }),
       }),
     );
   });

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -50,7 +50,7 @@ export const normalizeAnalysisName = (value: string): string =>
 /**
  * Loads ticker-scoped analysis context: eligible data sources, vocabulary, and existing KG entities.
  *
- * @param query - Parsed GET query (`unanalyzed` defaults to incremental backlog only).
+ * @param query - Parsed GET query (`unanalyzed` defaults to incremental backlog only; optional `start` / `end` bound `DataSource.createdAt` inclusively when set).
  * @param deps - Injectable database delegates for tests.
  * @returns Payload matching `getAnalysisResponseSchema`.
  */
@@ -60,8 +60,17 @@ export const loadAnalysisContext = async (
 ): Promise<GetAnalysisResponse> => {
   const db = deps.db ?? defaultDb;
 
+  const createdAtWhere =
+    query.start !== undefined || query.end !== undefined
+      ? ({
+          ...(query.start !== undefined ? { gte: new Date(query.start) } : {}),
+          ...(query.end !== undefined ? { lte: new Date(query.end) } : {}),
+        } satisfies Prisma.DateTimeFilter)
+      : undefined;
+
   const dataSourceWhere = {
     tickerId: query.tickerId,
+    ...(createdAtWhere ? { createdAt: createdAtWhere } : {}),
     ...(query.unanalyzed
       ? {
           NOT: {

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -15,7 +15,7 @@ agent-data-api is the **HTTP persistence layer between agents and the database**
 - **Bearer auth** — Requests must send `Authorization: Bearer <jwt>` (the same short-lived invocation JWT Hermes sends to agents). Verified with agent-auth-api `POST /api/verify` via `verifyTokenViaAuthApi`; agents forward the `Authorization` header from their run context to the SDK.
 - **Content generation** — Stores and loads generated newsletter-style output so downstream steps can reuse it without reshaping ad hoc payloads.
 - **Data collection** — Stores and loads crawled or gathered source material (pages, feeds, etc.) so collection and later stages see the same structured snapshot.
-- **Analysis** — Loads unanalyzed (or full re-score) `DataSource` rows plus KG vocabulary (`entityTypes`, `relationTypes`, `existingEntities`) for the article-analysis agent, and accepts POST payloads that upsert entities, relations, `article_entity`, and `article_relevance` for a ticker.
+- **Analysis** — Loads unanalyzed (or full re-score) `DataSource` rows plus KG vocabulary (`entityTypes`, `relationTypes`, `existingEntities`) for the article-analysis agent, and accepts POST payloads that upsert entities, relations, `article_entity`, and `article_relevance` for a ticker. Optional GET bounds (`start`, `end`, ISO 8601) filter `DataSource.createdAt` **server-side** (FR1 / FR2 eligibility windows) so bounded runs do not download an unbounded history.
 - **Delivery** — Loads the latest newsletter for a ticker, **subscriber emails** and **`userTickerId`** from enabled `user_ticker` rows, plus **`deliveredUserTickerIds`** (existing checkpoints for idempotent replays). When there is no newsletter, **GET returns 200** with `newsletter: null`, `subscribers: []`, and empty checkpoint ids (agents skip without treating the call as an error). **POST** records a **`newsletter_delivery_checkpoint`** after a successful send (`userTickerId`, `newsletterId`, optional Resend id).
 - **Delivery run** — **POST** persists one diagnostic run and per-recipient rows (including optional **`runSkipReason`**, Hermes **`jobId` / `hermesExecutionId` / `hermesScheduleId`**, and per-recipient **`errorCategory`**). **GET** lists runs with optional filters (`tickerId`, `outcome`, `start`, `end` — each of `start` / `end` applies **`createdAt` `gte` / `lte` independently** when provided). Used by the delivery agent for Hermes-visible outcomes (`success`, `skipped`, `failed`, `partial_success`, `skipped_all_already_delivered`). The Mediapulse Hermes **Delivery runs** table supports the same filters via query string (`tickerId`, `outcome`, `start`, `end`) in addition to search (`q`) and sort.
 
@@ -47,10 +47,16 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 
 Implemented in `apps/mediapulse/agent-data-api/src/routes/analysis.ts`. Schemas live in `@workspace/agent-data-api-contract` (`analysis.ts`).
 
-- **GET** — Query: `tickerId` (required), `unanalyzed` optional (`true` | `false` as strings). When `unanalyzed` is omitted, the API defaults to `true` (incremental backlog: sources with no `article_relevance` row for that ticker). When `unanalyzed=false`, returns all `DataSource` rows for the ticker for re-scoring workflows.
+**Engineering note (MP-ART-ANALYSIS-002):** Eligibility time windows are applied **on the server** via optional GET query params. That differs from **`GET /api/v1/data-collection`**, which only applies a `createdAt` range when **both** `start` and `end` are present; analysis GET applies `gte` / `lte` **independently** when each param is set (same pattern as delivery-run listing). Omitting both preserves the previous unbounded (by time) behavior.
+
+- **GET** — Query (`getAnalysisQuerySchema`):
+  - `tickerId` (required).
+  - `unanalyzed` — optional (`"true"` | `"false"` strings). When omitted, defaults to `"true"` (incremental backlog: sources with no `article_relevance` row for that ticker). `"false"` returns all `DataSource` rows for the ticker for re-scoring workflows (FR2).
+  - `start` — optional ISO 8601 datetime; when set, only sources with `createdAt >= start` (inclusive), FR1.
+  - `end` — optional ISO 8601 datetime; when set, only sources with `createdAt <= end` (inclusive), FR1. If both `start` and `end` are set, `start` must not be after `end` (validation error).
 - **POST** — Body validated by `postAnalysisBodySchema`: `tickerId`, optional arrays `entities`, `relations`, `articleEntities`, `articleRelevances`. Response includes aggregate counts (`entitiesCreated`, `entitiesReused`, `relationsCreated`, `articlesScored`, `articlesSelected`).
 
-From agents, use the SDK namespace **`analysis`**: `get` for the query object, **`create`** for POST.
+From agents, use the SDK namespace **`analysis`**: `get` for the query object, **`create`** for POST. **MP-ART-ANALYSIS-003** will map agent run `timeWindow` (when present) to these query params on `analysis.get` instead of filtering only client-side after fetch.
 
 ### Delivery run (`/api/v1/delivery-run`)
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -157,6 +157,37 @@ describe("createAgentDataApiClient", () => {
     );
   });
 
+  it("serializes optional start and end on analysis GET", async () => {
+    const getFn = vi.fn().mockResolvedValue({
+      body: JSON.stringify({
+        dataSources: [],
+        entityTypes: [],
+        relationTypes: [],
+        existingEntities: [],
+      }),
+      statusCode: 200,
+    });
+    const client = createAgentDataApiClient({
+      baseUrl: "http://agent-data-api",
+      token: "Bearer sdk-token",
+      getFn,
+    });
+
+    await client.analysis.get({
+      tickerId: "11111111-1111-4111-a111-111111111111",
+      unanalyzed: true,
+      start: "2026-01-01T00:00:00.000Z",
+      end: "2026-01-31T00:00:00.000Z",
+    });
+
+    expect(getFn).toHaveBeenCalledWith(
+      `http://agent-data-api${agentDataApiPathname(AGENT_DATA_API_DEFAULT_VERSION, "analysis")}?tickerId=11111111-1111-4111-a111-111111111111&unanalyzed=true&start=2026-01-01T00%3A00%3A00.000Z&end=2026-01-31T00%3A00%3A00.000Z`,
+      expect.objectContaining({
+        headers: { Authorization: "Bearer sdk-token" },
+      }),
+    );
+  });
+
   it("posts analysis payload and parses response", async () => {
     const postFn = vi.fn().mockResolvedValue({
       body: JSON.stringify({

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -2,14 +2,38 @@ import { z } from "zod";
 
 const sentimentSchema = z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL"]);
 
-export const getAnalysisQuerySchema = z.object({
-  tickerId: z.string().trim().min(1),
-  /** Omitted query param defaults to incremental unanalyzed-only runs (PRD FR2). */
-  unanalyzed: z
-    .enum(["true", "false"])
-    .default("true")
-    .transform((value) => value === "true"),
-});
+export const getAnalysisQuerySchema = z
+  .object({
+    tickerId: z.string().trim().min(1),
+    /** Omitted query param defaults to incremental unanalyzed-only runs (PRD FR2). */
+    unanalyzed: z
+      .enum(["true", "false"])
+      .default("true")
+      .transform((value) => value === "true"),
+    /** Inclusive lower bound on `DataSource.createdAt` (ISO 8601), FR1 eligibility window. */
+    start: z.preprocess(
+      (v) => (v === "" || v === undefined ? undefined : v),
+      z.string().datetime().optional(),
+    ),
+    /** Inclusive upper bound on `DataSource.createdAt` (ISO 8601), FR1 eligibility window. */
+    end: z.preprocess(
+      (v) => (v === "" || v === undefined ? undefined : v),
+      z.string().datetime().optional(),
+    ),
+  })
+  .superRefine((data, ctx) => {
+    if (data.start !== undefined && data.end !== undefined) {
+      const startMs = new Date(data.start).getTime();
+      const endMs = new Date(data.end).getTime();
+      if (startMs > endMs) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "start must be before or equal to end",
+          path: ["start"],
+        });
+      }
+    }
+  });
 
 export const postAnalysisBodySchema = z.object({
   tickerId: z.string().trim().min(1),


### PR DESCRIPTION
## Summary

Implements **MP-ART-ANALYSIS-002** by adding optional ISO 8601 **`start`** and **`end`** query parameters to `GET /api/v1/analysis`. When set, they bound eligible `DataSource` rows by **`createdAt`** (inclusive `gte` / `lte`) on the server, reducing payloads for large histories. Cross-field validation rejects **`start` after `end`**. Omitted bounds preserve previous behavior.

## Related issues

Closes #212

## Important changes

- Contract: `getAnalysisQuerySchema` gains preprocessed optional `start` / `end` (same pattern as delivery-run query hygiene) plus ordering `superRefine`.
- Service: `loadAnalysisContext` merges Prisma `createdAt` filters with existing `tickerId` and `unanalyzed` logic.
- Dev-docs describe FR1/FR2 alignment, contrast with data-collection GET (both bounds required there), and note **MP-ART-ANALYSIS-003** will forward run `timeWindow` to these params.

## Other changes

- Extended unit and integration tests for the schema, service `where` clause, agent-data-api GET, and SDK query serialization.

## Key files to review

- `packages/shared/agent-data-api-contract/src/analysis.ts` — query schema and validation.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — Prisma `createdAt` filter merge.
- `dev-docs/docs/mediapulse/apps/agent-data-api.mdx` — public contract documentation.

## How to test

1. From repo root run `pnpm code-quality` (passes on this branch).
2. Call `GET /api/v1/analysis?tickerId=…&unanalyzed=true&start=…&end=…` with a valid token; confirm responses only include sources in range and invalid `start`/`end` order returns a validation error path consistent with other Zod failures on this route.
