### PR TITLE
docs(cursor): add create-github-issue skill and cross-links

### DIFF
--- a/.cursor/skills/create-github-issue/SKILL.md
+++ b/.cursor/skills/create-github-issue/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: create-github-issue
+description: Structures GitHub issue titles and markdown bodies (Summary, Scope, Acceptance criteria, Dependencies, Notes) and creates issues with gh using --body-file and temp files outside the repo. Use when creating or drafting a GitHub issue, running gh issue create, filing a ticket before a PR, or when the user asks for issue format or templates.
+---
+
+# Create GitHub issue
+
+## When to use
+
+- User asks to **create**, **file**, or **draft** a GitHub issue.
+- User runs or asks for **`gh issue create`**.
+- Work is tracked in GitHub and an issue must exist **before** a PR ([open-github-pr](../open-github-pr/SKILL.md) hard gate).
+
+## Issue title
+
+- Short, **imperative**, verb-first (same spirit as PR titles).
+- For PR-scoped work, align with the **upcoming PR title** intent.
+- For initiatives or epics, a slightly broader title is fine if scope is clarified in **Scope**.
+
+## Issue body structure
+
+Use these **H2** sections in order. Ground content in facts (diff, commits, PRD, design doc)—not placeholders.
+
+| Section | Content |
+| ------- | ------- |
+| **Summary** | 1–3 sentences: problem, intended change, user/maintainer impact. Use **bold** on key terms when it helps quick scanning. |
+| **Scope** | Bullets: **In scope** and **Out of scope** (use explicit “none” for out-of-scope when everything is in scope). |
+| **Acceptance criteria** | `- [ ]` checklist items that are **testable** (behavior, docs, or scripted verification). |
+| **Dependencies** | `- Depends on:` and `- Blocks:` with ticket ids (e.g. `PREFIX-001`), requirement ids (`REQ-…`), other issue numbers, or `none`. |
+| **Notes** | PRD section refs, policy conflicts, rollout risks; **omit** the section if there is nothing material. |
+
+### Copy-paste template
+
+```markdown
+## Summary
+
+
+
+## Scope
+
+- In scope:
+- Out of scope:
+
+## Acceptance criteria
+
+- [ ]
+
+## Dependencies
+
+- Depends on:
+- Blocks:
+
+## Notes
+
+
+```
+
+## `gh issue create` workflow
+
+1. **Repository and auth** — Use the same **step 1** as [open-github-pr](../open-github-pr/SKILL.md) (resolve `host` / `owner` / `repo`, `gh auth switch`, verify with `gh api`).
+2. **Body file** — Never write issue bodies inside the repo clone.
+   - `ISSUE_FILE="$(mktemp "${TMPDIR:-/tmp}/gh-issue-body.XXXXXX")"`
+   - `trap 'rm -f "$ISSUE_FILE"' EXIT`
+   - Write the markdown body to `"$ISSUE_FILE"`.
+3. **Create** — `gh issue create --repo "<owner>/<repo>" -t "Imperative concise title" --body-file "$ISSUE_FILE"`  
+   Add **`-l label`** when team conventions or [prd-to-tickets](../prd-to-tickets/SKILL.md) batch labeling applies (`group_slug`, epic label, etc.).
+4. **Capture and verify** — From the printed URL: `gh issue view "<url>" --repo "<owner>/<repo>" --json number,state,title -q .number` (or equivalent). Confirm **`state` is `OPEN`**. Use `#N` in the PR body per open-github-pr (`Closes` / `Refs` / `Fixes`).
+
+If `gh issue create` fails (auth, permissions), stop, fix context or have the user create the issue manually—then **`gh issue view`** before opening the PR.
+
+## From PRD ticket markdown ([prd-to-tickets](../prd-to-tickets/SKILL.md))
+
+When promoting a ticket file to GitHub:
+
+- **Title:** the ticket `title` (from frontmatter or the `# …` heading).
+- **Body:** everything **below the YAML frontmatter**—sections already match this skill.
+- Apply the batch **label** if the PRD run used `group_slug` / labeling rules.
+
+## Quality checklist
+
+- Title is imperative and scoped appropriately.
+- Summary, Scope, Acceptance criteria, and Dependencies are filled; Notes present or omitted on purpose.
+- Acceptance criteria are observable (merged behavior, docs, or checks).
+- Issue was created with **`mktemp`** + **`--body-file`** + **`trap`**; no body file left in the repo.
+- **`gh issue view`** confirms the issue is **OPEN** before linking from a PR.

--- a/.cursor/skills/git-town-stacked-changes/SKILL.md
+++ b/.cursor/skills/git-town-stacked-changes/SKILL.md
@@ -96,7 +96,7 @@ git town sync --all
 ## PRs and review
 
 - **Base branch:** Git Town usually sets the PR base to the **parent branch** so reviewers see a **small diff** (not the whole stack in one PR). After the parent merges, **update or retarget** the next PR to `main` per your hosting provider (or via Git Town ship/sync workflow).
