### PR TITLE
Add article-analysis run inputs, GET window, and batch cap

### DIFF
--- a/apps/mediapulse/agents/article-analysis/package.json
+++ b/apps/mediapulse/agents/article-analysis/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@workspace/agent-data-api-contract": "workspace:*",
     "@workspace/agent-data-api-client": "workspace:*",
     "@workspace/agent-auth-client": "workspace:*",
     "@workspace/agent-runtime": "workspace:*",

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -1,12 +1,11 @@
 import { createAgentApp } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { z } from "zod";
+import {
+  articleAnalysisInputSchema,
+  type ArticleAnalysisInput,
+} from "./input-schema.js";
 import { run } from "./run";
-
-// InputSchema is the schema for the input of the agent, which will be sent by Hermes to the agent when the agent is invoked
-const InputSchema = z.object({
-  tickerId: z.string().trim().min(1),
-});
 
 // ConfigSchema is the schema for the config of the agent, which will be sent by Hermes to the agent when the agent is invoked
 const ConfigSchema = z.object({
@@ -14,11 +13,11 @@ const ConfigSchema = z.object({
 });
 
 export type Config = z.infer<typeof ConfigSchema>;
-export type Input = z.infer<typeof InputSchema>;
+export type Input = ArticleAnalysisInput;
 
 const app = createAgentApp<
   Input,
-  typeof InputSchema,
+  typeof articleAnalysisInputSchema,
   Config,
   typeof ConfigSchema
 >(
@@ -26,8 +25,8 @@ const app = createAgentApp<
     agentId: "article-analysis", // this should be stable for the lifetime of the agent
     agentVersion: "1.0.0", // this should be incremented when the agent is updated
     description:
-      "Loads analysis context from agent-data-api (unanalyzed sources) per ticker. Extraction and scoring follow in later milestones.", // Optional description of the agent but recommended for admins to see in the agent registry
-    inputSchema: InputSchema,
+      "Loads analysis context from agent-data-api: incremental (unanalyzed) or re-scoring (`reanalyze`), optional `timeWindow` (ISO start/end) and `maxBatchSize`. Extraction and scoring follow in later milestones.",
+    inputSchema: articleAnalysisInputSchema,
     configSchema: ConfigSchema,
     run,
   },

--- a/apps/mediapulse/agents/article-analysis/src/input-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/input-schema.test.ts
@@ -1,0 +1,37 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { articleAnalysisInputSchema } from "./input-schema.js";
+
+describe("articleAnalysisInputSchema", () => {
+  it("rejects reanalyze without maxBatchSize or timeWindow bounds", () => {
+    const result = articleAnalysisInputSchema.safeParse({
+      tickerId: "t1",
+      reanalyze: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts reanalyze with maxBatchSize only", () => {
+    const result = articleAnalysisInputSchema.safeParse({
+      tickerId: "t1",
+      reanalyze: true,
+      maxBatchSize: 10,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts reanalyze with timeWindow start only", () => {
+    const result = articleAnalysisInputSchema.safeParse({
+      tickerId: "t1",
+      reanalyze: true,
+      timeWindow: { start: "2026-01-01T00:00:00.000Z" },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("allows omitted reanalyze", () => {
+    const result = articleAnalysisInputSchema.parse({ tickerId: "t1" });
+    expect(result.reanalyze).toBeUndefined();
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/input-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/input-schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+const timeWindowSchema = z
+  .object({
+    start: z.string().datetime().optional(),
+    end: z.string().datetime().optional(),
+  })
+  .optional();
+
+/**
+ * Hermes run input for the article-analysis agent (Phase A: context load and batch bounds only).
+ *
+ * When `reanalyze` is true, callers must supply `maxBatchSize` and/or a `timeWindow` with at least
+ * one of `start` or `end` (ISO 8601), matching MP-ART-ANALYSIS-003 / FR1.
+ */
+export const articleAnalysisInputSchema = z
+  .object({
+    tickerId: z.string().trim().min(1),
+    reanalyze: z.boolean().optional(),
+    timeWindow: timeWindowSchema,
+    maxBatchSize: z.number().int().positive().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.reanalyze !== true) {
+      return;
+    }
+    const hasWindow =
+      data.timeWindow?.start !== undefined ||
+      data.timeWindow?.end !== undefined;
+    const hasCap = data.maxBatchSize !== undefined;
+    if (!hasWindow && !hasCap) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "reanalyze requires maxBatchSize and/or timeWindow with start or end",
+        path: ["reanalyze"],
+      });
+    }
+  });
+
+export type ArticleAnalysisInput = z.infer<typeof articleAnalysisInputSchema>;

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { ArticleAnalysisInput } from "./input-schema.js";
+import { articleAnalysisInputSchema } from "./input-schema.js";
+import {
+  applyMaxBatchSizeCap,
+  buildAnalysisGetQuery,
+  sortAnalysisDataSourcesByCreatedAt,
+} from "./run-helpers.js";
+
+describe("buildAnalysisGetQuery", () => {
+  it("maps incremental run to unanalyzed true", () => {
+    const input = articleAnalysisInputSchema.parse({
+      tickerId: "tick-a",
+    });
+    expect(buildAnalysisGetQuery(input)).toEqual({
+      tickerId: "tick-a",
+      unanalyzed: true,
+    });
+  });
+
+  it("maps reanalyze to unanalyzed false", () => {
+    const input = articleAnalysisInputSchema.parse({
+      tickerId: "tick-b",
+      reanalyze: true,
+      maxBatchSize: 5,
+    });
+    expect(buildAnalysisGetQuery(input)).toEqual({
+      tickerId: "tick-b",
+      unanalyzed: false,
+    });
+  });
+
+  it("forwards timeWindow start and end", () => {
+    const input: ArticleAnalysisInput = {
+      tickerId: "tick-c",
+      reanalyze: false,
+      timeWindow: {
+        start: "2026-01-01T00:00:00.000Z",
+        end: "2026-01-31T00:00:00.000Z",
+      },
+    };
+    expect(buildAnalysisGetQuery(input)).toEqual({
+      tickerId: "tick-c",
+      unanalyzed: true,
+      start: "2026-01-01T00:00:00.000Z",
+      end: "2026-01-31T00:00:00.000Z",
+    });
+  });
+});
+
+describe("sortAnalysisDataSourcesByCreatedAt", () => {
+  it("sorts by createdAt then id", () => {
+    const rows = [
+      {
+        id: "b",
+        createdAt: new Date("2026-01-02T00:00:00.000Z"),
+      },
+      {
+        id: "a",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+      {
+        id: "c",
+        createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      },
+    ];
+    const sorted = sortAnalysisDataSourcesByCreatedAt(rows);
+    expect(sorted.map((r) => r.id)).toEqual(["a", "c", "b"]);
+  });
+});
+
+describe("applyMaxBatchSizeCap", () => {
+  it("returns full copy when maxBatchSize is omitted", () => {
+    const sorted = [1, 2, 3];
+    expect(applyMaxBatchSizeCap(sorted)).toEqual([1, 2, 3]);
+  });
+
+  it("truncates to first N items", () => {
+    const sorted = ["a", "b", "c"];
+    expect(applyMaxBatchSizeCap(sorted, 2)).toEqual(["a", "b"]);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
@@ -1,0 +1,75 @@
+import type { GetAnalysisQuery } from "@workspace/agent-data-api-contract";
+
+import type { ArticleAnalysisInput } from "./input-schema.js";
+
+/**
+ * Builds the typed agent-data-api `analysis.get` query from validated run input.
+ *
+ * @param input - Parsed article-analysis input (`timeWindow` bounds forward as `start` / `end` when set).
+ * @returns Query object for `createAgentDataApiClient().analysis.get`.
+ */
+export const buildAnalysisGetQuery = (
+  input: ArticleAnalysisInput,
+): GetAnalysisQuery => {
+  const base = {
+    tickerId: input.tickerId,
+    unanalyzed: !input.reanalyze,
+  } satisfies Pick<GetAnalysisQuery, "tickerId" | "unanalyzed">;
+
+  const start = input.timeWindow?.start;
+  const end = input.timeWindow?.end;
+  if (start !== undefined && end !== undefined) {
+    return { ...base, start, end };
+  }
+  if (start !== undefined) {
+    return { ...base, start };
+  }
+  if (end !== undefined) {
+    return { ...base, end };
+  }
+  return base;
+};
+
+/**
+ * Returns a new array sorted by `createdAt` ascending, then `id` lexicographically for stable ordering.
+ *
+ * @param sources - Data source rows from analysis GET (not mutated).
+ * @returns Sorted copy.
+ */
+export const sortAnalysisDataSourcesByCreatedAt = <
+  T extends { id: string; createdAt: Date | string },
+>(
+  sources: readonly T[],
+): T[] => {
+  return [...sources].sort((a, b) => {
+    const ta =
+      a.createdAt instanceof Date
+        ? a.createdAt.getTime()
+        : new Date(a.createdAt).getTime();
+    const tb =
+      b.createdAt instanceof Date
+        ? b.createdAt.getTime()
+        : new Date(b.createdAt).getTime();
+    if (ta !== tb) {
+      return ta - tb;
+    }
+    return a.id.localeCompare(b.id);
+  });
+};
+
+/**
+ * Keeps the first `maxBatchSize` items of an already-sorted list; no-op when `maxBatchSize` is omitted.
+ *
+ * @param sorted - Sources in deterministic process order (e.g. after {@link sortAnalysisDataSourcesByCreatedAt}).
+ * @param maxBatchSize - Optional positive cap for Phase A batching.
+ * @returns Possibly truncated array (same references as `sorted` when under cap or uncapped).
+ */
+export const applyMaxBatchSizeCap = <T>(
+  sorted: readonly T[],
+  maxBatchSize?: number,
+): T[] => {
+  if (maxBatchSize === undefined) {
+    return [...sorted];
+  }
+  return sorted.slice(0, maxBatchSize);
+};

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -45,9 +45,9 @@ describe("run", () => {
     analysisGet.mockReset();
   });
 
-  it("returns success with backlog count when analysis GET succeeds", async () => {
+  it("returns success with source count when analysis GET succeeds", async () => {
     analysisGet.mockResolvedValue({
-      dataSources: [{ id: "1" }, { id: "2" }],
+      dataSources: [{ id: "ds-1" }, { id: "ds-2" }],
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
@@ -62,11 +62,70 @@ describe("run", () => {
 
     expect(result).toEqual({
       success: true,
-      message: "analysis context loaded (2 unanalyzed source(s))",
+      message: "analysis context loaded (2 source(s))",
+      details: {
+        dataSourcesReturned: 2,
+        dataSourcesSelected: 2,
+        reanalyze: false,
+      },
     });
     expect(analysisGet).toHaveBeenCalledWith({
       tickerId: "ticker-1",
       unanalyzed: true,
+    });
+  });
+
+  it("uses unanalyzed false when reanalyze with maxBatchSize", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [],
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+    });
+
+    await run(
+      runContext({
+        input: {
+          tickerId: "ticker-r",
+          reanalyze: true,
+          maxBatchSize: 3,
+        },
+        config: {},
+      }),
+    );
+
+    expect(analysisGet).toHaveBeenCalledWith({
+      tickerId: "ticker-r",
+      unanalyzed: false,
+    });
+  });
+
+  it("passes timeWindow as start and end on GET", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [],
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+    });
+
+    await run(
+      runContext({
+        input: {
+          tickerId: "ticker-w",
+          timeWindow: {
+            start: "2026-01-01T00:00:00.000Z",
+            end: "2026-01-31T00:00:00.000Z",
+          },
+        },
+        config: {},
+      }),
+    );
+
+    expect(analysisGet).toHaveBeenCalledWith({
+      tickerId: "ticker-w",
+      unanalyzed: true,
+      start: "2026-01-01T00:00:00.000Z",
+      end: "2026-01-31T00:00:00.000Z",
     });
   });
 
@@ -87,7 +146,55 @@ describe("run", () => {
 
     expect(result).toEqual({
       success: true,
-      message: "analysis context loaded (0 unanalyzed source(s))",
+      message: "analysis context loaded (0 source(s))",
+      details: {
+        dataSourcesReturned: 0,
+        dataSourcesSelected: 0,
+        reanalyze: false,
+      },
+    });
+  });
+
+  it("reports batch cap when maxBatchSize is smaller than result set", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: "b",
+          createdAt: new Date("2026-01-02T00:00:00.000Z"),
+          url: "",
+          title: "",
+          content: "",
+          tickerId: "t",
+        },
+        {
+          id: "a",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          url: "",
+          title: "",
+          content: "",
+          tickerId: "t",
+        },
+      ],
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-cap", maxBatchSize: 1 },
+        config: {},
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe(
+      "analysis context loaded (2 source(s), processing batch of 1)",
+    );
+    expect(result.details).toEqual({
+      dataSourcesReturned: 2,
+      dataSourcesSelected: 1,
+      reanalyze: false,
     });
   });
 

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -4,18 +4,28 @@ import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
 
 import type { Config, Input } from "./index.js";
+import {
+  applyMaxBatchSizeCap,
+  buildAnalysisGetQuery,
+  sortAnalysisDataSourcesByCreatedAt,
+} from "./run-helpers.js";
 
 /**
- * Loads analysis context for the ticker (incremental unanalyzed sources only).
+ * Loads analysis context for the ticker (incremental or reanalyze), applies optional time window via GET,
+ * and deterministically caps the in-memory batch when `maxBatchSize` is set.
  *
  * @param context - Validated input, optional config, and bearer token for agent-data-api.
- * @returns Success with a short backlog summary, or failure when the data API call fails.
+ * @returns Success with backlog / batch summary, or failure when the data API call fails.
  */
 export const run = async ({
   input,
   config,
   token,
 }: AgentRunContext<Input, Config>): Promise<AgentRunResult> => {
+  /** Hermes applies input-schema defaults; direct `run` callers (tests) may omit optional fields. */
+  const reanalyze = input.reanalyze ?? false;
+  const inputForQuery = { ...input, reanalyze };
+
   if (config.verbose) {
     logger.info({ tickerId: input.tickerId }, "article-analysis run started");
   }
@@ -27,14 +37,34 @@ export const run = async ({
   });
 
   try {
-    const ctx = await dataApiClient.analysis.get({
-      tickerId: input.tickerId,
-      unanalyzed: true,
-    });
+    const query = buildAnalysisGetQuery(inputForQuery);
+    const ctx = await dataApiClient.analysis.get(query);
+
+    const rawCount = ctx.dataSources.length;
+    const sorted = sortAnalysisDataSourcesByCreatedAt(ctx.dataSources);
+    const batch = applyMaxBatchSizeCap(sorted, inputForQuery.maxBatchSize);
+    const selectedCount = batch.length;
+
+    let message: string;
+    if (rawCount === 0) {
+      message = "analysis context loaded (0 source(s))";
+    } else if (
+      inputForQuery.maxBatchSize !== undefined &&
+      selectedCount < rawCount
+    ) {
+      message = `analysis context loaded (${rawCount} source(s), processing batch of ${selectedCount})`;
+    } else {
+      message = `analysis context loaded (${rawCount} source(s))`;
+    }
 
     return {
       success: true,
-      message: `analysis context loaded (${ctx.dataSources.length} unanalyzed source(s))`,
+      message,
+      details: {
+        dataSourcesReturned: rawCount,
+        dataSourcesSelected: selectedCount,
+        reanalyze,
+      },
     };
   } catch (error) {
     const message =

--- a/dev-docs/docs/guide/development.mdx
+++ b/dev-docs/docs/guide/development.mdx
@@ -81,7 +81,7 @@ Use **pnpm** for install/scripts.
 | content-generation agent | 4002 | Mediapulse agent                               |
 | delivery agent           | 4003 | Mediapulse agent                               |
 | ticker-echo agent        | 4010 | Minimal test agent                             |
-| article-analysis agent   | 4011 | Mediapulse agent (KG analysis)                 |
+| article-analysis agent   | 4011 | Mediapulse agent (KG analysis) — invoke `input`: `tickerId` (required); optional `reanalyze` (default false); optional `timeWindow` with ISO `start` / `end`; optional `maxBatchSize` (positive int). When `reanalyze` is true, Hermes must send at least one of `timeWindow` bounds or `maxBatchSize`. Uses `AGENT_DATA_API_URL` + bearer token like other agents. |
 | domain-api (Mediapulse)  | 8090 | Hermes domain integration API (default in dev) |
 | hermes-worker            | —    | Background worker (no HTTP port)               |
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,6 +469,9 @@ importers:
       '@workspace/agent-data-api-client':
         specifier: workspace:*
         version: link:../../../../packages/shared/agent-data-api-client
+      '@workspace/agent-data-api-contract':
+        specifier: workspace:*
+        version: link:../../../../packages/shared/agent-data-api-contract
       '@workspace/agent-runtime':
         specifier: workspace:*
         version: link:../../../../packages/shared/agent-runtime
@@ -5169,6 +5172,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt@6.0.0:
     resolution: {integrity: sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==}


### PR DESCRIPTION
## Summary

Implements **MP-ART-ANALYSIS-003**: article-analysis **run `input`** with `tickerId`, optional `reanalyze`, optional `timeWindow` (`start` / `end` ISO datetimes), and optional `maxBatchSize`, with validation that **reanalyze** requires a window bound and/or **maxBatchSize**. The agent calls **`analysis.get`** with the correct **`unanalyzed`** flag and passes **`start` / `end`** when set, then **sorts** sources by `createdAt` and `id` and applies **batch capping**. Success responses include **`details`** with counts for downstream pipeline work.

The shared **analysis GET** contract and **`loadAnalysisContext`** gained optional **`createdAt`** bounds (same semantics as **MP-ART-ANALYSIS-002**) so the agent’s window is honored server-side.

## Related issues

Closes #213

## Important changes

- New **`input-schema`**, **`run-helpers`**, and expanded **`run`** plus tests for validation, GET wiring, empty backlog, and cap behavior.
- **`getAnalysisQuerySchema`** / **`loadAnalysisContext`** support optional **`start`** / **`end`** for eligibility filtering.

## Other changes

- **dev-docs** development table: documents article-analysis invoke **`input`** and reanalyze rule.
- **`@mediapulse/article-analysis`** depends on **`@workspace/agent-data-api-contract`** for **`GetAnalysisQuery`** typing.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/input-schema.ts` — cross-field reanalyze validation.
- `apps/mediapulse/agents/article-analysis/src/run-helpers.ts` — query build, sort, cap.
- `apps/mediapulse/agents/article-analysis/src/run.ts` — GET + messaging / details.
- `packages/shared/agent-data-api-contract/src/analysis.ts` — optional GET window params.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — Prisma **`createdAt`** filter merge.

## How to test

1. From repo root: **`pnpm code-quality`** (passes on this branch).
2. **`pnpm --filter @mediapulse/article-analysis exec vitest run`** — covers schema, helpers, and run mocks.
3. Optional: invoke the agent with **`reanalyze: true`** and no window/cap → **400** from Zod; with **`timeWindow`** or **`maxBatchSize`** → **200** and **`analysis.get`** receives expected query params.
