### PR TITLE
Add article relevance scoring and chunked articleRelevances

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -230,6 +230,10 @@ describe("agent-data-api", () => {
         entityTypes: [],
         relationTypes: [],
         existingEntities: [],
+        relevanceSelectionState: {
+          utcDayStartIso: "2026-03-19T00:00:00.000Z",
+          selectedCountToday: 0,
+        },
       });
 
       const { app } = await import("./index.js");
@@ -254,6 +258,10 @@ describe("agent-data-api", () => {
         entityTypes: [],
         relationTypes: [],
         existingEntities: [],
+        relevanceSelectionState: {
+          utcDayStartIso: "2026-03-19T00:00:00.000Z",
+          selectedCountToday: 0,
+        },
       });
 
       const start = "2026-01-01T00:00:00.000Z";
@@ -329,7 +337,14 @@ describe("agent-data-api", () => {
             {
               dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
               score: 0.5,
-              scoreBreakdown: { _version: 1, a: 0.5 },
+              scoreBreakdown: {
+                _version: 1,
+                breakingNews: 0.5,
+                kgRelation: 0.5,
+                fundamental: 0.5,
+                tickerSalience: 0.5,
+                sourceQuality: 0.5,
+              },
               selected: false,
             },
           ],

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -73,7 +73,10 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+      },
       $transaction: vi.fn(),
     };
 
@@ -94,6 +97,7 @@ describe("loadAnalysisContext", () => {
         }),
       }),
     );
+    expect(db.articleRelevance.count).toHaveBeenCalled();
   });
 
   it("loads all ticker sources when unanalyzed is false", async () => {
@@ -111,11 +115,14 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(2),
+      },
       $transaction: vi.fn(),
     };
 
-    await loadAnalysisContext(
+    const result = await loadAnalysisContext(
       { tickerId: "ticker-2", unanalyzed: false },
       { db: db as never },
     );
@@ -125,6 +132,7 @@ describe("loadAnalysisContext", () => {
         where: { tickerId: "ticker-2" },
       }),
     );
+    expect(result.relevanceSelectionState.selectedCountToday).toBe(2);
   });
 
   it("filters by createdAt gte when start is set", async () => {
@@ -142,7 +150,10 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+      },
       $transaction: vi.fn(),
     };
 
@@ -179,7 +190,10 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+      },
       $transaction: vi.fn(),
     };
 
@@ -216,7 +230,10 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+      },
       $transaction: vi.fn(),
     };
 
@@ -267,7 +284,10 @@ describe("loadAnalysisContext", () => {
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
-      articleRelevance: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+      },
       $transaction: vi.fn(),
     };
 

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -32,7 +32,7 @@ type AnalysisDb = {
   tickerEntity: Pick<typeof prisma.tickerEntity, "create" | "findFirst">;
   entityRelation: Pick<typeof prisma.entityRelation, "create" | "findUnique">;
   articleEntity: Pick<typeof prisma.articleEntity, "upsert">;
-  articleRelevance: Pick<typeof prisma.articleRelevance, "upsert">;
+  articleRelevance: Pick<typeof prisma.articleRelevance, "upsert" | "count">;
   $transaction: typeof prisma.$transaction;
 };
 
@@ -111,13 +111,30 @@ export const loadAnalysisContext = async (
     orderBy: { canonicalName: "asc" as const },
   } satisfies Prisma.EntityFindManyArgs;
 
-  const [dataSources, entityTypes, relationTypes, existingEntityRows] =
-    await Promise.all([
-      db.dataSource.findMany(dataSourceArgs),
-      db.entityType.findMany(entityTypeArgs),
-      db.relationType.findMany(relationTypeArgs),
-      db.entity.findMany(existingEntityArgs),
-    ]);
+  const utcDayStart = new Date();
+  utcDayStart.setUTCHours(0, 0, 0, 0);
+
+  const relevanceCountArgs = {
+    where: {
+      tickerId: query.tickerId,
+      selected: true,
+      scoredAt: { gte: utcDayStart },
+    },
+  } satisfies Prisma.ArticleRelevanceCountArgs;
+
+  const [
+    dataSources,
+    entityTypes,
+    relationTypes,
+    existingEntityRows,
+    selectedCountToday,
+  ] = await Promise.all([
+    db.dataSource.findMany(dataSourceArgs),
+    db.entityType.findMany(entityTypeArgs),
+    db.relationType.findMany(relationTypeArgs),
+    db.entity.findMany(existingEntityArgs),
+    db.articleRelevance.count(relevanceCountArgs),
+  ]);
 
   return {
     dataSources,
@@ -129,6 +146,10 @@ export const loadAnalysisContext = async (
       typeId: row.typeId,
       aliases: row.aliases.map((a) => a.alias),
     })),
+    relevanceSelectionState: {
+      utcDayStartIso: utcDayStart.toISOString(),
+      selectedCountToday,
+    },
   };
 };
 
