### PR TITLE
Add article-analysis run observability and safe logging

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -1,0 +1,235 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { ArticleRelevanceRow } from "./analysis-relevance-scoring.js";
+import {
+  ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+  aggregateRelevanceObservability,
+  buildArticleAnalysisRunSummaryPayload,
+  scoreBucketFor,
+  toSafeLogError,
+} from "./article-analysis-observability.js";
+
+describe("toSafeLogError", () => {
+  it("returns name and message for Error", () => {
+    const err = new TypeError("boom");
+    expect(toSafeLogError(err)).toEqual({
+      type: "TypeError",
+      message: "boom",
+    });
+  });
+
+  it("stringifies non-Error values", () => {
+    expect(toSafeLogError("x")).toEqual({ type: "string", message: "x" });
+    expect(toSafeLogError(42)).toEqual({ type: "number", message: "42" });
+    expect(toSafeLogError(null)).toEqual({ type: "object", message: "null" });
+  });
+});
+
+describe("scoreBucketFor", () => {
+  it("maps boundary scores into half-open buckets", () => {
+    expect(scoreBucketFor(0)).toBe("0_0.2");
+    expect(scoreBucketFor(0.199)).toBe("0_0.2");
+    expect(scoreBucketFor(0.2)).toBe("0.2_0.4");
+    expect(scoreBucketFor(0.8)).toBe("0.8_1");
+    expect(scoreBucketFor(1)).toBe("0.8_1");
+  });
+});
+
+describe("aggregateRelevanceObservability", () => {
+  const row = (
+    score: number,
+    breakdown: ArticleRelevanceRow["scoreBreakdown"],
+  ): ArticleRelevanceRow => ({
+    dataSourceId: "ds",
+    score,
+    scoreBreakdown: breakdown,
+    selected: false,
+  });
+
+  it("returns zeroed stats for empty rows", () => {
+    const a = aggregateRelevanceObservability([]);
+    expect(a.rowCount).toBe(0);
+    expect(a.scoreMean).toBe(0);
+    expect(a.scoreBuckets["0_0.2"]).toBe(0);
+    expect(a.breakdownVersion).toBe(0);
+    expect(a.breakdownKeyMeans.breakingNews).toBe(0);
+  });
+
+  it("aggregates scores and breakdown keys", () => {
+    const a = aggregateRelevanceObservability([
+      row(0.1, {
+        _version: 1,
+        breakingNews: 0,
+        kgRelation: 0.5,
+        fundamental: 0.5,
+        tickerSalience: 0.5,
+        sourceQuality: 0.5,
+      }),
+      row(0.9, {
+        _version: 1,
+        breakingNews: 1,
+        kgRelation: 0.5,
+        fundamental: 0.5,
+        tickerSalience: 0.5,
+        sourceQuality: 0.5,
+      }),
+    ]);
+    expect(a.rowCount).toBe(2);
+    expect(a.scoreMin).toBe(0.1);
+    expect(a.scoreMax).toBe(0.9);
+    expect(a.scoreMean).toBe(0.5);
+    expect(a.scoreBuckets["0_0.2"]).toBe(1);
+    expect(a.scoreBuckets["0.8_1"]).toBe(1);
+    expect(a.breakdownVersion).toBe(1);
+    expect(a.breakdownKeyMeans.breakingNews).toBe(0.5);
+    expect(a.breakdownKeyMins.breakingNews).toBe(0);
+    expect(a.breakdownKeyMaxs.breakingNews).toBe(1);
+  });
+
+  it("marks mixed breakdown versions", () => {
+    const a = aggregateRelevanceObservability([
+      row(0.5, {
+        _version: 1,
+        breakingNews: 0.5,
+        kgRelation: 0.5,
+        fundamental: 0.5,
+        tickerSalience: 0.5,
+        sourceQuality: 0.5,
+      }),
+      row(0.5, {
+        _version: 2,
+        breakingNews: 0.5,
+        kgRelation: 0.5,
+        fundamental: 0.5,
+        tickerSalience: 0.5,
+        sourceQuality: 0.5,
+      }),
+    ]);
+    expect(a.breakdownVersion).toBe("mixed");
+  });
+});
+
+describe("buildArticleAnalysisRunSummaryPayload", () => {
+  it("includes extraction and POST failure tallies", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 3,
+      extractionSuccessCount: 2,
+      extractionFailures: [
+        {
+          dataSourceId: "a",
+          stage: "vocabulary",
+          message: "bad",
+        },
+        { dataSourceId: "b", stage: "llm", message: "timeout" },
+      ],
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 1,
+        articleEntityChunkParseErrors: 2,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [
+        {
+          chunkKind: "entities_relations",
+          chunkIndex: 0,
+          errorCategory: "agent_data_api_http",
+          httpStatus: 500,
+          message: "Agent data API error: 500",
+        },
+        {
+          chunkKind: "article_relevances",
+          chunkIndex: 1,
+          errorCategory: "unknown",
+          message: "x",
+        },
+      ],
+      entitiesCreated: 2,
+      entitiesReused: 2,
+      relationsCreated: 3,
+      articlesScored: 2,
+      articlesSelected: 1,
+      relevanceAggregate: null,
+      llmUsage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      extractionLatencyMsTotal: 300,
+      extractionCalls: 2,
+      runStatusLabel: "partial_success",
+    });
+
+    expect(payload.event).toBe(ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE);
+    expect(payload.extractionFailuresVocabulary).toBe(1);
+    expect(payload.extractionFailuresLlm).toBe(1);
+    expect(payload.scoreFailureCount).toBe(1);
+    expect(payload.chunkParseErrorsEntityRelation).toBe(1);
+    expect(payload.chunkParseErrorsArticleEntity).toBe(2);
+    expect(payload.postFailuresByChunkKind).toEqual({
+      entities_relations: 1,
+      article_entities: 0,
+      article_relevances: 1,
+    });
+    expect(payload.postFailuresByErrorCategory).toEqual({
+      agent_data_api_http: 1,
+      unknown: 1,
+    });
+    expect(payload.entityReuseRatio).toBe(0.5);
+    expect(payload.avgExtractionLatencyMs).toBe(150);
+    expect(payload.llmTotalTokens).toBe(30);
+  });
+
+  it("omits LLM usage keys when usage is null", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 1,
+      extractionSuccessCount: 1,
+      extractionFailures: [],
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 0,
+    });
+    expect("llmTotalTokens" in payload).toBe(false);
+    expect(payload.scoreFailureCount).toBe(0);
+  });
+
+  it("embeds failure reason and safe error for top-level failures", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "failure",
+      articlesProcessed: 0,
+      extractionSuccessCount: 0,
+      extractionFailures: [],
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 0,
+      semanticFailureReason: "empty vocabulary",
+      topLevelError: { type: "Error", message: "network" },
+    });
+    expect(payload.semanticFailureReason).toBe("empty vocabulary");
+    expect(payload.error).toEqual({ type: "Error", message: "network" });
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -1,0 +1,339 @@
+import type { ArticleRelevanceRow } from "./analysis-relevance-scoring.js";
+import { RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1 } from "./analysis-relevance-scoring.js";
+import type {
+  ArticleAnalysisExtractionFailureRecord,
+  ArticleAnalysisPostFailureRecord,
+} from "./article-analysis-run-policy.js";
+
+/** Stable name for grep / log pipelines. */
+export const ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE =
+  "article_analysis.run.summary";
+
+/**
+ * Serializes an unknown error for structured logs without attaching rich provider payloads.
+ *
+ * @param error - Thrown value or Error.
+ * @returns `{ type, message }` safe for Pino `bindings`.
+ */
+export const toSafeLogError = (
+  error: unknown,
+): { type: string; message: string } => {
+  if (error instanceof Error) {
+    return { type: error.name, message: error.message };
+  }
+  return { type: typeof error, message: String(error) };
+};
+
+const SCORE_BUCKET_LABELS = [
+  "0_0.2",
+  "0.2_0.4",
+  "0.4_0.6",
+  "0.6_0.8",
+  "0.8_1",
+] as const;
+
+export type ScoreBucketCounts = Record<
+  (typeof SCORE_BUCKET_LABELS)[number],
+  number
+>;
+
+export type RelevanceObservabilityAggregate = {
+  rowCount: number;
+  scoreMin: number;
+  scoreMax: number;
+  scoreSum: number;
+  scoreMean: number;
+  scoreBuckets: ScoreBucketCounts;
+  breakdownVersion: "mixed" | number;
+  breakdownKeyMeans: Record<
+    (typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number],
+    number
+  >;
+  breakdownKeyMins: Record<
+    (typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number],
+    number
+  >;
+  breakdownKeyMaxs: Record<
+    (typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number],
+    number
+  >;
+};
+
+/**
+ * Picks the half-open score bucket label for a value in `[0, 1]`.
+ *
+ * @param score - Weighted relevance score.
+ * @returns One of five fixed bucket keys; values at upper boundaries map to the higher bucket except `1` → last bucket.
+ */
+export const scoreBucketFor = (score: number): keyof ScoreBucketCounts => {
+  if (score >= 0.8) {
+    return "0.8_1";
+  }
+  if (score >= 0.6) {
+    return "0.6_0.8";
+  }
+  if (score >= 0.4) {
+    return "0.4_0.6";
+  }
+  if (score >= 0.2) {
+    return "0.2_0.4";
+  }
+  return "0_0.2";
+};
+
+const emptyBuckets = (): ScoreBucketCounts => ({
+  "0_0.2": 0,
+  "0.2_0.4": 0,
+  "0.4_0.6": 0,
+  "0.6_0.8": 0,
+  "0.8_1": 0,
+});
+
+/**
+ * Aggregates score distribution and canonical breakdown stats over final relevance rows.
+ *
+ * @param rows - Article relevance rows (e.g. after selection); empty yields zeroed stats.
+ * @returns Min/max/mean, fixed histogram buckets, per-key breakdown means; `_version` must match or `mixed`.
+ */
+export const aggregateRelevanceObservability = (
+  rows: readonly ArticleRelevanceRow[],
+): RelevanceObservabilityAggregate => {
+  if (rows.length === 0) {
+    const zeros = Object.fromEntries(
+      RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [k, 0]),
+    ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+    return {
+      rowCount: 0,
+      scoreMin: 0,
+      scoreMax: 0,
+      scoreSum: 0,
+      scoreMean: 0,
+      scoreBuckets: emptyBuckets(),
+      breakdownVersion: 0,
+      breakdownKeyMeans: { ...zeros },
+      breakdownKeyMins: { ...zeros },
+      breakdownKeyMaxs: { ...zeros },
+    };
+  }
+
+  let scoreMin = Number.POSITIVE_INFINITY;
+  let scoreMax = Number.NEGATIVE_INFINITY;
+  let scoreSum = 0;
+  const buckets = emptyBuckets();
+  let versionSeen: number | undefined;
+  let versionMixed = false;
+
+  const keySums = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [k, 0]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  const keyMins = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [
+      k,
+      Number.POSITIVE_INFINITY,
+    ]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  const keyMaxs = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [
+      k,
+      Number.NEGATIVE_INFINITY,
+    ]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  for (const row of rows) {
+    const s = row.score;
+    scoreMin = Math.min(scoreMin, s);
+    scoreMax = Math.max(scoreMax, s);
+    scoreSum += s;
+    buckets[scoreBucketFor(s)] += 1;
+
+    const ver = row.scoreBreakdown._version;
+    if (typeof ver === "number" && Number.isFinite(ver)) {
+      if (versionSeen === undefined) {
+        versionSeen = ver;
+      } else if (versionSeen !== ver) {
+        versionMixed = true;
+      }
+    }
+
+    for (const key of RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1) {
+      const v = row.scoreBreakdown[key];
+      if (typeof v === "number" && Number.isFinite(v)) {
+        keySums[key] += v;
+        keyMins[key] = Math.min(keyMins[key], v);
+        keyMaxs[key] = Math.max(keyMaxs[key], v);
+      }
+    }
+  }
+
+  const n = rows.length;
+  const breakdownKeyMeans = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [k, keySums[k] / n]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  const breakdownKeyMinsFinal = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [
+      k,
+      keyMins[k] === Number.POSITIVE_INFINITY ? 0 : keyMins[k],
+    ]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  const breakdownKeyMaxsFinal = Object.fromEntries(
+    RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1.map((k) => [
+      k,
+      keyMaxs[k] === Number.NEGATIVE_INFINITY ? 0 : keyMaxs[k],
+    ]),
+  ) as Record<(typeof RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1)[number], number>;
+
+  return {
+    rowCount: n,
+    scoreMin,
+    scoreMax,
+    scoreSum,
+    scoreMean: scoreSum / n,
+    scoreBuckets: buckets,
+    breakdownVersion: versionMixed ? "mixed" : (versionSeen ?? 0),
+    breakdownKeyMeans,
+    breakdownKeyMins: breakdownKeyMinsFinal,
+    breakdownKeyMaxs: breakdownKeyMaxsFinal,
+  };
+};
+
+export type ChunkBuildParseCounts = {
+  entityRelationChunkParseErrors: number;
+  articleEntityChunkParseErrors: number;
+  articleRelevanceChunkParseErrors: number;
+};
+
+export type LlmUsageTotals = {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+};
+
+export type ArticleAnalysisRunSummaryInput = {
+  outcome: "success" | "failure";
+  articlesProcessed: number;
+  extractionSuccessCount: number;
+  extractionFailures: readonly ArticleAnalysisExtractionFailureRecord[];
+  relevanceRowValidationFailures: number;
+  chunkParseCounts: ChunkBuildParseCounts;
+  postFailures: readonly ArticleAnalysisPostFailureRecord[];
+  entitiesCreated: number;
+  entitiesReused: number;
+  relationsCreated: number;
+  articlesScored: number;
+  articlesSelected: number;
+  relevanceAggregate: RelevanceObservabilityAggregate | null;
+  llmUsage: LlmUsageTotals | null;
+  extractionLatencyMsTotal: number;
+  extractionCalls: number;
+  runStatusLabel?: string;
+  semanticFailureReason?: string;
+  topLevelError?: ReturnType<typeof toSafeLogError>;
+};
+
+/**
+ * Builds a single JSON-safe object for one structured info log line.
+ *
+ * @param input - Counters and aggregates at end of run (or failure path).
+ * @returns Payload to pass as first argument to `log.info`.
+ */
+export const buildArticleAnalysisRunSummaryPayload = (
+  input: ArticleAnalysisRunSummaryInput,
+): Record<string, unknown> => {
+  const vocabFails = input.extractionFailures.filter(
+    (f) => f.stage === "vocabulary",
+  ).length;
+  const llmFails = input.extractionFailures.filter(
+    (f) => f.stage === "llm",
+  ).length;
+
+  const postByKind = {
+    entities_relations: 0,
+    article_entities: 0,
+    article_relevances: 0,
+  } as Record<ArticleAnalysisPostFailureRecord["chunkKind"], number>;
+
+  const postByCategory = {
+    agent_data_api_http: 0,
+    unknown: 0,
+  } as Record<ArticleAnalysisPostFailureRecord["errorCategory"], number>;
+
+  for (const p of input.postFailures) {
+    postByKind[p.chunkKind] += 1;
+    postByCategory[p.errorCategory] += 1;
+  }
+
+  const denom = input.entitiesCreated + input.entitiesReused;
+  const entityReuseRatio = denom > 0 ? input.entitiesReused / denom : null;
+  const scoreFailureCount =
+    input.relevanceRowValidationFailures +
+    input.chunkParseCounts.articleRelevanceChunkParseErrors +
+    postByKind.article_relevances;
+
+  const extractionCalls = input.extractionCalls;
+  const avgExtractionLatencyMs =
+    extractionCalls > 0
+      ? input.extractionLatencyMsTotal / extractionCalls
+      : null;
+
+  const base: Record<string, unknown> = {
+    event: ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    outcome: input.outcome,
+    articlesProcessed: input.articlesProcessed,
+    extractionSuccessCount: input.extractionSuccessCount,
+    extractionFailureCount: input.extractionFailures.length,
+    extractionFailuresVocabulary: vocabFails,
+    extractionFailuresLlm: llmFails,
+    scoreFailureCount,
+    relevanceRowValidationFailures: input.relevanceRowValidationFailures,
+    chunkParseErrorsEntityRelation:
+      input.chunkParseCounts.entityRelationChunkParseErrors,
+    chunkParseErrorsArticleEntity:
+      input.chunkParseCounts.articleEntityChunkParseErrors,
+    chunkParseErrorsArticleRelevance:
+      input.chunkParseCounts.articleRelevanceChunkParseErrors,
+    postFailureCount: input.postFailures.length,
+    postFailuresByChunkKind: postByKind,
+    postFailuresByErrorCategory: postByCategory,
+    entitiesCreated: input.entitiesCreated,
+    entitiesReused: input.entitiesReused,
+    entityReuseRatio,
+    relationsCreated: input.relationsCreated,
+    articlesScored: input.articlesScored,
+    articlesSelected: input.articlesSelected,
+    extractionLatencyMsTotal: input.extractionLatencyMsTotal,
+    extractionCalls,
+    avgExtractionLatencyMs,
+  };
+
+  if (input.runStatusLabel !== undefined) {
+    base.runStatus = input.runStatusLabel;
+  }
+  if (input.semanticFailureReason !== undefined) {
+    base.semanticFailureReason = input.semanticFailureReason;
+  }
+  if (input.topLevelError !== undefined) {
+    base.error = input.topLevelError;
+  }
+  if (input.llmUsage !== null) {
+    base.llmPromptTokens = input.llmUsage.promptTokens;
+    base.llmCompletionTokens = input.llmUsage.completionTokens;
+    base.llmTotalTokens = input.llmUsage.totalTokens;
+  }
+  if (input.relevanceAggregate !== null) {
+    base.relevanceRowCount = input.relevanceAggregate.rowCount;
+    base.scoreMin = input.relevanceAggregate.scoreMin;
+    base.scoreMax = input.relevanceAggregate.scoreMax;
+    base.scoreMean = input.relevanceAggregate.scoreMean;
+    base.scoreBuckets = input.relevanceAggregate.scoreBuckets;
+    base.breakdownVersion = input.relevanceAggregate.breakdownVersion;
+    base.breakdownKeyMeans = input.relevanceAggregate.breakdownKeyMeans;
+    base.breakdownKeyMins = input.relevanceAggregate.breakdownKeyMins;
+    base.breakdownKeyMaxs = input.relevanceAggregate.breakdownKeyMaxs;
+  }
+
+  return base;
+};

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -22,7 +22,7 @@ const app = createAgentApp<
     agentId: "article-analysis",
     agentVersion: "1.0.0",
     description:
