### PR TITLE
Document git town --version install check

### DIFF
--- a/.cursor/skills/git-town-stacked-changes/SKILL.md
+++ b/.cursor/skills/git-town-stacked-changes/SKILL.md
@@ -16,6 +16,7 @@ Official reference: [Stacked changes (Git Town)](https://www.git-town.com/stacke
 ## Prerequisites
 
 - [Git Town](https://www.git-town.com/) installed and configured for this repo (parent branch, remote, per-project settings as needed).
+  - **Verify installation:** run `git town --version` (prints the Git Town version). Do **not** run `git town version`—that is not the supported check and can fail or exit non-zero, so agents may incorrectly assume Git Town is not installed.
 - User (or CI) can merge **oldest PR first** when branches depend on each other.
 
 ## How this pairs with `/prd-to-tickets`


### PR DESCRIPTION
## Summary

Updates the Git Town stacked-changes Cursor skill so agents use `git town --version` to verify the CLI. Documents that `git town version` is not a reliable probe and can make tools think Git Town is missing.

## Related issues

Closes #228

## Important changes

- Prerequisites now spell out the canonical install check and the anti-pattern to avoid.

## Other changes

- None.

## Key files to review

- `.cursor/skills/git-town-stacked-changes/SKILL.md` — single new prerequisite bullet under **Verify installation**.

## How to test

1. Open the skill and confirm **Prerequisites** recommends `git town --version` and warns against `git town version`.
2. Locally run `git town --version` and confirm it prints a version (optional sanity check).
