### PR TITLE
Align domain integration env naming across Mediapulse agents

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -41,7 +41,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/content-generation/src/index.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.ts
@@ -101,7 +101,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/data-collection/src/index.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.ts
@@ -26,7 +26,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_KEY ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/delivery/src/index.ts
+++ b/apps/mediapulse/agents/delivery/src/index.ts
@@ -306,7 +306,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/query-analysis/src/index.ts
+++ b/apps/mediapulse/agents/query-analysis/src/index.ts
@@ -28,17 +28,12 @@ const app = createAgentApp<
   },
   {
     authApiUrl: env.AGENT_AUTH_API_URL,
-    autoRegister:
-      env.AGENT_REGISTRY_URL &&
-      env.DOMAIN_INTEGRATION_API_KEY &&
-      env.AGENT_PUBLIC_URL
-        ? {
-            registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
-            domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
-            agentUrl: env.AGENT_PUBLIC_URL,
-          }
-        : undefined,
+    autoRegister: {
+      registryUrl: env.AGENT_REGISTRY_URL,
+      domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
+      domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
+      agentUrl: env.AGENT_PUBLIC_URL,
+    },
   },
 );
 

--- a/apps/mediapulse/agents/query-analysis/src/index.ts
+++ b/apps/mediapulse/agents/query-analysis/src/index.ts
@@ -34,7 +34,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/ticker-echo/src/index.ts
+++ b/apps/mediapulse/agents/ticker-echo/src/index.ts
@@ -43,7 +43,7 @@ const app = createAgentApp<
       env.AGENT_PUBLIC_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/agents/user-registration/src/index.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.test.ts
@@ -13,7 +13,7 @@ vi.mock("@mediapulse/env/agents-user-registration", () => ({
     AGENT_REGISTRY_URL: undefined,
     AGENT_PUBLIC_URL: undefined,
     DOMAIN_INTEGRATION_API_KEY: undefined,
-    DOMAIN_INTEGRATION_KEY: undefined,
+    DOMAIN_INTEGRATION_ID: undefined,
   },
 }));
 

--- a/apps/mediapulse/agents/user-registration/src/index.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.ts
@@ -191,7 +191,7 @@ const app = createAgentApp<
       env.AGENT_AUTH_API_URL
         ? {
             registryUrl: env.AGENT_REGISTRY_URL,
-            domainIntegrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+            domainIntegrationId: env.DOMAIN_INTEGRATION_ID,
             domainIntegrationApiKey: env.DOMAIN_INTEGRATION_API_KEY,
             agentUrl: env.AGENT_PUBLIC_URL,
           }