-      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api. Supports configurable runPolicy for partial extraction failure, per-chunk POST error isolation with optional transient retries, and structured diagnostics (MP-ART-ANALYSIS-007).",
+      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api. Supports configurable runPolicy for partial extraction failure, per-chunk POST error isolation with optional transient retries, structured diagnostics (MP-ART-ANALYSIS-007), and structured run-summary observability with safe log fields (MP-ART-ANALYSIS-008).",
     inputSchema: articleAnalysisInputSchema,
     configSchema: articleAnalysisConfigSchema,
     run,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildExtractionSystemContent,
   buildExtractionUserContent,
+  normalizeLlmUsageFromSdk,
 } from "./llm-extract-entities.js";
 
 const TID = "11111111-1111-4111-a111-111111111111";
@@ -35,5 +36,46 @@ describe("buildExtractionUserContent", () => {
     expect(u).toContain("T");
     expect(u).toContain("Hello");
     expect(u).toContain("Body text");
+  });
+});
+
+describe("normalizeLlmUsageFromSdk", () => {
+  it("returns null when all token fields are absent", () => {
+    expect(normalizeLlmUsageFromSdk({})).toBeNull();
+    expect(
+      normalizeLlmUsageFromSdk({
+        inputTokens: undefined,
+        outputTokens: undefined,
+        totalTokens: undefined,
+      }),
+    ).toBeNull();
+  });
+
+  it("coalesces partial usage into a numeric triple", () => {
+    expect(
+      normalizeLlmUsageFromSdk({
+        inputTokens: 3,
+        outputTokens: 2,
+        totalTokens: undefined,
+      }),
+    ).toEqual({
+      inputTokens: 3,
+      outputTokens: 2,
+      totalTokens: 5,
+    });
+  });
+
+  it("respects explicit totalTokens", () => {
+    expect(
+      normalizeLlmUsageFromSdk({
+        inputTokens: 1,
+        outputTokens: 1,
+        totalTokens: 99,
+      }),
+    ).toEqual({
+      inputTokens: 1,
+      outputTokens: 1,
+      totalTokens: 99,
+    });
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -37,12 +37,60 @@ export const llmExtractionOutputSchema = z.object({
 
 export type LlmExtractionOutput = z.infer<typeof llmExtractionOutputSchema>;
 
+/** Normalized token counts from the AI SDK (`generateObject` usage), if the provider reports them. */
+export type LlmExtractionUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+};
+
+export type LlmExtractionCallResult = {
+  object: LlmExtractionOutput;
+  usage: LlmExtractionUsage | null;
+};
+
 export type GenerateObjectForExtraction = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmExtractionOutputSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
-}) => Promise<{ object: LlmExtractionOutput }>;
+}) => Promise<LlmExtractionCallResult>;
+
+/**
+ * Converts AI SDK `LanguageModelUsage` into compact counters; `null` when the provider omits usage.
+ *
+ * @param usage - Raw usage from `generateObject`.
+ * @returns Numeric triple or null when no token fields are present.
+ */
+export const normalizeLlmUsageFromSdk = (usage: {
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+  totalTokens?: number | undefined;
+}): LlmExtractionUsage | null => {
+  const inputTokens = usage.inputTokens;
+  const outputTokens = usage.outputTokens;
+  const totalTokens = usage.totalTokens;
+  if (inputTokens == null && outputTokens == null && totalTokens == null) {
+    return null;
+  }
+  const inTok = inputTokens ?? 0;
+  const outTok = outputTokens ?? 0;
+  return {
+    inputTokens: inTok,
+    outputTokens: outTok,
+    totalTokens: totalTokens ?? inTok + outTok,
+  };
+};
+
+const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
+  args,
+) => {
+  const result = await generateObject(args);
+  return {
+    object: result.object,
+    usage: normalizeLlmUsageFromSdk(result.usage),
+  };
+};
 
 /**
  * System prompt listing allowed entity and relation type UUIDs from analysis GET.
@@ -90,8 +138,8 @@ export const buildExtractionUserContent = (args: {
  * Runs structured extraction for one data source via `generateObject`.
  *
  * @param params - API key, model, token limit, chat messages.
- * @param deps - Injectable `generateObject` (tests swap mock).
- * @returns Parsed entities and relations.
+ * @param deps - Injectable `generateObject` wrapper (tests swap mock).
+ * @returns Parsed entities and relations plus optional tokenizer usage.
  */
 export const extractEntitiesAndRelationsForSource = async (
   params: {
@@ -101,15 +149,14 @@ export const extractEntitiesAndRelationsForSource = async (
     messages: ModelMessage[];
   },
   deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
-    generateObjectForExtraction: generateObject,
+    generateObjectForExtraction: defaultGenerateObjectForExtraction,
   },
-): Promise<LlmExtractionOutput> => {
+): Promise<LlmExtractionCallResult> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
-  const { object } = await deps.generateObjectForExtraction({
+  return deps.generateObjectForExtraction({
     model: openai(params.model),
     schema: llmExtractionOutputSchema,
     maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
   });
-  return object;
 };

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -2,6 +2,7 @@
 import type { AgentRunContext } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE } from "./article-analysis-observability.js";
 import * as RelevancePostChunks from "./analysis-relevance-post-chunks.js";
 import * as Llm from "./llm-extract-entities.js";
 import type { ArticleAnalysisConfig } from "./config-schema.js";