-- **Title/body:** Reference the ticket `id`, `group_slug`, and `prd_refs` from the ticket file. For `gh pr create`, follow the repo’s [open-github-pr](../open-github-pr/SKILL.md) skill (`--body-file`, etc.).
+- **Title/body:** Reference the ticket `id`, `group_slug`, and `prd_refs` from the ticket file. For GitHub issues before PRs, follow [create-github-issue](../create-github-issue/SKILL.md); for `gh pr create`, follow the repo’s [open-github-pr](../open-github-pr/SKILL.md) skill (`--body-file`, etc.).
 - Optional: [Git Town GitHub Action](https://www.git-town.com/) for a visible stack graph on PRs (if enabled in the project).
 
 ## Agent checklist (implementation follow-up)

--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: open-github-pr
-description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and verified GitHub issue links (Closes/Fixes/Refs). Always resolve or create related issues before gh pr create so the PR can link to tickets. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (including Related issues).
+description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and verified GitHub issue links (Closes/Fixes/Refs). Always resolve or create related issues before gh pr create so the PR can link to tickets; when drafting new issues, follow the create-github-issue skill for title and body structure. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (including Related issues).
 ---
 
 # Open GitHub Pull Request
 
 Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body. **Do not run `gh pr create` until at least one related GitHub issue exists, is open, and is verified** (see **Mandatory: resolve or create issues before the PR**). Then include **`## Related issues`** with `Closes`/`Fixes`/`Refs` so the PR appears under each issue’s Development section.
+
+**Creating or drafting GitHub issues** (title, body sections, `gh issue create`): use [create-github-issue](../create-github-issue/SKILL.md).
 
 ## When to use this skill
 
@@ -52,7 +54,7 @@ Run this **after** you have the same `<base>` used for `git diff <base>...HEAD` 
 
 2. **Select or create**
    - If one or more issues clearly match: run `gh issue view <n|url> --repo "<owner>/<repo>" --json number,state,title,url` and require **`state` is `OPEN`**. If the issue is closed, stop and resolve with the user (reopen, new issue, or different ticket)—do not open a PR that only links to a closed issue unless they explicitly want that.
-   - If **no** suitable open issue exists in this repo (and the user did not point to external-repo-only tracking): **draft** an issue whose title aligns with the upcoming PR title intent and whose body includes short **context**, **scope**, and **acceptance** / expected outcome—grounded in `git diff <base>...HEAD` and the commit story, not an empty placeholder. Create with **`gh issue create --repo "<owner>/<repo>" -t "..." --body-file "$ISSUE_FILE"`**, where **`$ISSUE_FILE`** is from **`mktemp`** under the system temp dir only, with **`trap 'rm -f "$ISSUE_FILE"' EXIT`** (same rules as PR bodies—**never** write under the clone). Add **`-l name`** when team conventions or the user specify labels.
+   - If **no** suitable open issue exists in this repo (and the user did not point to external-repo-only tracking): **draft** an issue whose title aligns with the upcoming PR title intent and whose body follows [create-github-issue](../create-github-issue/SKILL.md) (Summary, Scope, Acceptance criteria, Dependencies, Notes)—grounded in `git diff <base>...HEAD` and the commit story, not an empty placeholder. Create with **`gh issue create --repo "<owner>/<repo>" -t "..." --body-file "$ISSUE_FILE"`**, where **`$ISSUE_FILE`** is from **`mktemp`** under the system temp dir only, with **`trap 'rm -f "$ISSUE_FILE"' EXIT`** (same rules as PR bodies—**never** write under the clone). Add **`-l name`** when team conventions or the user specify labels.
 
 3. **Capture number** — `gh issue create` prints the new issue URL. Resolve the number reliably:  
    `ISSUE_NUM="$(gh issue view "<printed-url>" --repo "<owner>/<repo>" --json number -q .number)"`  

--- a/.cursor/skills/prd-to-tickets/SKILL.md
+++ b/.cursor/skills/prd-to-tickets/SKILL.md
@@ -46,7 +46,7 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 | `group_slug`    | Yes         | **Stable machine id** for the initiative: `kebab-case`, no spaces (e.g. `hermes-admin-password-reset`). Use for GitHub **label** names, Linear project keys, Jira epic links, branch naming hints. |
 | `group_label`   | Recommended | **Human-readable** title for the same group (e.g. `Hermes admin password reset`). Shown in tables and when creating issues.                                                                        |
 
-**When exporting to GitHub (or similar):** create or apply a **label** equal to `group_slug`, or use `group_slug` as a namespace prefix (e.g. label `epic:hermes-admin-password-reset`)—**stay consistent within the batch** and document the choice in the chat reply.
+**When exporting to GitHub (or similar):** create or apply a **label** equal to `group_slug`, or use `group_slug` as a namespace prefix (e.g. label `epic:hermes-admin-password-reset`)—**stay consistent within the batch** and document the choice in the chat reply. When creating the GitHub issue from a ticket, use the body structure and `gh` patterns in [create-github-issue](../create-github-issue/SKILL.md).
 
 **Optional sub-batch:** If the PRD defines phases, add `phase: 1` (or `discovery` / `build`) in frontmatter so ordering is clear without splitting `group_slug`.
 


### PR DESCRIPTION
## Summary

Introduces **create-github-issue** so Cursor agents use a single template (Summary, Scope, Acceptance criteria, Dependencies, Notes) and the same **`mktemp` + `--body-file`** pattern as PR bodies. **open-github-pr**, **prd-to-tickets**, and **git-town-stacked-changes** now point to it when drafting or exporting GitHub issues.

## Related issues

Closes #265

## Important changes

- New [.cursor/skills/create-github-issue/SKILL.md](.cursor/skills/create-github-issue/SKILL.md) with issue template and `gh issue create` workflow.
- **open-github-pr** frontmatter and mandatory “create issue” step reference the new skill; intro cross-link for issue drafting.

## Other changes

- **prd-to-tickets**: GitHub export note links to **create-github-issue**.
- **git-town-stacked-changes**: PRs section distinguishes issue skill vs PR skill.

## Key files to review

- `.cursor/skills/create-github-issue/SKILL.md` — structure, template, checklist.
- `.cursor/skills/open-github-pr/SKILL.md` — cross-links and create-step wording.

## How to test

1. Open the new skill in the repo and confirm relative links to **open-github-pr** / **prd-to-tickets** resolve in the IDE.
2. (Optional) Run `gh issue view 265` and confirm the issue matches the shipped scope.
