### PR TITLE
Require verified GitHub issues before open-github-pr workflow

### DIFF
--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: open-github-pr
-description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and GitHub issue links (Closes/Fixes/Refs) so PRs connect to tickets. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (plus Related issues when applicable).
+description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and verified GitHub issue links (Closes/Fixes/Refs). Always resolve or create related issues before gh pr create so the PR can link to tickets. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (including Related issues).
 ---
 
 # Open GitHub Pull Request
 
-Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body. When work maps to GitHub issues, include **`## Related issues`** with `Closes`/`Fixes`/`Refs` (see **Link PRs to GitHub issues**) so the PR appears under each issue’s Development section.
+Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body. **Do not run `gh pr create` until at least one related GitHub issue exists, is open, and is verified** (see **Mandatory: resolve or create issues before the PR**). Then include **`## Related issues`** with `Closes`/`Fixes`/`Refs` so the PR appears under each issue’s Development section.
 
 ## When to use this skill
 
@@ -39,11 +39,32 @@ See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for stack o
 
 GitHub connects a PR to issues when the **body or commits** contain recognized references. PRs opened with this skill must **actively include** those references—otherwise the Development panel stays empty and nothing links “ticket → PR.”
 
-### Resolve issue numbers before drafting the body
+### Mandatory: resolve or create issues before the PR
 
-1. **From the work** — branch name (`…/mp-142-…`), ticket filename from `prd-to-tickets` / Linear export, or the user’s stated IDs.
-2. **From the repo** — `gh issue list --repo "<owner>/<repo>" --limit 20` (or search: `gh issue list --search "title text"`).
-3. **Same repo** — use `#123`. **Other repo** — use `owner/other-repo#123` or a full issue URL (GitHub still links and tracks development when the keyword is present).
+**Hard gate:** do not draft the final PR body or run `gh pr create` until every issue you will reference is **real, open, and verified** (`gh issue view`). If no suitable issue exists yet, **draft and create** it first, then verify.
+
+Run this **after** you have the same `<base>` used for `git diff <base>...HEAD` (so the issue description can reflect the actual change set).
+
+1. **Discover**
+   - **From the work** — branch name (`…/mp-142-…`), ticket filename from [`prd-to-tickets`](../prd-to-tickets/SKILL.md) / Linear export, or the user’s stated IDs.
+   - **From the repo** — `gh issue list --repo "<owner>/<repo>" --limit 20` (or search: `gh issue list --search "title text"`). Use the same `--repo` / host / account context as in the workflow’s first step.
+   - **Same repo** — you will use `#123` in the PR body. **Other repo** — use `owner/other-repo#123` or a full issue URL in **`## Related issues`** (only when the user explicitly tracks work there—see **Cross-repo / external tracking** below).
+
+2. **Select or create**
+   - If one or more issues clearly match: run `gh issue view <n|url> --repo "<owner>/<repo>" --json number,state,title,url` and require **`state` is `OPEN`**. If the issue is closed, stop and resolve with the user (reopen, new issue, or different ticket)—do not open a PR that only links to a closed issue unless they explicitly want that.
+   - If **no** suitable open issue exists in this repo (and the user did not point to external-repo-only tracking): **draft** an issue whose title aligns with the upcoming PR title intent and whose body includes short **context**, **scope**, and **acceptance** / expected outcome—grounded in `git diff <base>...HEAD` and the commit story, not an empty placeholder. Create with **`gh issue create --repo "<owner>/<repo>" -t "..." --body-file "$ISSUE_FILE"`**, where **`$ISSUE_FILE`** is from **`mktemp`** under the system temp dir only, with **`trap 'rm -f "$ISSUE_FILE"' EXIT`** (same rules as PR bodies—**never** write under the clone). Add **`-l name`** when team conventions or the user specify labels.
+
+3. **Capture number** — `gh issue create` prints the new issue URL. Resolve the number reliably:  
+   `ISSUE_NUM="$(gh issue view "<printed-url>" --repo "<owner>/<repo>" --json number -q .number)"`  
+   (or use the number from `gh issue view` after create). Use that `#N` in the PR body.
+
+4. **Verify before `gh pr create`** — For **each** issue you will reference, run `gh issue view` again (`number` or `url`) and confirm **`state` is `OPEN`** and the title still matches expectations. Only then proceed to draft the PR and **`gh pr create`**.
+
+### Cross-repo / external tracking
+
+If the user **explicitly** says work is tracked in **another** repository, **do not** auto-create a duplicate issue in the current repo. Put `owner/other-repo#N` or the full URL under **`## Related issues`** with the appropriate `Closes` / `Fixes` / `Refs` keywords, and still **verify** with `gh issue view <url>` (needs access to that repo). The **`## Related issues`** section remains mandatory; only the “create in this repo” step is skipped.
+
+If the user explicitly confirms **external-repo-only** tracking, the PR body must still contain the linking keywords—there is no PR without a verified link target.
 
 ### Keywords (pick intentionally)
 
