### PR TITLE
Add article-analysis articleEntities mentions and chunked POST

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.test.ts
@@ -1,0 +1,220 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  applyPerArticleArticleMentionCap,
+  applyPerRunArticleEntityCap,
+  buildArticleEntityPostChunks,
+  buildNormalizedEntityCatalogForArticle,
+  buildNormalizedEntityCatalogFromProposals,
+  dedupeArticleEntityMentions,
+  filterArticleEntityRowsToRunCatalog,
+  filterMentionsToArticleEntityCatalog,
+  toArticleEntityRowsForSource,
+} from "./analysis-article-mentions.js";
+
+const TYPE_ID = "11111111-1111-4111-a111-111111111111";
+const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+describe("buildNormalizedEntityCatalogForArticle", () => {
+  it("includes normalized canonical and aliases", () => {
+    // Setup
+    const entities = [
+      {
+        canonicalName: "Acme Corp",
+        typeId: TYPE_ID,
+        aliases: ["ACME"],
+      },
+    ];
+    // Act
+    const set = buildNormalizedEntityCatalogForArticle(entities);
+    // Assert
+    expect(set.has("acme corp")).toBe(true);
+    expect(set.has("acme")).toBe(true);
+  });
+});
+
+describe("buildNormalizedEntityCatalogFromProposals", () => {
+  it("matches per-article catalog for the same entities", () => {
+    // Act
+    const a = buildNormalizedEntityCatalogFromProposals([
+      { canonicalName: "X", typeId: TYPE_ID, aliases: [] },
+    ]);
+    const b = buildNormalizedEntityCatalogForArticle([
+      { canonicalName: "X", typeId: TYPE_ID, aliases: [] },
+    ]);
+    // Assert
+    expect([...a].sort()).toEqual([...b].sort());
+  });
+});
+
+describe("filterMentionsToArticleEntityCatalog", () => {
+  it("keeps only mentions in the allowed set", () => {
+    // Setup
+    const allowed = new Set(["foo"]);
+    // Act
+    const out = filterMentionsToArticleEntityCatalog(
+      [
+        { entityName: "Foo", mentionCount: 1, confidence: 0.9 },
+        { entityName: "Bar", mentionCount: 1, confidence: 0.5 },
+      ],
+      allowed,
+    );
+    // Assert
+    expect(out).toHaveLength(1);
+    expect(out[0]?.entityName).toBe("Foo");
+  });
+});
+
+describe("applyPerArticleArticleMentionCap", () => {
+  it("truncates to max in input order", () => {
+    // Act
+    const out = applyPerArticleArticleMentionCap(
+      [
+        { entityName: "a", mentionCount: 1, confidence: 1 },
+        { entityName: "b", mentionCount: 1, confidence: 1 },
+        { entityName: "c", mentionCount: 1, confidence: 1 },
+      ],
+      2,
+    );
+    // Assert
+    expect(out.map((m) => m.entityName)).toEqual(["a", "b"]);
+  });
+});
+
+describe("toArticleEntityRowsForSource", () => {
+  it("injects dataSourceId and trims entityName", () => {
+    // Act
+    const rows = toArticleEntityRowsForSource(DS, [
+      {
+        entityName: "  Foo  ",
+        mentionCount: 2,
+        confidence: 0.7,
+        sentiment: "POSITIVE",
+      },
+    ]);
+    // Assert
+    expect(rows).toEqual([
+      {
+        dataSourceId: DS,
+        entityName: "Foo",
+        mentionCount: 2,
+        confidence: 0.7,
+        sentiment: "POSITIVE",
+      },
+    ]);
+  });
+});
+
+describe("filterArticleEntityRowsToRunCatalog", () => {
+  it("drops rows not in run catalog", () => {
+    // Setup
+    const catalog = new Set(["foo"]);
+    // Act
+    const { rows, droppedCount } = filterArticleEntityRowsToRunCatalog(
+      [
+        {
+          dataSourceId: DS,
+          entityName: "Foo",
+          mentionCount: 1,
+          confidence: 0.5,
+        },
+        {
+          dataSourceId: DS,
+          entityName: "Bar",
+          mentionCount: 1,
+          confidence: 0.5,
+        },
+      ],
+      catalog,
+    );
+    // Assert
+    expect(droppedCount).toBe(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.entityName).toBe("Foo");
+  });
+});
+
+describe("dedupeArticleEntityMentions", () => {
+  it("sums mentionCount and maxes confidence", () => {
+    // Act
+    const rows = dedupeArticleEntityMentions([
+      {
+        dataSourceId: DS,
+        entityName: "Foo",
+        mentionCount: 2,
+        confidence: 0.3,
+        sentiment: "NEGATIVE",
+      },
+      {
+        dataSourceId: DS,
+        entityName: "FOO",
+        mentionCount: 1,
+        confidence: 0.9,
+      },
+    ]);
+    // Assert
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.mentionCount).toBe(3);
+    expect(rows[0]?.confidence).toBe(0.9);
+    expect(rows[0]?.sentiment).toBe("NEGATIVE");
+  });
+});
+
+describe("applyPerRunArticleEntityCap", () => {
+  it("truncates after dedupe", () => {
+    // Act
+    const out = applyPerRunArticleEntityCap(
+      [
+        {
+          dataSourceId: DS,
+          entityName: "a",
+          mentionCount: 1,
+          confidence: 1,
+        },
+        {
+          dataSourceId: DS,
+          entityName: "b",
+          mentionCount: 1,
+          confidence: 1,
+        },
+      ],
+      1,
+    );
+    // Assert
+    expect(out).toHaveLength(1);
+    expect(out[0]?.entityName).toBe("a");
+  });
+});
+
+describe("buildArticleEntityPostChunks", () => {
+  it("partitions rows and passes safeParse", () => {
+    // Setup
+    const rows = [
+      {
+        dataSourceId: DS,
+        entityName: "Foo",
+        mentionCount: 1,
+        confidence: 0.5,
+      },
+      {
+        dataSourceId: DS,
+        entityName: "Bar",
+        mentionCount: 2,
+        confidence: 0.8,
+      },
+    ];
+    // Act
+    const { chunks, parseErrors } = buildArticleEntityPostChunks(
+      "ticker-1",
+      rows,
+      1,
+    );
+    // Assert
+    expect(parseErrors).toHaveLength(0);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.articleEntities).toHaveLength(1);
+    expect(chunks[0]?.entities).toHaveLength(0);
+    expect(chunks[0]?.articleRelevances).toHaveLength(0);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
@@ -1,0 +1,209 @@
+import {
+  postAnalysisBodySchema,
+  type PostAnalysisBody,
+} from "@workspace/agent-data-api-contract";
+
+import type { EntityProposal } from "./analysis-vocabulary.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+/** One row for `postAnalysisBodySchema.articleEntities` (same shape as contract). */
+export type ArticleEntityRow = PostAnalysisBody["articleEntities"][number];
+
+/**
+ * Proposal from LLM `articleMentions` before `dataSourceId` is injected.
+ *
+ * @see llmExtractionOutputSchema
+ */
+export type ArticleMentionProposal = Pick<
+  ArticleEntityRow,
+  "entityName" | "mentionCount" | "confidence" | "sentiment"
+>;
+
+/**
+ * Builds the set of normalized names accepted for this article after per-article entity/relation caps.
+ *
+ * @param entities - Capped entity proposals for one source.
+ * @returns Normalized canonical and alias strings.
+ */
+export const buildNormalizedEntityCatalogForArticle = (
+  entities: readonly EntityProposal[],
+): Set<string> => {
+  const s = new Set<string>();
+  for (const e of entities) {
+    s.add(normalizeEntityName(e.canonicalName));
+    for (const a of e.aliases) {
+      s.add(normalizeEntityName(a));
+    }
+  }
+  return s;
+};
+
+/**
+ * Builds normalized name set for final run-level deduped entities (mentions must resolve after run caps).
+ *
+ * @param entities - Deduped and run-capped entities for the batch.
+ * @returns Normalized catalog keys.
+ */
+export const buildNormalizedEntityCatalogFromProposals = (
+  entities: readonly EntityProposal[],
+): Set<string> => {
+  return buildNormalizedEntityCatalogForArticle(entities);
+};
+
+/**
+ * Keeps LLM mentions whose name appears in the per-article allowed set (after entity cap).
+ *
+ * @param mentions - Raw `articleMentions` for one source.
+ * @param allowedNormalizedNames - Catalog from {@link buildNormalizedEntityCatalogForArticle}.
+ * @returns Filtered mentions in input order.
+ */
+export const filterMentionsToArticleEntityCatalog = (
+  mentions: readonly ArticleMentionProposal[],
+  allowedNormalizedNames: ReadonlySet<string>,
+): ArticleMentionProposal[] =>
+  mentions.filter((m) =>
+    allowedNormalizedNames.has(normalizeEntityName(m.entityName)),
+  );
+
+/**
+ * Truncates mention list for one article to a max count (deterministic prefix order).
+ *
+ * @param mentions - Mentions already filtered to capped entities.
+ * @param maxPerArticle - Config cap.
+ * @returns Slice of mentions.
+ */
+export const applyPerArticleArticleMentionCap = (
+  mentions: readonly ArticleMentionProposal[],
+  maxPerArticle: number,
+): ArticleMentionProposal[] => mentions.slice(0, maxPerArticle);
+
+/**
+ * Maps mention proposals to POST rows using the trusted `dataSourceId` for this source.
+ *
+ * @param dataSourceId - UUID of the `DataSource` row (never from the LLM).
+ * @param mentions - Capped mention proposals.
+ * @returns `articleEntities` payload rows.
+ */
+export const toArticleEntityRowsForSource = (
+  dataSourceId: string,
+  mentions: readonly ArticleMentionProposal[],
+): ArticleEntityRow[] =>
+  mentions.map((m) => ({
+    dataSourceId,
+    entityName: m.entityName.trim(),
+    mentionCount: m.mentionCount,
+    confidence: m.confidence,
+    sentiment: m.sentiment,
+  }));
+
+/**
+ * Drops mention rows whose `entityName` does not normalize-match the run-level entity catalog.
+ *
+ * @param rows - Merged `articleEntities` rows for the run.
+ * @param catalog - Normalized keys from {@link buildNormalizedEntityCatalogFromProposals}.
+ * @returns Kept rows and drop count (e.g. after run-level entity cap removed some entities).
+ */
+export const filterArticleEntityRowsToRunCatalog = (
+  rows: readonly ArticleEntityRow[],
+  catalog: ReadonlySet<string>,
+): { rows: ArticleEntityRow[]; droppedCount: number } => {
+  const out: ArticleEntityRow[] = [];
+  let droppedCount = 0;
+  for (const r of rows) {
+    if (catalog.has(normalizeEntityName(r.entityName))) {
+      out.push(r);
+    } else {
+      droppedCount += 1;
+    }
+  }
+  return { rows: out, droppedCount };
+};
+
+/**
+ * Dedupes by (`dataSourceId`, normalized `entityName`). Sums `mentionCount`, takes max `confidence`,
+ * keeps first non-undefined `sentiment` if any.
+ *
+ * @param rows - Rows possibly containing duplicates for the same source and entity.
+ * @returns Deduplicated rows (Map iteration order).
+ */
+export const dedupeArticleEntityMentions = (
+  rows: readonly ArticleEntityRow[],
+): ArticleEntityRow[] => {
+  const map = new Map<string, ArticleEntityRow>();
+  for (const r of rows) {
+    const key = `${r.dataSourceId}\0${normalizeEntityName(r.entityName)}`;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, { ...r });
+    } else {
+      map.set(key, {
+        ...existing,
+        mentionCount: existing.mentionCount + r.mentionCount,
+        confidence: Math.max(existing.confidence, r.confidence),
+        sentiment: existing.sentiment ?? r.sentiment,
+      });
+    }
+  }
+  return [...map.values()];
+};
+
+/**
+ * Applies run-level cap on total `articleEntities` rows after deduplication.
+ *
+ * @param rows - Deduped mention rows.
+ * @param maxForRun - Maximum rows to keep (prefix order).
+ * @returns Truncated rows.
+ */
+export const applyPerRunArticleEntityCap = (
+  rows: readonly ArticleEntityRow[],
+  maxForRun: number,
+): ArticleEntityRow[] => rows.slice(0, maxForRun);
+
+export type BuildArticleEntityPostChunksResult = {
+  chunks: PostAnalysisBody[];
+  parseErrors: string[];
+};
+
+/**
+ * Partitions `articleEntities` into sequential POST bodies (`empty entities/relations/articleRelevances`).
+ * Skips batches that fail `postAnalysisBodySchema.safeParse` and records error messages.
+ *
+ * @param tickerId - Ticker for each body.
+ * @param articleEntities - Final rows to post.
+ * @param postChunkArticleEntityBatchSize - Max rows per POST.
+ * @returns Validated chunks and parse diagnostics.
+ */
+export const buildArticleEntityPostChunks = (
+  tickerId: string,
+  articleEntities: readonly ArticleEntityRow[],
+  postChunkArticleEntityBatchSize: number,
+): BuildArticleEntityPostChunksResult => {
+  const chunks: PostAnalysisBody[] = [];
+  const parseErrors: string[] = [];
+  for (
+    let i = 0;
+    i < articleEntities.length;
+    i += postChunkArticleEntityBatchSize
+  ) {
+    const window = articleEntities.slice(
+      i,
+      i + postChunkArticleEntityBatchSize,
+    );
+    const body: PostAnalysisBody = {
+      tickerId,
+      entities: [],
+      relations: [],
+      articleEntities: [...window],
+      articleRelevances: [],
+    };
+    const parsed = postAnalysisBodySchema.safeParse(body);
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        parseErrors.push(issue.message);
+      }
+      continue;
+    }
+    chunks.push(parsed.data);
+  }
+  return { chunks, parseErrors };
+};

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
@@ -95,6 +95,21 @@ describe("buildAnalysisPostChunks", () => {
     expect(droppedRelations).toBe(1);
   });
 
