### PR TITLE
Add article-analysis partial failure handling and structured POST errors

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -359,4 +359,87 @@ describe("applyAnalysisPost", () => {
       ),
     ).rejects.toThrow(AnalysisPostValidationError);
   });
+
+  it("upserts article relevance on repeat POST with the same keys (idempotent)", async () => {
+    const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const tx = {
+      dataSource: {
+        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
+      },
+      articleRelevance: { upsert: vi.fn() },
+    };
+    const db = {
+      dataSource: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      entityType: { findMany: vi.fn() },
+      relationType: { findMany: vi.fn() },
+      entity: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn(), count: vi.fn() },
+      $transaction: vi.fn((fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
+    };
+
+    const body = {
+      tickerId: "ticker-1",
+      entities: [],
+      relations: [],
+      articleEntities: [],
+      articleRelevances: [
+        {
+          dataSourceId: DS,
+          score: 0.5,
+          scoreBreakdown: {
+            breakingNews: 0.1,
+            kgRelation: 0.1,
+            fundamental: 0.1,
+            tickerSalience: 0.1,
+            sourceQuality: 0.1,
+            _version: 1,
+          },
+          selected: false,
+        },
+      ],
+    };
+
+    await applyAnalysisPost(body, { db: db as never });
+    await applyAnalysisPost(body, { db: db as never });
+
+    expect(tx.articleRelevance.upsert).toHaveBeenCalledTimes(2);
+    expect(tx.articleRelevance.upsert).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        where: {
+          dataSourceId_tickerId: {
+            dataSourceId: DS,
+            tickerId: "ticker-1",
+          },
+        },
+        create: expect.objectContaining({
+          dataSourceId: DS,
+          tickerId: "ticker-1",
+        }),
+        update: expect.objectContaining({
+          score: 0.5,
+          selected: false,
+        }),
+      }),
+    );
+    expect(tx.articleRelevance.upsert).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: {
+          dataSourceId_tickerId: {
+            dataSourceId: DS,
+            tickerId: "ticker-1",
+          },
+        },
+      }),
+    );
+  });
 });

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.test.ts
@@ -1,0 +1,148 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  executeAnalysisCreateWithTransientRetries,
+  isTransientAgentDataApiHttpStatus,
+  parseAgentDataApiHttpStatus,
+  toArticleAnalysisPostFailureRecord,
+} from "./article-analysis-agent-data-api-post.js";
+
+describe("parseAgentDataApiHttpStatus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns status from agent-data-api client error messages", () => {
+    expect(
+      parseAgentDataApiHttpStatus(new Error("Agent data API error: 503")),
+    ).toBe(503);
+  });
+
+  it("returns undefined for unrelated errors", () => {
+    expect(parseAgentDataApiHttpStatus(new Error("boom"))).toBeUndefined();
+    expect(parseAgentDataApiHttpStatus(null)).toBeUndefined();
+  });
+});
+
+describe("isTransientAgentDataApiHttpStatus", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("treats 429 and 5xx as transient", () => {
+    expect(isTransientAgentDataApiHttpStatus(429)).toBe(true);
+    expect(isTransientAgentDataApiHttpStatus(500)).toBe(true);
+    expect(isTransientAgentDataApiHttpStatus(503)).toBe(true);
+  });
+
+  it("treats missing or 4xx (except 429) as non-transient", () => {
+    expect(isTransientAgentDataApiHttpStatus(undefined)).toBe(false);
+    expect(isTransientAgentDataApiHttpStatus(400)).toBe(false);
+    expect(isTransientAgentDataApiHttpStatus(404)).toBe(false);
+  });
+});
+
+describe("toArticleAnalysisPostFailureRecord", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("classifies HTTP-shaped errors", () => {
+    const rec = toArticleAnalysisPostFailureRecord(
+      "entities_relations",
+      2,
+      new Error("Agent data API error: 502"),
+    );
+    expect(rec).toMatchObject({
+      chunkKind: "entities_relations",
+      chunkIndex: 2,
+      errorCategory: "agent_data_api_http",
+      httpStatus: 502,
+      message: "Agent data API error: 502",
+    });
+  });
+
+  it("classifies unknown errors", () => {
+    const rec = toArticleAnalysisPostFailureRecord(
+      "article_entities",
+      0,
+      new Error("network reset"),
+    );
+    expect(rec).toMatchObject({
+      chunkKind: "article_entities",
+      chunkIndex: 0,
+      errorCategory: "unknown",
+      message: "network reset",
+    });
+    expect(rec).not.toHaveProperty("httpStatus");
+  });
+});
+
+describe("executeAnalysisCreateWithTransientRetries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the result when the first attempt succeeds", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      executeAnalysisCreateWithTransientRetries(op, {
+        maxRetries: 2,
+        baseDelayMs: 10,
+        sleep,
+      }),
+    ).resolves.toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("retries on transient error then succeeds", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Agent data API error: 503"))
+      .mockResolvedValueOnce("recovered");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      executeAnalysisCreateWithTransientRetries(op, {
+        maxRetries: 2,
+        baseDelayMs: 10,
+        sleep,
+      }),
+    ).resolves.toBe("recovered");
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(10);
+  });
+
+  it("does not retry non-transient errors", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValue(new Error("Agent data API error: 400"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      executeAnalysisCreateWithTransientRetries(op, {
+        maxRetries: 2,
+        baseDelayMs: 10,
+        sleep,
+      }),
+    ).rejects.toThrow("Agent data API error: 400");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("throws after exhausting retries", async () => {
+    const err = new Error("Agent data API error: 503");
+    const op = vi.fn().mockRejectedValue(err);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    await expect(
+      executeAnalysisCreateWithTransientRetries(op, {
+        maxRetries: 1,
+        baseDelayMs: 5,
+        sleep,
+      }),
+    ).rejects.toBe(err);
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(5);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.ts
@@ -1,0 +1,106 @@
+import type {
+  ArticleAnalysisPostChunkKind,
+  ArticleAnalysisPostFailureRecord,
+} from "./article-analysis-run-policy.js";
+
+const agentDataApiErrorPattern = /^Agent data API error: (\d+)$/;
+
+/**
+ * Parses HTTP status from {@link createAgentDataApiClient} POST errors, when present.
+ *
+ * @param error - Thrown value from `analysis.create`.
+ * @returns Status code, or `undefined` if not an HTTP error message from the client.
+ */
+export const parseAgentDataApiHttpStatus = (
+  error: unknown,
+): number | undefined => {
+  if (!(error instanceof Error)) {
+    return undefined;
+  }
+  const match = agentDataApiErrorPattern.exec(error.message);
+  if (!match) {
+    return undefined;
+  }
+  return Number(match[1]);
+};
+
+/**
+ * Returns true when a failed request may succeed on retry (429 or 5xx).
+ *
+ * @param status - Parsed HTTP status, if any.
+ * @returns Whether the client may retry the same payload.
+ */
+export const isTransientAgentDataApiHttpStatus = (
+  status: number | undefined,
+): boolean => {
+  if (status === undefined) {
+    return false;
+  }
+  if (status === 429) {
+    return true;
+  }
+  return status >= 500 && status <= 599;
+};
+
+/**
+ * Builds a structured POST failure record without logging article bodies or secrets.
+ *
+ * @param chunkKind - POST phase.
+ * @param chunkIndex - Index within that phase’s loop.
+ * @param error - Thrown error from `analysis.create`.
+ * @returns Serializable failure row for `details.postFailures`.
+ */
+export const toArticleAnalysisPostFailureRecord = (
+  chunkKind: ArticleAnalysisPostChunkKind,
+  chunkIndex: number,
+  error: unknown,
+): ArticleAnalysisPostFailureRecord => {
+  const httpStatus = parseAgentDataApiHttpStatus(error);
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    chunkKind,
+    chunkIndex,
+    errorCategory: httpStatus !== undefined ? "agent_data_api_http" : "unknown",
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    message,
+  };
+};
+
+export type TransientRetryDeps = {
+  /** Number of retries after the first attempt (0 = no retries). */
+  maxRetries: number;
+  /** Initial backoff; delay doubles each retry (`base * 2^attempt`). */
+  baseDelayMs: number;
+  /** Injectable sleep for tests. */
+  sleep: (ms: number) => Promise<void>;
+};
+
+/**
+ * Runs an async POST operation, retrying only on transient HTTP statuses from the agent-data-api client.
+ *
+ * @param operation - Typically `() => dataApiClient.analysis.create(body)`.
+ * @param deps - Retry limits and sleep injection.
+ * @returns The fulfilled result from `operation`.
+ * @throws The last error when non-transient or retries are exhausted.
+ */
+export const executeAnalysisCreateWithTransientRetries = async <T>(
+  operation: () => Promise<T>,
+  deps: TransientRetryDeps,
+): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= deps.maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (e) {
+      lastError = e;
+      const status = parseAgentDataApiHttpStatus(e);
+      const mayRetry =
+        attempt < deps.maxRetries && isTransientAgentDataApiHttpStatus(status);
+      if (!mayRetry) {
+        throw e;
+      }
+      await deps.sleep(deps.baseDelayMs * 2 ** attempt);
+    }
+  }
+  throw lastError;
+};

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.test.ts
@@ -1,0 +1,80 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  deriveArticleAnalysisRunStatusLabel,
+  isArticleAnalysisExtractionPolicyFailure,
+} from "./article-analysis-run-policy.js";
+
+describe("isArticleAnalysisExtractionPolicyFailure", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns false when failOnZeroSuccess is false", () => {
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(0, {
+        minSuccessfulSources: 1,
+        failOnZeroSuccess: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when successes are below minimum and failOnZeroSuccess is true", () => {
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(0, {
+        minSuccessfulSources: 1,
+        failOnZeroSuccess: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(1, {
+        minSuccessfulSources: 2,
+        failOnZeroSuccess: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when successes meet or exceed minimum", () => {
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(1, {
+        minSuccessfulSources: 1,
+        failOnZeroSuccess: true,
+      }),
+    ).toBe(false);
+
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(2, {
+        minSuccessfulSources: 1,
+        failOnZeroSuccess: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when minimum is zero even if no successes", () => {
+    expect(
+      isArticleAnalysisExtractionPolicyFailure(0, {
+        minSuccessfulSources: 0,
+        failOnZeroSuccess: true,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("deriveArticleAnalysisRunStatusLabel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns success when there are no failures", () => {
+    expect(deriveArticleAnalysisRunStatusLabel(0, 0)).toBe("success");
+  });
+
+  it("returns partial_success when there were extraction failures", () => {
+    expect(deriveArticleAnalysisRunStatusLabel(1, 0)).toBe("partial_success");
+  });
+
+  it("returns partial_success when there were POST failures", () => {
+    expect(deriveArticleAnalysisRunStatusLabel(0, 1)).toBe("partial_success");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
@@ -1,0 +1,66 @@
+/**
+ * Run policy, per-source extraction failures, and POST failure records for article-analysis (MP-ART-ANALYSIS-007, #217).
+ */
+
+/** Stage at which per-source extraction stopped. */
+export type ArticleAnalysisExtractionFailureStage = "llm" | "vocabulary";
+
+/** One source that did not contribute to the merged extraction payload. */
+export type ArticleAnalysisExtractionFailureRecord = {
+  dataSourceId: string;
+  stage: ArticleAnalysisExtractionFailureStage;
+  message: string;
+};
+
+/** POST phase labels aligned with `run.ts` logging. */
+export type ArticleAnalysisPostChunkKind =
+  | "entities_relations"
+  | "article_entities"
+  | "article_relevances";
+
+/** One failed `analysis.create` chunk (FR7 diagnostics). */
+export type ArticleAnalysisPostFailureRecord = {
+  chunkKind: ArticleAnalysisPostChunkKind;
+  chunkIndex: number;
+  errorCategory: "agent_data_api_http" | "unknown";
+  httpStatus?: number;
+  message: string;
+};
+
+/** Hermes-configurable policy mirroring data-collection `runPolicy` semantics. */
+export type ArticleAnalysisRunPolicy = {
+  minSuccessfulSources: number;
+  failOnZeroSuccess: boolean;
+};
+
+/** Outcome label for Hermes / observability when some work failed but the run is semantically OK. */
+export type ArticleAnalysisRunStatusLabel = "success" | "partial_success";
+
+/**
+ * Whether the run must fail before POST because too few sources produced a successful extraction.
+ *
+ * @param extractionSuccessCount - Sources that passed LLM + vocabulary for this batch.
+ * @param policy - Resolved Hermes run policy.
+ * @returns True when the run should return `success: false` (semantic failure).
+ */
+export const isArticleAnalysisExtractionPolicyFailure = (
+  extractionSuccessCount: number,
+  policy: ArticleAnalysisRunPolicy,
+): boolean =>
+  policy.failOnZeroSuccess &&
+  extractionSuccessCount < policy.minSuccessfulSources;
+
+/**
+ * Derives HTTP 200 envelope run status from extraction and POST failure counts.
+ *
+ * @param extractionFailureCount - Number of per-source extraction failures recorded.
+ * @param postFailureCount - Number of failed `analysis.create` calls.
+ * @returns `partial_success` if any failure was recorded; otherwise `success`.
+ */
+export const deriveArticleAnalysisRunStatusLabel = (
+  extractionFailureCount: number,
+  postFailureCount: number,
+): ArticleAnalysisRunStatusLabel =>
+  extractionFailureCount > 0 || postFailureCount > 0
+    ? "partial_success"
+    : "success";

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,5 +1,11 @@
 import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
+import type { ArticleAnalysisRunPolicy } from "./article-analysis-run-policy.js";
 import { z } from "zod";
+
+const articleAnalysisRunPolicySchema = z.object({
+  minSuccessfulSources: z.number().int().nonnegative().optional(),
+  failOnZeroSuccess: z.boolean().optional(),
+});
 
 /**
  * Hermes agent config for article-analysis (extraction, caps, chunking).
@@ -44,6 +50,17 @@ export const articleAnalysisConfigSchema = z.object({
     .optional(),
   /** Max `articleRelevances` rows per POST chunk. */
   postChunkArticleRelevanceBatchSize: z.number().int().positive().optional(),
+  /**
+   * When `failOnZeroSuccess` is true, require at least this many sources to complete extraction
+   * (LLM + vocabulary) before POST (MP-ART-ANALYSIS-007).
+   */
+  runPolicy: articleAnalysisRunPolicySchema.optional(),
+  /**
+   * Retries after the first attempt for `analysis.create` when the API returns 429 or 5xx.
+   */
+  postTransientRetries: z.number().int().nonnegative().optional(),
+  /** Initial backoff in ms; delay doubles each retry (`base * 2^attempt`). */
+  postTransientRetryBaseDelayMs: z.number().int().positive().optional(),
 });
 
 export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
@@ -70,6 +87,9 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   relevanceMinScore: number;
   maxSelectedRelevancePerTickerPerDay: number;
   postChunkArticleRelevanceBatchSize: number;
+  runPolicy: ArticleAnalysisRunPolicy;
+  postTransientRetries: number;
+  postTransientRetryBaseDelayMs: number;
 };
 
 /** Production-oriented defaults merged onto parsed Hermes config. */
@@ -94,6 +114,12 @@ export const articleAnalysisConfigDefaults = {
   relevanceMinScore: 0.35,
   maxSelectedRelevancePerTickerPerDay: 10,
   postChunkArticleRelevanceBatchSize: 40,
+  runPolicy: {
+    minSuccessfulSources: 1,
+    failOnZeroSuccess: true,
+  },
+  postTransientRetries: 0,
+  postTransientRetryBaseDelayMs: 500,
 } as const;
 
 /**
@@ -164,6 +190,20 @@ export const resolveArticleAnalysisConfig = (
     postChunkArticleRelevanceBatchSize:
       config.postChunkArticleRelevanceBatchSize ??
       articleAnalysisConfigDefaults.postChunkArticleRelevanceBatchSize,
+    runPolicy: {
+      minSuccessfulSources:
+        config.runPolicy?.minSuccessfulSources ??
+        articleAnalysisConfigDefaults.runPolicy.minSuccessfulSources,
+      failOnZeroSuccess:
+        config.runPolicy?.failOnZeroSuccess ??
+        articleAnalysisConfigDefaults.runPolicy.failOnZeroSuccess,
+    },
+    postTransientRetries:
+      config.postTransientRetries ??
+      articleAnalysisConfigDefaults.postTransientRetries,
+    postTransientRetryBaseDelayMs:
+      config.postTransientRetryBaseDelayMs ??
+      articleAnalysisConfigDefaults.postTransientRetryBaseDelayMs,
   };
 };
 

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -22,7 +22,7 @@ const app = createAgentApp<
     agentId: "article-analysis",
     agentVersion: "1.0.0",
     description:
-      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api.",
+      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api. Supports configurable runPolicy for partial extraction failure, per-chunk POST error isolation with optional transient retries, and structured diagnostics (MP-ART-ANALYSIS-007).",
     inputSchema: articleAnalysisInputSchema,
     configSchema: articleAnalysisConfigSchema,
     run,

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -245,6 +245,14 @@ describe("run", () => {
       articlesSelected: 1,
       relevancePostChunks: 1,
     });
+    expect(
+      (result.details as { extractionFailures?: { stage: string }[] })
+        .extractionFailures,
+    ).toHaveLength(1);
+    expect(
+      (result.details as { extractionFailures?: { stage: string }[] })
+        .extractionFailures?.[0]?.stage,
+    ).toBe("vocabulary");
     expect(analysisCreate).toHaveBeenCalledTimes(2);
   });
 
@@ -626,6 +634,189 @@ describe("run", () => {
         (relation: { fromEntityName: string }) => relation.fromEntityName,
       ),
     ).toContain("Alpha Incorporated");
+  });
+
+  it("continues after vocabulary failure on one source when another succeeds (partial_success)", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u1",
+          title: "T1",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+        {
+          id: DS_ID_2,
+          url: "u2",
+          title: "T2",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    let extractCall = 0;
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockImplementation(
+      async () => {
+        extractCall += 1;
+        if (extractCall === 1) {
+          return {
+            entities: [
+              {
+                canonicalName: "Bad",
+                typeId: "99999999-9999-4999-a999-999999999999",
+                aliases: [],
+              },
+            ],
+            relations: [],
+            articleMentions: [],
+          };
+        }
+        return {
+          entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+          relations: [],
+          articleMentions: [],
+        };
+      },
+    );
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 0,
+      });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(true);
+    expect(result.details?.runStatus).toBe("partial_success");
+    expect(result.details?.extractionFailures).toHaveLength(1);
+    expect(
+      (result.details?.extractionFailures as { stage: string }[])[0]?.stage,
+    ).toBe("vocabulary");
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops POST phases after ER chunk failure and records postFailures", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [
+        { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
+      ],
+      relations: [
+        { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
+        { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
+      ],
+      articleMentions: [],
+    });
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 1,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockRejectedValueOnce(new Error("Agent data API error: 500"));
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { postChunkRelationBatchSize: 1 },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.details?.runStatus).toBe("partial_success");
+    expect(result.details?.postFailures).toHaveLength(1);
+    expect(
+      (result.details?.postFailures as { chunkKind: string }[])[0]?.chunkKind,
+    ).toBe("entities_relations");
+    expect(analysisCreate).toHaveBeenCalledTimes(2);
+    expect(result.details?.postChunks).toBe(1);
+    expect(result.details?.relevancePostChunks).toBe(0);
+    expect(result.details?.mentionPostChunks).toBe(0);
+  });
+
+  it("fails run when extraction successes are below runPolicy minimum", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+        {
+          id: DS_ID_2,
+          url: "u2",
+          title: "T2",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
+      entities: [
+        {
+          canonicalName: "Bad",
+          typeId: "99999999-9999-4999-a999-999999999999",
+          aliases: [],
+        },
+      ],
+      relations: [],
+      articleMentions: [],
+    });
+
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain("run policy");
+    expect(analysisCreate).not.toHaveBeenCalled();
   });
 
   it("logs verbose start", async () => {

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -33,6 +33,16 @@ import {
   type EntityProposal,
   type RelationProposal,
 } from "./analysis-vocabulary.js";
+import {
+  executeAnalysisCreateWithTransientRetries,
+  toArticleAnalysisPostFailureRecord,
+} from "./article-analysis-agent-data-api-post.js";
+import {
+  deriveArticleAnalysisRunStatusLabel,
+  isArticleAnalysisExtractionPolicyFailure,
+  type ArticleAnalysisExtractionFailureRecord,
+  type ArticleAnalysisPostFailureRecord,
+} from "./article-analysis-run-policy.js";
 import { buildAnalysisPostChunks } from "./build-analysis-post-chunks.js";
 import {
   resolveArticleAnalysisConfig,
@@ -147,12 +157,19 @@ const resolveAgainstExistingEntities = (
   };
 };
 
+const sleepMs = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 /**
  * Runs analysis: GET context, optional batch cap, LLM extraction per source,
- * vocabulary validation, canonicalization against existing entities, caps,
- * chunked POST of entities/relations, then chunked POST of `articleEntities` (after ER commits),
- * then chunked `articleRelevances` with canonical `scoreBreakdown`, weighted `score`, and
- * configurable `selected` (UTC-day budget from GET).
+ * vocabulary validation, caps, chunked POST of entities/relations, then chunked POST of
+ * `articleEntities` (after ER commits), then chunked `articleRelevances` with canonical
+ * `scoreBreakdown`, weighted `score`, and configurable `selected` (UTC-day budget from GET).
+ *
+ * Partial failure (MP-ART-ANALYSIS-007): optional `runPolicy` rejects the run when too few
+ * sources extract successfully; vocabulary/LLM failures per source are recorded and skipped;
+ * POST failures stop later phases and only API-confirmed counts are aggregated.
+ * Successful extractions are canonicalized against existing KG entities (mainline behavior).
  *
  * @param context - Hermes input/config and bearer token.
  * @returns Aggregated success with POST tallies or structured failure.
@@ -201,6 +218,11 @@ export const run = async ({
           dataSourcesReturned: ctx.dataSources.length,
           dataSourcesSelected: 0,
           reanalyze,
+          runStatus: "success" as const,
+          extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
+          extractionSuccessCount: 0,
+          postFailures: [] as ArticleAnalysisPostFailureRecord[],
+          vocabularyFailures: 0,
           entitiesCreated: 0,
           entitiesReused: 0,
           relationsCreated: 0,
@@ -232,7 +254,7 @@ export const run = async ({
     const systemContent = buildExtractionSystemContent(ctx);
     const existingLookup = buildExistingEntityLookup(ctx.existingEntities);
 
-    let llmFailures = 0;
+    const extractionFailures: ArticleAnalysisExtractionFailureRecord[] = [];
     let vocabularyFailures = 0;
     const mergedEntities: EntityProposal[] = [];
     const mergedRelations: RelationProposal[] = [];
@@ -270,13 +292,18 @@ export const run = async ({
         );
         if (!vocab.ok) {
           vocabularyFailures += 1;
+          extractionFailures.push({
+            dataSourceId: source.id,
+            stage: "vocabulary",
+            message: vocab.message,
+          });
           logger.warn(
             {
               tickerId: input.tickerId,
               dataSourceId: source.id,
-              validationMessage: vocab.message,
+              stage: "vocabulary",
             },
-            "article-analysis skipped source due to vocabulary mismatch",
+            "article-analysis vocabulary validation failed for source; skipping",
           );
           continue;
         }
@@ -327,12 +354,48 @@ export const run = async ({
           textLower: truncated.toLowerCase(),
         });
       } catch (err) {
-        llmFailures += 1;
+        const message = err instanceof Error ? err.message : String(err);
+        extractionFailures.push({
+          dataSourceId: source.id,
+          stage: "llm",
+          message,
+        });
         logger.warn(
-          { err, dataSourceId: source.id, tickerId: input.tickerId },
+          {
+            tickerId: input.tickerId,
+            dataSourceId: source.id,
+            stage: "llm",
+            message,
+          },
           "article-analysis LLM extraction failed for source; skipping",
         );
       }
+    }
+
+    const extractionSuccessCount = perSourceSignals.length;
+
+    if (
+      isArticleAnalysisExtractionPolicyFailure(
+        extractionSuccessCount,
+        cfg.runPolicy,
+      )
+    ) {
+      return {
+        success: false,
+        message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.runPolicy.minSuccessfulSources}.`,
+        details: {
+          extractionFailures,
+          extractionSuccessCount,
+          runPolicy: cfg.runPolicy,
+          vocabularyFailures,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
+          postFailures: [] as ArticleAnalysisPostFailureRecord[],
+          dataSourcesProcessed: batch.length,
+          reanalyze,
+        },
+      };
     }
 
     let entities = dedupeEntities(mergedEntities);
@@ -346,17 +409,29 @@ export const run = async ({
     entities = runCapped.entities;
     relations = runCapped.relations;
 
+    const llmFailureCount = extractionFailures.filter(
+      (f) => f.stage === "llm",
+    ).length;
+
     if (entities.length === 0 && relations.length === 0) {
+      const postFailures: ArticleAnalysisPostFailureRecord[] = [];
       return {
         success: true,
         message:
-          llmFailures > 0
-            ? `no extraction produced (${llmFailures} source(s) failed LLM; check logs)`
+          llmFailureCount > 0 || extractionFailures.length > 0
+            ? `no extraction produced (${extractionFailures.length} source(s) failed extraction; check logs)`
             : "extraction produced no entities or relations",
         details: {
           dataSourcesProcessed: batch.length,
-          llmFailures,
+          extractionFailures,
+          extractionSuccessCount,
+          postFailures,
+          llmFailures: llmFailureCount,
           vocabularyFailures,
+          runStatus: deriveArticleAnalysisRunStatusLabel(
+            extractionFailures.length,
+            postFailures.length,
+          ),
           entitiesCreated: 0,
           entitiesReused: 0,
           relationsCreated: 0,
@@ -414,6 +489,7 @@ export const run = async ({
     }
 
     if (chunks.length === 0) {
+      const postFailures: ArticleAnalysisPostFailureRecord[] = [];
       return {
         success: true,
         message:
@@ -423,8 +499,15 @@ export const run = async ({
           relationCountAfterCaps: relations.length,
           droppedRelations,
           parseErrors: parseErrors.slice(0, 20),
-          llmFailures,
+          extractionFailures,
+          extractionSuccessCount,
+          postFailures,
+          llmFailures: llmFailureCount,
           vocabularyFailures,
+          runStatus: deriveArticleAnalysisRunStatusLabel(
+            extractionFailures.length,
+            postFailures.length,
+          ),
           articleEntityRowsPosted: 0,
           mentionPostChunks: 0,
           droppedArticleMentionsNotInRunCatalog,
@@ -436,9 +519,12 @@ export const run = async ({
       };
     }
 
+    const postFailures: ArticleAnalysisPostFailureRecord[] = [];
     let entitiesCreated = 0;
     let entitiesReused = 0;
     let relationsCreated = 0;
+    let erPostChunksCompleted = 0;
+    let erPhaseFailed = false;
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]!;
@@ -453,55 +539,108 @@ export const run = async ({
         },
         "article-analysis posting chunk",
       );
-      const res = await dataApiClient.analysis.create(chunk);
-      entitiesCreated += res.entitiesCreated;
-      entitiesReused += res.entitiesReused;
-      relationsCreated += res.relationsCreated;
+      try {
+        const res = await executeAnalysisCreateWithTransientRetries(
+          () => dataApiClient.analysis.create(chunk),
+          {
+            maxRetries: cfg.postTransientRetries,
+            baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+            sleep: sleepMs,
+          },
+        );
+        entitiesCreated += res.entitiesCreated;
+        entitiesReused += res.entitiesReused;
+        relationsCreated += res.relationsCreated;
+        erPostChunksCompleted += 1;
+      } catch (err) {
+        postFailures.push(
+          toArticleAnalysisPostFailureRecord("entities_relations", i, err),
+        );
+        logger.warn(
+          {
+            tickerId: input.tickerId,
+            chunkKind: "entities_relations",
+            chunkIndex: i,
+            err,
+          },
+          "article-analysis entities/relations POST failed; aborting remaining POST phases",
+        );
+        erPhaseFailed = true;
+        break;
+      }
     }
 
     let articleEntityRowsPosted = 0;
-    let mentionPostChunks = 0;
-    const {
-      chunks: articleEntityChunks,
-      parseErrors: articleEntityParseErrors,
-    } = buildArticleEntityPostChunks(
-      input.tickerId,
-      articleEntitiesForPost,
-      cfg.postChunkArticleEntityBatchSize,
-    );
+    let mentionPostChunksCompleted = 0;
+    let mentionPhaseFailed = false;
+    let articleEntityParseErrors: string[] = [];
 
-    if (articleEntityParseErrors.length > 0) {
-      logger.warn(
-        {
-          tickerId: input.tickerId,
-          parseErrorSample: articleEntityParseErrors.slice(0, 10),
-        },
-        "article-analysis articleEntity chunk build reported parse issues",
-      );
-    }
+    if (!erPhaseFailed) {
+      const { chunks: articleEntityChunks, parseErrors } =
+        buildArticleEntityPostChunks(
+          input.tickerId,
+          articleEntitiesForPost,
+          cfg.postChunkArticleEntityBatchSize,
+        );
+      articleEntityParseErrors = parseErrors;
 
-    for (let j = 0; j < articleEntityChunks.length; j++) {
-      const mentionChunk = articleEntityChunks[j]!;
-      logger.info(
-        {
-          tickerId: input.tickerId,
-          chunkKind: "article_entities",
-          chunkIndex: j,
-          chunkArticleEntities: mentionChunk.articleEntities.length,
-          model: cfg.openaiModel,
-        },
-        "article-analysis posting chunk",
-      );
-      await dataApiClient.analysis.create(mentionChunk);
-      articleEntityRowsPosted += mentionChunk.articleEntities.length;
+      if (articleEntityParseErrors.length > 0) {
+        logger.warn(
+          {
+            tickerId: input.tickerId,
+            parseErrorSample: articleEntityParseErrors.slice(0, 10),
+          },
+          "article-analysis articleEntity chunk build reported parse issues",
+        );
+      }
+
+      for (let j = 0; j < articleEntityChunks.length; j++) {
+        const mentionChunk = articleEntityChunks[j]!;
+        logger.info(
+          {
+            tickerId: input.tickerId,
+            chunkKind: "article_entities",
+            chunkIndex: j,
+            chunkArticleEntities: mentionChunk.articleEntities.length,
+            model: cfg.openaiModel,
+          },
+          "article-analysis posting chunk",
+        );
+        try {
+          await executeAnalysisCreateWithTransientRetries(
+            () => dataApiClient.analysis.create(mentionChunk),
+            {
+              maxRetries: cfg.postTransientRetries,
+              baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+              sleep: sleepMs,
+            },
+          );
+          articleEntityRowsPosted += mentionChunk.articleEntities.length;
+          mentionPostChunksCompleted += 1;
+        } catch (err) {
+          postFailures.push(
+            toArticleAnalysisPostFailureRecord("article_entities", j, err),
+          );
+          logger.warn(
+            {
+              tickerId: input.tickerId,
+              chunkKind: "article_entities",
+              chunkIndex: j,
+              err,
+            },
+            "article-analysis articleEntities POST failed; aborting relevance phase",
+          );
+          mentionPhaseFailed = true;
+          break;
+        }
+      }
     }
-    mentionPostChunks = articleEntityChunks.length;
 
     let articlesScoredTotal = 0;
     let articlesSelectedTotal = 0;
-    let relevancePostChunks = 0;
+    let relevancePostChunksCompleted = 0;
 
-    if (perSourceSignals.length > 0) {
+    if (!erPhaseFailed && !mentionPhaseFailed && perSourceSignals.length > 0) {
       const weightMap = toRelevanceWeightMapV1(cfg);
       const relevanceDrafts = perSourceSignals.map((sig) =>
         buildDraftRelevanceRow(sig, cfg.scoreBreakdownVersion, weightMap),
@@ -583,36 +722,68 @@ export const run = async ({
           },
           "article-analysis posting chunk",
         );
-        const relRes = await dataApiClient.analysis.create(relChunk);
-        articlesScoredTotal += relRes.articlesScored;
-        articlesSelectedTotal += relRes.articlesSelected;
+        try {
+          const relRes = await executeAnalysisCreateWithTransientRetries(
+            () => dataApiClient.analysis.create(relChunk),
+            {
+              maxRetries: cfg.postTransientRetries,
+              baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+              sleep: sleepMs,
+            },
+          );
+          articlesScoredTotal += relRes.articlesScored;
+          articlesSelectedTotal += relRes.articlesSelected;
+          relevancePostChunksCompleted += 1;
+        } catch (err) {
+          postFailures.push(
+            toArticleAnalysisPostFailureRecord("article_relevances", k, err),
+          );
+          logger.warn(
+            {
+              tickerId: input.tickerId,
+              chunkKind: "article_relevances",
+              chunkIndex: k,
+              err,
+            },
+            "article-analysis articleRelevances POST failed",
+          );
+          break;
+        }
       }
-      relevancePostChunks = relevanceChunks.length;
     }
+
+    const runStatus = deriveArticleAnalysisRunStatusLabel(
+      extractionFailures.length,
+      postFailures.length,
+    );
 
     return {
       success: true,
-      message: `analysis complete: ${chunks.length} ER chunk(s), ${mentionPostChunks} articleEntity chunk(s), ${relevancePostChunks} relevance chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted} articlesScored=${articlesScoredTotal} articlesSelected=${articlesSelectedTotal}`,
+      message: `complete (${runStatus}): ${erPostChunksCompleted}/${chunks.length} ER chunk(s), ${mentionPostChunksCompleted} articleEntity chunk(s), ${relevancePostChunksCompleted} relevance chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted} articlesScored=${articlesScoredTotal} articlesSelected=${articlesSelectedTotal}`,
       details: {
         dataSourcesProcessed: batch.length,
         dataSourcesReturned: ctx.dataSources.length,
-        postChunks: chunks.length,
+        extractionFailures,
+        extractionSuccessCount,
+        postFailures,
+        llmFailures: llmFailureCount,
+        vocabularyFailures,
+        runStatus,
+        postChunks: erPostChunksCompleted,
         entitiesCreated,
         entitiesReused,
         relationsCreated,
         articleEntityRowsPosted,
-        mentionPostChunks,
+        mentionPostChunks: mentionPostChunksCompleted,
         droppedArticleMentionsNotInRunCatalog,
         articlesScored: articlesScoredTotal,
         articlesSelected: articlesSelectedTotal,
-        relevancePostChunks,
+        relevancePostChunks: relevancePostChunksCompleted,
         relevanceSelectionBudgetRemaining: Math.max(
           0,
           cfg.maxSelectedRelevancePerTickerPerDay -
             ctx.relevanceSelectionState.selectedCountToday,
         ),
-        llmFailures,
-        vocabularyFailures,
         droppedRelations,
         articleEntityParseErrors: articleEntityParseErrors.slice(0, 20),
         reanalyze,

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -31,6 +31,28 @@ Optional additional numeric keys may appear for experiments. **Weighted `score`*
 
 **Selection:** `GET /api/v1/analysis` includes `relevanceSelectionState` (`utcDayStartIso`, `selectedCountToday`) so the agent can enforce **max additional `selected` rows per UTC day** after applying **`relevanceMinScore`**. Tie-break: higher `score`, then newer article `createdAt`.
 
+## Partial failure, POST phases, and diagnostics (MP-ART-ANALYSIS-007, [#217](https://github.com/hyperjumptech/mediapulse/issues/217))
+
+Hermes config **`runPolicy`** mirrors data-collection semantics:
+
+| Field | Default | Meaning |
+| ----- | ------- | ------- |
+| `minSuccessfulSources` | `1` | Minimum sources that must complete LLM + vocabulary validation before any `POST` |
+| `failOnZeroSuccess` | `true` | When true, the run returns **`success: false`** if fewer than `minSuccessfulSources` extract successfully |
+
+Per-source **LLM** or **vocabulary** errors are **skipped** (no whole-run abort); the response includes **`extractionFailures`** (`dataSourceId`, `stage`, `message`) and **`extractionSuccessCount`**. If some sources succeed, the run can continue with **`details.runStatus`: `partial_success`**.
+
+**`analysis.create` (POST) phases** run in order: **entities/relations** chunks → **articleEntities** → **articleRelevances**. If any chunk in a phase throws, **remaining chunks in that phase are skipped** and **later phases are not started** (avoids inconsistent KG + relevance). Only **API-confirmed** tallies are aggregated. Failures are listed in **`postFailures`** (`chunkKind`, `chunkIndex`, `errorCategory`, optional `httpStatus`, `message`).
+
+**Retries:** `postTransientRetries` (default `0`) and `postTransientRetryBaseDelayMs` (default `500`) retry the same chunk on **429** or **5xx** from agent-data-api, with exponential backoff (`base * 2^attempt`).
+
+## Idempotency and incremental runs
+
+- **`unanalyzed=true` (default on GET):** `loadAnalysisContext` returns only data sources that do **not** yet have an **`article_relevance`** row for the ticker—routine re-runs skip already-scored articles.
+- **Reanalyze** with bounds uses the same `POST` handler; **`article_entity`** and **`article_relevance`** are **upserted** on stable keys (`data_source_id` + `entity_id`, and `data_source_id` + `ticker_id`), so repeat POSTs update rows instead of creating duplicates.
+
+Structured logs use **`tickerId`**, **`dataSourceId`**, and chunk indices—**not** full article bodies or secrets.
+
 ## I/O contract
 
 - **Input:** `{ tickerId: string }`

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -169,7 +169,7 @@ describe("createAgentDataApiClient", () => {
         relationTypes: [],
         existingEntities: [],
         relevanceSelectionState: {
-          utcDayStartIso: "2026-04-09T00:00:00.000Z",
+          utcDayStartIso: "2026-01-01T00:00:00.000Z",
           selectedCountToday: 0,
         },
       }),


### PR DESCRIPTION
## Summary

Adds MP-ART-ANALYSIS-007: configurable **`runPolicy`** (minimum successful extractions before POST), per-source **`extractionFailures`**, per-chunk **`postFailures`** with safe abort of later POST phases, optional **429/5xx retries** on `analysis.create`, and **`details.runStatus`** (`partial_success` vs success). Documents idempotency and fixes related tests (agent-data-api-client GET mocks, `loadAnalysisContext` stubs with `articleRelevance.count`).

## Related issues

Refs #217

## Important changes

- **article-analysis `run.ts`:** vocabulary/LLM skips recorded; POST try/catch + phase gating; honest chunk/count metrics.
- **Hermes config:** `runPolicy`, `postTransientRetries`, `postTransientRetryBaseDelayMs`.

## Other changes

- **agent-data-api:** idempotent `articleRelevance` upsert test; analysis route test mock includes `relevanceSelectionState`.
- **agent-data-api-client:** analysis GET test body includes `relevanceSelectionState`.
- **dev-docs:** `analysis.mdx` partial failure and idempotency.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — orchestration and details shape.
- `apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts` — policy + run status label.
- `apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.ts` — error parse + retries.
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` — new config fields.

## How to test

1. From repo root: `pnpm code-quality`.
2. Run article-analysis with Hermes `runPolicy` / partial extraction and confirm `details.extractionFailures` and `postFailures`; induce a failed ER chunk and assert mentions/relevance are not posted.