@@ -324,6 +345,7 @@ export const applyAnalysisPost = async (
 
     let articlesScored = 0;
     for (const relRow of body.articleRelevances) {
+      const scoreBreakdown = relRow.scoreBreakdown as Prisma.InputJsonValue;
       await tx.articleRelevance.upsert({
         where: {
           dataSourceId_tickerId: {
@@ -335,13 +357,13 @@ export const applyAnalysisPost = async (
           dataSourceId: relRow.dataSourceId,
           tickerId: body.tickerId,
           score: relRow.score,
-          scoreBreakdown: relRow.scoreBreakdown,
+          scoreBreakdown,
           selected: relRow.selected,
           scoredAt: new Date(),
         },
         update: {
           score: relRow.score,
-          scoreBreakdown: relRow.scoreBreakdown,
+          scoreBreakdown,
           selected: relRow.selected,
           scoredAt: new Date(),
         },

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { buildArticleRelevancePostChunks } from "./analysis-relevance-post-chunks.js";
+
+const DS_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const DS_B = "bbbbbbbb-bbbb-4bbb-bbbb-bbbbbbbbbbbb";
+
+describe("buildArticleRelevancePostChunks", () => {
+  it("splits relevance rows into validated chunks", () => {
+    const rows = [
+      {
+        dataSourceId: DS_A,
+        score: 0.5,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 0.5,
+          kgRelation: 0.5,
+          fundamental: 0.5,
+          tickerSalience: 0.5,
+          sourceQuality: 0.5,
+        },
+        selected: false,
+      },
+      {
+        dataSourceId: DS_B,
+        score: 0.6,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 0.6,
+          kgRelation: 0.6,
+          fundamental: 0.6,
+          tickerSalience: 0.6,
+          sourceQuality: 0.6,
+        },
+        selected: true,
+      },
+    ];
+
+    const { chunks, parseErrors } = buildArticleRelevancePostChunks(
+      "ticker-1",
+      rows,
+      1,
+    );
+
+    expect(parseErrors).toHaveLength(0);
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]?.articleRelevances).toHaveLength(1);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.ts
@@ -1,0 +1,56 @@
+import {
+  postAnalysisBodySchema,
+  type PostAnalysisBody,
+} from "@workspace/agent-data-api-contract";
+
+import type { ArticleRelevanceRow } from "./analysis-relevance-scoring.js";
+
+export type BuildArticleRelevancePostChunksResult = {
+  chunks: PostAnalysisBody[];
+  parseErrors: string[];
+};
+
+/**
+ * Partitions `articleRelevances` into sequential POST bodies (other arrays empty per FR9-style chunking).
+ *
+ * @param tickerId - Ticker id for each body.
+ * @param articleRelevances - Final rows after selection.
+ * @param postChunkArticleRelevanceBatchSize - Max rows per POST.
+ * @returns Chunks that pass `postAnalysisBodySchema.safeParse`.
+ */
+export const buildArticleRelevancePostChunks = (
+  tickerId: string,
+  articleRelevances: readonly ArticleRelevanceRow[],
+  postChunkArticleRelevanceBatchSize: number,
+): BuildArticleRelevancePostChunksResult => {
+  const chunks: PostAnalysisBody[] = [];
+  const parseErrors: string[] = [];
+
+  for (
+    let i = 0;
+    i < articleRelevances.length;
+    i += postChunkArticleRelevanceBatchSize
+  ) {
+    const window = articleRelevances.slice(
+      i,
+      i + postChunkArticleRelevanceBatchSize,
+    );
+    const body: PostAnalysisBody = {
+      tickerId,
+      entities: [],
+      relations: [],
+      articleEntities: [],
+      articleRelevances: [...window],
+    };
+    const parsed = postAnalysisBodySchema.safeParse(body);
+    if (!parsed.success) {
+      for (const issue of parsed.error.issues) {
+        parseErrors.push(issue.message);
+      }
+      continue;
+    }
+    chunks.push(parsed.data);
+  }
+
+  return { chunks, parseErrors };
+};

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.test.ts
@@ -1,0 +1,86 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDraftRelevanceRow,
+  buildScoreBreakdownV1,
+  clampUnitInterval,
+  computeWeightedScore,
+  RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1,
+  validateRelevanceRowForPost,
+  type PerSourceRelevanceSignals,
+} from "./analysis-relevance-scoring.js";
+
+const WEIGHTS = {
+  breakingNews: 0.2,
+  kgRelation: 0.2,
+  fundamental: 0.2,
+  tickerSalience: 0.2,
+  sourceQuality: 0.2,
+} as const;
+
+const baseSignals = (): PerSourceRelevanceSignals => ({
+  dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+  createdAt: new Date("2026-04-09T12:00:00Z"),
+  url: "https://example.com/x",
+  entityCount: 2,
+  relationCount: 1,
+  mentionCount: 2,
+  avgMentionConfidence: 0.8,
+  titleLower: "company reports earnings",
+  textLower: "revenue grew year over year",
+});
+
+describe("clampUnitInterval", () => {
+  it("clamps to zero one", () => {
+    expect(clampUnitInterval(-1)).toBe(0);
+    expect(clampUnitInterval(2)).toBe(1);
+    expect(clampUnitInterval(0.5)).toBe(0.5);
+  });
+});
+
+describe("buildScoreBreakdownV1", () => {
+  it("includes five canonical keys and _version", () => {
+    const b = buildScoreBreakdownV1(baseSignals(), 1);
+    expect(b._version).toBe(1);
+    for (const k of RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1) {
+      expect(typeof b[k]).toBe("number");
+      expect(b[k]).toBeGreaterThanOrEqual(0);
+      expect(b[k]).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("computeWeightedScore", () => {
+  it("weights canonical keys only", () => {
+    const b = buildScoreBreakdownV1(baseSignals(), 1);
+    const s = computeWeightedScore(b, WEIGHTS);
+    expect(s).toBeGreaterThan(0);
+    expect(s).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("validateRelevanceRowForPost", () => {
+  it("accepts a draft row from buildDraftRelevanceRow", () => {
+    const row = buildDraftRelevanceRow(baseSignals(), 1, WEIGHTS);
+    expect(validateRelevanceRowForPost(row, WEIGHTS)).toBeNull();
+  });
+
+  it("rejects score drift", () => {
+    const row = buildDraftRelevanceRow(baseSignals(), 1, WEIGHTS);
+    const bad = { ...row, score: 0.01 };
+    expect(validateRelevanceRowForPost(bad, WEIGHTS)).not.toBeNull();
+  });
+
+  it("rejects non-integer scoreBreakdown _version", () => {
+    const row = buildDraftRelevanceRow(baseSignals(), 1, WEIGHTS);
+    const bad = {
+      ...row,
+      scoreBreakdown: {
+        ...row.scoreBreakdown,
+        _version: 1.5,
+      },
+    };
+    expect(validateRelevanceRowForPost(bad, WEIGHTS)).toContain("integer >= 1");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.ts
@@ -1,0 +1,182 @@
+import type { PostAnalysisBody } from "@workspace/agent-data-api-contract";
+
+/**
+ * Canonical v1 keys for `scoreBreakdown` on article relevance (MP-ART-ANALYSIS-006 / GitHub #216).
+ * Aligns with product dimensions: breaking news, KG relation change, fundamentals, ticker salience, source quality.
+ */
+export const RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1 = [
+  "breakingNews",
+  "kgRelation",
+  "fundamental",
+  "tickerSalience",
+  "sourceQuality",
+] as const;
+
+/** Numeric map for weighted score (excludes `_version` and experimental keys). */
+export type RelevanceWeightMapV1 = Record<
+  (typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number],
+  number
+>;
+
+export type PerSourceRelevanceSignals = {
+  dataSourceId: string;
+  createdAt: Date;
+  url: string;
+  entityCount: number;
+  relationCount: number;
+  mentionCount: number;
+  avgMentionConfidence: number;
+  titleLower: string;
+  textLower: string;
+};
+
+export type ArticleRelevanceRow = PostAnalysisBody["articleRelevances"][number];
+
+const BREAKING_HINTS =
+  /\b(breaking|urgent|halt|crash|plunge|surge|lawsuit|investigation|sec investigation|wire:|alert)\b/i;
+const FUNDAMENTAL_HINTS =
+  /\b(earnings|revenue|eps|guidance|ebitda|margin|dividend|buyback|10-k|10-q|8-k|fiscal|outlook|forecast)\b/i;
+const TIER1_HOST = /\b(reuters\.|bloomberg\.|wsj\.|ft\.com|cnbc\.)/i;
+
+/**
+ * Clamps a number into `[0, 1]`.
+ *
+ * @param n - Raw value.
+ * @returns Clamped value.
+ */
+export const clampUnitInterval = (n: number): number =>
+  Math.min(1, Math.max(0, n));
+
+/**
+ * Heuristic v1: derives normalized subscores in `[0, 1]` from per-source extraction signals (no extra LLM call).
+ *
+ * @param signals - Counts and text snippets for one `DataSource`.
+ * @param scoreBreakdownVersion - Stored as `scoreBreakdown._version` for chart/schema compatibility.
+ * @returns Breakdown including `_version` and the five canonical keys (optionally more experimental keys later).
+ */
+export const buildScoreBreakdownV1 = (
+  signals: PerSourceRelevanceSignals,
+  scoreBreakdownVersion: number,
+): Record<string, number> => {
+  const haystack = `${signals.titleLower}\n${signals.textLower}`;
+  const breakingNews = clampUnitInterval(
+    BREAKING_HINTS.test(haystack) ? 0.82 : 0.25,
+  );
+  const kgRelation = clampUnitInterval(
+    signals.relationCount === 0
+      ? 0.15
+      : Math.min(1, 0.35 + signals.relationCount * 0.12),
+  );
+  const fundamental = clampUnitInterval(
+    FUNDAMENTAL_HINTS.test(haystack) ? 0.75 : 0.28,
+  );
+  const tickerSalience = clampUnitInterval(
+    signals.mentionCount === 0 && signals.entityCount === 0
+      ? 0.12
+      : Math.min(
+          1,
+          0.2 +
+            signals.mentionCount * 0.1 +
+            signals.avgMentionConfidence * 0.45 +
+            Math.min(0.25, signals.entityCount * 0.04),
+        ),
+  );
+  const sourceQuality = clampUnitInterval(
+    TIER1_HOST.test(signals.url.toLowerCase()) ? 0.78 : 0.52,
+  );
+
+  return {
+    _version: scoreBreakdownVersion,
+    breakingNews,
+    kgRelation,
+    fundamental,
+    tickerSalience,
+    sourceQuality,
+  };
+};
+
+/**
+ * Weighted aggregate score over canonical v1 keys only (`_version` excluded).
+ *
+ * @param breakdown - Map including canonical keys and optional extras.
+ * @param weights - Non-negative weights (should sum to ~1 for interpretability).
+ * @returns Score in `[0, 1]` before row-level clamp.
+ */
+export const computeWeightedScore = (
+  breakdown: Readonly<Record<string, unknown>>,
+  weights: RelevanceWeightMapV1,
+): number => {
+  let s = 0;
+  for (const key of RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1) {
+    const raw = breakdown[key];
+    const v = typeof raw === "number" ? raw : 0;
+    s += weights[key] * v;
+  }
+  return clampUnitInterval(s);
+};
+
+/**
+ * Builds a relevance POST row with `selected: false` (selection applied later).
+ *
+ * @param signals - Source signals after extraction caps.
+ * @param scoreBreakdownVersion - `_version` in breakdown JSON.
+ * @param weights - Hermes-configured weights.
+ * @returns One `articleRelevances` element.
+ */
+export const buildDraftRelevanceRow = (
+  signals: PerSourceRelevanceSignals,
+  scoreBreakdownVersion: number,
+  weights: RelevanceWeightMapV1,
+): ArticleRelevanceRow => {
+  const scoreBreakdown = buildScoreBreakdownV1(signals, scoreBreakdownVersion);
+  const score = computeWeightedScore(scoreBreakdown, weights);
+  return {
+    dataSourceId: signals.dataSourceId,
+    score,
+    scoreBreakdown:
+      scoreBreakdown as PostAnalysisBody["articleRelevances"][number]["scoreBreakdown"],
+    selected: false,
+  };
+};
+
+/**
+ * Returns an error message if the row cannot be posted, otherwise `null`.
+ *
+ * @param row - Candidate relevance row.
+ * @param weights - Same weights used to compute `row.score`.
+ * @param epsilon - Tolerance for floating score comparison.
+ * @returns Human-readable validation failure or `null`.
+ */
+export const validateRelevanceRowForPost = (
+  row: ArticleRelevanceRow,
+  weights: RelevanceWeightMapV1,
+  epsilon = 1e-6,
+): string | null => {
+  if (row.score < 0 || row.score > 1) {
+    return "relevance score must be in [0, 1]";
+  }
+  const b = row.scoreBreakdown;
+  if (Object.keys(b).length === 0) {
+    return "scoreBreakdown must be non-empty";
+  }
+  const ver = b._version;
+  if (
+    typeof ver !== "number" ||
+    !Number.isFinite(ver) ||
+    !Number.isInteger(ver) ||
+    ver < 1
+  ) {
+    return "scoreBreakdown._version must be an integer >= 1";
+  }
+  for (const key of RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1) {
+    const v = b[key];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0 || v > 1) {
+      return `scoreBreakdown.${key} must be a number in [0, 1]`;
+    }
+  }
+  const expected = computeWeightedScore(b, weights);
+  if (Math.abs(expected - row.score) > epsilon) {
+    return `score ${row.score} does not match weighted breakdown (expected ~${expected})`;
+  }
+  return null;
+};

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { applyRelevanceSelection } from "./analysis-relevance-selection.js";
+
+describe("applyRelevanceSelection", () => {
+  it("marks top scores when above min and within budget", () => {
+    const rows = [
+      {
+        dataSourceId: "a",
+        score: 0.9,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 1,
+          kgRelation: 1,
+          fundamental: 1,
+          tickerSalience: 1,
+          sourceQuality: 1,
+        },
+        selected: false,
+        _sortCreatedAt: new Date("2026-04-09T10:00:00Z"),
+      },
+      {
+        dataSourceId: "b",
+        score: 0.4,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 1,
+          kgRelation: 1,
+          fundamental: 1,
+          tickerSalience: 1,
+          sourceQuality: 1,
+        },
+        selected: false,
+        _sortCreatedAt: new Date("2026-04-09T11:00:00Z"),
+      },
+    ];
+
+    const out = applyRelevanceSelection(rows, 0.35, 1);
+
+    expect(out.find((r) => r.dataSourceId === "a")?.selected).toBe(true);
+    expect(out.find((r) => r.dataSourceId === "b")?.selected).toBe(false);
+  });
+
+  it("prefers newer tie-break at equal score", () => {
+    const rows = [
+      {
+        dataSourceId: "old",
+        score: 0.8,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 1,
+          kgRelation: 1,
+          fundamental: 1,
+          tickerSalience: 1,
+          sourceQuality: 1,
+        },
+        selected: false,
+        _sortCreatedAt: new Date("2026-04-09T09:00:00Z"),
+      },
+      {
+        dataSourceId: "new",
+        score: 0.8,
+        scoreBreakdown: {
+          _version: 1,
+          breakingNews: 1,
+          kgRelation: 1,
+          fundamental: 1,
+          tickerSalience: 1,
+          sourceQuality: 1,
+        },
+        selected: false,
+        _sortCreatedAt: new Date("2026-04-09T12:00:00Z"),
+      },
+    ];
+
+    const out = applyRelevanceSelection(rows, 0, 1);
+    expect(out.find((r) => r.dataSourceId === "new")?.selected).toBe(true);
+    expect(out.find((r) => r.dataSourceId === "old")?.selected).toBe(false);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts
@@ -1,0 +1,47 @@
+import type { ArticleRelevanceRow } from "./analysis-relevance-scoring.js";
+
+export type RelevanceSelectionInputRow = ArticleRelevanceRow & {
+  /** Source `createdAt` for stable tie-breaking (not sent on POST). */
+  _sortCreatedAt: Date;
+};
+
+/**
+ * Applies minimum score and top-K selection budget (UTC day budget is pre-computed by the caller).
+ * Rows below `minScore` stay `selected: false`. Among the rest, highest scores win; ties break on newer `createdAt`.
+ *
+ * @param rows - Draft rows with `_sortCreatedAt` attached.
+ * @param minScore - Inclusive threshold for eligibility to be marked selected.
+ * @param remainingBudget - Max additional `selected: true` rows allowed this run (e.g. daily cap minus already selected).
+ * @returns New rows with `selected` set; sorted order is not preserved (only flags matter).
+ */
+export const applyRelevanceSelection = (
+  rows: readonly RelevanceSelectionInputRow[],
+  minScore: number,
+  remainingBudget: number,
+): ArticleRelevanceRow[] => {
+  const sorted = [...rows].sort((a, b) => {
+    if (b.score !== a.score) {
+      return b.score - a.score;
+    }
+    return b._sortCreatedAt.getTime() - a._sortCreatedAt.getTime();
+  });
+
+  let slots = Math.max(0, Math.floor(remainingBudget));
+  const out: ArticleRelevanceRow[] = [];
+
+  for (const row of sorted) {
+    const eligible = row.score >= minScore && slots > 0;
+    const selected = eligible;
+    if (eligible) {
+      slots -= 1;
+    }
+    out.push({
+      dataSourceId: row.dataSourceId,
+      score: row.score,
+      scoreBreakdown: row.scoreBreakdown,
+      selected,
+    });
+  }
+
+  return out;
+};

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,3 +1,4 @@
+import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
 import { z } from "zod";
 
 /**
@@ -26,6 +27,23 @@ export const articleAnalysisConfigSchema = z.object({
   maxArticleEntitiesPerRun: z.number().int().positive().optional(),
   /** Max `articleEntities` rows per POST chunk. */
   postChunkArticleEntityBatchSize: z.number().int().positive().optional(),
+  /** Stored in `scoreBreakdown._version` (MP-ART-ANALYSIS-009 env mirror later). */
+  scoreBreakdownVersion: z.number().int().min(1).optional(),
+  relevanceWeightBreakingNews: z.number().nonnegative().optional(),
+  relevanceWeightKgRelation: z.number().nonnegative().optional(),
+  relevanceWeightFundamental: z.number().nonnegative().optional(),
+  relevanceWeightTickerSalience: z.number().nonnegative().optional(),
+  relevanceWeightSourceQuality: z.number().nonnegative().optional(),
+  /** Minimum score to be eligible for `selected: true`. */
+  relevanceMinScore: z.number().min(0).max(1).optional(),
+  /** Cap on additional `selected` rows per UTC day (budget minus GET `selectedCountToday`). */
+  maxSelectedRelevancePerTickerPerDay: z
+    .number()
+    .int()
+    .nonnegative()
+    .optional(),
+  /** Max `articleRelevances` rows per POST chunk. */
+  postChunkArticleRelevanceBatchSize: z.number().int().positive().optional(),
 });
 
 export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
@@ -43,6 +61,15 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   maxArticleEntitiesPerArticle: number;
   maxArticleEntitiesPerRun: number;
   postChunkArticleEntityBatchSize: number;
+  scoreBreakdownVersion: number;
+  relevanceWeightBreakingNews: number;
+  relevanceWeightKgRelation: number;
+  relevanceWeightFundamental: number;
+  relevanceWeightTickerSalience: number;
+  relevanceWeightSourceQuality: number;
+  relevanceMinScore: number;
+  maxSelectedRelevancePerTickerPerDay: number;
+  postChunkArticleRelevanceBatchSize: number;
 };
 
 /** Production-oriented defaults merged onto parsed Hermes config. */
@@ -58,6 +85,15 @@ export const articleAnalysisConfigDefaults = {
   maxArticleEntitiesPerArticle: 30,
   maxArticleEntitiesPerRun: 500,
   postChunkArticleEntityBatchSize: 50,
+  scoreBreakdownVersion: 1,
+  relevanceWeightBreakingNews: 0.2,
+  relevanceWeightKgRelation: 0.2,
+  relevanceWeightFundamental: 0.2,
+  relevanceWeightTickerSalience: 0.2,
+  relevanceWeightSourceQuality: 0.2,
+  relevanceMinScore: 0.35,
+  maxSelectedRelevancePerTickerPerDay: 10,
+  postChunkArticleRelevanceBatchSize: 40,
 } as const;
 
 /**
@@ -101,5 +137,48 @@ export const resolveArticleAnalysisConfig = (
     postChunkArticleEntityBatchSize:
       config.postChunkArticleEntityBatchSize ??
       articleAnalysisConfigDefaults.postChunkArticleEntityBatchSize,
+    scoreBreakdownVersion:
+      config.scoreBreakdownVersion ??
+      articleAnalysisConfigDefaults.scoreBreakdownVersion,
+    relevanceWeightBreakingNews:
+      config.relevanceWeightBreakingNews ??
+      articleAnalysisConfigDefaults.relevanceWeightBreakingNews,
+    relevanceWeightKgRelation:
+      config.relevanceWeightKgRelation ??
+      articleAnalysisConfigDefaults.relevanceWeightKgRelation,
+    relevanceWeightFundamental:
+      config.relevanceWeightFundamental ??
+      articleAnalysisConfigDefaults.relevanceWeightFundamental,
+    relevanceWeightTickerSalience:
+      config.relevanceWeightTickerSalience ??
+      articleAnalysisConfigDefaults.relevanceWeightTickerSalience,
+    relevanceWeightSourceQuality:
+      config.relevanceWeightSourceQuality ??
+      articleAnalysisConfigDefaults.relevanceWeightSourceQuality,
+    relevanceMinScore:
+      config.relevanceMinScore ??
+      articleAnalysisConfigDefaults.relevanceMinScore,
+    maxSelectedRelevancePerTickerPerDay:
+      config.maxSelectedRelevancePerTickerPerDay ??
+      articleAnalysisConfigDefaults.maxSelectedRelevancePerTickerPerDay,
+    postChunkArticleRelevanceBatchSize:
+      config.postChunkArticleRelevanceBatchSize ??
+      articleAnalysisConfigDefaults.postChunkArticleRelevanceBatchSize,
   };
 };
+
+/**
+ * Maps resolved Hermes relevance weights into the v1 weight map used by scoring.
+ *
+ * @param cfg - Fully resolved article-analysis config.
+ * @returns Weights for canonical breakdown keys.
+ */
+export const toRelevanceWeightMapV1 = (
+  cfg: ResolvedArticleAnalysisConfig,
+): RelevanceWeightMapV1 => ({
+  breakingNews: cfg.relevanceWeightBreakingNews,
+  kgRelation: cfg.relevanceWeightKgRelation,
+  fundamental: cfg.relevanceWeightFundamental,
+  tickerSalience: cfg.relevanceWeightTickerSalience,
+  sourceQuality: cfg.relevanceWeightSourceQuality,
+});

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -22,7 +22,7 @@ const app = createAgentApp<
     agentId: "article-analysis",
     agentVersion: "1.0.0",
     description:
-      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, and persists in chunked POSTs to agent-data-api.",
+      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api.",
     inputSchema: articleAnalysisInputSchema,
     configSchema: articleAnalysisConfigSchema,
     run,

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -2,6 +2,7 @@
 import type { AgentRunContext } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as RelevancePostChunks from "./analysis-relevance-post-chunks.js";
 import * as Llm from "./llm-extract-entities.js";
 import type { ArticleAnalysisConfig } from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./input-schema.js";
@@ -38,6 +39,12 @@ const REL_ID = "22222222-2222-4222-a222-222222222222";
 const DS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const DS_ID_2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
+/** Required on `analysis.get` responses (see `getAnalysisResponseSchema`). */
+const relevanceSelectionState = {
+  utcDayStartIso: "2026-04-09T00:00:00.000Z",
+  selectedCountToday: 0,
+} as const;
+
 const baseConfig: ArticleAnalysisConfig = {
   openaiApiKey: "sk-test",
 };
@@ -58,6 +65,7 @@ describe("run", () => {
   beforeEach(() => {
     analysisGet.mockReset();
     analysisCreate.mockReset();
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockReset();
   });
 
   afterEach(() => {
@@ -79,6 +87,7 @@ describe("run", () => {
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
@@ -94,6 +103,7 @@ describe("run", () => {
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     await run(
@@ -118,6 +128,7 @@ describe("run", () => {
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     await run(
@@ -146,6 +157,7 @@ describe("run", () => {
       entityTypes: [],
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
@@ -167,6 +179,7 @@ describe("run", () => {
       entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource")
@@ -204,13 +217,21 @@ describe("run", () => {
         articleMentions: [],
       });
 
-    analysisCreate.mockResolvedValueOnce({
-      entitiesCreated: 1,
-      entitiesReused: 0,
-      relationsCreated: 0,
-      articlesScored: 0,
-      articlesSelected: 0,
-    });
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
@@ -220,8 +241,11 @@ describe("run", () => {
       entitiesCreated: 1,
       articleEntityRowsPosted: 0,
       mentionPostChunks: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+      relevancePostChunks: 1,
     });
-    expect(analysisCreate).toHaveBeenCalledTimes(1);
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
   });
 
   it("posts chunks and aggregates POST response counts", async () => {
@@ -230,6 +254,7 @@ describe("run", () => {
       entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
@@ -259,6 +284,13 @@ describe("run", () => {
         relationsCreated: 1,
         articlesScored: 0,
         articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
       });
 
     const result = await run(
@@ -269,7 +301,10 @@ describe("run", () => {
     );
 
     expect(result.success).toBe(true);
-    expect(analysisCreate).toHaveBeenCalledTimes(2);
+    expect(analysisCreate).toHaveBeenCalledTimes(3);
+    expect(analysisCreate.mock.calls[2]?.[0]?.articleRelevances).toHaveLength(
+      1,
+    );
     expect(result.details).toMatchObject({
       postChunks: 2,
       entitiesCreated: 2,
@@ -277,6 +312,9 @@ describe("run", () => {
       relationsCreated: 2,
       articleEntityRowsPosted: 0,
       mentionPostChunks: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+      relevancePostChunks: 1,
     });
   });
 
@@ -295,6 +333,7 @@ describe("run", () => {
       entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
@@ -324,12 +363,19 @@ describe("run", () => {
         relationsCreated: 0,
         articlesScored: 0,
         articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
       });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
     expect(result.success).toBe(true);
-    expect(analysisCreate).toHaveBeenCalledTimes(2);
+    expect(analysisCreate).toHaveBeenCalledTimes(3);
     expect(analysisCreate.mock.calls[0]?.[0]?.articleEntities).toEqual([]);
     expect(analysisCreate.mock.calls[1]?.[0]?.articleEntities).toHaveLength(1);
     expect(
@@ -345,6 +391,9 @@ describe("run", () => {
       postChunks: 1,
       mentionPostChunks: 1,
       articleEntityRowsPosted: 1,
+      articlesScored: 1,
+      articlesSelected: 1,
+      relevancePostChunks: 1,
     });
   });
 
@@ -363,6 +412,7 @@ describe("run", () => {
       entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
@@ -378,18 +428,26 @@ describe("run", () => {
       ],
     });
 
-    analysisCreate.mockResolvedValueOnce({
-      entitiesCreated: 1,
-      entitiesReused: 0,
-      relationsCreated: 0,
-      articlesScored: 0,
-      articlesSelected: 0,
-    });
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 0,
+      });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
     expect(result.success).toBe(true);
-    expect(analysisCreate).toHaveBeenCalledTimes(1);
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
     expect(result.details).toMatchObject({
       mentionPostChunks: 0,
       articleEntityRowsPosted: 0,
@@ -404,6 +462,95 @@ describe("run", () => {
       (result.details as { articleEntityParseErrors?: unknown[] })
         .articleEntityParseErrors?.length,
     ).toBeGreaterThan(0);
+  });
+
+  it("fails run when relevance rows fail validation before selection", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [],
+    });
+
+    analysisCreate.mockResolvedValueOnce({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { scoreBreakdownVersion: 1.5 },
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("validation failed before selection");
+  });
+
+  it("fails run when relevance chunk parse errors are reported", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [],
+    });
+
+    analysisCreate.mockResolvedValueOnce({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+    });
+
+    vi.spyOn(
+      RelevancePostChunks,
+      "buildArticleRelevancePostChunks",
+    ).mockReturnValue({
+      chunks: [],
+      parseErrors: ["bad row"],
+    });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("relevance chunk parse failed");
   });
 
   it("returns failure when analysis GET throws", async () => {
@@ -431,6 +578,7 @@ describe("run", () => {
           aliases: ["Alpha"],
         },
       ],
+      relevanceSelectionState,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
@@ -448,13 +596,21 @@ describe("run", () => {
       articleMentions: [],
     });
 
-    analysisCreate.mockResolvedValueOnce({
-      entitiesCreated: 1,
-      entitiesReused: 1,
-      relationsCreated: 1,
-      articlesScored: 0,
-      articlesSelected: 0,
-    });
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 1,
+        relationsCreated: 1,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
@@ -478,6 +634,7 @@ describe("run", () => {
       entityTypes: [],
       relationTypes: [],
       existingEntities: [],
+      relevanceSelectionState,
     });
 
     await run(

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -4,6 +4,12 @@ import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
 
 import {
+  applyPerArticleExtractionCaps,
+  applyPerRunCaps,
+  dedupeEntities,
+  dedupeRelations,
+} from "./analysis-caps-dedupe.js";
+import {
   applyPerArticleArticleMentionCap,
   applyPerRunArticleEntityCap,
   buildArticleEntityPostChunks,
@@ -15,12 +21,13 @@ import {
   toArticleEntityRowsForSource,
   type ArticleEntityRow,
 } from "./analysis-article-mentions.js";
+import { buildArticleRelevancePostChunks } from "./analysis-relevance-post-chunks.js";
 import {
-  applyPerArticleExtractionCaps,
-  applyPerRunCaps,
-  dedupeEntities,
-  dedupeRelations,
-} from "./analysis-caps-dedupe.js";
+  buildDraftRelevanceRow,
+  validateRelevanceRowForPost,
+  type PerSourceRelevanceSignals,
+} from "./analysis-relevance-scoring.js";
+import { applyRelevanceSelection } from "./analysis-relevance-selection.js";
 import {
   validateExtractionVocabulary,
   type EntityProposal,
@@ -29,6 +36,7 @@ import {
 import { buildAnalysisPostChunks } from "./build-analysis-post-chunks.js";
 import {
   resolveArticleAnalysisConfig,
+  toRelevanceWeightMapV1,
   type ArticleAnalysisConfig,
 } from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./input-schema.js";
@@ -37,12 +45,12 @@ import {
   buildExtractionUserContent,
   extractEntitiesAndRelationsForSource,
 } from "./llm-extract-entities.js";
-import { normalizeEntityName } from "./normalize-entity-name.js";
 import {
   buildAnalysisGetQuery,
   applyMaxBatchSizeCap,
   sortAnalysisDataSourcesByCreatedAt,
 } from "./run-helpers.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
 
 type ExistingEntity = {
   canonicalName: string;
@@ -142,9 +150,9 @@ const resolveAgainstExistingEntities = (
 /**
  * Runs analysis: GET context, optional batch cap, LLM extraction per source,
  * vocabulary validation, canonicalization against existing entities, caps,
- * chunked POST of entities/relations, then chunked POST of `articleEntities`
- * (after ER commits so names resolve in the API). `articleRelevances` remain
- * empty until a later milestone.
+ * chunked POST of entities/relations, then chunked POST of `articleEntities` (after ER commits),
+ * then chunked `articleRelevances` with canonical `scoreBreakdown`, weighted `score`, and
+ * configurable `selected` (UTC-day budget from GET).
  *
  * @param context - Hermes input/config and bearer token.
  * @returns Aggregated success with POST tallies or structured failure.
@@ -199,6 +207,9 @@ export const run = async ({
           postChunks: 0,
           articleEntityRowsPosted: 0,
           mentionPostChunks: 0,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
         },
       };
     }
@@ -211,6 +222,9 @@ export const run = async ({
         details: {
           entityTypeCount: ctx.entityTypes.length,
           relationTypeCount: ctx.relationTypes.length,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
         },
       };
     }
@@ -223,6 +237,7 @@ export const run = async ({
     const mergedEntities: EntityProposal[] = [];
     const mergedRelations: RelationProposal[] = [];
     const mergedArticleEntityRows: ArticleEntityRow[] = [];
+    const perSourceSignals: PerSourceRelevanceSignals[] = [];
 
     for (const source of batch) {
       const truncated =
@@ -294,6 +309,23 @@ export const run = async ({
         mergedArticleEntityRows.push(
           ...toArticleEntityRowsForSource(source.id, mentionCapped),
         );
+
+        const avgMentionConfidence =
+          mentionCapped.length === 0
+            ? 0
+            : mentionCapped.reduce((s, m) => s + m.confidence, 0) /
+              mentionCapped.length;
+        perSourceSignals.push({
+          dataSourceId: source.id,
+          createdAt: source.createdAt,
+          url: source.url,
+          entityCount: capped.entities.length,
+          relationCount: capped.relations.length,
+          mentionCount: mentionCapped.length,
+          avgMentionConfidence,
+          titleLower: source.title.toLowerCase(),
+          textLower: truncated.toLowerCase(),
+        });
       } catch (err) {
         llmFailures += 1;
         logger.warn(
@@ -331,6 +363,9 @@ export const run = async ({
           postChunks: 0,
           articleEntityRowsPosted: 0,
           mentionPostChunks: 0,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
           reanalyze,
         },
       };
@@ -393,6 +428,9 @@ export const run = async ({
           articleEntityRowsPosted: 0,
           mentionPostChunks: 0,
           droppedArticleMentionsNotInRunCatalog,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
           reanalyze,
         },
       };
@@ -459,9 +497,102 @@ export const run = async ({
     }
     mentionPostChunks = articleEntityChunks.length;
 
+    let articlesScoredTotal = 0;
+    let articlesSelectedTotal = 0;
+    let relevancePostChunks = 0;
+
+    if (perSourceSignals.length > 0) {
+      const weightMap = toRelevanceWeightMapV1(cfg);
+      const relevanceDrafts = perSourceSignals.map((sig) =>
+        buildDraftRelevanceRow(sig, cfg.scoreBreakdownVersion, weightMap),
+      );
+      const relevanceValidationErrors: string[] = [];
+      for (const row of relevanceDrafts) {
+        const vErr = validateRelevanceRowForPost(row, weightMap);
+        if (vErr) {
+          relevanceValidationErrors.push(`${row.dataSourceId}: ${vErr}`);
+          logger.warn(
+            { tickerId: input.tickerId, dataSourceId: row.dataSourceId, vErr },
+            "article-analysis relevance row validation failed before selection",
+          );
+        }
+      }
+      if (relevanceValidationErrors.length > 0) {
+        return {
+          success: false,
+          message:
+            "article-analysis relevance row validation failed before selection",
+          details: {
+            tickerId: input.tickerId,
+            validationErrorCount: relevanceValidationErrors.length,
+            relevanceValidationErrors: relevanceValidationErrors.slice(0, 20),
+          },
+        };
+      }
+
+      const selectionInput = relevanceDrafts.map((row, idx) => ({
+        ...row,
+        _sortCreatedAt: perSourceSignals[idx]!.createdAt,
+      }));
+      const remainingBudget = Math.max(
+        0,
+        cfg.maxSelectedRelevancePerTickerPerDay -
+          ctx.relevanceSelectionState.selectedCountToday,
+      );
+      const relevanceRows = applyRelevanceSelection(
+        selectionInput,
+        cfg.relevanceMinScore,
+        remainingBudget,
+      );
+
+      const { chunks: relevanceChunks, parseErrors: relevanceParseErrors } =
+        buildArticleRelevancePostChunks(
+          input.tickerId,
+          relevanceRows,
+          cfg.postChunkArticleRelevanceBatchSize,
+        );
+
+      if (relevanceParseErrors.length > 0) {
+        logger.warn(
+          {
+            tickerId: input.tickerId,
+            parseErrorSample: relevanceParseErrors.slice(0, 10),
+          },
+          "article-analysis relevance chunk build reported parse issues",
+        );
+        return {
+          success: false,
+          message: "article-analysis relevance chunk parse failed",
+          details: {
+            tickerId: input.tickerId,
+            parseErrorCount: relevanceParseErrors.length,
+            relevanceParseErrors: relevanceParseErrors.slice(0, 20),
+          },
+        };
+      }
+
+      for (let k = 0; k < relevanceChunks.length; k++) {
+        const relChunk = relevanceChunks[k]!;
+        logger.info(
+          {
+            tickerId: input.tickerId,
+            chunkKind: "article_relevances",
+            chunkIndex: k,
+            chunkArticleRelevances: relChunk.articleRelevances.length,
+            model: cfg.openaiModel,
+          },
+          "article-analysis posting chunk",
+        );
+        const relRes = await dataApiClient.analysis.create(relChunk);
+        articlesScoredTotal += relRes.articlesScored;
+        articlesSelectedTotal += relRes.articlesSelected;
+      }
+      relevancePostChunks = relevanceChunks.length;
+    }
+
     return {
       success: true,
-      message: `analysis complete: ${chunks.length} ER chunk(s), ${mentionPostChunks} articleEntity chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted}`,
+      message: `analysis complete: ${chunks.length} ER chunk(s), ${mentionPostChunks} articleEntity chunk(s), ${relevancePostChunks} relevance chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted} articlesScored=${articlesScoredTotal} articlesSelected=${articlesSelectedTotal}`,
       details: {
         dataSourcesProcessed: batch.length,
         dataSourcesReturned: ctx.dataSources.length,
@@ -472,6 +603,14 @@ export const run = async ({
         articleEntityRowsPosted,
         mentionPostChunks,
         droppedArticleMentionsNotInRunCatalog,
+        articlesScored: articlesScoredTotal,
+        articlesSelected: articlesSelectedTotal,
+        relevancePostChunks,
+        relevanceSelectionBudgetRemaining: Math.max(
+          0,
+          cfg.maxSelectedRelevancePerTickerPerDay -
+            ctx.relevanceSelectionState.selectedCountToday,
+        ),
         llmFailures,
         vocabularyFailures,
         droppedRelations,

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -14,19 +14,22 @@ Core responsibilities:
 2. Upsert KG records (`entity`, `entity_alias`, `ticker_entity`, `entity_relation`, `article_entity`).
 3. Score article relevance and mark top-K rows as `selected` in `article_relevance`.
 
-## Relevance scoring signals
+## Relevance scoring signals (canonical `scoreBreakdown` v1)
 
-| Signal          | Weight | Description                                      |
-| --------------- | ------ | ------------------------------------------------ |
-| `aliasMatch`    | `0.30` | Symbol/name/alias match against article text     |
-| `entityOverlap` | `0.30` | Overlap between extracted entities and ticker KG |
-| `freshness`     | `0.20` | Recency score                                    |
-| `sourceQuality` | `0.10` | Source trust score                               |
-| `novelty`       | `0.10` | Dedup and diversity score                        |
+The **article-analysis** agent stores subscores in `article_relevance.score_breakdown` JSON. Required keys for charts and observability (MP-ART-ANALYSIS-006):
 
-Formula:
+| Key               | Role (product order)                                      |
+| ----------------- | ----------------------------------------------------------- |
+| `breakingNews`    | Timely / market-moving event signal                         |
+| `kgRelation`      | Strength of extracted KG relations for the article          |
+| `fundamental`     | Earnings, filings, guidance-style fundamentals              |
+| `tickerSalience`  | How strongly the ticker / entities show up in the piece   |
+| `sourceQuality`   | Trust / tier prior for the source                           |
+| `_version`        | Integer schema version (Hermes `scoreBreakdownVersion`)     |
 
-`score = 0.30*aliasMatch + 0.30*entityOverlap + 0.20*freshness + 0.10*sourceQuality + 0.10*novelty`
+Optional additional numeric keys may appear for experiments. **Weighted `score`** is in `[0, 1]` and defaults to equal weights (`0.2` each) over the five dimensions; tune via Hermes config (`relevanceWeight*` keys).
+
+**Selection:** `GET /api/v1/analysis` includes `relevanceSelectionState` (`utcDayStartIso`, `selectedCountToday`) so the agent can enforce **max additional `selected` rows per UTC day** after applying **`relevanceMinScore`**. Tie-break: higher `score`, then newer article `createdAt`.
 
 ## I/O contract
 

--- a/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
+++ b/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
@@ -169,40 +169,32 @@ In short:
 
 ## Relevance scoring model (analysis agent)
 
-The analysis stage computes a weighted composite score per article and ticker:
+The **article-analysis** agent computes a **weighted composite score** in `[0, 1]` per `(data_source_id, ticker_id)` and persists subscores in `article_relevance.score_breakdown` JSON.
 
-| Signal          | Weight | Description                                              |
-| --------------- | ------ | -------------------------------------------------------- |
-| `aliasMatch`    | `0.30` | Symbol/name/alias matches found in title and content     |
-| `entityOverlap` | `0.30` | Portion of extracted entities that overlap the ticker KG |
-| `freshness`     | `0.20` | Time-decay score favoring newer articles                 |
-| `sourceQuality` | `0.10` | Domain trust score from allowlist/config                 |
-| `novelty`       | `0.10` | Dedup signal favoring non-redundant articles             |
+**Canonical v1 keys** (required for each scored article; align with downstream charts):
 
-Formula:
+| Key               | Description |
+| ----------------- | ----------- |
+| `breakingNews`    | Breaking / urgent / market-moving cues from title and body heuristics |
+| `kgRelation`      | Signal from extracted relation count |
+| `fundamental`     | Filings, earnings, guidance, and similar keywords |
+| `tickerSalience`  | Mentions and extracted entity coverage |
+| `sourceQuality`   | Host-tier trust prior |
+| `_version`        | Integer breakdown version (Hermes `scoreBreakdownVersion`; env alignment in MP-ART-ANALYSIS-009) |
 
-`score = 0.30*aliasMatch + 0.30*entityOverlap + 0.20*freshness + 0.10*sourceQuality + 0.10*novelty`
+`score = sum_k relevanceWeight_k * scoreBreakdown[k]` over the five dimensions (default weights `0.2` each via Hermes).
 
-Practical interpretation:
-
-- `aliasMatch`: direct match confidence against ticker symbol/name/entity aliases.
-- `entityOverlap`: how much extracted article graph intersects ticker graph.
-- `freshness`: time-decay score to prioritize recent events.
-- `sourceQuality`: trust prior of source domain or feed.
-- `novelty`: reduces duplicate story clusters and rewards new information.
-
-Top-K scored rows are marked `selected = true` in `article_relevance` and then consumed by content-generation.
+Top-scoring rows that pass **`relevanceMinScore`** are candidates for **`selected = true`**, up to the **remaining daily budget**: `maxSelectedRelevancePerTickerPerDay - selectedCountToday`, where `selectedCountToday` is returned on **`GET /api/v1/analysis`** as **`relevanceSelectionState.selectedCountToday`** (UTC day start in **`utcDayStartIso`**). Content-generation consumes **`selected`** rows scored today.
 
 ## Selection policy and tie-breakers
 
-When scores are close, ranking should prefer:
+When assigning **`selected`** in a batch:
 
 1. Higher `score`
-2. More recent `scored_at` / article timestamp
-3. Better `sourceQuality` component
-4. Higher novelty to avoid repetitive newsletters
+2. Newer `data_source.createdAt` at equal `score`
+3. Respect the daily cap above
 
-If no row crosses your practical quality threshold, content-generation should skip with a clear status instead of producing low-signal output.
+If no row crosses **`relevanceMinScore`**, all rows may remain `selected = false` for that run; content-generation should skip with a clear status instead of producing low-signal output.
 
 ## Extraction quality guidelines
 
@@ -226,7 +218,7 @@ If no row crosses your practical quality threshold, content-generation should sk
 | Symptom                    | Likely cause                          | First checks                                              |
 | -------------------------- | ------------------------------------- | --------------------------------------------------------- |
 | Very few selected articles | Strict scoring or weak query coverage | Check search query quality and source volume              |
-| Repetitive newsletters     | Novelty too weak or same-source bias  | Inspect `score_breakdown.novelty` + source spread         |
+| Repetitive newsletters     | Selection cap or weak salience signals  | Inspect `score_breakdown.tickerSalience` + source spread  |
 | Wrong entity labels        | Ambiguous entity type definitions     | Refine `entity_type.description`                          |
 | Nonsensical relations      | Directionality confusion in labels    | Clarify relation semantics in `relation_type.description` |
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -135,6 +135,10 @@ describe("createAgentDataApiClient", () => {
         entityTypes: [],
         relationTypes: [],
         existingEntities: [],
+        relevanceSelectionState: {
+          utcDayStartIso: "2026-04-09T00:00:00.000Z",
+          selectedCountToday: 0,
+        },
       }),
       statusCode: 200,
     });
@@ -164,6 +168,10 @@ describe("createAgentDataApiClient", () => {
         entityTypes: [],
         relationTypes: [],
         existingEntities: [],
+        relevanceSelectionState: {
+          utcDayStartIso: "2026-04-09T00:00:00.000Z",
+          selectedCountToday: 0,
+        },
       }),
       statusCode: 200,
     });

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
 const sentimentSchema = z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL"]);
+const relevanceBreakdownSchema = z
+  .object({
+    _version: z.number().int().min(1),
+    breakingNews: z.number().min(0).max(1),
+    kgRelation: z.number().min(0).max(1),
+    fundamental: z.number().min(0).max(1),
+    tickerSalience: z.number().min(0).max(1),
+    sourceQuality: z.number().min(0).max(1),
+  })
+  .passthrough();
 
 export const getAnalysisQuerySchema = z
   .object({
@@ -72,7 +82,7 @@ export const postAnalysisBodySchema = z.object({
       z.object({
         dataSourceId: z.string().uuid(),
         score: z.number().min(0).max(1),
-        scoreBreakdown: z.record(z.string(), z.number()),
+        scoreBreakdown: relevanceBreakdownSchema,
         selected: z.boolean(),
       }),
     )
@@ -107,11 +117,20 @@ export const analysisExistingEntitySchema = z.object({
   aliases: z.array(z.string()),
 });
 
+/** UTC-day selection budget for article relevance (see article-analysis agent). */
+export const analysisRelevanceSelectionStateSchema = z.object({
+  /** ISO 8601 instant for UTC midnight at the start of the scoring "today". */
+  utcDayStartIso: z.string(),
+  /** Count of `articleRelevance` rows with `selected: true` and `scoredAt` on or after `utcDayStartIso`. */
+  selectedCountToday: z.number().int().nonnegative(),
+});
+
 export const getAnalysisResponseSchema = z.object({
   dataSources: z.array(analysisDataSourceSchema),
   entityTypes: z.array(analysisEntityTypeSchema),
   relationTypes: z.array(analysisRelationTypeSchema),
   existingEntities: z.array(analysisExistingEntitySchema),
+  relevanceSelectionState: analysisRelevanceSelectionStateSchema,
 });
 
 export const postAnalysisResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Implements per-article relevance scoring for the article-analysis agent: canonical v1 `scoreBreakdown` (including `_version`), weighted `score`, Hermes-configurable selection (minimum score plus top-K per ticker per UTC day using `relevanceSelectionState` from analysis GET), and chunked `articleRelevances` POSTs after `articleEntities`. Responses aggregate `articlesScored` and `articlesSelected`.

## Related issues

Refs #216

## Important changes

- **`GET /api/v1/analysis`** now returns **`relevanceSelectionState`** (`utcDayStartIso`, `selectedCountToday`) from a single Prisma count on today’s selected rows.
- **Agent** builds heuristic breakdown, applies selection against remaining daily budget, validates chunks with `postAnalysisBodySchema.safeParse`, and posts **`article_relevances`** chunks with structured logging.

## Other changes

- Unit tests for scoring, selection, chunking, agent-data-api GET, and `run` integration.
- Updates to **analysis** and **knowledge-graph** dev-docs for canonical keys and selection rules.

## Key files to review

- `packages/shared/agent-data-api-contract/src/analysis.ts` — GET contract for `relevanceSelectionState`.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — UTC-day count and context load.
- `apps/mediapulse/agents/article-analysis/src/run.ts` — orchestration after mention POSTs.
- `apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.ts` — v1 breakdown and validation.
- `apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts` — min score, budget, tie-break.
- `apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.ts` — chunked POST bodies.

## How to test

1. From repo root: `pnpm code-quality` (passes).
2. Run article-analysis against agent-data-api with Hermes config for weights / `relevanceMinScore` / `maxSelectedRelevancePerTickerPerDay`; confirm relevance rows in DB and `articlesScored` / `articlesSelected` in responses match POSTed `selected` flags.