+  it("emits one chunk with entities only when there are no relations", () => {
+    // Setup
+    const tickerId = "t1";
+    const entities = [
+      { canonicalName: "A", typeId: TID, aliases: [] as string[] },
+      { canonicalName: "B", typeId: TID, aliases: [] as string[] },
+    ];
+    // Act
+    const { chunks } = buildAnalysisPostChunks(tickerId, entities, [], 10);
+    // Assert
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.entities).toHaveLength(2);
+    expect(chunks[0]?.relations).toHaveLength(0);
+  });
+
   it("reports parse error when chunk body fails schema validation", () => {
     // Act
     const { chunks, parseErrors } = buildAnalysisPostChunks(

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
@@ -57,6 +57,25 @@ export const buildAnalysisPostChunks = (
   let droppedRelations = 0;
   const nameLookup = buildEntityNameLookup(entities);
 
+  if (relations.length === 0) {
+    if (entities.length > 0) {
+      const body: PostAnalysisBody = {
+        tickerId,
+        entities: [...entities],
+        relations: [],
+        articleEntities: [],
+        articleRelevances: [],
+      };
+      const parsed = postAnalysisBodySchema.safeParse(body);
+      if (!parsed.success) {
+        parseErrors.push(parsed.error.flatten().formErrors.join("; "));
+      } else {
+        chunks.push(parsed.data);
+      }
+    }
+    return { chunks, droppedRelations, parseErrors };
+  }
+
   for (let i = 0; i < relations.length; i += postChunkRelationBatchSize) {
     const relWindow = relations.slice(i, i + postChunkRelationBatchSize);
     const filtered = relWindow.filter((r) => {

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -20,6 +20,12 @@ export const articleAnalysisConfigSchema = z.object({
   maxRelationsPerRun: z.number().int().positive().optional(),
   /** Max relations per POST chunk (FR9); entity closure is added per chunk. */
   postChunkRelationBatchSize: z.number().int().positive().optional(),
+  /** Max `articleEntities` rows per source after LLM extract (before run merge). */
+  maxArticleEntitiesPerArticle: z.number().int().positive().optional(),
+  /** Max `articleEntities` rows for the run after dedupe (before POST). */
+  maxArticleEntitiesPerRun: z.number().int().positive().optional(),
+  /** Max `articleEntities` rows per POST chunk. */
+  postChunkArticleEntityBatchSize: z.number().int().positive().optional(),
 });
 
 export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
@@ -34,6 +40,9 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   maxEntitiesPerRun: number;
   maxRelationsPerRun: number;
   postChunkRelationBatchSize: number;
+  maxArticleEntitiesPerArticle: number;
+  maxArticleEntitiesPerRun: number;
+  postChunkArticleEntityBatchSize: number;
 };
 
 /** Production-oriented defaults merged onto parsed Hermes config. */
@@ -46,6 +55,9 @@ export const articleAnalysisConfigDefaults = {
   maxEntitiesPerRun: 200,
   maxRelationsPerRun: 200,
   postChunkRelationBatchSize: 25,
+  maxArticleEntitiesPerArticle: 30,
+  maxArticleEntitiesPerRun: 500,
+  postChunkArticleEntityBatchSize: 50,
 } as const;
 
 /**
@@ -80,5 +92,14 @@ export const resolveArticleAnalysisConfig = (
     postChunkRelationBatchSize:
       config.postChunkRelationBatchSize ??
       articleAnalysisConfigDefaults.postChunkRelationBatchSize,
+    maxArticleEntitiesPerArticle:
+      config.maxArticleEntitiesPerArticle ??
+      articleAnalysisConfigDefaults.maxArticleEntitiesPerArticle,
+    maxArticleEntitiesPerRun:
+      config.maxArticleEntitiesPerRun ??
+      articleAnalysisConfigDefaults.maxArticleEntitiesPerRun,
+    postChunkArticleEntityBatchSize:
+      config.postChunkArticleEntityBatchSize ??
+      articleAnalysisConfigDefaults.postChunkArticleEntityBatchSize,
   };
 };

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -22,7 +22,7 @@ const app = createAgentApp<
     agentId: "article-analysis",
     agentVersion: "1.0.0",
     description:
-      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations via LLM with vocabulary constraints, and persists in chunked POSTs to agent-data-api.",
+      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, and persists in chunked POSTs to agent-data-api.",
     inputSchema: articleAnalysisInputSchema,
     configSchema: articleAnalysisConfigSchema,
     run,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -21,6 +21,7 @@ describe("buildExtractionSystemContent", () => {
     expect(text).toContain("Company");
     expect(text).toContain(RID);
     expect(text).toContain("PART_OF");
+    expect(text).toContain("articleMentions");
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -3,6 +3,8 @@ import { generateObject, type ModelMessage } from "ai";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
+const sentimentSchema = z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL"]);
+
 /** Structured extraction result validated by the AI SDK. */
 export const llmExtractionOutputSchema = z.object({
   entities: z.array(
@@ -20,6 +22,17 @@ export const llmExtractionOutputSchema = z.object({
       relationTypeId: z.string().uuid(),
     }),
   ),
+  /** Per-article entity mention signals (aligned with `postAnalysisBodySchema.articleEntities`, without `dataSourceId`). */
+  articleMentions: z
+    .array(
+      z.object({
+        entityName: z.string().trim().min(1),
+        mentionCount: z.number().int().positive(),
+        confidence: z.number().min(0).max(1),
+        sentiment: sentimentSchema.optional(),
+      }),
+    )
+    .default([]),
 });
 
 export type LlmExtractionOutput = z.infer<typeof llmExtractionOutputSchema>;
@@ -47,7 +60,9 @@ export const buildExtractionSystemContent = (
     "Use ONLY entity typeId values listed under ENTITY TYPES and ONLY relationTypeId values under RELATION TYPES.",
     "Relation fromEntityName and toEntityName must match canonicalName strings of entities you output (not aliases).",
     "Prefer high-precision entities; omit uncertain extractions.",
-    "Return JSON object with keys entities and relations (arrays, possibly empty).",
+    "Also populate articleMentions: for entities in your entities array that appear in the article text, estimate mentionCount (positive integer), confidence (0–1), and optional sentiment POSITIVE | NEGATIVE | NEUTRAL.",
+    "Each articleMentions.entityName must exactly match the canonicalName of one row in your entities array (same spelling as canonicalName).",
+    "Return JSON object with keys entities, relations, and articleMentions (arrays; articleMentions may be empty).",
     "ENTITY TYPES (uuid — label):\n" + et,
     "RELATION TYPES (uuid — label):\n" + rt,
   ].join("\n\n");

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -179,6 +179,7 @@ describe("run", () => {
           },
         ],
         relations: [],
+        articleMentions: [],
       })
       .mockResolvedValueOnce({
         entities: [
@@ -200,6 +201,7 @@ describe("run", () => {
             relationTypeId: REL_ID,
           },
         ],
+        articleMentions: [],
       });
 
     analysisCreate.mockResolvedValueOnce({
@@ -216,6 +218,8 @@ describe("run", () => {
     expect(result.details).toMatchObject({
       vocabularyFailures: 1,
       entitiesCreated: 1,
+      articleEntityRowsPosted: 0,
+      mentionPostChunks: 0,
     });
     expect(analysisCreate).toHaveBeenCalledTimes(1);
   });
@@ -238,6 +242,7 @@ describe("run", () => {
         { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
         { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
       ],
+      articleMentions: [],
     });
 
     analysisCreate
@@ -270,7 +275,135 @@ describe("run", () => {
       entitiesCreated: 2,
       entitiesReused: 2,
       relationsCreated: 2,
+      articleEntityRowsPosted: 0,
+      mentionPostChunks: 0,
     });
+  });
+
+  it("posts articleEntities after ER chunks when LLM returns articleMentions", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [
+        {
+          entityName: "A",
+          mentionCount: 2,
+          confidence: 0.91,
+          sentiment: "POSITIVE",
+        },
+      ],
+    });
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(true);
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
+    expect(analysisCreate.mock.calls[0]?.[0]?.articleEntities).toEqual([]);
+    expect(analysisCreate.mock.calls[1]?.[0]?.articleEntities).toHaveLength(1);
+    expect(
+      analysisCreate.mock.calls[1]?.[0]?.articleEntities?.[0],
+    ).toMatchObject({
+      dataSourceId: DS_ID,
+      entityName: "A",
+      mentionCount: 2,
+      confidence: 0.91,
+      sentiment: "POSITIVE",
+    });
+    expect(result.details).toMatchObject({
+      postChunks: 1,
+      mentionPostChunks: 1,
+      articleEntityRowsPosted: 1,
+    });
+  });
+
+  it("surfaces article entity parse errors in run details", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [
+        {
+          entityName: "A",
+          mentionCount: 2,
+          confidence: 1.5,
+          sentiment: "POSITIVE",
+        },
+      ],
+    });
+
+    analysisCreate.mockResolvedValueOnce({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+    });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(true);
+    expect(analysisCreate).toHaveBeenCalledTimes(1);
+    expect(result.details).toMatchObject({
+      mentionPostChunks: 0,
+      articleEntityRowsPosted: 0,
+    });
+    expect(
+      Array.isArray(
+        (result.details as { articleEntityParseErrors?: unknown[] })
+          .articleEntityParseErrors,
+      ),
+    ).toBe(true);
+    expect(
+      (result.details as { articleEntityParseErrors?: unknown[] })
+        .articleEntityParseErrors?.length,
+    ).toBeGreaterThan(0);
   });
 
   it("returns failure when analysis GET throws", async () => {
@@ -312,6 +445,7 @@ describe("run", () => {
           relationTypeId: REL_ID,
         },
       ],
+      articleMentions: [],
     });
 
     analysisCreate.mockResolvedValueOnce({

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -4,6 +4,18 @@ import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
 
 import {
+  applyPerArticleArticleMentionCap,
+  applyPerRunArticleEntityCap,
+  buildArticleEntityPostChunks,
+  buildNormalizedEntityCatalogForArticle,
+  buildNormalizedEntityCatalogFromProposals,
+  dedupeArticleEntityMentions,
+  filterArticleEntityRowsToRunCatalog,
+  filterMentionsToArticleEntityCatalog,
+  toArticleEntityRowsForSource,
+  type ArticleEntityRow,
+} from "./analysis-article-mentions.js";
+import {
   applyPerArticleExtractionCaps,
   applyPerRunCaps,
   dedupeEntities,
@@ -25,12 +37,12 @@ import {
   buildExtractionUserContent,
   extractEntitiesAndRelationsForSource,
 } from "./llm-extract-entities.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
 import {
   buildAnalysisGetQuery,
   applyMaxBatchSizeCap,
   sortAnalysisDataSourcesByCreatedAt,
 } from "./run-helpers.js";
-import { normalizeEntityName } from "./normalize-entity-name.js";
 
 type ExistingEntity = {
   canonicalName: string;
@@ -128,8 +140,11 @@ const resolveAgainstExistingEntities = (
 };
 
 /**
- * Runs analysis Phase A–C: GET context, optional batch cap, LLM extraction per source,
- * vocabulary validation, caps, chunked POST of entities/relations (no articleEntities yet).
+ * Runs analysis: GET context, optional batch cap, LLM extraction per source,
+ * vocabulary validation, canonicalization against existing entities, caps,
+ * chunked POST of entities/relations, then chunked POST of `articleEntities`
+ * (after ER commits so names resolve in the API). `articleRelevances` remain
+ * empty until a later milestone.
  *
  * @param context - Hermes input/config and bearer token.
  * @returns Aggregated success with POST tallies or structured failure.
@@ -182,6 +197,8 @@ export const run = async ({
           entitiesReused: 0,
           relationsCreated: 0,
           postChunks: 0,
+          articleEntityRowsPosted: 0,
+          mentionPostChunks: 0,
         },
       };
     }
@@ -205,6 +222,7 @@ export const run = async ({
     let vocabularyFailures = 0;
     const mergedEntities: EntityProposal[] = [];
     const mergedRelations: RelationProposal[] = [];
+    const mergedArticleEntityRows: ArticleEntityRow[] = [];
 
     for (const source of batch) {
       const truncated =
@@ -261,6 +279,21 @@ export const run = async ({
         );
         mergedEntities.push(...capped.entities);
         mergedRelations.push(...capped.relations);
+
+        const allowedCatalog = buildNormalizedEntityCatalogForArticle(
+          capped.entities,
+        );
+        const mentionFiltered = filterMentionsToArticleEntityCatalog(
+          extracted.articleMentions,
+          allowedCatalog,
+        );
+        const mentionCapped = applyPerArticleArticleMentionCap(
+          mentionFiltered,
+          cfg.maxArticleEntitiesPerArticle,
+        );
+        mergedArticleEntityRows.push(
+          ...toArticleEntityRowsForSource(source.id, mentionCapped),
+        );
       } catch (err) {
         llmFailures += 1;
         logger.warn(
@@ -296,10 +329,36 @@ export const run = async ({
           entitiesReused: 0,
           relationsCreated: 0,
           postChunks: 0,
+          articleEntityRowsPosted: 0,
+          mentionPostChunks: 0,
           reanalyze,
         },
       };
     }
+
+    const entityCatalog = buildNormalizedEntityCatalogFromProposals(entities);
+    const {
+      rows: articleRowsForRun,
+      droppedCount: droppedArticleMentionsNotInRunCatalog,
+    } = filterArticleEntityRowsToRunCatalog(
+      mergedArticleEntityRows,
+      entityCatalog,
+    );
+    if (droppedArticleMentionsNotInRunCatalog > 0) {
+      logger.warn(
+        {
+          tickerId: input.tickerId,
+          droppedArticleMentionsNotInRunCatalog,
+        },
+        "article-analysis dropped article entity mentions not in run entity catalog",
+      );
+    }
+
+    let articleEntitiesForPost = dedupeArticleEntityMentions(articleRowsForRun);
+    articleEntitiesForPost = applyPerRunArticleEntityCap(
+      articleEntitiesForPost,
+      cfg.maxArticleEntitiesPerRun,
+    );
 
     const { chunks, parseErrors, droppedRelations } = buildAnalysisPostChunks(
       input.tickerId,
@@ -331,6 +390,9 @@ export const run = async ({
           parseErrors: parseErrors.slice(0, 20),
           llmFailures,
           vocabularyFailures,
+          articleEntityRowsPosted: 0,
+          mentionPostChunks: 0,
+          droppedArticleMentionsNotInRunCatalog,
           reanalyze,
         },
       };
@@ -345,6 +407,7 @@ export const run = async ({
       logger.info(
         {
           tickerId: input.tickerId,
+          chunkKind: "entities_relations",
           chunkIndex: i,
           chunkEntities: chunk.entities.length,
           chunkRelations: chunk.relations.length,
@@ -358,9 +421,47 @@ export const run = async ({
       relationsCreated += res.relationsCreated;
     }
 
+    let articleEntityRowsPosted = 0;
+    let mentionPostChunks = 0;
+    const {
+      chunks: articleEntityChunks,
+      parseErrors: articleEntityParseErrors,
+    } = buildArticleEntityPostChunks(
+      input.tickerId,
+      articleEntitiesForPost,
+      cfg.postChunkArticleEntityBatchSize,
+    );
+
+    if (articleEntityParseErrors.length > 0) {
+      logger.warn(
+        {
+          tickerId: input.tickerId,
+          parseErrorSample: articleEntityParseErrors.slice(0, 10),
+        },
+        "article-analysis articleEntity chunk build reported parse issues",
+      );
+    }
+
+    for (let j = 0; j < articleEntityChunks.length; j++) {
+      const mentionChunk = articleEntityChunks[j]!;
+      logger.info(
+        {
+          tickerId: input.tickerId,
+          chunkKind: "article_entities",
+          chunkIndex: j,
+          chunkArticleEntities: mentionChunk.articleEntities.length,
+          model: cfg.openaiModel,
+        },
+        "article-analysis posting chunk",
+      );
+      await dataApiClient.analysis.create(mentionChunk);
+      articleEntityRowsPosted += mentionChunk.articleEntities.length;
+    }
+    mentionPostChunks = articleEntityChunks.length;
+
     return {
       success: true,
-      message: `analysis complete: ${chunks.length} POST chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated}`,
+      message: `analysis complete: ${chunks.length} ER chunk(s), ${mentionPostChunks} articleEntity chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted}`,
       details: {
         dataSourcesProcessed: batch.length,
         dataSourcesReturned: ctx.dataSources.length,
@@ -368,9 +469,13 @@ export const run = async ({
         entitiesCreated,
         entitiesReused,
         relationsCreated,
+        articleEntityRowsPosted,
+        mentionPostChunks,
+        droppedArticleMentionsNotInRunCatalog,
         llmFailures,
         vocabularyFailures,
         droppedRelations,
+        articleEntityParseErrors: articleEntityParseErrors.slice(0, 20),
         reanalyze,
       },
     };

--- a/dev-docs/docs/guide/development.mdx
+++ b/dev-docs/docs/guide/development.mdx
@@ -101,7 +101,7 @@ For pipeline stages that read third-party keys from env (e.g. data collection, s
 
 **Delivery (Resend):** configure `resendApiKey` and `resend.from` on the **delivery Agent config** in Hermes (variables/secrets), not in this env file.
 
-**Article analysis:** configure the **article-analysis** agent in Hermes with `openaiApiKey` (required). Optional tuning: `openaiModel`, `maxOutputTokens`, `maxContentChars`, per-article caps `maxEntitiesPerArticle` / `maxRelationsPerArticle`, per-run caps `maxEntitiesPerRun` / `maxRelationsPerRun`, and `postChunkRelationBatchSize` for POST chunking (each chunk’s body includes endpoint entities so relation names resolve in one `analysis.create` transaction).
+**Article analysis:** configure the **article-analysis** agent in Hermes with `openaiApiKey` (required). Optional tuning: `openaiModel`, `maxOutputTokens`, `maxContentChars`, per-article caps `maxEntitiesPerArticle` / `maxRelationsPerArticle`, per-run caps `maxEntitiesPerRun` / `maxRelationsPerRun`, and `postChunkRelationBatchSize` for POST chunking (each chunk’s body includes endpoint entities so relation names resolve in one `analysis.create` transaction). Mention rows use `maxArticleEntitiesPerArticle`, `maxArticleEntitiesPerRun`, and `postChunkArticleEntityBatchSize` for `articleEntities` POST batching after entities/relations are committed.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements MP-ART-ANALYSIS-005: structured `articleMentions` from the LLM (with sentiment), mapping to `postAnalysisBodySchema.articleEntities` with trusted `dataSourceId`, per-article and run-level caps, deduplication, and sequential `analysis.create` bodies **after** entity/relation chunks so names resolve via the API. Adds an entities-only ER chunk when there are entities but no relations. Documents new Hermes config keys for mention limits and POST batching.

## Related issues

Closes #215

## Important changes

- LLM output and prompts extended with `articleMentions`; Hermes config: `maxArticleEntitiesPerArticle`, `maxArticleEntitiesPerRun`, `postChunkArticleEntityBatchSize`.
- `run.ts` posts `article_entities` chunks after ER chunks; `details` include `articleEntityRowsPosted`, `mentionPostChunks`, `droppedArticleMentionsNotInRunCatalog`.
- `buildAnalysisPostChunks` emits one chunk for entities-only runs (no relations).

## Other changes

- Development guide note for article-analysis mention/chunk settings.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — orchestration and POST order.
- `apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts` — catalog filter, dedupe, chunk builder.
- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` — schema and prompts.
- `apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts` — entities-only chunk branch.

## How to test

1. `pnpm code-quality` from repo root.
2. With Hermes config set, run article-analysis against sources that produce entities; confirm second-phase POSTs include `articleEntities` and `articleRelevances` stay empty.