@@ -57,10 +78,15 @@ Place keywords in **`## Related issues`** (recommended) or in **`## Summary`** s
 
 ### Stacked PRs + tickets
 
+- **Every stacked PR layer** must still satisfy **Mandatory: resolve or create issues before the PR** (verified open issue(s))—only the **`Refs` vs `Closes` / `Fixes`** choice changes by layer, not whether an issue exists first.
 - **One ticket, multiple PRs in a stack:** Use **`Refs #N`** on every layer that is not the last merge to the default branch; use **`Closes #N`** (or **`Fixes`**) only on the PR that should complete the ticket when merged (often the **top** of the stack once it targets `main`, or the single PR that delivers the remaining work—align with your team). If every layer used `Closes #N`, the issue could close too early when an intermediate PR merges.
 - **One ticket per PR in the stack:** Each PR body should **`Closes`** (or **`Fixes`**) **its** issue only.
 
 If unsure whether intermediate merges close issues in your org, prefer **`Refs`** until the final PR, then **`Closes`** there.
+
+### When issue creation fails
+
+`gh issue create` needs write access to the repo (and correct `gh auth switch` / token scopes). If creation fails, **do not** open the PR until the user fixes auth, creates the issue manually and supplies a number/URL, or grants access—then run **`gh issue view`** and continue from step 4 of the mandatory gate.
 
 ## PR body: prefer `--body-file`
 
@@ -94,7 +120,7 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
 4. **Publish**  
    `git push -u origin HEAD`
 
-5. **Open the PR** using **`--body-file`** (see above), with `--repo`, `--base`, and `--head` as needed.
+5. **Resolve or create related issues, then open the PR** — Run **Mandatory: resolve or create issues before the PR** (same `<base>` / `--repo` / auth as the main workflow). Then create the PR using **`--body-file`** with `--repo`, `--base`, and `--head` as needed.
 
 6. **Remove the worktree** (branch stays on `origin`; the PR remains open)  
    From the primary repo:  
@@ -121,24 +147,26 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
 4. Ensure the branch exists and is pushed:
    - If needed, create/switch to feature branch.
    - Push with upstream tracking: `git push -u origin HEAD`.
-5. Draft PR content using `/pr-title-description`:
+5. **Resolve or create related GitHub issue(s)** — Follow **Mandatory: resolve or create issues before the PR** (discover → select or create with `--body-file` + `mktemp` when creating → capture number → verify each issue is **OPEN**). Do not continue until you have stable issue number(s) or URL(s) for every line that will appear under **`## Related issues`**.
+6. Draft PR content using `/pr-title-description`:
    - Title: short, imperative, verb-first.
-   - **Resolve GitHub issue numbers** for this PR (see **Link PRs to GitHub issues** above). If the work came from tickets, the body must include `Refs`/`Closes`/`Fixes` lines so GitHub links the PR.
+   - **`## Related issues` is always mandatory.** Use `#N` for this repo, or `owner/repo#N` / full URLs when work is tracked elsewhere (**Cross-repo / external tracking**). Include `Refs`/`Closes`/`Fixes` per **Stacked PRs + tickets** so GitHub links the PR.
    - Description sections:
      - `## Summary`
-     - `## Related issues` (when any ticket/issue applies — include `Closes`/`Fixes`/`Refs` lines; omit the section only if there is truly no tracking issue)
+     - `## Related issues` — at least one verified line with `Closes`/`Fixes`/`Refs` (or cross-repo form).
      - `## Important changes`
      - `## Other changes`
      - `## Key files to review`
      - `## How to test`
-6. Create PR in one shot with a **body file** (no post-create edits for footer cleanup):
+7. Create PR in one shot with a **body file** (no post-create edits for footer cleanup):
    - Create a temp file with `mktemp` under the system temp directory only; use the template below (not a path inside the clone).
    - Write the full markdown to `$BODY_FILE`. Remove any accidental signature lines if they appear (for example lines matching `Made with [Cursor](https://cursor.com)` or `Made with Cursor`).
    - `gh pr create --repo "<owner>/<repo>" --title "..." --body-file "$BODY_FILE"`
    - Add `--base <base>` when the PR must not target the repo default (stacked branches). Add `--head <head>` if the head branch name is not inferred correctly (e.g. fork or multiple remotes).