--- a/apps/mediapulse/domain-api/src/http/register-with-hermes.ts
+++ b/apps/mediapulse/domain-api/src/http/register-with-hermes.ts
@@ -28,7 +28,7 @@ export const registerWithHermes = async (): Promise<void> => {
   }
 
   const requestBody = registerDomainIntegrationRequestSchema.parse({
-    integrationId: env.DOMAIN_INTEGRATION_ID ?? "mediapulse",
+    integrationId: env.DOMAIN_INTEGRATION_ID,
     name: env.DOMAIN_INTEGRATION_NAME ?? "Mediapulse",
     baseUrl: env.MEDIAPULSE_API_URL,
     version: env.DOMAIN_INTEGRATION_VERSION,

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -27,9 +27,10 @@ It uses:
 | `PORT`                       | Yes      | Agent HTTP port                                            |
 | `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                          |
 | `AGENT_DATA_API_URL`         | Yes      | Base URL for data API calls                                |
-| `AGENT_REGISTRY_URL`         | No       | Needed for auto-register                                   |
-| `DOMAIN_INTEGRATION_API_KEY` | No       | Hermes domain integration API key for auto-register (mint JWT) |
-| `AGENT_PUBLIC_URL`           | No       | Needed for auto-register                                   |
+| `AGENT_REGISTRY_URL`         | Yes      | Agent-registry-api base URL (startup auto-register)        |
+| `AGENT_PUBLIC_URL`           | Yes      | Public URL of this agent (registry `endpoint`)             |
+| `DOMAIN_INTEGRATION_API_KEY` | Yes      | Hermes domain integration API key for auto-register (mint JWT) |
+| `DOMAIN_INTEGRATION_ID`      | Yes      | Stable Hermes domain integration id (e.g. `mediapulse`)      |
 
 ## Hermes agent `config` (strategy + LLM)
 

--- a/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
+++ b/dev-docs/docs/mediapulse/knowledge-graph/knowledge-graph.mdx
@@ -245,9 +245,10 @@ If no row crosses your practical quality threshold, content-generation should sk
 - `AGENT_DATA_API_URL`
 - `OPENAI_API_KEY`
 - `OPENAI_MODEL`
-- `AGENT_REGISTRY_URL` (optional auto-register)
-- `DOMAIN_INTEGRATION_API_KEY` (optional Hermes domain integration API key for auto-register)
-- `AGENT_PUBLIC_URL` (optional auto-register)
+- `AGENT_REGISTRY_URL` (agent-registry-api; startup auto-register)
+- `AGENT_PUBLIC_URL`
+- `DOMAIN_INTEGRATION_API_KEY`
+- `DOMAIN_INTEGRATION_ID`
 - `PORT`
 
 ### analysis

--- a/packages/mediapulse/env/README.md
+++ b/packages/mediapulse/env/README.md
@@ -16,7 +16,7 @@ import { env } from "@mediapulse/env/agents-delivery";
 
 ## Agent-specific overrides (development)
 
-Mediapulse agents under `apps/mediapulse/agents/*` share `packages/mediapulse/env/.env` for most variables but need **per-agent** values for `PORT`, `AGENT_PUBLIC_URL`, and optionally `DOMAIN_INTEGRATION_API_KEY` (Hermes **domain integration API key** for auto-registration JWT minting).
+Mediapulse agents under `apps/mediapulse/agents/*` share `packages/mediapulse/env/.env` for most variables but need **per-agent** values for `PORT`, `AGENT_PUBLIC_URL`, and `DOMAIN_INTEGRATION_API_KEY` (Hermes **domain integration API key** for auto-registration JWT minting).
 
 **How it works:**
 

--- a/packages/mediapulse/env/env.agents.data-collection.example
+++ b/packages/mediapulse/env/env.agents.data-collection.example
@@ -10,4 +10,4 @@ AGENT_AUTH_API_URL="http://localhost:8080" # required
 AGENT_REGISTRY_URL="http://localhost:8082" # required
 AGENT_PUBLIC_URL="http://localhost:4001" # required
 DOMAIN_INTEGRATION_API_KEY= # required
-DOMAIN_INTEGRATION_KEY=mediapulse # required # default
+DOMAIN_INTEGRATION_ID=mediapulse # required # default

--- a/packages/mediapulse/env/env.agents.query-analysis.example
+++ b/packages/mediapulse/env/env.agents.query-analysis.example
@@ -3,7 +3,7 @@
 PORT=4005 #number #default
 AGENT_DATA_API_URL="http://localhost:8081" #required
 AGENT_AUTH_API_URL="http://localhost:8080" #required
-AGENT_REGISTRY_URL="http://localhost:8082"
-AGENT_PUBLIC_URL="http://localhost:4005"
-DOMAIN_INTEGRATION_API_KEY=
+AGENT_REGISTRY_URL="http://localhost:8082" # required
+AGENT_PUBLIC_URL="http://localhost:4005" # required
+DOMAIN_INTEGRATION_API_KEY= # required
 DOMAIN_INTEGRATION_ID=mediapulse # required # default

--- a/packages/mediapulse/env/env.agents.query-analysis.example
+++ b/packages/mediapulse/env/env.agents.query-analysis.example
@@ -6,4 +6,4 @@ AGENT_AUTH_API_URL="http://localhost:8080" #required
 AGENT_REGISTRY_URL="http://localhost:8082"
 AGENT_PUBLIC_URL="http://localhost:4005"
 DOMAIN_INTEGRATION_API_KEY=
-DOMAIN_INTEGRATION_ID=mediapulse
+DOMAIN_INTEGRATION_ID=mediapulse # required # default

--- a/packages/mediapulse/env/src/agents-data-collection.ts
+++ b/packages/mediapulse/env/src/agents-data-collection.ts
@@ -11,7 +11,7 @@ export const env = createEnv({
     AGENT_REGISTRY_URL: z.string().min(1),
     AGENT_PUBLIC_URL: z.string().min(1),
     DOMAIN_INTEGRATION_API_KEY: z.string().min(1),
-    DOMAIN_INTEGRATION_KEY: z.string().min(1),
+    DOMAIN_INTEGRATION_ID: z.string().min(1),
   },
   client: {
   },

--- a/packages/mediapulse/env/src/agents-query-analysis.ts
+++ b/packages/mediapulse/env/src/agents-query-analysis.ts
@@ -8,9 +8,9 @@ export const env = createEnv({
     PORT: z.number({ coerce: true }).optional(),
     AGENT_DATA_API_URL: z.string().min(1),
     AGENT_AUTH_API_URL: z.string().min(1),
-    AGENT_REGISTRY_URL: z.string().optional(),
-    AGENT_PUBLIC_URL: z.string().optional(),
-    DOMAIN_INTEGRATION_API_KEY: z.string().optional(),
+    AGENT_REGISTRY_URL: z.string().min(1),
+    AGENT_PUBLIC_URL: z.string().min(1),
+    DOMAIN_INTEGRATION_API_KEY: z.string().min(1),
     DOMAIN_INTEGRATION_ID: z.string().min(1),
   },
   client: {

--- a/packages/mediapulse/env/src/agents-query-analysis.ts
+++ b/packages/mediapulse/env/src/agents-query-analysis.ts
@@ -8,9 +8,9 @@ export const env = createEnv({
     PORT: z.number({ coerce: true }).optional(),
     AGENT_DATA_API_URL: z.string().min(1),
     AGENT_AUTH_API_URL: z.string().min(1),
-    AGENT_REGISTRY_URL: z.string().min(1),
-    AGENT_PUBLIC_URL: z.string().min(1),
-    DOMAIN_INTEGRATION_API_KEY: z.string().min(1),
+    AGENT_REGISTRY_URL: z.string().optional(),
+    AGENT_PUBLIC_URL: z.string().optional(),
+    DOMAIN_INTEGRATION_API_KEY: z.string().optional(),
     DOMAIN_INTEGRATION_ID: z.string().min(1),
   },
   client: {


### PR DESCRIPTION
## Summary

Standardizes **domain integration** environment usage: **`DOMAIN_INTEGRATION_API_KEY`** remains the Hermes secret; **`DOMAIN_INTEGRATION_ID`** is the stable id everywhere (replacing **`DOMAIN_INTEGRATION_KEY`** on **data-collection**). Removes redundant `?? "mediapulse"` defaults now that ids are required in env validation.

## Related issues

Closes #273

## Important changes

- **data-collection:** example env + generated `@mediapulse/env/agents-data-collection` use **`DOMAIN_INTEGRATION_ID`**; auto-register reads **`env.DOMAIN_INTEGRATION_ID`** directly.
- **query-analysis:** **`DOMAIN_INTEGRATION_ID`** is required in the example and generated schema (was optional).
- **Agents + domain-api:** **`domainIntegrationId` / `integrationId`** use **`env.DOMAIN_INTEGRATION_ID`** with no inline default.
- **user-registration** unit test mock field renamed to **`DOMAIN_INTEGRATION_ID`**.

## Other changes

- none

## Key files to review

- `packages/mediapulse/env/env.agents.data-collection.example` and `src/agents-data-collection.ts` — naming and regeneration.
- `packages/mediapulse/env/env.agents.query-analysis.example` and `src/agents-query-analysis.ts` — required id.
- `apps/mediapulse/domain-api/src/http/register-with-hermes.ts` — registration payload **`integrationId`**.

## How to test

1. From repo root: `pnpm code-quality` (passes on this branch).
2. For **data-collection** / **query-analysis** local runs: ensure `.env` / `.env.local` defines **`DOMAIN_INTEGRATION_ID`** (e.g. `mediapulse`) and, when using auto-register, **`DOMAIN_INTEGRATION_API_KEY`**; confirm agent starts and registry registration still works if those URLs are set.
