### PR TITLE
Add Hermes debounce tunables and analysis GET last scored time

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -234,6 +234,7 @@ describe("agent-data-api", () => {
           utcDayStartIso: "2026-03-19T00:00:00.000Z",
           selectedCountToday: 0,
         },
+        lastRelevanceScoredAtIso: null,
       });
 
       const { app } = await import("./index.js");
@@ -262,6 +263,7 @@ describe("agent-data-api", () => {
           utcDayStartIso: "2026-03-19T00:00:00.000Z",
           selectedCountToday: 0,
         },
+        lastRelevanceScoredAtIso: null,
       });
 
       const start = "2026-01-01T00:00:00.000Z";

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -76,6 +76,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };
@@ -98,6 +99,13 @@ describe("loadAnalysisContext", () => {
       }),
     );
     expect(db.articleRelevance.count).toHaveBeenCalled();
+    expect(db.articleRelevance.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tickerId: "ticker-1" },
+        orderBy: { scoredAt: "desc" },
+        select: { scoredAt: true },
+      }),
+    );
   });
 
   it("loads all ticker sources when unanalyzed is false", async () => {
@@ -118,6 +126,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(2),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };
@@ -133,6 +142,42 @@ describe("loadAnalysisContext", () => {
       }),
     );
     expect(result.relevanceSelectionState.selectedCountToday).toBe(2);
+    expect(result.lastRelevanceScoredAtIso).toBeNull();
+  });
+
+  it("returns lastRelevanceScoredAtIso from the latest scored row", async () => {
+    const scoredAt = new Date("2026-03-10T12:00:00.000Z");
+    const db = {
+      dataSource: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      entityType: { findMany: vi.fn().mockResolvedValue([]) },
+      relationType: { findMany: vi.fn().mockResolvedValue([]) },
+      entity: {
+        findMany: vi.fn().mockResolvedValue([]),
+        findFirst: vi.fn(),
+        create: vi.fn(),
+      },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: {
+        upsert: vi.fn(),
+        count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue({ scoredAt }),
+      },
+      $transaction: vi.fn(),
+    };
+
+    const result = await loadAnalysisContext(
+      { tickerId: "ticker-debounce", unanalyzed: true },
+      { db: db as never },
+    );
+
+    expect(result.lastRelevanceScoredAtIso).toBe(scoredAt.toISOString());
   });
 
   it("filters by createdAt gte when start is set", async () => {
@@ -153,6 +198,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };
@@ -193,6 +239,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };
@@ -233,6 +280,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };
@@ -287,6 +335,7 @@ describe("loadAnalysisContext", () => {
       articleRelevance: {
         upsert: vi.fn(),
         count: vi.fn().mockResolvedValue(0),
+        findFirst: vi.fn().mockResolvedValue(null),
       },
       $transaction: vi.fn(),
     };

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -32,7 +32,10 @@ type AnalysisDb = {
   tickerEntity: Pick<typeof prisma.tickerEntity, "create" | "findFirst">;
   entityRelation: Pick<typeof prisma.entityRelation, "create" | "findUnique">;
   articleEntity: Pick<typeof prisma.articleEntity, "upsert">;
-  articleRelevance: Pick<typeof prisma.articleRelevance, "upsert" | "count">;
+  articleRelevance: Pick<
+    typeof prisma.articleRelevance,
+    "upsert" | "count" | "findFirst"
+  >;
   $transaction: typeof prisma.$transaction;
 };
 
@@ -122,18 +125,26 @@ export const loadAnalysisContext = async (
     },
   } satisfies Prisma.ArticleRelevanceCountArgs;
 