-   - When verification (step 7) finishes in the same shell, exiting the shell runs the `trap` and deletes the file. If you run `gh` in separate tool invocations without a persistent shell, run `rm -f "$BODY_FILE"` after step 7.
+   - When verification (step 8) finishes in the same shell, exiting the shell runs the `trap` and deletes the file. If you run `gh` in separate tool invocations without a persistent shell, run `rm -f "$BODY_FILE"` after step 8.
 
 ```bash
+# Prerequisites: Steps 1–5 completed — related issues exist, are OPEN, and verified via gh issue view.
 # Set BASE to the parent branch for stacked PRs, or the repo default for the root of the stack.
 # Example (Git Town): BASE="$(git town config get-parent)"
 # Example (single PR off main): BASE="main"  # or output of gh repo view --json defaultBranchRef ...
@@ -181,22 +209,23 @@ gh pr create --repo "<owner>/<repo>" --base "$BASE" --title "Add concise verb-fi
 
 Set `BASE` before this command so it matches the three-dot range in step 3: **stacked PRs** → parent from `git town config get-parent` (or equivalent); **root of stack or single PR** → repo default branch name (same as `gh repo view --json defaultBranchRef`). Passing `--base "$BASE"` when `BASE` is the default branch is equivalent to omitting `--base` but keeps diff and PR creation in sync.
 
-7. Verify body after create (read-only check only):
+8. Verify body after create (read-only check only):
    - Fetch body: `gh pr view --repo "<owner>/<repo>" --json number,body --jq '.body'`
    - Confirm it does **not** contain `Made with [Cursor](https://cursor.com)` or `Made with Cursor`.
-   - If tickets apply, confirm the body still contains the intended `Closes`/`Fixes`/`Refs` lines (GitHub parses these from the merged body text).
+   - Confirm the body still contains the intended `Closes`/`Fixes`/`Refs` lines (GitHub parses these from the merged body text).
    - Do **not** run `gh pr edit` for footer cleanup; if cleanup is needed, close/recreate so final PR is not marked edited.
-8. Return the PR URL and a short test note (mention `<base>` → `<head>` if useful for reviewers).
+9. Return the PR URL and a short test note (mention `<base>` → `<head>` if useful for reviewers).
 
 ## Quality checklist
 
 - PR title starts with a verb and has no trailing period.
-- Description follows `/pr-title-description` sections, with **`## Related issues`** inserted after **Summary** when work is tracked in GitHub issues.
+- **Related issues:** Before `gh pr create`, every referenced issue was verified **OPEN** via `gh issue view`. If an issue was created in-session, it used **`gh issue create`** with **`--body-file`** and a **`mktemp`** path (plus `trap` cleanup), never a path inside the repo.
+- **No PR without a link target:** The PR body includes **`## Related issues`** with at least one `Closes`/`Fixes`/`Refs` line (`#N` same repo, or `owner/repo#N` / URL for external tracking after explicit exemption from creating a duplicate in this repo).
+- Description follows `/pr-title-description` sections, with **`## Related issues`** immediately after **Summary**.
 - Do not include any signature/footer such as `Made with Cursor` in the PR title or body.
 - Body is supplied via **`--body-file`** so automated footers are not injected into `--body`; the body file is created with **`mktemp`** under the system temp dir and **removed** (`trap` and/or explicit `rm`), never left as `.cursor/tmp-pr-body.md` (or any path inside the repo).
 - After creation, run a read-only body verification check (no `gh pr edit` footer cleanup).
 - High-risk behavior and reviewer-critical files are explicitly called out.
 - Test steps are concrete and include expected outcomes.
 - The command uses `--repo <owner>/<repo>` and a verified account context (`gh auth switch -h <host> -u <account>` + `gh api` access check).
-- **Stacked PRs:** `--base` matches the real parent branch (`git town config get-parent` or equivalent); `git diff <base>...HEAD` matches what GitHub will show.
-- **Tickets:** Body includes **`## Related issues`** with at least one `Closes`/`Fixes`/`Refs` line (or cross-repo `owner/repo#N`) when work is tracked in GitHub; stacked layers use `Refs` until the appropriate final PR uses `Closes`/`Fixes` so issues are not closed prematurely.
+- **Stacked PRs:** `--base` matches the real parent branch (`git town config get-parent` or equivalent); `git diff <base>...HEAD` matches what GitHub will show; each layer still has verified issue(s), using **`Refs`** until the appropriate final PR uses **`Closes`/`Fixes`** so issues are not closed prematurely.


### PR DESCRIPTION
## Summary

Updates the `open-github-pr` Cursor skill so agents **always** resolve or create related GitHub issues and verify they are **OPEN** before drafting the PR or running `gh pr create`. This keeps Development-panel linkage reliable and documents cross-repo, stacked-PR, and auth-failure behavior.

## Related issues

Closes #231

## Important changes

- New **Mandatory: resolve or create issues before the PR** gate (discover → select or create with `mktemp` + `--body-file` → capture number → verify).
- **Cross-repo / external tracking** and **When issue creation fails** guidance.
- Workflow renumbered (issue step after push); worktree flow updated; checklist expanded.

## Other changes

- Front matter description and intro updated to reflect the hard gate.

## Key files to review

- `.cursor/skills/open-github-pr/SKILL.md` — full workflow and checklist for PR + issue linkage.

## How to test

1. Read the skill end-to-end and confirm step order matches: auth/repo → base → diff/push → **issues** → PR body → `gh pr create`.
2. Optionally run `gh issue view 231` and confirm state remains `OPEN` until merge.
