### PR TITLE
Add article-analysis LLM extraction and chunked analysis POST

### DIFF
--- a/apps/mediapulse/agents/article-analysis/package.json
+++ b/apps/mediapulse/agents/article-analysis/package.json
@@ -12,6 +12,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.49",
     "@workspace/agent-data-api-contract": "workspace:*",
     "@workspace/agent-data-api-client": "workspace:*",
     "@workspace/agent-auth-client": "workspace:*",
@@ -19,6 +20,7 @@
     "@workspace/agent-types": "workspace:*",
     "@mediapulse/env": "workspace:*",
     "@workspace/logger": "workspace:*",
+    "ai": "^6.0.142",
     "hono": "catalog:",
     "hono-pino": "catalog:",
     "zod": "catalog:"

--- a/apps/mediapulse/agents/article-analysis/src/analysis-caps-dedupe.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-caps-dedupe.test.ts
@@ -1,0 +1,87 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPerArticleExtractionCaps,
+  applyPerRunCaps,
+  dedupeEntities,
+  dedupeRelations,
+} from "./analysis-caps-dedupe.js";
+
+const TID = "11111111-1111-4111-a111-111111111111";
+
+describe("applyPerArticleExtractionCaps", () => {
+  it("truncates entities and relations", () => {
+    // Act
+    const out = applyPerArticleExtractionCaps(
+      [
+        { canonicalName: "A", typeId: TID, aliases: [] },
+        { canonicalName: "B", typeId: TID, aliases: [] },
+      ],
+      [
+        {
+          fromEntityName: "A",
+          toEntityName: "B",
+          relationTypeId: "22222222-2222-4222-a222-222222222222",
+        },
+        {
+          fromEntityName: "B",
+          toEntityName: "A",
+          relationTypeId: "22222222-2222-4222-a222-222222222222",
+        },
+      ],
+      1,
+      1,
+    );
+    // Assert
+    expect(out.entities).toHaveLength(1);
+    expect(out.relations).toHaveLength(1);
+  });
+});
+
+describe("dedupeEntities", () => {
+  it("keeps first entity per normalized canonical and typeId", () => {
+    // Act
+    const out = dedupeEntities([
+      { canonicalName: " Acme ", typeId: TID, aliases: [] },
+      { canonicalName: "ACME", typeId: TID, description: "dup", aliases: [] },
+    ]);
+    // Assert
+    expect(out).toHaveLength(1);
+    expect(out[0]?.canonicalName).toBe(" Acme ");
+  });
+});
+
+describe("dedupeRelations", () => {
+  it("dedupes by normalized endpoints and relation type", () => {
+    // Act
+    const rid = "22222222-2222-4222-a222-222222222222";
+    const out = dedupeRelations([
+      { fromEntityName: "A", toEntityName: "B", relationTypeId: rid },
+      { fromEntityName: " a ", toEntityName: " b ", relationTypeId: rid },
+    ]);
+    // Assert
+    expect(out).toHaveLength(1);
+  });
+});
+
+describe("applyPerRunCaps", () => {
+  it("drops relations whose endpoints are removed by the entity cap", () => {
+    // Act
+    const ents = [
+      { canonicalName: "A", typeId: TID, aliases: [] },
+      { canonicalName: "B", typeId: TID, aliases: [] },
+    ];
+    const rels = [
+      {
+        fromEntityName: "A",
+        toEntityName: "B",
+        relationTypeId: "22222222-2222-4222-a222-222222222222",
+      },
+    ];
+    const out = applyPerRunCaps(ents, rels, 1, 1);
+    // Assert
+    expect(out.entities).toHaveLength(1);
+    expect(out.relations).toHaveLength(0);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-caps-dedupe.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-caps-dedupe.ts
@@ -1,0 +1,104 @@
+import type {
+  EntityProposal,
+  RelationProposal,
+} from "./analysis-vocabulary.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+/**
+ * Truncates per-article extraction to configured maxima (deterministic: array prefix order).
+ *
+ * @param entities - Proposed entities for one article.
+ * @param relations - Proposed relations for one article.
+ * @param maxEntitiesPerArticle - Cap on entities.
+ * @param maxRelationsPerArticle - Cap on relations.
+ * @returns Truncated copies.
+ */
+export const applyPerArticleExtractionCaps = (
+  entities: readonly EntityProposal[],
+  relations: readonly RelationProposal[],
+  maxEntitiesPerArticle: number,
+  maxRelationsPerArticle: number,
+): { entities: EntityProposal[]; relations: RelationProposal[] } => ({
+  entities: entities.slice(0, maxEntitiesPerArticle),
+  relations: relations.slice(0, maxRelationsPerArticle),
+});
+
+/**
+ * Deduplicates entities by normalized canonical name plus `typeId`.
+ *
+ * @param entities - Merged proposals across articles.
+ * @returns First-seen entity per key.
+ */
+export const dedupeEntities = (
+  entities: readonly EntityProposal[],
+): EntityProposal[] => {
+  const seen = new Set<string>();
+  const out: EntityProposal[] = [];
+  for (const e of entities) {
+    const key = `${normalizeEntityName(e.canonicalName)}\0${e.typeId}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(e);
+    }
+  }
+  return out;
+};
+
+/**
+ * Deduplicates relations by normalized endpoint pair and relation type id.
+ *
+ * @param relations - Merged relations.
+ * @returns First-seen relation per key.
+ */
+export const dedupeRelations = (
+  relations: readonly RelationProposal[],
+): RelationProposal[] => {
+  const seen = new Set<string>();
+  const out: RelationProposal[] = [];
+  for (const r of relations) {
+    const key = `${normalizeEntityName(r.fromEntityName)}\0${normalizeEntityName(r.toEntityName)}\0${r.relationTypeId}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      out.push(r);
+    }
+  }
+  return out;
+};
+
+/**
+ * Truncates run-level merged lists after deduplication.
+ *
+ * @param entities - Deduped entities.
+ * @param relations - Deduped relations.
+ * @param maxEntitiesPerRun - Run cap on entities.
+ * @param maxRelationsPerRun - Run cap on relations.
+ * @returns Truncated copies.
+ */
+export const applyPerRunCaps = (
+  entities: readonly EntityProposal[],
+  relations: readonly RelationProposal[],
+  maxEntitiesPerRun: number,
+  maxRelationsPerRun: number,
+): { entities: EntityProposal[]; relations: RelationProposal[] } => {
+  const cappedEntities = entities.slice(0, maxEntitiesPerRun);
+
+  const survivingNames = new Set<string>();
+  for (const entity of cappedEntities) {
+    survivingNames.add(normalizeEntityName(entity.canonicalName));
+    for (const alias of entity.aliases) {
+      survivingNames.add(normalizeEntityName(alias));
+    }
+  }
+
+  const endpointFilteredRelations = relations.filter((relation) => {
+    return (
+      survivingNames.has(normalizeEntityName(relation.fromEntityName)) &&
+      survivingNames.has(normalizeEntityName(relation.toEntityName))
+    );
+  });
+
+  return {
+    entities: cappedEntities,
+    relations: endpointFilteredRelations.slice(0, maxRelationsPerRun),
+  };
+};

--- a/apps/mediapulse/agents/article-analysis/src/analysis-vocabulary.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-vocabulary.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { validateExtractionVocabulary } from "./analysis-vocabulary.js";
+
+const TYPE_OK = "11111111-1111-4111-a111-111111111111";
+const TYPE_BAD = "22222222-2222-4222-a222-222222222222";
+const REL_OK = "33333333-3333-4333-a333-333333333333";
+const REL_BAD = "44444444-4444-4444-a444-444444444444";
+
+describe("validateExtractionVocabulary", () => {
+  it("accepts ids present on GET vocabulary", () => {
+    // Act
+    const r = validateExtractionVocabulary(
+      [
+        {
+          canonicalName: "Acme",
+          typeId: TYPE_OK,
+          aliases: [],
+        },
+      ],
+      [
+        {
+          fromEntityName: "Acme",
+          toEntityName: "Beta",
+          relationTypeId: REL_OK,
+        },
+      ],
+      {
+        entityTypes: [{ id: TYPE_OK, name: "Co", description: null }],
+        relationTypes: [{ id: REL_OK, name: "owns", description: null }],
+      },
+    );
+    // Assert
+    expect(r).toEqual({ ok: true });
+  });
+
+  it("rejects unknown entity typeId", () => {
+    // Act
+    const r = validateExtractionVocabulary(
+      [{ canonicalName: "X", typeId: TYPE_BAD, aliases: [] }],
+      [],
+      {
+        entityTypes: [{ id: TYPE_OK, name: "Co", description: null }],
+        relationTypes: [],
+      },
+    );
+    // Assert
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("Invalid entity typeId");
+    }
+  });
+
+  it("rejects unknown relationTypeId", () => {
+    // Act
+    const r = validateExtractionVocabulary(
+      [],
+      [
+        {
+          fromEntityName: "A",
+          toEntityName: "B",
+          relationTypeId: REL_BAD,
+        },
+      ],
+      {
+        entityTypes: [],
+        relationTypes: [{ id: REL_OK, name: "r", description: null }],
+      },
+    );
+    // Assert
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.message).toContain("Invalid relationTypeId");
+    }
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-vocabulary.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-vocabulary.ts
@@ -1,0 +1,47 @@
+import type {
+  GetAnalysisResponse,
+  PostAnalysisBody,
+} from "@workspace/agent-data-api-contract";
+
+export type EntityProposal = PostAnalysisBody["entities"][number];
+export type RelationProposal = PostAnalysisBody["relations"][number];
+
+/**
+ * Ensures every extracted `typeId` and `relationTypeId` appears on the analysis GET vocabulary (FR3).
+ *
+ * @param entities - Proposed entities from the LLM.
+ * @param relations - Proposed relations from the LLM.
+ * @param ctx - GET response subsets `entityTypes` and `relationTypes`.
+ * @returns Success or failure with a human-readable message (no POST).
+ */
+export const validateExtractionVocabulary = (
+  entities: readonly EntityProposal[],
+  relations: readonly RelationProposal[],
+  ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">,
+):
+  | { ok: true }
+  | {
+      ok: false;
+      message: string;
+    } => {
+  const typeIds = new Set(ctx.entityTypes.map((e) => e.id));
+  const relIds = new Set(ctx.relationTypes.map((r) => r.id));
+
+  for (const e of entities) {
+    if (!typeIds.has(e.typeId)) {
+      return {
+        ok: false,
+        message: `Invalid entity typeId ${e.typeId} (not in GET vocabulary for this ticker run)`,
+      };
+    }
+  }
+  for (const r of relations) {
+    if (!relIds.has(r.relationTypeId)) {
+      return {
+        ok: false,
+        message: `Invalid relationTypeId ${r.relationTypeId} (not in GET vocabulary for this ticker run)`,
+      };
+    }
+  }
+  return { ok: true };
+};

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
@@ -1,0 +1,122 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildAnalysisPostChunks,
+  buildEntityNameLookup,
+} from "./build-analysis-post-chunks.js";
+
+const TID = "11111111-1111-4111-a111-111111111111";
+const RID = "22222222-2222-4222-a222-222222222222";
+
+describe("buildEntityNameLookup", () => {
+  it("maps canonical and alias", () => {
+    // Setup
+    const entities = [
+      {
+        canonicalName: "Apple Inc",
+        typeId: TID,
+        aliases: ["Apple"],
+      },
+    ];
+    // Act
+    const map = buildEntityNameLookup(entities);
+    // Assert
+    expect(map.get("apple inc")?.canonicalName).toBe("Apple Inc");
+    expect(map.get("apple")?.canonicalName).toBe("Apple Inc");
+  });
+});
+
+describe("buildAnalysisPostChunks", () => {
+  it("includes entity closure per chunk for cross-chunk endpoint reuse", () => {
+    // Setup
+    const tickerId = "t1";
+    const entities = [
+      {
+        canonicalName: "A",
+        typeId: TID,
+        aliases: [],
+      },
+      {
+        canonicalName: "B",
+        typeId: TID,
+        aliases: [],
+      },
+      {
+        canonicalName: "C",
+        typeId: TID,
+        aliases: [],
+      },
+    ];
+    const relations = [
+      { fromEntityName: "A", toEntityName: "B", relationTypeId: RID },
+      { fromEntityName: "B", toEntityName: "C", relationTypeId: RID },
+    ];
+    // Act
+    const { chunks } = buildAnalysisPostChunks(
+      tickerId,
+      entities,
+      relations,
+      1,
+    );
+    // Assert
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.relations).toHaveLength(1);
+    expect(chunks[0]?.entities.map((e) => e.canonicalName).sort()).toEqual(
+      ["A", "B"].sort(),
+    );
+    expect(chunks[1]?.entities.map((e) => e.canonicalName).sort()).toEqual(
+      ["B", "C"].sort(),
+    );
+  });
+
+  it("drops relations when endpoint is missing from catalog", () => {
+    // Act
+    const { chunks, droppedRelations } = buildAnalysisPostChunks(
+      "t",
+      [
+        {
+          canonicalName: "Only",
+          typeId: TID,
+          aliases: [],
+        },
+      ],
+      [
+        {
+          fromEntityName: "Only",
+          toEntityName: "Ghost",
+          relationTypeId: RID,
+        },
+      ],
+      10,
+    );
+    // Assert
+    expect(chunks).toHaveLength(0);
+    expect(droppedRelations).toBe(1);
+  });
+
+  it("reports parse error when chunk body fails schema validation", () => {
+    // Act
+    const { chunks, parseErrors } = buildAnalysisPostChunks(
+      "",
+      [
+        {
+          canonicalName: "A",
+          typeId: TID,
+          aliases: [],
+        },
+        {
+          canonicalName: "B",
+          typeId: TID,
+          aliases: [],
+        },
+      ],
+      [{ fromEntityName: "A", toEntityName: "B", relationTypeId: RID }],
+      10,
+    );
+
+    // Assert
+    expect(chunks).toHaveLength(0);
+    expect(parseErrors.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
@@ -1,0 +1,116 @@
+import {
+  postAnalysisBodySchema,
+  type PostAnalysisBody,
+} from "@workspace/agent-data-api-contract";
+
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+/**
+ * Indexes entities by normalized canonical name and alias strings for relation endpoint closure.
+ *
+ * @param entities - Full deduped entity list for the run.
+ * @returns Map from normalized name to entity row (first registration wins).
+ */
+export const buildEntityNameLookup = (
+  entities: ReadonlyArray<PostAnalysisBody["entities"][number]>,
+): Map<string, PostAnalysisBody["entities"][number]> => {
+  const map = new Map<string, PostAnalysisBody["entities"][number]>();
+  const register = (raw: string, row: PostAnalysisBody["entities"][number]) => {
+    const k = normalizeEntityName(raw);
+    if (!map.has(k)) {
+      map.set(k, row);
+    }
+  };
+  for (const e of entities) {
+    register(e.canonicalName, e);
+    for (const a of e.aliases) {
+      register(a, e);
+    }
+  }
+  return map;
+};
+
+export type BuildAnalysisPostChunksResult = {
+  chunks: PostAnalysisBody[];
+  droppedRelations: number;
+  parseErrors: string[];
+};
+
+/**
+ * Splits relations into sequential POST bodies; each chunk includes entity closure required
+ * by `applyAnalysisPost` (endpoints must appear in the same body's `entities` array).
+ *
+ * @param tickerId - Ticker for POST body.
+ * @param entities - Deduped entities for the run (global catalog).
+ * @param relations - Deduped relations for the run.
+ * @param postChunkRelationBatchSize - Max relations per chunk (FR9).
+ * @returns Validated chunks and any validation messages (no secrets / content).
+ */
+export const buildAnalysisPostChunks = (
+  tickerId: string,
+  entities: PostAnalysisBody["entities"],
+  relations: PostAnalysisBody["relations"],
+  postChunkRelationBatchSize: number,
+): BuildAnalysisPostChunksResult => {
+  const chunks: PostAnalysisBody[] = [];
+  const parseErrors: string[] = [];
+  let droppedRelations = 0;
+  const nameLookup = buildEntityNameLookup(entities);
+
+  for (let i = 0; i < relations.length; i += postChunkRelationBatchSize) {
+    const relWindow = relations.slice(i, i + postChunkRelationBatchSize);
+    const filtered = relWindow.filter((r) => {
+      const hasFrom = nameLookup.has(normalizeEntityName(r.fromEntityName));
+      const hasTo = nameLookup.has(normalizeEntityName(r.toEntityName));
+      if (!hasFrom || !hasTo) {
+        droppedRelations += 1;
+        parseErrors.push(
+          `Dropped relation (missing entity endpoint in catalog): ${r.fromEntityName} -> ${r.toEntityName}`,
+        );
+        return false;
+      }
+      return true;
+    });
+
+    if (filtered.length === 0) {
+      continue;
+    }
+
+    const neededNorm = new Set<string>();
+    for (const r of filtered) {
+      neededNorm.add(normalizeEntityName(r.fromEntityName));
+      neededNorm.add(normalizeEntityName(r.toEntityName));
+    }
+
+    const chunkEntities: PostAnalysisBody["entities"] = [];
+    const seenEntityKey = new Set<string>();
+    for (const nk of neededNorm) {
+      const ent = nameLookup.get(nk);
+      if (!ent) {
+        continue;
+      }
+      const ek = `${normalizeEntityName(ent.canonicalName)}\0${ent.typeId}`;
+      if (!seenEntityKey.has(ek)) {
+        seenEntityKey.add(ek);
+        chunkEntities.push(ent);
+      }
+    }
+
+    const body: PostAnalysisBody = {
+      tickerId,
+      entities: chunkEntities,
+      relations: filtered,
+      articleEntities: [],
+      articleRelevances: [],
+    };
+
+    const parsed = postAnalysisBodySchema.safeParse(body);
+    if (!parsed.success) {
+      parseErrors.push(parsed.error.flatten().formErrors.join("; "));
+      continue;
+    }
+    chunks.push(parsed.data);
+  }
+
+  return { chunks, droppedRelations, parseErrors };
+};

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+/**
+ * Hermes agent config for article-analysis (extraction, caps, chunking).
+ * Placeholder numeric defaults until MP-ART-ANALYSIS-009 env alignment.
+ */
+export const articleAnalysisConfigSchema = z.object({
+  verbose: z.boolean().optional(),
+  /** OpenAI-compatible API key for structured extraction. */
+  openaiApiKey: z.string().min(1),
+  /** Chat model id (e.g. `gpt-4o-mini`). */
+  openaiModel: z.string().min(1).optional(),
+  /** Max output tokens for `generateObject`. */
+  maxOutputTokens: z.number().int().positive().optional(),
+  /** Truncate article text in the LLM user message (full text remains in DB). */
+  maxContentChars: z.number().int().positive().optional(),
+  maxEntitiesPerArticle: z.number().int().positive().optional(),
+  maxRelationsPerArticle: z.number().int().positive().optional(),
+  maxEntitiesPerRun: z.number().int().positive().optional(),
+  maxRelationsPerRun: z.number().int().positive().optional(),
+  /** Max relations per POST chunk (FR9); entity closure is added per chunk. */
+  postChunkRelationBatchSize: z.number().int().positive().optional(),
+});
+
+export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
+
+/** Config with optional fields filled from {@link articleAnalysisConfigDefaults}. */
+export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
+  openaiModel: string;
+  maxOutputTokens: number;
+  maxContentChars: number;
+  maxEntitiesPerArticle: number;
+  maxRelationsPerArticle: number;
+  maxEntitiesPerRun: number;
+  maxRelationsPerRun: number;
+  postChunkRelationBatchSize: number;
+};
+
+/** Production-oriented defaults merged onto parsed Hermes config. */
+export const articleAnalysisConfigDefaults = {
+  openaiModel: "gpt-4o-mini",
+  maxOutputTokens: 8192,
+  maxContentChars: 12_000,
+  maxEntitiesPerArticle: 20,
+  maxRelationsPerArticle: 20,
+  maxEntitiesPerRun: 200,
+  maxRelationsPerRun: 200,
+  postChunkRelationBatchSize: 25,
+} as const;
+
+/**
+ * Returns effective config with defaults applied for optional numeric/string fields.
+ *
+ * @param config - Parsed Hermes config.
+ * @returns Config safe to use at runtime.
+ */
+export const resolveArticleAnalysisConfig = (
+  config: ArticleAnalysisConfig,
+): ResolvedArticleAnalysisConfig => {
+  return {
+    ...config,
+    openaiModel:
+      config.openaiModel ?? articleAnalysisConfigDefaults.openaiModel,
+    maxOutputTokens:
+      config.maxOutputTokens ?? articleAnalysisConfigDefaults.maxOutputTokens,
+    maxContentChars:
+      config.maxContentChars ?? articleAnalysisConfigDefaults.maxContentChars,
+    maxEntitiesPerArticle:
+      config.maxEntitiesPerArticle ??
+      articleAnalysisConfigDefaults.maxEntitiesPerArticle,
+    maxRelationsPerArticle:
+      config.maxRelationsPerArticle ??
+      articleAnalysisConfigDefaults.maxRelationsPerArticle,
+    maxEntitiesPerRun:
+      config.maxEntitiesPerRun ??
+      articleAnalysisConfigDefaults.maxEntitiesPerRun,
+    maxRelationsPerRun:
+      config.maxRelationsPerRun ??
+      articleAnalysisConfigDefaults.maxRelationsPerRun,
+    postChunkRelationBatchSize:
+      config.postChunkRelationBatchSize ??
+      articleAnalysisConfigDefaults.postChunkRelationBatchSize,
+  };
+};

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -1,38 +1,33 @@
 import { createAgentApp } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { z } from "zod";
+
+import { articleAnalysisConfigSchema } from "./config-schema.js";
 import {
   articleAnalysisInputSchema,
   type ArticleAnalysisInput,
 } from "./input-schema.js";
-import { run } from "./run";
+import { run } from "./run.js";
 
-// ConfigSchema is the schema for the config of the agent, which will be sent by Hermes to the agent when the agent is invoked
-const ConfigSchema = z.object({
-  verbose: z.boolean().optional(),
-});
-
-export type Config = z.infer<typeof ConfigSchema>;
 export type Input = ArticleAnalysisInput;
+export type Config = z.infer<typeof articleAnalysisConfigSchema>;
 
 const app = createAgentApp<
   Input,
   typeof articleAnalysisInputSchema,
   Config,
-  typeof ConfigSchema
+  typeof articleAnalysisConfigSchema
 >(
   {
-    agentId: "article-analysis", // this should be stable for the lifetime of the agent
-    agentVersion: "1.0.0", // this should be incremented when the agent is updated
+    agentId: "article-analysis",
+    agentVersion: "1.0.0",
     description:
-      "Loads analysis context from agent-data-api: incremental (unanalyzed) or re-scoring (`reanalyze`), optional `timeWindow` (ISO start/end) and `maxBatchSize`. Extraction and scoring follow in later milestones.",
+      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations via LLM with vocabulary constraints, and persists in chunked POSTs to agent-data-api.",
     inputSchema: articleAnalysisInputSchema,
-    configSchema: ConfigSchema,
+    configSchema: articleAnalysisConfigSchema,
     run,
   },
-  // Options for the agent app
   {
-    // Auto-register: AGENT_REGISTRY_URL, AGENT_PUBLIC_URL, DOMAIN_INTEGRATION_API_KEY, AGENT_AUTH_API_URL
     authApiUrl: env.AGENT_AUTH_API_URL ?? "",
     autoRegister:
       env.AGENT_REGISTRY_URL &&
@@ -48,7 +43,6 @@ const app = createAgentApp<
   },
 );
 
-// Export the agent app as a default export
 export default {
   port: env.PORT ?? 4010,
   fetch: app.fetch,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -1,0 +1,38 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildExtractionSystemContent,
+  buildExtractionUserContent,
+} from "./llm-extract-entities.js";
+
+const TID = "11111111-1111-4111-a111-111111111111";
+const RID = "22222222-2222-4222-a222-222222222222";
+
+describe("buildExtractionSystemContent", () => {
+  it("includes vocabulary ids and labels", () => {
+    // Act
+    const text = buildExtractionSystemContent({
+      entityTypes: [{ id: TID, name: "Company", description: null }],
+      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
+    });
+    // Assert
+    expect(text).toContain(TID);
+    expect(text).toContain("Company");
+    expect(text).toContain(RID);
+    expect(text).toContain("PART_OF");
+  });
+});
+
+describe("buildExtractionUserContent", () => {
+  it("includes ticker title and body", () => {
+    const u = buildExtractionUserContent({
+      tickerId: "T",
+      title: "Hello",
+      contentTruncated: "Body text",
+    });
+    expect(u).toContain("T");
+    expect(u).toContain("Hello");
+    expect(u).toContain("Body text");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -1,0 +1,100 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateObject, type ModelMessage } from "ai";
+import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
+import { z } from "zod";
+
+/** Structured extraction result validated by the AI SDK. */
+export const llmExtractionOutputSchema = z.object({
+  entities: z.array(
+    z.object({
+      canonicalName: z.string().trim().min(1),
+      typeId: z.string().uuid(),
+      description: z.string().optional(),
+      aliases: z.array(z.string().trim().min(1)).default([]),
+    }),
+  ),
+  relations: z.array(
+    z.object({
+      fromEntityName: z.string().trim().min(1),
+      toEntityName: z.string().trim().min(1),
+      relationTypeId: z.string().uuid(),
+    }),
+  ),
+});
+
+export type LlmExtractionOutput = z.infer<typeof llmExtractionOutputSchema>;
+
+export type GenerateObjectForExtraction = (args: {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  schema: typeof llmExtractionOutputSchema;
+  maxOutputTokens: number;
+  messages: ModelMessage[];
+}) => Promise<{ object: LlmExtractionOutput }>;
+
+/**
+ * System prompt listing allowed entity and relation type UUIDs from analysis GET.
+ *
+ * @param ctx - Vocabulary from analysis GET.
+ * @returns System message string (no article body, no secrets).
+ */
+export const buildExtractionSystemContent = (
+  ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">,
+): string => {
+  const et = ctx.entityTypes.map((e) => `- ${e.id} — ${e.name}`).join("\n");
+  const rt = ctx.relationTypes.map((r) => `- ${r.id} — ${r.name}`).join("\n");
+  return [
+    "You extract knowledge-graph entities and relations from ONE article for equity research tooling.",
+    "Use ONLY entity typeId values listed under ENTITY TYPES and ONLY relationTypeId values under RELATION TYPES.",
+    "Relation fromEntityName and toEntityName must match canonicalName strings of entities you output (not aliases).",
+    "Prefer high-precision entities; omit uncertain extractions.",
+    "Return JSON object with keys entities and relations (arrays, possibly empty).",
+    "ENTITY TYPES (uuid — label):\n" + et,
+    "RELATION TYPES (uuid — label):\n" + rt,
+  ].join("\n\n");
+};
+
+/**
+ * User message with ticker metadata and truncated article text.
+ *
+ * @param args - Ticker, title, truncated body (already capped for token budget).
+ * @returns User message string.
+ */
+export const buildExtractionUserContent = (args: {
+  tickerId: string;
+  title: string;
+  contentTruncated: string;
+}): string =>
+  [
+    `tickerId: ${args.tickerId}`,
+    `title: ${args.title}`,
+    "article:",
+    args.contentTruncated,
+  ].join("\n\n");
+
+/**
+ * Runs structured extraction for one data source via `generateObject`.
+ *
+ * @param params - API key, model, token limit, chat messages.
+ * @param deps - Injectable `generateObject` (tests swap mock).
+ * @returns Parsed entities and relations.
+ */
+export const extractEntitiesAndRelationsForSource = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    messages: ModelMessage[];
+  },
+  deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
+    generateObjectForExtraction: generateObject,
+  },
+): Promise<LlmExtractionOutput> => {
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  const { object } = await deps.generateObjectForExtraction({
+    model: openai(params.model),
+    schema: llmExtractionOutputSchema,
+    maxOutputTokens: params.maxOutputTokens,
+    messages: params.messages,
+  });
+  return object;
+};

--- a/apps/mediapulse/agents/article-analysis/src/normalize-entity-name.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/normalize-entity-name.test.ts
@@ -1,0 +1,13 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+describe("normalizeEntityName", () => {
+  it("trims and lowercases", () => {
+    // Act
+    const out = normalizeEntityName("  Acme Corp  ");
+    // Assert
+    expect(out).toBe("acme corp");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/normalize-entity-name.ts
+++ b/apps/mediapulse/agents/article-analysis/src/normalize-entity-name.ts
@@ -1,0 +1,9 @@
+/**
+ * Normalizes an entity name or alias for case-insensitive matching.
+ * Must stay aligned with `normalizeAnalysisName` in agent-data-api `services/analysis.ts`.
+ *
+ * @param value - Raw string from the LLM or API.
+ * @returns Trimmed lowercase string.
+ */
+export const normalizeEntityName = (value: string): string =>
+  value.trim().toLowerCase();

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
@@ -73,8 +73,8 @@ describe("sortAnalysisDataSourcesByCreatedAt", () => {
 
 describe("applyMaxBatchSizeCap", () => {
   it("returns full copy when maxBatchSize is omitted", () => {
-    const sorted = [1, 2, 3];
-    expect(applyMaxBatchSizeCap(sorted)).toEqual([1, 2, 3]);
+    const sorted = [1, 2];
+    expect(applyMaxBatchSizeCap(sorted)).toEqual([1, 2]);
   });
 
   it("truncates to first N items", () => {

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
@@ -11,9 +11,10 @@ import type { ArticleAnalysisInput } from "./input-schema.js";
 export const buildAnalysisGetQuery = (
   input: ArticleAnalysisInput,
 ): GetAnalysisQuery => {
+  const reanalyze = input.reanalyze ?? false;
   const base = {
     tickerId: input.tickerId,
-    unanalyzed: !input.reanalyze,
+    unanalyzed: !reanalyze,
   } satisfies Pick<GetAnalysisQuery, "tickerId" | "unanalyzed">;
 
   const start = input.timeWindow?.start;

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -1,16 +1,20 @@
 /** @vitest-environment node */
 import type { AgentRunContext } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { Config, Input } from "./index";
-import { run } from "./run";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as Llm from "./llm-extract-entities.js";
+import type { ArticleAnalysisConfig } from "./config-schema.js";
+import type { ArticleAnalysisInput } from "./input-schema.js";
+import { run } from "./run.js";
 
 const analysisGet = vi.fn();
+const analysisCreate = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
     analysis: {
       get: analysisGet,
+      create: analysisCreate,
     },
   })),
 }));
@@ -29,50 +33,59 @@ vi.mock("@workspace/logger", () => ({
   },
 }));
 
-/** Builds a minimal run context for tests. */
+const TYPE_ID = "11111111-1111-4111-a111-111111111111";
+const REL_ID = "22222222-2222-4222-a222-222222222222";
+const DS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const DS_ID_2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const baseConfig: ArticleAnalysisConfig = {
+  openaiApiKey: "sk-test",
+};
+
 function runContext(overrides: {
-  input: Input;
-  config: Config;
+  input: ArticleAnalysisInput;
+  config?: Partial<ArticleAnalysisConfig>;
   token?: string;
-}): AgentRunContext<Input, Config> {
-  return { ...overrides, token: overrides.token ?? "Bearer test" };
+}): AgentRunContext<ArticleAnalysisInput, ArticleAnalysisConfig> {
+  return {
+    input: overrides.input,
+    config: { ...baseConfig, ...overrides.config },
+    token: overrides.token ?? "Bearer test",
+  };
 }
 
 describe("run", () => {
   beforeEach(() => {
-    vi.mocked(logger.info).mockClear();
-    vi.mocked(logger.error).mockClear();
     analysisGet.mockReset();
+    analysisCreate.mockReset();
   });
 
-  it("returns success with source count when analysis GET succeeds", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const source = {
+    id: DS_ID,
+    url: "u",
+    title: "T",
+    content: "c",
+    tickerId: "ticker-1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  };
+
+  it("returns success when no data sources after GET", async () => {
     analysisGet.mockResolvedValue({
-      dataSources: [{ id: "ds-1" }, { id: "ds-2" }],
+      dataSources: [],
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
     });
 
-    const result = await run(
-      runContext({
-        input: { tickerId: "ticker-1" },
-        config: {},
-      }),
-    );
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
-    expect(result).toEqual({
-      success: true,
-      message: "analysis context loaded (2 source(s))",
-      details: {
-        dataSourcesReturned: 2,
-        dataSourcesSelected: 2,
-        reanalyze: false,
-      },
-    });
-    expect(analysisGet).toHaveBeenCalledWith({
-      tickerId: "ticker-1",
-      unanalyzed: true,
-    });
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("0 source(s)");
+    expect(analysisCreate).not.toHaveBeenCalled();
   });
 
   it("uses unanalyzed false when reanalyze with maxBatchSize", async () => {
@@ -90,7 +103,6 @@ describe("run", () => {
           reanalyze: true,
           maxBatchSize: 3,
         },
-        config: {},
       }),
     );
 
@@ -117,7 +129,6 @@ describe("run", () => {
             end: "2026-01-31T00:00:00.000Z",
           },
         },
-        config: {},
       }),
     );
 
@@ -129,84 +140,143 @@ describe("run", () => {
     });
   });
 
-  it("returns success when backlog is empty", async () => {
+  it("fails when vocabulary is empty", async () => {
     analysisGet.mockResolvedValue({
-      dataSources: [],
+      dataSources: [source],
       entityTypes: [],
-      relationTypes: [],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
     });
 
-    const result = await run(
-      runContext({
-        input: { tickerId: "ticker-2" },
-        config: {},
-      }),
-    );
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
-    expect(result).toEqual({
-      success: true,
-      message: "analysis context loaded (0 source(s))",
-      details: {
-        dataSourcesReturned: 0,
-        dataSourcesSelected: 0,
-        reanalyze: false,
-      },
-    });
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("vocabulary");
   });
 
-  it("reports batch cap when maxBatchSize is smaller than result set", async () => {
+  it("skips vocabulary-invalid slices and continues processing others", async () => {
     analysisGet.mockResolvedValue({
       dataSources: [
+        source,
         {
-          id: "b",
-          createdAt: new Date("2026-01-02T00:00:00.000Z"),
-          url: "",
-          title: "",
-          content: "",
-          tickerId: "t",
-        },
-        {
-          id: "a",
-          createdAt: new Date("2026-01-01T00:00:00.000Z"),
-          url: "",
-          title: "",
-          content: "",
-          tickerId: "t",
+          ...source,
+          id: DS_ID_2,
+          title: "T2",
         },
       ],
-      entityTypes: [],
-      relationTypes: [],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
     });
 
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            canonicalName: "Bad",
+            typeId: "99999999-9999-4999-a999-999999999999",
+            aliases: [],
+          },
+        ],
+        relations: [],
+      })
+      .mockResolvedValueOnce({
+        entities: [
+          {
+            canonicalName: "Good",
+            typeId: TYPE_ID,
+            aliases: [],
+          },
+          {
+            canonicalName: "Other",
+            typeId: TYPE_ID,
+            aliases: [],
+          },
+        ],
+        relations: [
+          {
+            fromEntityName: "Good",
+            toEntityName: "Other",
+            relationTypeId: REL_ID,
+          },
+        ],
+      });
+
+    analysisCreate.mockResolvedValueOnce({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+    });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(true);
+    expect(result.details).toMatchObject({
+      vocabularyFailures: 1,
+      entitiesCreated: 1,
+    });
+    expect(analysisCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("posts chunks and aggregates POST response counts", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [source],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [
+        { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
+      ],
+      relations: [
+        { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
+        { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
+      ],
+    });
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 2,
+        entitiesReused: 0,
+        relationsCreated: 1,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 2,
+        relationsCreated: 1,
+        articlesScored: 0,
+        articlesSelected: 0,
+      });
+
     const result = await run(
       runContext({
-        input: { tickerId: "ticker-cap", maxBatchSize: 1 },
-        config: {},
+        input: { tickerId: "ticker-1" },
+        config: { postChunkRelationBatchSize: 1 },
       }),
     );
 
     expect(result.success).toBe(true);
-    expect(result.message).toBe(
-      "analysis context loaded (2 source(s), processing batch of 1)",
-    );
-    expect(result.details).toEqual({
-      dataSourcesReturned: 2,
-      dataSourcesSelected: 1,
-      reanalyze: false,
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
+    expect(result.details).toMatchObject({
+      postChunks: 2,
+      entitiesCreated: 2,
+      entitiesReused: 2,
+      relationsCreated: 2,
     });
   });
 
   it("returns failure when analysis GET throws", async () => {
     analysisGet.mockRejectedValue(new Error("upstream error"));
 
-    const result = await run(
-      runContext({
-        input: { tickerId: "ticker-3" },
-        config: {},
-      }),
-    );
+    const result = await run(runContext({ input: { tickerId: "ticker-3" } }));
 
     expect(result).toEqual({
       success: false,
@@ -215,7 +285,60 @@ describe("run", () => {
     expect(logger.error).toHaveBeenCalled();
   });
 
-  it("logs when config.verbose is true", async () => {
+  it("resolves extracted names to existing canonical entities before POST", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [source],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [
+        {
+          id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+          canonicalName: "Alpha Incorporated",
+          typeId: TYPE_ID,
+          aliases: ["Alpha"],
+        },
+      ],
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [
+        { canonicalName: "Alpha", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "Beta", typeId: TYPE_ID, aliases: [] },
+      ],
+      relations: [
+        {
+          fromEntityName: "Alpha",
+          toEntityName: "Beta",
+          relationTypeId: REL_ID,
+        },
+      ],
+    });
+
+    analysisCreate.mockResolvedValueOnce({
+      entitiesCreated: 1,
+      entitiesReused: 1,
+      relationsCreated: 1,
+      articlesScored: 0,
+      articlesSelected: 0,
+    });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(true);
+    const postBody = analysisCreate.mock.calls[0]?.[0];
+    expect(
+      postBody?.entities.map(
+        (entity: { canonicalName: string }) => entity.canonicalName,
+      ),
+    ).toContain("Alpha Incorporated");
+    expect(
+      postBody?.relations.map(
+        (relation: { fromEntityName: string }) => relation.fromEntityName,
+      ),
+    ).toContain("Alpha Incorporated");
+  });
+
+  it("logs verbose start", async () => {
     analysisGet.mockResolvedValue({
       dataSources: [],
       entityTypes: [],
@@ -225,14 +348,11 @@ describe("run", () => {
 
     await run(
       runContext({
-        input: { tickerId: "t-verbose" },
+        input: { tickerId: "tv" },
         config: { verbose: true },
       }),
     );
 
-    expect(logger.info).toHaveBeenCalledWith(
-      { tickerId: "t-verbose" },
-      "article-analysis run started",
-    );
+    expect(logger.info).toHaveBeenCalled();
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -3,31 +3,158 @@ import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
 
-import type { Config, Input } from "./index.js";
 import {
-  applyMaxBatchSizeCap,
+  applyPerArticleExtractionCaps,
+  applyPerRunCaps,
+  dedupeEntities,
+  dedupeRelations,
+} from "./analysis-caps-dedupe.js";
+import {
+  validateExtractionVocabulary,
+  type EntityProposal,
+  type RelationProposal,
+} from "./analysis-vocabulary.js";
+import { buildAnalysisPostChunks } from "./build-analysis-post-chunks.js";
+import {
+  resolveArticleAnalysisConfig,
+  type ArticleAnalysisConfig,
+} from "./config-schema.js";
+import type { ArticleAnalysisInput } from "./input-schema.js";
+import {
+  buildExtractionSystemContent,
+  buildExtractionUserContent,
+  extractEntitiesAndRelationsForSource,
+} from "./llm-extract-entities.js";
+import {
   buildAnalysisGetQuery,
+  applyMaxBatchSizeCap,
   sortAnalysisDataSourcesByCreatedAt,
 } from "./run-helpers.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+type ExistingEntity = {
+  canonicalName: string;
+  typeId: string;
+  aliases: string[];
+};
 
 /**
- * Loads analysis context for the ticker (incremental or reanalyze), applies optional time window via GET,
- * and deterministically caps the in-memory batch when `maxBatchSize` is set.
+ * Builds normalized lookup for existing canonical names and aliases.
  *
- * @param context - Validated input, optional config, and bearer token for agent-data-api.
- * @returns Success with backlog / batch summary, or failure when the data API call fails.
+ * @param existingEntities - Entities returned by analysis GET.
+ * @returns Normalized name/alias lookup for canonicalization.
+ */
+const buildExistingEntityLookup = (
+  existingEntities: ReadonlyArray<ExistingEntity>,
+): Map<string, ExistingEntity> => {
+  const lookup = new Map<string, ExistingEntity>();
+  const register = (rawName: string, entity: ExistingEntity) => {
+    const normalized = normalizeEntityName(rawName);
+    if (!lookup.has(normalized)) {
+      lookup.set(normalized, entity);
+    }
+  };
+
+  for (const entity of existingEntities) {
+    register(entity.canonicalName, entity);
+    for (const alias of entity.aliases) {
+      register(alias, entity);
+    }
+  }
+
+  return lookup;
+};
+
+/**
+ * Canonicalizes extracted entities and relation endpoints using existing KG aliases/canonical names.
+ *
+ * @param entities - Extracted entities for one source.
+ * @param relations - Extracted relations for one source.
+ * @param existingLookup - Normalized lookup for existing entities.
+ * @returns Canonicalized entities and relations.
+ */
+const resolveAgainstExistingEntities = (
+  entities: readonly EntityProposal[],
+  relations: readonly RelationProposal[],
+  existingLookup: ReadonlyMap<string, ExistingEntity>,
+): {
+  entities: EntityProposal[];
+  relations: RelationProposal[];
+} => {
+  const resolvedEntities = entities.map((entity) => {
+    const directMatch = existingLookup.get(
+      normalizeEntityName(entity.canonicalName),
+    );
+    const aliasMatch = entity.aliases
+      .map((alias) => existingLookup.get(normalizeEntityName(alias)))
+      .find((existing) => existing !== undefined);
+    const match = directMatch ?? aliasMatch;
+
+    if (!match) {
+      return entity;
+    }
+
+    const aliases = new Set(entity.aliases);
+    if (
+      normalizeEntityName(entity.canonicalName) !==
+      normalizeEntityName(match.canonicalName)
+    ) {
+      aliases.add(entity.canonicalName.trim());
+    }
+
+    return {
+      ...entity,
+      canonicalName: match.canonicalName,
+      typeId: match.typeId,
+      aliases: [...aliases],
+    };
+  });
+
+  const resolveName = (name: string): string => {
+    const resolved = existingLookup.get(normalizeEntityName(name));
+    return resolved?.canonicalName ?? name;
+  };
+
+  const resolvedRelations = relations.map((relation) => ({
+    ...relation,
+    fromEntityName: resolveName(relation.fromEntityName),
+    toEntityName: resolveName(relation.toEntityName),
+  }));
+
+  return {
+    entities: resolvedEntities,
+    relations: resolvedRelations,
+  };
+};
+
+/**
+ * Runs analysis Phase A–C: GET context, optional batch cap, LLM extraction per source,
+ * vocabulary validation, caps, chunked POST of entities/relations (no articleEntities yet).
+ *
+ * @param context - Hermes input/config and bearer token.
+ * @returns Aggregated success with POST tallies or structured failure.
  */
 export const run = async ({
   input,
   config,
   token,
-}: AgentRunContext<Input, Config>): Promise<AgentRunResult> => {
-  /** Hermes applies input-schema defaults; direct `run` callers (tests) may omit optional fields. */
+}: AgentRunContext<
+  ArticleAnalysisInput,
+  ArticleAnalysisConfig
+>): Promise<AgentRunResult> => {
   const reanalyze = input.reanalyze ?? false;
   const inputForQuery = { ...input, reanalyze };
+  const cfg = resolveArticleAnalysisConfig(config);
 
-  if (config.verbose) {
-    logger.info({ tickerId: input.tickerId }, "article-analysis run started");
+  if (cfg.verbose) {
+    logger.info(
+      {
+        tickerId: input.tickerId,
+        openaiModel: cfg.openaiModel,
+        maxContentChars: cfg.maxContentChars,
+      },
+      "article-analysis run started",
+    );
   }
 
   const dataApiClient = createAgentDataApiClient({
@@ -40,29 +167,210 @@ export const run = async ({
     const query = buildAnalysisGetQuery(inputForQuery);
     const ctx = await dataApiClient.analysis.get(query);
 
-    const rawCount = ctx.dataSources.length;
     const sorted = sortAnalysisDataSourcesByCreatedAt(ctx.dataSources);
     const batch = applyMaxBatchSizeCap(sorted, inputForQuery.maxBatchSize);
-    const selectedCount = batch.length;
 
-    let message: string;
-    if (rawCount === 0) {
-      message = "analysis context loaded (0 source(s))";
-    } else if (
-      inputForQuery.maxBatchSize !== undefined &&
-      selectedCount < rawCount
-    ) {
-      message = `analysis context loaded (${rawCount} source(s), processing batch of ${selectedCount})`;
-    } else {
-      message = `analysis context loaded (${rawCount} source(s))`;
+    if (batch.length === 0) {
+      return {
+        success: true,
+        message: "analysis context loaded (0 source(s)); nothing to process",
+        details: {
+          dataSourcesReturned: ctx.dataSources.length,
+          dataSourcesSelected: 0,
+          reanalyze,
+          entitiesCreated: 0,
+          entitiesReused: 0,
+          relationsCreated: 0,
+          postChunks: 0,
+        },
+      };
+    }
+
+    if (ctx.entityTypes.length === 0 || ctx.relationTypes.length === 0) {
+      return {
+        success: false,
+        message:
+          "KG vocabulary from analysis GET is empty (entityTypes or relationTypes); cannot extract",
+        details: {
+          entityTypeCount: ctx.entityTypes.length,
+          relationTypeCount: ctx.relationTypes.length,
+        },
+      };
+    }
+
+    const systemContent = buildExtractionSystemContent(ctx);
+    const existingLookup = buildExistingEntityLookup(ctx.existingEntities);
+
+    let llmFailures = 0;
+    let vocabularyFailures = 0;
+    const mergedEntities: EntityProposal[] = [];
+    const mergedRelations: RelationProposal[] = [];
+
+    for (const source of batch) {
+      const truncated =
+        source.content.length > cfg.maxContentChars
+          ? source.content.slice(0, cfg.maxContentChars)
+          : source.content;
+
+      try {
+        const extracted = await extractEntitiesAndRelationsForSource({
+          apiKey: cfg.openaiApiKey,
+          model: cfg.openaiModel,
+          maxOutputTokens: cfg.maxOutputTokens,
+          messages: [
+            { role: "system", content: systemContent },
+            {
+              role: "user",
+              content: buildExtractionUserContent({
+                tickerId: input.tickerId,
+                title: source.title,
+                contentTruncated: truncated,
+              }),
+            },
+          ],
+        });
+
+        const vocab = validateExtractionVocabulary(
+          extracted.entities,
+          extracted.relations,
+          ctx,
+        );
+        if (!vocab.ok) {
+          vocabularyFailures += 1;
+          logger.warn(
+            {
+              tickerId: input.tickerId,
+              dataSourceId: source.id,
+              validationMessage: vocab.message,
+            },
+            "article-analysis skipped source due to vocabulary mismatch",
+          );
+          continue;
+        }
+
+        const resolved = resolveAgainstExistingEntities(
+          extracted.entities,
+          extracted.relations,
+          existingLookup,
+        );
+        const capped = applyPerArticleExtractionCaps(
+          resolved.entities,
+          resolved.relations,
+          cfg.maxEntitiesPerArticle,
+          cfg.maxRelationsPerArticle,
+        );
+        mergedEntities.push(...capped.entities);
+        mergedRelations.push(...capped.relations);
+      } catch (err) {
+        llmFailures += 1;
+        logger.warn(
+          { err, dataSourceId: source.id, tickerId: input.tickerId },
+          "article-analysis LLM extraction failed for source; skipping",
+        );
+      }
+    }
+
+    let entities = dedupeEntities(mergedEntities);
+    let relations = dedupeRelations(mergedRelations);
+    const runCapped = applyPerRunCaps(
+      entities,
+      relations,
+      cfg.maxEntitiesPerRun,
+      cfg.maxRelationsPerRun,
+    );
+    entities = runCapped.entities;
+    relations = runCapped.relations;
+
+    if (entities.length === 0 && relations.length === 0) {
+      return {
+        success: true,
+        message:
+          llmFailures > 0
+            ? `no extraction produced (${llmFailures} source(s) failed LLM; check logs)`
+            : "extraction produced no entities or relations",
+        details: {
+          dataSourcesProcessed: batch.length,
+          llmFailures,
+          vocabularyFailures,
+          entitiesCreated: 0,
+          entitiesReused: 0,
+          relationsCreated: 0,
+          postChunks: 0,
+          reanalyze,
+        },
+      };
+    }
+
+    const { chunks, parseErrors, droppedRelations } = buildAnalysisPostChunks(
+      input.tickerId,
+      entities,
+      relations,
+      cfg.postChunkRelationBatchSize,
+    );
+
+    if (parseErrors.length > 0) {
+      logger.warn(
+        {
+          tickerId: input.tickerId,
+          parseErrorCount: parseErrors.length,
+          droppedRelations,
+        },
+        "article-analysis chunk build reported issues",
+      );
+    }
+
+    if (chunks.length === 0) {
+      return {
+        success: true,
+        message:
+          "no valid POST chunks after extraction (check relation endpoint names vs entity canonicalName)",
+        details: {
+          dataSourcesProcessed: batch.length,
+          relationCountAfterCaps: relations.length,
+          droppedRelations,
+          parseErrors: parseErrors.slice(0, 20),
+          llmFailures,
+          vocabularyFailures,
+          reanalyze,
+        },
+      };
+    }
+
+    let entitiesCreated = 0;
+    let entitiesReused = 0;
+    let relationsCreated = 0;
+
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]!;
+      logger.info(
+        {
+          tickerId: input.tickerId,
+          chunkIndex: i,
+          chunkEntities: chunk.entities.length,
+          chunkRelations: chunk.relations.length,
+          model: cfg.openaiModel,
+        },
+        "article-analysis posting chunk",
+      );
+      const res = await dataApiClient.analysis.create(chunk);
+      entitiesCreated += res.entitiesCreated;
+      entitiesReused += res.entitiesReused;
+      relationsCreated += res.relationsCreated;
     }
 
     return {
       success: true,
-      message,
+      message: `analysis complete: ${chunks.length} POST chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated}`,
       details: {
-        dataSourcesReturned: rawCount,
-        dataSourcesSelected: selectedCount,
+        dataSourcesProcessed: batch.length,
+        dataSourcesReturned: ctx.dataSources.length,
+        postChunks: chunks.length,
+        entitiesCreated,
+        entitiesReused,
+        relationsCreated,
+        llmFailures,
+        vocabularyFailures,
+        droppedRelations,
         reanalyze,
       },
     };
@@ -70,7 +378,7 @@ export const run = async ({
     const message =
       error instanceof Error
         ? error.message
-        : "agent-data-api analysis GET failed";
+        : "agent-data-api article-analysis run failed";
     logger.error({ tickerId: input.tickerId, err: error }, message);
     return { success: false, message };
   }

--- a/dev-docs/docs/guide/development.mdx
+++ b/dev-docs/docs/guide/development.mdx
@@ -101,6 +101,8 @@ For pipeline stages that read third-party keys from env (e.g. data collection, s
 
 **Delivery (Resend):** configure `resendApiKey` and `resend.from` on the **delivery Agent config** in Hermes (variables/secrets), not in this env file.
 
+**Article analysis:** configure the **article-analysis** agent in Hermes with `openaiApiKey` (required). Optional tuning: `openaiModel`, `maxOutputTokens`, `maxContentChars`, per-article caps `maxEntitiesPerArticle` / `maxRelationsPerArticle`, per-run caps `maxEntitiesPerRun` / `maxRelationsPerRun`, and `postChunkRelationBatchSize` for POST chunking (each chunk’s body includes endpoint entities so relation names resolve in one `analysis.create` transaction).
+
 ---
 
 ## Optional: Agent auto-registration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -460,6 +460,9 @@ importers:
 
   apps/mediapulse/agents/article-analysis:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.49
+        version: 3.0.49(zod@3.25.76)
       '@mediapulse/env':
         specifier: workspace:*
         version: link:../../../../packages/mediapulse/env
@@ -481,6 +484,9 @@ importers:
       '@workspace/logger':
         specifier: workspace:*
         version: link:../../../../packages/shared/logger
+      ai:
+        specifier: ^6.0.142
+        version: 6.0.142(zod@3.25.76)
       hono:
         specifier: 'catalog:'
         version: 4.11.9


### PR DESCRIPTION
## Summary

Delivers MP-ART-ANALYSIS-004: the article-analysis agent now performs structured LLM extraction of entities and relations constrained to `analysis.get` vocabulary, applies per-article and per-run caps with deduplication, builds POST bodies with entity closure per chunk (so relation endpoints resolve in each `analysis.create` transaction), and posts chunks sequentially while aggregating create tallies for observability. `articleEntities` and `articleRelevances` remain empty until follow-up tickets. `analysis.get` supports optional `start` / `end` for sourcing windows.

## Related issues

Closes #214

## Important changes

- Article-analysis: OpenAI-backed `generateObject` extraction, Hermes config for API key, model, token/content limits, caps, and chunk size; safe logging (counts and model id, not raw article bodies or keys).
- Chunked `analysis.create`: each chunk validates with `postAnalysisBodySchema` and includes endpoint entities for its relations.
- Agent-data-api: `loadAnalysisContext` respects optional `createdAt` range from query params when present.

## Other changes

- Development guide note for article-analysis Hermes config keys.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — orchestration: GET, extract, validate, cap, chunk, POST.
- `apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts` — relation partitioning and entity closure.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — time-window merge for GET context.
- `packages/shared/agent-data-api-contract/src/analysis.ts` — optional `start` / `end` on get query schema.

## How to test

1. From repo root: `pnpm code-quality`.
2. Configure Hermes agent with `openaiApiKey` and run article-analysis against a ticker with analysis vocabulary and data sources; confirm logs show chunk indices and aggregated `entitiesCreated` / `relationsCreated` (or expected early exits when empty).