+  const lastRelevanceArgs = {
+    where: { tickerId: query.tickerId },
+    orderBy: { scoredAt: "desc" as const },
+    select: { scoredAt: true },
+  } satisfies Prisma.ArticleRelevanceFindFirstArgs;
+
   const [
     dataSources,
     entityTypes,
     relationTypes,
     existingEntityRows,
     selectedCountToday,
+    lastRelevanceRow,
   ] = await Promise.all([
     db.dataSource.findMany(dataSourceArgs),
     db.entityType.findMany(entityTypeArgs),
     db.relationType.findMany(relationTypeArgs),
     db.entity.findMany(existingEntityArgs),
     db.articleRelevance.count(relevanceCountArgs),
+    db.articleRelevance.findFirst(lastRelevanceArgs),
   ]);
 
   return {
@@ -150,6 +161,9 @@ export const loadAnalysisContext = async (
       utcDayStartIso: utcDayStart.toISOString(),
       selectedCountToday,
     },
+    lastRelevanceScoredAtIso: lastRelevanceRow
+      ? lastRelevanceRow.scoredAt.toISOString()
+      : null,
   };
 };
 

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -1,0 +1,108 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDraftRelevanceRow,
+  type PerSourceRelevanceSignals,
+} from "./analysis-relevance-scoring.js";
+import {
+  articleAnalysisConfigSchema,
+  articleAnalysisConfigDefaults,
+  resolveArticleAnalysisConfig,
+  toRelevanceWeightMapV1,
+} from "./config-schema.js";
+
+const minimalConfig = {
+  openaiApiKey: "sk-test",
+} satisfies Parameters<typeof articleAnalysisConfigSchema.parse>[0];
+
+const minimalSignals = {
+  dataSourceId: "00000000-0000-4000-8000-000000000001",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  url: "https://reuters.com/article",
+  entityCount: 1,
+  relationCount: 1,
+  mentionCount: 1,
+  avgMentionConfidence: 0.5,
+  titleLower: "headline",
+  textLower: "body",
+} satisfies PerSourceRelevanceSignals;
+
+describe("articleAnalysisConfigSchema", () => {
+  it("parses optional debounce and default batch fields", () => {
+    // Act
+    const parsed = articleAnalysisConfigSchema.parse({
+      ...minimalConfig,
+      debounceMinUnanalyzedCount: 3,
+      debounceMinMinutesSinceLastScore: 15,
+      defaultMaxBatchSize: 20,
+    });
+
+    // Assert
+    expect(parsed.debounceMinUnanalyzedCount).toBe(3);
+    expect(parsed.debounceMinMinutesSinceLastScore).toBe(15);
+    expect(parsed.defaultMaxBatchSize).toBe(20);
+  });
+});
+
+describe("resolveArticleAnalysisConfig", () => {
+  it("fills debounce defaults of zero when Hermes omits them", () => {
+    // Act
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse(minimalConfig),
+    );
+
+    // Assert
+    expect(resolved.debounceMinUnanalyzedCount).toBe(0);
+    expect(resolved.debounceMinMinutesSinceLastScore).toBe(0);
+  });
+
+  it("preserves Hermes debounce and defaultMaxBatchSize overrides", () => {
+    // Act
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse({
+        ...minimalConfig,
+        debounceMinUnanalyzedCount: 5,
+        debounceMinMinutesSinceLastScore: 30,
+        defaultMaxBatchSize: 12,
+      }),
+    );
+
+    // Assert
+    expect(resolved.debounceMinUnanalyzedCount).toBe(5);
+    expect(resolved.debounceMinMinutesSinceLastScore).toBe(30);
+    expect(resolved.defaultMaxBatchSize).toBe(12);
+  });
+
+  it("maps scoreBreakdownVersion to resolved config used for POST breakdown", () => {
+    // Act
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse({
+        ...minimalConfig,
+        scoreBreakdownVersion: 7,
+      }),
+    );
+    const row = buildDraftRelevanceRow(
+      minimalSignals,
+      resolved.scoreBreakdownVersion,
+      toRelevanceWeightMapV1(resolved),
+    );
+
+    // Assert
+    expect(resolved.scoreBreakdownVersion).toBe(7);
+    expect(row.scoreBreakdown._version).toBe(7);
+  });
+
+  it("uses package default scoreBreakdownVersion when Hermes omits it", () => {
+    // Act
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse(minimalConfig),
+    );
+
+    // Assert
+    expect(resolved.scoreBreakdownVersion).toBe(
+      articleAnalysisConfigDefaults.scoreBreakdownVersion,
+    );
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -8,8 +8,8 @@ const articleAnalysisRunPolicySchema = z.object({
 });
 
 /**
- * Hermes agent config for article-analysis (extraction, caps, chunking).
- * Placeholder numeric defaults until MP-ART-ANALYSIS-009 env alignment.
+ * Hermes agent config for article-analysis (extraction, caps, chunking, relevance, debounce).
+ * Operational defaults are filled by {@link resolveArticleAnalysisConfig}.
  */
 export const articleAnalysisConfigSchema = z.object({
   verbose: z.boolean().optional(),
@@ -33,7 +33,7 @@ export const articleAnalysisConfigSchema = z.object({
   maxArticleEntitiesPerRun: z.number().int().positive().optional(),
   /** Max `articleEntities` rows per POST chunk. */
   postChunkArticleEntityBatchSize: z.number().int().positive().optional(),
-  /** Stored in `scoreBreakdown._version` (MP-ART-ANALYSIS-009 env mirror later). */
+  /** Stored in `scoreBreakdown._version` (must match Hermes when bumping breakdown schema). */
   scoreBreakdownVersion: z.number().int().min(1).optional(),
   relevanceWeightBreakingNews: z.number().nonnegative().optional(),
   relevanceWeightKgRelation: z.number().nonnegative().optional(),
@@ -61,6 +61,18 @@ export const articleAnalysisConfigSchema = z.object({
   postTransientRetries: z.number().int().nonnegative().optional(),
   /** Initial backoff in ms; delay doubles each retry (`base * 2^attempt`). */
   postTransientRetryBaseDelayMs: z.number().int().positive().optional(),
+  /**
+   * Incremental runs only: when Hermes input omits `maxBatchSize`, cap eligible sources to this count (unset = no cap).
+   */
+  defaultMaxBatchSize: z.number().int().positive().optional(),
+  /**
+   * When greater than zero, skip the run (success no-op) if GET returns fewer unanalyzed sources than this threshold.
+   */
+  debounceMinUnanalyzedCount: z.number().int().nonnegative().optional(),
+  /**
+   * When greater than zero, skip the run (success no-op) if any relevance was scored for this ticker within the last N minutes (requires GET `lastRelevanceScoredAtIso`).
+   */
+  debounceMinMinutesSinceLastScore: z.number().int().nonnegative().optional(),
 });
 
 export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
@@ -90,6 +102,8 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   runPolicy: ArticleAnalysisRunPolicy;
   postTransientRetries: number;
   postTransientRetryBaseDelayMs: number;
+  debounceMinUnanalyzedCount: number;
+  debounceMinMinutesSinceLastScore: number;
 };
 
 /** Production-oriented defaults merged onto parsed Hermes config. */
@@ -120,10 +134,13 @@ export const articleAnalysisConfigDefaults = {
   },
   postTransientRetries: 0,
   postTransientRetryBaseDelayMs: 500,
+  debounceMinUnanalyzedCount: 0,
+  debounceMinMinutesSinceLastScore: 0,
 } as const;
 
 /**
- * Returns effective config with defaults applied for optional numeric/string fields.
+ * Returns effective config with defaults applied for optional numeric/string fields,
+ * including debounce knobs and optional `defaultMaxBatchSize` passthrough from Hermes.
  *
  * @param config - Parsed Hermes config.
  * @returns Config safe to use at runtime.
@@ -204,6 +221,12 @@ export const resolveArticleAnalysisConfig = (
     postTransientRetryBaseDelayMs:
       config.postTransientRetryBaseDelayMs ??
       articleAnalysisConfigDefaults.postTransientRetryBaseDelayMs,
+    debounceMinUnanalyzedCount:
+      config.debounceMinUnanalyzedCount ??
+      articleAnalysisConfigDefaults.debounceMinUnanalyzedCount,
+    debounceMinMinutesSinceLastScore:
+      config.debounceMinMinutesSinceLastScore ??
+      articleAnalysisConfigDefaults.debounceMinMinutesSinceLastScore,
   };
 };
 

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -106,6 +106,7 @@ describe("run", () => {
       relationTypes: [],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
@@ -176,6 +177,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
@@ -198,6 +200,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource")
@@ -285,6 +288,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
@@ -366,6 +370,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
@@ -694,6 +699,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     let extractCall = 0;
@@ -781,6 +787,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
@@ -851,6 +858,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
@@ -890,6 +898,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockRejectedValue(
@@ -925,6 +934,7 @@ describe("run", () => {
       relationTypes: [{ id: REL_ID, name: "r", description: null }],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
@@ -966,6 +976,7 @@ describe("run", () => {
       relationTypes: [],
       existingEntities: [],
       relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
     });
 
     await run(
@@ -976,5 +987,157 @@ describe("run", () => {
     );
 
     expect(mockLog.info).toHaveBeenCalled();
+  });
+
+  it("applies defaultMaxBatchSize on incremental runs when input omits maxBatchSize", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u1",
+          title: "T1",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+        {
+          id: DS_ID_2,
+          url: "u2",
+          title: "T2",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
+    });
+
+    const extractSpy = vi
+      .spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValue(
+        llmResult({
+          entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+          relations: [],
+          articleMentions: [],
+        }),
+      );
+
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 1,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 0,
+      });
+
+    await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { defaultMaxBatchSize: 1 },
+      }),
+    );
+
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips run when unanalyzed backlog is below debounceMinUnanalyzedCount", async () => {
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+        {
+          id: DS_ID_2,
+          url: "u2",
+          title: "T2",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { debounceMinUnanalyzedCount: 5 },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("debounce");
+    expect(analysisCreate).not.toHaveBeenCalled();
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { semanticFailureReason?: string }).semanticFailureReason ===
+          "debounce_min_unanalyzed_count",
+    );
+    expect(summaryCall).toBeDefined();
+  });
+
+  it("skips run when last relevance scored within debounceMinMinutesSinceLastScore", async () => {
+    const lastScored = new Date(Date.now() - 30 * 60_000).toISOString();
+    analysisGet.mockResolvedValue({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: "u",
+          title: "T",
+          content: "c",
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [],
+      relevanceSelectionState,
+      lastRelevanceScoredAtIso: lastScored,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { debounceMinMinutesSinceLastScore: 60 },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("debounce");
+    expect(analysisCreate).not.toHaveBeenCalled();
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { semanticFailureReason?: string }).semanticFailureReason ===
+          "debounce_min_minutes_since_last_score",
+    );
+    expect(summaryCall).toBeDefined();
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -172,6 +172,15 @@ const resolveAgainstExistingEntities = (
 const sleepMs = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
+/**
+ * Minutes elapsed from an ISO 8601 instant to now (floating).
+ *
+ * @param iso - UTC instant from the analysis GET payload.
+ * @returns Non-negative when `iso` is in the past.
+ */
+const minutesSinceUtcIso = (iso: string): number =>
+  (Date.now() - new Date(iso).getTime()) / 60_000;
+
 const emptyChunkParseCounts = (): ChunkBuildParseCounts => ({
   entityRelationChunkParseErrors: 0,
   articleEntityChunkParseErrors: 0,
@@ -286,8 +295,112 @@ export const run = async ({
     const query = buildAnalysisGetQuery(inputForQuery);
     const ctx = await dataApiClient.analysis.get(query);
 
+    const backlogSources = ctx.dataSources.length;
+    if (
+      backlogSources > 0 &&
+      cfg.debounceMinUnanalyzedCount > 0 &&
+      backlogSources < cfg.debounceMinUnanalyzedCount
+    ) {
+      emitRunSummary({
+        outcome: "success",
+        articlesProcessed: 0,
+        extractionSuccessCount: 0,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: emptyChunkParseCounts(),
+        postFailures: [],
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 0,
+        runStatusLabel: "success",
+        semanticFailureReason: "debounce_min_unanalyzed_count",
+      });
+      return {
+        success: true,
+        message: `debounce: ${backlogSources} unanalyzed source(s) below min ${cfg.debounceMinUnanalyzedCount}; skipping run`,
+        details: {
+          dataSourcesReturned: backlogSources,
+          dataSourcesSelected: 0,
+          reanalyze,
+          runStatus: "success" as const,
+          extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
+          extractionSuccessCount: 0,
+          postFailures: [] as ArticleAnalysisPostFailureRecord[],
+          entitiesCreated: 0,
+          entitiesReused: 0,
+          relationsCreated: 0,
+          postChunks: 0,
+          articleEntityRowsPosted: 0,
+          mentionPostChunks: 0,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
+        },
+      };
+    }
+
+    if (
+      backlogSources > 0 &&
+      cfg.debounceMinMinutesSinceLastScore > 0 &&
+      ctx.lastRelevanceScoredAtIso !== null &&
+      minutesSinceUtcIso(ctx.lastRelevanceScoredAtIso) <
+        cfg.debounceMinMinutesSinceLastScore
+    ) {
+      emitRunSummary({
+        outcome: "success",
+        articlesProcessed: 0,
+        extractionSuccessCount: 0,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: emptyChunkParseCounts(),
+        postFailures: [],
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 0,
+        runStatusLabel: "success",
+        semanticFailureReason: "debounce_min_minutes_since_last_score",
+      });
+      return {
+        success: true,
+        message: `debounce: last relevance scored at ${ctx.lastRelevanceScoredAtIso} is within ${cfg.debounceMinMinutesSinceLastScore} minute(s); skipping run`,
+        details: {
+          dataSourcesReturned: backlogSources,
+          dataSourcesSelected: 0,
+          reanalyze,
+          runStatus: "success" as const,
+          extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
+          extractionSuccessCount: 0,
+          postFailures: [] as ArticleAnalysisPostFailureRecord[],
+          entitiesCreated: 0,
+          entitiesReused: 0,
+          relationsCreated: 0,
+          postChunks: 0,
+          articleEntityRowsPosted: 0,
+          mentionPostChunks: 0,
+          articlesScored: 0,
+          articlesSelected: 0,
+          relevancePostChunks: 0,
+        },
+      };
+    }
+
     const sorted = sortAnalysisDataSourcesByCreatedAt(ctx.dataSources);
-    const batch = applyMaxBatchSizeCap(sorted, inputForQuery.maxBatchSize);
+    const effectiveMaxBatchSize = reanalyze
+      ? input.maxBatchSize
+      : (input.maxBatchSize ?? cfg.defaultMaxBatchSize);
+    const batch = applyMaxBatchSizeCap(sorted, effectiveMaxBatchSize);
     articlesProcessedForSummary = batch.length;
 
     if (batch.length === 0) {

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -54,6 +54,7 @@ Implemented in `apps/mediapulse/agent-data-api/src/routes/analysis.ts`. Schemas 
   - `unanalyzed` — optional (`"true"` | `"false"` strings). When omitted, defaults to `"true"` (incremental backlog: sources with no `article_relevance` row for that ticker). `"false"` returns all `DataSource` rows for the ticker for re-scoring workflows (FR2).
   - `start` — optional ISO 8601 datetime; when set, only sources with `createdAt >= start` (inclusive), FR1.
   - `end` — optional ISO 8601 datetime; when set, only sources with `createdAt <= end` (inclusive), FR1. If both `start` and `end` are set, `start` must not be after `end` (validation error).
+- **GET response** — Includes `dataSources`, vocabulary, `existingEntities`, `relevanceSelectionState` (**`utcDayStartIso`**, **`selectedCountToday`**), and **`lastRelevanceScoredAtIso`**: ISO 8601 of the latest `article_relevance.scored_at` for the ticker, or `null` if none (used by article-analysis debounce).
 - **POST** — Body validated by `postAnalysisBodySchema`: `tickerId`, optional arrays `entities`, `relations`, `articleEntities`, `articleRelevances`. Response includes aggregate counts (`entitiesCreated`, `entitiesReused`, `relationsCreated`, `articlesScored`, `articlesSelected`).
 
 From agents, use the SDK namespace **`analysis`**: `get` for the query object, **`create`** for POST. **MP-ART-ANALYSIS-003** will map agent run `timeWindow` (when present) to these query params on `analysis.get` instead of filtering only client-side after fetch.

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -53,7 +53,7 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 | Area | Fields (examples) |
 | ---- | ----------------- |
 | Correlation | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present |
-| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy) |
+| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**) |
 | Extraction | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`** |
 | Validation | **`relevanceRowValidationFailures`** (pre-POST row checks), **`chunkParseErrors*`** (entity/relation chunks, `articleEntities`, `articleRelevances` chunk-build / Zod issues) |
 | Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |
@@ -72,30 +72,44 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 
 Structured logs use **`tickerId`**, **`dataSourceId`**, and chunk indices—**not** full article bodies or secrets.
 
+## Debounce (Hermes config)
+
+Optional guards reduce thrash when schedules fire more often than needed. All are **Hermes agent config** keys on **article-analysis** (see `articleAnalysisConfigSchema`):
+
+- **`debounceMinUnanalyzedCount`** — When greater than zero, the run exits **success** with no POST if the incremental GET returns **fewer** unanalyzed sources than this threshold (but at least one).
+- **`debounceMinMinutesSinceLastScore`** — When greater than zero, the run exits **success** with no POST if **`GET /api/v1/analysis`** reports **`lastRelevanceScoredAtIso`** within the last N minutes and there is at least one eligible source.
+
+These are **additive** to calendar staggering: prefer running **data-collection** before **article-analysis** so backlog exists when analysis runs.
+
 ## I/O contract
 
 - **Input:** `{ tickerId: string }`
 - **Reads:** `GET /api/analysis?tickerId=...&unanalyzed=true`
 - **Writes:** `POST /api/analysis` (bulk KG + relevance updates)
 
-## Environment variables
+## Hermes agent configuration (operational tuning)
+
+Tuning for extraction, chunking, **`scoreBreakdownVersion`** (maps to `_version` in stored breakdowns), relevance weights, selection caps, **`runPolicy`**, POST retries, **`defaultMaxBatchSize`** (incremental runs when input omits `maxBatchSize`), and **debounce** fields lives in the **article-analysis** agent config in Hermes (Zod schema `articleAnalysisConfigSchema`). **`openaiApiKey`** and model limits are set there—**not** via `OPENAI_*` process env on the agent container.
+
+## Deployment environment (`@mediapulse/env/agents-article-analysis`)
 
 | Variable                     | Required | Notes                                                      |
 | ---------------------------- | -------- | ---------------------------------------------------------- |
 | `PORT`                       | Yes      | Agent HTTP port                                            |
 | `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                          |
-| `AGENT_DATA_API_URL`         | Yes      | Base URL for data API calls                                |
-| `OPENAI_API_KEY`             | Yes      | LLM provider key                                           |
-| `OPENAI_MODEL`               | Yes      | Model id for extraction/scoring prompts                    |
+| `AGENT_DATA_API_URL`         | Yes      | Base URL for agent-data-api                                |
 | `AGENT_REGISTRY_URL`         | No       | Needed for auto-register                                   |
 | `DOMAIN_INTEGRATION_API_KEY` | No       | Hermes domain integration API key for auto-register (mint JWT) |
 | `AGENT_PUBLIC_URL`           | No       | Needed for auto-register                                   |
+| `DOMAIN_INTEGRATION_ID`      | No       | Domain id (default `mediapulse`)                           |
+| `ALLOW_ANY_BEARER_FOR_LOCAL` | No       | Local-only; never use in production                        |
 
 ## Pipeline usage
 
-- Included in **Pipeline C: Analysis & Newsletter**
-- Order: `analysis -> content-generation -> delivery`
-- Schedule: `0 20 * * *` in `Asia/Jakarta`
+Mediapulse KG flow order: **query-analysis** → **data-collection** → **article-analysis** → **content-generation** → **delivery**. Stagger collection ahead of analysis (for example by cron) so analysis sees fresh **`data_source`** rows.
+
+- Included in **Pipeline C: Analysis & Newsletter** for the newsletter tail: `article-analysis -> content-generation -> delivery`
+- Example newsletter schedule: `0 20 * * *` in `Asia/Jakarta`
 - Input fan-out: `{ "tickerId": "db:userTicker:tickerId?where.enabled=true" }`
 
 ## Related docs

--- a/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
+++ b/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
@@ -180,9 +180,9 @@ The **article-analysis** agent computes a **weighted composite score** in `[0, 1
 | `fundamental`     | Filings, earnings, guidance, and similar keywords |
 | `tickerSalience`  | Mentions and extracted entity coverage |
 | `sourceQuality`   | Host-tier trust prior |
-| `_version`        | Integer breakdown version (Hermes `scoreBreakdownVersion`; env alignment in MP-ART-ANALYSIS-009) |
+| `_version`        | Integer breakdown version — set via Hermes agent config **`scoreBreakdownVersion`** (must match stored JSON when bumping schema) |
 
-`score = sum_k relevanceWeight_k * scoreBreakdown[k]` over the five dimensions (default weights `0.2` each via Hermes).
+`score = sum_k relevanceWeight_k * scoreBreakdown[k]` over the five dimensions (default weights `0.2` each; tune via Hermes **`relevanceWeight*`** keys on article-analysis).
 
 Top-scoring rows that pass **`relevanceMinScore`** are candidates for **`selected = true`**, up to the **remaining daily budget**: `maxSelectedRelevancePerTickerPerDay - selectedCountToday`, where `selectedCountToday` is returned on **`GET /api/v1/analysis`** as **`relevanceSelectionState.selectedCountToday`** (UTC day start in **`utcDayStartIso`**). Content-generation consumes **`selected`** rows scored today.
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -139,6 +139,7 @@ describe("createAgentDataApiClient", () => {
           utcDayStartIso: "2026-04-09T00:00:00.000Z",
           selectedCountToday: 0,
         },
+        lastRelevanceScoredAtIso: null,
       }),
       statusCode: 200,
     });
@@ -172,6 +173,7 @@ describe("createAgentDataApiClient", () => {
           utcDayStartIso: "2026-01-01T00:00:00.000Z",
           selectedCountToday: 0,
         },
+        lastRelevanceScoredAtIso: null,
       }),
       statusCode: 200,
     });

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -131,6 +131,11 @@ export const getAnalysisResponseSchema = z.object({
   relationTypes: z.array(analysisRelationTypeSchema),
   existingEntities: z.array(analysisExistingEntitySchema),
   relevanceSelectionState: analysisRelevanceSelectionStateSchema,
+  /**
+   * ISO 8601 instant of the most recent `article_relevance.scored_at` for this ticker,
+   * or `null` if no relevance row exists (debounce support for article-analysis).
+   */
+  lastRelevanceScoredAtIso: z.string().datetime().nullable(),
 });
 
 export const postAnalysisResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Completes MP-ART-ANALYSIS-009 by extending Hermes **article-analysis** config with debounce and incremental **defaultMaxBatchSize**, returning **lastRelevanceScoredAtIso** on **GET /api/v1/analysis** for time-based debounce, and aligning dev-docs with Hermes vs `@mediapulse/env` (no new agent env tunables).

## Related issues

Closes #219

## Important changes

- **Hermes config:** `debounceMinUnanalyzedCount`, `debounceMinMinutesSinceLastScore`, `defaultMaxBatchSize` (+ resolution defaults and tests).
- **Agent runtime:** Success no-ops with structured summary `semanticFailureReason` when debounce trips; incremental batch cap uses config when input omits `maxBatchSize`.
- **agent-data-api:** `loadAnalysisContext` adds latest `article_relevance.scored_at` as `lastRelevanceScoredAtIso` on the GET payload (contract + client mocks updated).

## Other changes

- Dev-docs for analysis agent, knowledge graph, and agent-data-api describe the new field and operational tuning via Hermes.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` — new optional config keys and defaults.
- `apps/mediapulse/agents/article-analysis/src/run.ts` — debounce guards and effective max batch size.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — `findFirst` for last scored instant.
- `packages/shared/agent-data-api-contract/src/analysis.ts` — response schema.

## How to test

1. `pnpm code-quality` (passes on this branch).
2. Optional: run article-analysis against agent-data-api with Hermes config debounce values set and confirm GET includes `lastRelevanceScoredAtIso`; trigger low-backlog or recent-score debounce and expect success no-op plus summary reason.