@@ -26,13 +27,26 @@ vi.mock("@mediapulse/env/agents-article-analysis", () => ({
   },
 }));
 
+const mockLog = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
 vi.mock("@workspace/logger", () => ({
   logger: {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
+    child: vi.fn(() => mockLog),
   },
 }));
+
+/** Wraps LLM output for mocks (`extractEntitiesAndRelationsForSource`). */
+const llmResult = (
+  object: Llm.LlmExtractionOutput,
+  usage: Llm.LlmExtractionUsage | null = null,
+): Llm.LlmExtractionCallResult => ({ object, usage });
 
 const TYPE_ID = "11111111-1111-4111-a111-111111111111";
 const REL_ID = "22222222-2222-4222-a222-222222222222";
@@ -65,6 +79,10 @@ describe("run", () => {
   beforeEach(() => {
     analysisGet.mockReset();
     analysisCreate.mockReset();
+    mockLog.info.mockReset();
+    mockLog.warn.mockReset();
+    mockLog.error.mockReset();
+    vi.mocked(logger.child).mockClear();
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockReset();
   });
 
@@ -183,39 +201,43 @@ describe("run", () => {
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource")
-      .mockResolvedValueOnce({
-        entities: [
-          {
-            canonicalName: "Bad",
-            typeId: "99999999-9999-4999-a999-999999999999",
-            aliases: [],
-          },
-        ],
-        relations: [],
-        articleMentions: [],
-      })
-      .mockResolvedValueOnce({
-        entities: [
-          {
-            canonicalName: "Good",
-            typeId: TYPE_ID,
-            aliases: [],
-          },
-          {
-            canonicalName: "Other",
-            typeId: TYPE_ID,
-            aliases: [],
-          },
-        ],
-        relations: [
-          {
-            fromEntityName: "Good",
-            toEntityName: "Other",
-            relationTypeId: REL_ID,
-          },
-        ],
-        articleMentions: [],
-      });
+      .mockResolvedValueOnce(
+        llmResult({
+          entities: [
+            {
+              canonicalName: "Bad",
+              typeId: "99999999-9999-4999-a999-999999999999",
+              aliases: [],
+            },
+          ],
+          relations: [],
+          articleMentions: [],
+        }),
+      )
+      .mockResolvedValueOnce(
+        llmResult({
+          entities: [
+            {
+              canonicalName: "Good",
+              typeId: TYPE_ID,
+              aliases: [],
+            },
+            {
+              canonicalName: "Other",
+              typeId: TYPE_ID,
+              aliases: [],
+            },
+          ],
+          relations: [
+            {
+              fromEntityName: "Good",
+              toEntityName: "Other",
+              relationTypeId: REL_ID,
+            },
+          ],
+          articleMentions: [],
+        }),
+      );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -265,18 +287,20 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [
-        { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
-        { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
-        { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
-      ],
-      relations: [
-        { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
-        { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
-      ],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
+        ],
+        relations: [
+          { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
+          { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
+        ],
+        articleMentions: [],
+      }),
+    );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -344,18 +368,20 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
-      relations: [],
-      articleMentions: [
-        {
-          entityName: "A",
-          mentionCount: 2,
-          confidence: 0.91,
-          sentiment: "POSITIVE",
-        },
-      ],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [
+          {
+            entityName: "A",
+            mentionCount: 2,
+            confidence: 0.91,
+            sentiment: "POSITIVE",
+          },
+        ],
+      }),
+    );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -423,18 +449,20 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
-      relations: [],
-      articleMentions: [
-        {
-          entityName: "A",
-          mentionCount: 2,
-          confidence: 1.5,
-          sentiment: "POSITIVE",
-        },
-      ],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [
+          {
+            entityName: "A",
+            mentionCount: 2,
+            confidence: 1.5,
+            sentiment: "POSITIVE",
+          },
+        ],
+      }),
+    );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -490,11 +518,13 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
-      relations: [],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
 
     analysisCreate.mockResolvedValueOnce({
       entitiesCreated: 1,
@@ -533,11 +563,13 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
-      relations: [],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
 
     analysisCreate.mockResolvedValueOnce({
       entitiesCreated: 1,
@@ -570,7 +602,7 @@ describe("run", () => {
       success: false,
       message: "upstream error",
     });
-    expect(logger.error).toHaveBeenCalled();
+    expect(mockLog.error).toHaveBeenCalled();
   });
 
   it("resolves extracted names to existing canonical entities before POST", async () => {
@@ -589,20 +621,22 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [
-        { canonicalName: "Alpha", typeId: TYPE_ID, aliases: [] },
-        { canonicalName: "Beta", typeId: TYPE_ID, aliases: [] },
-      ],
-      relations: [
-        {
-          fromEntityName: "Alpha",
-          toEntityName: "Beta",
-          relationTypeId: REL_ID,
-        },
-      ],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          { canonicalName: "Alpha", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "Beta", typeId: TYPE_ID, aliases: [] },
+        ],
+        relations: [
+          {
+            fromEntityName: "Alpha",
+            toEntityName: "Beta",
+            relationTypeId: REL_ID,
+          },
+        ],
+        articleMentions: [],
+      }),
+    );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -667,7 +701,7 @@ describe("run", () => {
       async () => {
         extractCall += 1;
         if (extractCall === 1) {
-          return {
+          return llmResult({
             entities: [
               {
                 canonicalName: "Bad",
@@ -677,13 +711,13 @@ describe("run", () => {
             ],
             relations: [],
             articleMentions: [],
-          };
+          });
         }
-        return {
+        return llmResult({
           entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
           relations: [],
           articleMentions: [],
-        };
+        });
       },
     );
 
@@ -712,6 +746,23 @@ describe("run", () => {
       (result.details?.extractionFailures as { stage: string }[])[0]?.stage,
     ).toBe("vocabulary");
     expect(analysisCreate).toHaveBeenCalledTimes(2);
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect(
+      (summaryCall?.[0] as { extractionFailuresVocabulary: number })
+        .extractionFailuresVocabulary,
+    ).toBe(1);
+    expect(
+      (summaryCall?.[0] as { extractionFailuresLlm: number })
+        .extractionFailuresLlm,
+    ).toBe(0);
   });
 
   it("stops POST phases after ER chunk failure and records postFailures", async () => {
@@ -732,18 +783,20 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [
-        { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
-        { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
-        { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
-      ],
-      relations: [
-        { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
-        { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
-      ],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "C", typeId: TYPE_ID, aliases: [] },
+        ],
+        relations: [
+          { fromEntityName: "A", toEntityName: "B", relationTypeId: REL_ID },
+          { fromEntityName: "B", toEntityName: "C", relationTypeId: REL_ID },
+        ],
+        articleMentions: [],
+      }),
+    );
 
     analysisCreate
       .mockResolvedValueOnce({
@@ -800,23 +853,110 @@ describe("run", () => {
       relevanceSelectionState,
     });
 
-    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue({
-      entities: [
-        {
-          canonicalName: "Bad",
-          typeId: "99999999-9999-4999-a999-999999999999",
-          aliases: [],
-        },
-      ],
-      relations: [],
-      articleMentions: [],
-    });
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          {
+            canonicalName: "Bad",
+            typeId: "99999999-9999-4999-a999-999999999999",
+            aliases: [],
+          },
+        ],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("run policy");
     expect(analysisCreate).not.toHaveBeenCalled();
+  });
+
+  it("logs safe error shape when LLM extraction throws", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "short",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockRejectedValue(
+      new Error("provider timeout"),
+    );
+
+    await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      {
+        dataSourceId: DS_ID,
+        stage: "llm",
+        message: "provider timeout",
+      },
+      expect.any(String),
+    );
+  });
+
+  it("does not log raw article content in structured info payloads", async () => {
+    const secretBody = "DO_NOT_LOG_THIS_ARTICLE_BODY_SECRET";
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: secretBody,
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+    });
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
+
+    await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    const payloads = mockLog.info.mock.calls.map((c) => JSON.stringify(c[0]));
+    for (const p of payloads) {
+      expect(p).not.toContain(secretBody);
+    }
   });
 
   it("logs verbose start", async () => {
@@ -835,6 +975,6 @@ describe("run", () => {
       }),
     );
 
-    expect(logger.info).toHaveBeenCalled();
+    expect(mockLog.info).toHaveBeenCalled();
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -2,6 +2,7 @@ import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
+import crypto from "node:crypto";
 
 import {
   applyPerArticleExtractionCaps,
@@ -25,6 +26,7 @@ import { buildArticleRelevancePostChunks } from "./analysis-relevance-post-chunk
 import {
   buildDraftRelevanceRow,
   validateRelevanceRowForPost,
+  type ArticleRelevanceRow,
   type PerSourceRelevanceSignals,
 } from "./analysis-relevance-scoring.js";
 import { applyRelevanceSelection } from "./analysis-relevance-selection.js";
@@ -37,6 +39,15 @@ import {
   executeAnalysisCreateWithTransientRetries,
   toArticleAnalysisPostFailureRecord,
 } from "./article-analysis-agent-data-api-post.js";
+import {
+  ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+  aggregateRelevanceObservability,
+  buildArticleAnalysisRunSummaryPayload,
+  toSafeLogError,
+  type ArticleAnalysisRunSummaryInput,
+  type ChunkBuildParseCounts,
+  type LlmUsageTotals,
+} from "./article-analysis-observability.js";
 import {
   deriveArticleAnalysisRunStatusLabel,
   isArticleAnalysisExtractionPolicyFailure,
@@ -54,6 +65,7 @@ import {
   buildExtractionSystemContent,
   buildExtractionUserContent,
   extractEntitiesAndRelationsForSource,
+  type LlmExtractionUsage,
 } from "./llm-extract-entities.js";
 import {
   buildAnalysisGetQuery,
@@ -160,6 +172,12 @@ const resolveAgainstExistingEntities = (
 const sleepMs = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+const emptyChunkParseCounts = (): ChunkBuildParseCounts => ({
+  entityRelationChunkParseErrors: 0,
+  articleEntityChunkParseErrors: 0,
+  articleRelevanceChunkParseErrors: 0,
+});
+
 /**
  * Runs analysis: GET context, optional batch cap, LLM extraction per source,
  * vocabulary validation, caps, chunked POST of entities/relations, then chunked POST of
@@ -171,6 +189,9 @@ const sleepMs = (ms: number): Promise<void> =>
  * POST failures stop later phases and only API-confirmed counts are aggregated.
  * Successful extractions are canonicalized against existing KG entities (mainline behavior).
  *
+ * Observability (MP-ART-ANALYSIS-008): structured run summary log (`article_analysis.run.summary`)
+ * with per-stage counters, optional LLM usage, and safe error fields (no raw `Error` objects).
+ *
  * @param context - Hermes input/config and bearer token.
  * @returns Aggregated success with POST tallies or structured failure.
  */
@@ -178,6 +199,7 @@ export const run = async ({
   input,
   config,
   token,
+  hermesCorrelation,
 }: AgentRunContext<
   ArticleAnalysisInput,
   ArticleAnalysisConfig
@@ -185,11 +207,37 @@ export const run = async ({
   const reanalyze = input.reanalyze ?? false;
   const inputForQuery = { ...input, reanalyze };
   const cfg = resolveArticleAnalysisConfig(config);
+  const runId = crypto.randomUUID();
+
+  const log = logger.child({
+    component: "article-analysis",
+    runId,
+    tickerId: input.tickerId,
+    ...(hermesCorrelation?.jobId ? { jobId: hermesCorrelation.jobId } : {}),
+    ...(hermesCorrelation?.executionId
+      ? { executionId: hermesCorrelation.executionId }
+      : {}),
+    ...(hermesCorrelation?.scheduleId
+      ? { scheduleId: hermesCorrelation.scheduleId }
+      : {}),
+    ...(hermesCorrelation?.scheduleExecutionId
+      ? { scheduleExecutionId: hermesCorrelation.scheduleExecutionId }
+      : {}),
+    ...(hermesCorrelation?.pipelineStepId
+      ? { pipelineStepId: hermesCorrelation.pipelineStepId }
+      : {}),
+  });
+
+  const emitRunSummary = (summary: ArticleAnalysisRunSummaryInput): void => {
+    log.info(
+      buildArticleAnalysisRunSummaryPayload(summary),
+      ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+  };
 
   if (cfg.verbose) {
-    logger.info(
+    log.info(
       {
-        tickerId: input.tickerId,
         openaiModel: cfg.openaiModel,
         maxContentChars: cfg.maxContentChars,
       },
@@ -203,14 +251,65 @@ export const run = async ({
     token,
   });
 
+  let articlesProcessedForSummary = 0;
+  const chunkParseCounts = emptyChunkParseCounts();
+  let relevanceRowValidationFailures = 0;
+  const llmUsageTotals: LlmUsageTotals = {
+    promptTokens: 0,
+    completionTokens: 0,
+    totalTokens: 0,
+  };
+  let llmUsageAccumulated = false;
+  let extractionLatencyMsTotal = 0;
+  let extractionCalls = 0;
+  let relevanceRowsForObservability: ArticleRelevanceRow[] | null = null;
+  const extractionFailures: ArticleAnalysisExtractionFailureRecord[] = [];
+  let extractionSuccessCount = 0;
+  const postFailures: ArticleAnalysisPostFailureRecord[] = [];
+  let entitiesCreated = 0;
+  let entitiesReused = 0;
+  let relationsCreated = 0;
+  let articlesScoredTotal = 0;
+  let articlesSelectedTotal = 0;
+
+  const accumulateLlmUsage = (usage: LlmExtractionUsage | null): void => {
+    if (!usage) {
+      return;
+    }
+    llmUsageAccumulated = true;
+    llmUsageTotals.promptTokens += usage.inputTokens;
+    llmUsageTotals.completionTokens += usage.outputTokens;
+    llmUsageTotals.totalTokens += usage.totalTokens;
+  };
+
   try {
     const query = buildAnalysisGetQuery(inputForQuery);
     const ctx = await dataApiClient.analysis.get(query);
 
     const sorted = sortAnalysisDataSourcesByCreatedAt(ctx.dataSources);
     const batch = applyMaxBatchSizeCap(sorted, inputForQuery.maxBatchSize);
+    articlesProcessedForSummary = batch.length;
 
     if (batch.length === 0) {
+      emitRunSummary({
+        outcome: "success",
+        articlesProcessed: 0,
+        extractionSuccessCount: 0,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: emptyChunkParseCounts(),
+        postFailures: [],
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 0,
+        runStatusLabel: "success",
+      });
       return {
         success: true,
         message: "analysis context loaded (0 source(s)); nothing to process",
@@ -222,7 +321,6 @@ export const run = async ({
           extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
           extractionSuccessCount: 0,
           postFailures: [] as ArticleAnalysisPostFailureRecord[],
-          vocabularyFailures: 0,
           entitiesCreated: 0,
           entitiesReused: 0,
           relationsCreated: 0,
@@ -232,11 +330,31 @@ export const run = async ({
           articlesScored: 0,
           articlesSelected: 0,
           relevancePostChunks: 0,
+          vocabularyFailures: 0,
         },
       };
     }
 
     if (ctx.entityTypes.length === 0 || ctx.relationTypes.length === 0) {
+      emitRunSummary({
+        outcome: "failure",
+        articlesProcessed: batch.length,
+        extractionSuccessCount: 0,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: emptyChunkParseCounts(),
+        postFailures: [],
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 0,
+        semanticFailureReason: "empty_kg_vocabulary",
+      });
       return {
         success: false,
         message:
@@ -254,12 +372,11 @@ export const run = async ({
     const systemContent = buildExtractionSystemContent(ctx);
     const existingLookup = buildExistingEntityLookup(ctx.existingEntities);
 
-    const extractionFailures: ArticleAnalysisExtractionFailureRecord[] = [];
-    let vocabularyFailures = 0;
     const mergedEntities: EntityProposal[] = [];
     const mergedRelations: RelationProposal[] = [];
     const mergedArticleEntityRows: ArticleEntityRow[] = [];
     const perSourceSignals: PerSourceRelevanceSignals[] = [];
+    let vocabularyFailures = 0;
 
     for (const source of batch) {
       const truncated =
@@ -268,7 +385,8 @@ export const run = async ({
           : source.content;
 
       try {
-        const extracted = await extractEntitiesAndRelationsForSource({
+        const t0 = Date.now();
+        const extractedResult = await extractEntitiesAndRelationsForSource({
           apiKey: cfg.openaiApiKey,
           model: cfg.openaiModel,
           maxOutputTokens: cfg.maxOutputTokens,
@@ -284,6 +402,10 @@ export const run = async ({
             },
           ],
         });
+        extractionLatencyMsTotal += Date.now() - t0;
+        extractionCalls += 1;
+        accumulateLlmUsage(extractedResult.usage);
+        const extracted = extractedResult.object;
 
         const vocab = validateExtractionVocabulary(
           extracted.entities,
@@ -297,9 +419,8 @@ export const run = async ({
             stage: "vocabulary",
             message: vocab.message,
           });
-          logger.warn(
+          log.warn(
             {
-              tickerId: input.tickerId,
               dataSourceId: source.id,
               stage: "vocabulary",
             },
@@ -360,9 +481,8 @@ export const run = async ({
           stage: "llm",
           message,
         });
-        logger.warn(
+        log.warn(
           {
-            tickerId: input.tickerId,
             dataSourceId: source.id,
             stage: "llm",
             message,
@@ -372,7 +492,7 @@ export const run = async ({
       }
     }
 
-    const extractionSuccessCount = perSourceSignals.length;
+    extractionSuccessCount = perSourceSignals.length;
 
     if (
       isArticleAnalysisExtractionPolicyFailure(
@@ -380,6 +500,25 @@ export const run = async ({
         cfg.runPolicy,
       )
     ) {
+      emitRunSummary({
+        outcome: "failure",
+        articlesProcessed: batch.length,
+        extractionSuccessCount,
+        extractionFailures,
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: { ...chunkParseCounts },
+        postFailures: [],
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+        extractionLatencyMsTotal,
+        extractionCalls,
+        semanticFailureReason: "extraction_run_policy",
+      });
       return {
         success: false,
         message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.runPolicy.minSuccessfulSources}.`,
@@ -387,13 +526,13 @@ export const run = async ({
           extractionFailures,
           extractionSuccessCount,
           runPolicy: cfg.runPolicy,
-          vocabularyFailures,
           articlesScored: 0,
           articlesSelected: 0,
           relevancePostChunks: 0,
           postFailures: [] as ArticleAnalysisPostFailureRecord[],
           dataSourcesProcessed: batch.length,
           reanalyze,
+          vocabularyFailures,
         },
       };
     }
@@ -414,7 +553,29 @@ export const run = async ({
     ).length;
 
     if (entities.length === 0 && relations.length === 0) {
-      const postFailures: ArticleAnalysisPostFailureRecord[] = [];
+      const runStatus = deriveArticleAnalysisRunStatusLabel(
+        extractionFailures.length,
+        postFailures.length,
+      );
+      emitRunSummary({
+        outcome: "success",
+        articlesProcessed: batch.length,
+        extractionSuccessCount,
+        extractionFailures,
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: { ...chunkParseCounts },
+        postFailures,
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+        extractionLatencyMsTotal,
+        extractionCalls,
+        runStatusLabel: runStatus,
+      });
       return {
         success: true,
         message:
@@ -427,11 +588,7 @@ export const run = async ({
           extractionSuccessCount,
           postFailures,
           llmFailures: llmFailureCount,
-          vocabularyFailures,
-          runStatus: deriveArticleAnalysisRunStatusLabel(
-            extractionFailures.length,
-            postFailures.length,
-          ),
+          runStatus,
           entitiesCreated: 0,
           entitiesReused: 0,
           relationsCreated: 0,
@@ -442,6 +599,7 @@ export const run = async ({
           articlesSelected: 0,
           relevancePostChunks: 0,
           reanalyze,
+          vocabularyFailures,
         },
       };
     }
@@ -455,9 +613,8 @@ export const run = async ({
       entityCatalog,
     );
     if (droppedArticleMentionsNotInRunCatalog > 0) {
-      logger.warn(
+      log.warn(
         {
-          tickerId: input.tickerId,
           droppedArticleMentionsNotInRunCatalog,
         },
         "article-analysis dropped article entity mentions not in run entity catalog",
@@ -476,11 +633,11 @@ export const run = async ({
       relations,
       cfg.postChunkRelationBatchSize,
     );
+    chunkParseCounts.entityRelationChunkParseErrors = parseErrors.length;
 
     if (parseErrors.length > 0) {
-      logger.warn(
+      log.warn(
         {
-          tickerId: input.tickerId,
           parseErrorCount: parseErrors.length,
           droppedRelations,
         },
@@ -489,7 +646,29 @@ export const run = async ({
     }
 
     if (chunks.length === 0) {
-      const postFailures: ArticleAnalysisPostFailureRecord[] = [];
+      const runStatus = deriveArticleAnalysisRunStatusLabel(
+        extractionFailures.length,
+        postFailures.length,
+      );
+      emitRunSummary({
+        outcome: "success",
+        articlesProcessed: batch.length,
+        extractionSuccessCount,
+        extractionFailures,
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: { ...chunkParseCounts },
+        postFailures,
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+        extractionLatencyMsTotal,
+        extractionCalls,
+        runStatusLabel: runStatus,
+      });
       return {
         success: true,
         message:
@@ -503,11 +682,7 @@ export const run = async ({
           extractionSuccessCount,
           postFailures,
           llmFailures: llmFailureCount,
-          vocabularyFailures,
-          runStatus: deriveArticleAnalysisRunStatusLabel(
-            extractionFailures.length,
-            postFailures.length,
-          ),
+          runStatus,
           articleEntityRowsPosted: 0,
           mentionPostChunks: 0,
           droppedArticleMentionsNotInRunCatalog,
@@ -515,22 +690,18 @@ export const run = async ({
           articlesSelected: 0,
           relevancePostChunks: 0,
           reanalyze,
+          vocabularyFailures,
         },
       };
     }
 
-    const postFailures: ArticleAnalysisPostFailureRecord[] = [];
-    let entitiesCreated = 0;
-    let entitiesReused = 0;
-    let relationsCreated = 0;
     let erPostChunksCompleted = 0;
     let erPhaseFailed = false;
 
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i]!;
-      logger.info(
+      log.info(
         {
-          tickerId: input.tickerId,
           chunkKind: "entities_relations",
           chunkIndex: i,
           chunkEntities: chunk.entities.length,
@@ -556,12 +727,11 @@ export const run = async ({
         postFailures.push(
           toArticleAnalysisPostFailureRecord("entities_relations", i, err),
         );
-        logger.warn(
+        log.warn(
           {
-            tickerId: input.tickerId,
             chunkKind: "entities_relations",
             chunkIndex: i,
-            err,
+            err: toSafeLogError(err),
           },
           "article-analysis entities/relations POST failed; aborting remaining POST phases",
         );
@@ -583,12 +753,13 @@ export const run = async ({
           cfg.postChunkArticleEntityBatchSize,
         );
       articleEntityParseErrors = parseErrors;
+      chunkParseCounts.articleEntityChunkParseErrors =
+        articleEntityParseErrors.length;
 
       if (articleEntityParseErrors.length > 0) {
-        logger.warn(
+        log.warn(
           {
-            tickerId: input.tickerId,
-            parseErrorSample: articleEntityParseErrors.slice(0, 10),
+            parseErrorCount: articleEntityParseErrors.length,
           },
           "article-analysis articleEntity chunk build reported parse issues",
         );
@@ -596,9 +767,8 @@ export const run = async ({
 
       for (let j = 0; j < articleEntityChunks.length; j++) {
         const mentionChunk = articleEntityChunks[j]!;
-        logger.info(
+        log.info(
           {
-            tickerId: input.tickerId,
             chunkKind: "article_entities",
             chunkIndex: j,
             chunkArticleEntities: mentionChunk.articleEntities.length,
@@ -621,12 +791,11 @@ export const run = async ({
           postFailures.push(
             toArticleAnalysisPostFailureRecord("article_entities", j, err),
           );
-          logger.warn(
+          log.warn(
             {
-              tickerId: input.tickerId,
               chunkKind: "article_entities",
               chunkIndex: j,
-              err,
+              err: toSafeLogError(err),
             },
             "article-analysis articleEntities POST failed; aborting relevance phase",
           );
@@ -636,8 +805,6 @@ export const run = async ({
       }
     }
 
-    let articlesScoredTotal = 0;
-    let articlesSelectedTotal = 0;
     let relevancePostChunksCompleted = 0;
 
     if (!erPhaseFailed && !mentionPhaseFailed && perSourceSignals.length > 0) {
@@ -649,11 +816,12 @@ export const run = async ({
       for (const row of relevanceDrafts) {
         const vErr = validateRelevanceRowForPost(row, weightMap);
         if (vErr) {
-          relevanceValidationErrors.push(`${row.dataSourceId}: ${vErr}`);
-          logger.warn(
-            { tickerId: input.tickerId, dataSourceId: row.dataSourceId, vErr },
+          relevanceRowValidationFailures += 1;
+          log.warn(
+            { dataSourceId: row.dataSourceId, vErr },
             "article-analysis relevance row validation failed before selection",
           );
+          relevanceValidationErrors.push(`${row.dataSourceId}: ${vErr}`);
         }
       }
       if (relevanceValidationErrors.length > 0) {
@@ -683,6 +851,7 @@ export const run = async ({
         cfg.relevanceMinScore,
         remainingBudget,
       );
+      relevanceRowsForObservability = relevanceRows;
 
       const { chunks: relevanceChunks, parseErrors: relevanceParseErrors } =
         buildArticleRelevancePostChunks(
@@ -690,12 +859,13 @@ export const run = async ({
           relevanceRows,
           cfg.postChunkArticleRelevanceBatchSize,
         );
+      chunkParseCounts.articleRelevanceChunkParseErrors =
+        relevanceParseErrors.length;
 
       if (relevanceParseErrors.length > 0) {
-        logger.warn(
+        log.warn(
           {
-            tickerId: input.tickerId,
-            parseErrorSample: relevanceParseErrors.slice(0, 10),
+            parseErrorCount: relevanceParseErrors.length,
           },
           "article-analysis relevance chunk build reported parse issues",
         );
@@ -712,9 +882,8 @@ export const run = async ({
 
       for (let k = 0; k < relevanceChunks.length; k++) {
         const relChunk = relevanceChunks[k]!;
-        logger.info(
+        log.info(
           {
-            tickerId: input.tickerId,
             chunkKind: "article_relevances",
             chunkIndex: k,
             chunkArticleRelevances: relChunk.articleRelevances.length,
@@ -738,12 +907,11 @@ export const run = async ({
           postFailures.push(
             toArticleAnalysisPostFailureRecord("article_relevances", k, err),
           );
-          logger.warn(
+          log.warn(
             {
-              tickerId: input.tickerId,
               chunkKind: "article_relevances",
               chunkIndex: k,
-              err,
+              err: toSafeLogError(err),
             },
             "article-analysis articleRelevances POST failed",
           );
@@ -757,6 +925,31 @@ export const run = async ({
       postFailures.length,
     );
 
+    const relevanceAggregate =
+      relevanceRowsForObservability !== null
+        ? aggregateRelevanceObservability(relevanceRowsForObservability)
+        : null;
+
+    emitRunSummary({
+      outcome: "success",
+      articlesProcessed: batch.length,
+      extractionSuccessCount,
+      extractionFailures,
+      relevanceRowValidationFailures,
+      chunkParseCounts: { ...chunkParseCounts },
+      postFailures,
+      entitiesCreated,
+      entitiesReused,
+      relationsCreated,
+      articlesScored: articlesScoredTotal,
+      articlesSelected: articlesSelectedTotal,
+      relevanceAggregate,
+      llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+      extractionLatencyMsTotal,
+      extractionCalls,
+      runStatusLabel: runStatus,
+    });
+
     return {
       success: true,
       message: `complete (${runStatus}): ${erPostChunksCompleted}/${chunks.length} ER chunk(s), ${mentionPostChunksCompleted} articleEntity chunk(s), ${relevancePostChunksCompleted} relevance chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted} articlesScored=${articlesScoredTotal} articlesSelected=${articlesSelectedTotal}`,
@@ -767,7 +960,6 @@ export const run = async ({
         extractionSuccessCount,
         postFailures,
         llmFailures: llmFailureCount,
-        vocabularyFailures,
         runStatus,
         postChunks: erPostChunksCompleted,
         entitiesCreated,
@@ -787,6 +979,7 @@ export const run = async ({
         droppedRelations,
         articleEntityParseErrors: articleEntityParseErrors.slice(0, 20),
         reanalyze,
+        vocabularyFailures,
       },
     };
   } catch (error) {
@@ -794,7 +987,26 @@ export const run = async ({
       error instanceof Error
         ? error.message
         : "agent-data-api article-analysis run failed";
-    logger.error({ tickerId: input.tickerId, err: error }, message);
+    log.error({ err: toSafeLogError(error) }, message);
+    emitRunSummary({
+      outcome: "failure",
+      articlesProcessed: articlesProcessedForSummary,
+      extractionSuccessCount,
+      extractionFailures,
+      relevanceRowValidationFailures,
+      chunkParseCounts: { ...chunkParseCounts },
+      postFailures,
+      entitiesCreated,
+      entitiesReused,
+      relationsCreated,
+      articlesScored: articlesScoredTotal,
+      articlesSelected: articlesSelectedTotal,
+      relevanceAggregate: null,
+      llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+      extractionLatencyMsTotal,
+      extractionCalls,
+      topLevelError: toSafeLogError(error),
+    });
     return { success: false, message };
   }
 };

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -46,6 +46,25 @@ Per-source **LLM** or **vocabulary** errors are **skipped** (no whole-run abort)
 
 **Retries:** `postTransientRetries` (default `0`) and `postTransientRetryBaseDelayMs` (default `500`) retry the same chunk on **429** or **5xx** from agent-data-api, with exponential backoff (`base * 2^attempt`).
 
+## Observability and log hygiene (MP-ART-ANALYSIS-008)
+
+Every run emits a structured **info** log with message `article_analysis.run.summary` and payload fields suitable for metrics backends or log pipelines.
+
+| Area | Fields (examples) |
+| ---- | ----------------- |
+| Correlation | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present |
+| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy) |
+| Extraction | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`** |
+| Validation | **`relevanceRowValidationFailures`** (pre-POST row checks), **`chunkParseErrors*`** (entity/relation chunks, `articleEntities`, `articleRelevances` chunk-build / Zod issues) |
+| Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |
+| KG tallies | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected` |
+| Relevance stats | When relevance rows were built: `relevanceRowCount`, `scoreMin` / `scoreMax` / `scoreMean`, **`scoreBuckets`**, **`breakdownVersion`** (or `mixed`), **`breakdownKeyMeans`** / mins / maxes over canonical keys |
+| LLM | **`llmPromptTokens`**, **`llmCompletionTokens`**, **`llmTotalTokens`** summed over extraction calls **only if** the AI SDK reports usage for those calls; fields are **omitted** when the provider returns no token counts |
+| Timing | **`extractionLatencyMsTotal`**, **`extractionCalls`**, **`avgExtractionLatencyMs`** |
+| Top-level throw | Summary includes `error: { type, message }`; **`warn` / `error` logs use the same safe shape**—never attach raw `Error` objects (avoids leaking rich provider payloads) |
+
+**Security:** Logs intentionally exclude raw article `content`, API keys, and bearer tokens. Chunk and summary payloads use ids and counts only.
+
 ## Idempotency and incremental runs
 
 - **`unanalyzed=true` (default on GET):** `loadAnalysisContext` returns only data sources that do **not** yet have an **`article_relevance`** row for the ticker—routine re-runs skip already-scored articles.


### PR DESCRIPTION
## Summary

Implements MP-ART-ANALYSIS-008: structured observability for the article-analysis agent via a single `article_analysis.run.summary` log per run, with per-stage counters (extraction vocabulary vs LLM, relevance validation, chunk parse errors, POST failures), optional aggregated LLM token usage and extraction latency, score/breakdown aggregates when relevance rows are built, and safe `{ type, message }` error fields instead of raw `Error` objects. Hermes correlation ids are included on the child logger when present.

## Related issues

Closes #218

## Important changes

- New `article-analysis-observability` helpers for summary payload construction and relevance aggregates.
- `extractEntitiesAndRelationsForSource` returns `{ object, usage }` with normalized AI SDK usage when the provider reports token counts.
- `run.ts` uses `logger.child`, emits a summary on every exit path, and avoids logging article content or raw errors.

## Other changes

- Dev docs: new observability section on the Analysis Agent page.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts` — summary shape, aggregates, safe errors.
- `apps/mediapulse/agents/article-analysis/src/run.ts` — wiring, counters, summary emission.
- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` — usage return path.

## How to test

1. `pnpm code-quality` (passes).
2. `pnpm --filter @mediapulse/article-analysis test` — verifies mocks, summary fields, and redaction-oriented assertions.

