### PR TITLE
Add Hermes dashboard tables for KG entities and relations

### DIFF
--- a/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
+++ b/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
@@ -3,6 +3,8 @@ import type { DashboardPageInput } from "@hermes/domain-contract";
 import type { Hono } from "hono";
 import { dataSourcesHermesDashboardResource } from "../resources/data-sources/resource-definition";
 import { deliveryRunsHermesDashboardResource } from "../resources/delivery-runs/resource-definition";
+import { entitiesHermesDashboardResource } from "../resources/entities/resource-definition";
+import { entityRelationsHermesDashboardResource } from "../resources/entity-relations/resource-definition";
 import { entityTypesHermesDashboardResource } from "../resources/entity-types/resource-definition";
 import { mediapulseUsersHermesDashboardResource } from "../resources/mediapulse-users/resource-definition";
 import { relationTypesHermesDashboardResource } from "../resources/relation-types/resource-definition";
@@ -21,6 +23,8 @@ export const hermesDashboardResources = [
   mediapulseUsersHermesDashboardResource,
   entityTypesHermesDashboardResource,
   relationTypesHermesDashboardResource,
+  entitiesHermesDashboardResource,
+  entityRelationsHermesDashboardResource,
   dataSourcesHermesDashboardResource,
   searchQueriesHermesDashboardResource,
   deliveryRunsHermesDashboardResource,

--- a/apps/mediapulse/domain-api/src/http/hermes-dashboard-routing.test.ts
+++ b/apps/mediapulse/domain-api/src/http/hermes-dashboard-routing.test.ts
@@ -67,6 +67,8 @@ describe("Hermes dashboard routing contract", () => {
     // Assert — breaks if segments are renamed without updating mounts + manifest
     expect(HermesDashboardResource.tickers).toBe("tickers");
     expect(HermesDashboardResource.mediapulseUsers).toBe("mediapulse-users");
+    expect(HermesDashboardResource.entities).toBe("entities");
+    expect(HermesDashboardResource.entityRelations).toBe("entity-relations");
     expect(HermesDashboardResource.dataSources).toBe("data-sources");
     expect(HermesDashboardResource.deliveryRuns).toBe("delivery-runs");
     expect(hermesDashboardTableMountPath(HermesDashboardResource.tickers)).toBe(
@@ -75,5 +77,11 @@ describe("Hermes dashboard routing contract", () => {
     expect(
       hermesDashboardTableMountPath(HermesDashboardResource.dataSources),
     ).toBe("/hermes-dashboard/data-sources");
+    expect(
+      hermesDashboardTableMountPath(HermesDashboardResource.entities),
+    ).toBe("/hermes-dashboard/entities");
+    expect(
+      hermesDashboardTableMountPath(HermesDashboardResource.entityRelations),
+    ).toBe("/hermes-dashboard/entity-relations");
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
@@ -1,0 +1,43 @@
+/**
+ * Hermes `table-v1` manifest for canonical knowledge-graph entities (read-only list + detail).
+ */
+
+import type { DashboardPageInput } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const entitiesHermesPathSegment = "entities" as const;
+
+/** Hermes `table-v1` manifest page for KG entities. */
+export const entitiesDashboardPage = {
+  id: entitiesHermesPathSegment,
+  label: "Entities",
+  description:
+    "Canonical knowledge-graph entities extracted from articles (read-only).",
+  pathSegment: entitiesHermesPathSegment,
+  template: "table-v1" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(entitiesHermesPathSegment),
+  order: 32,
+  columns: columnsFor<ListItem>()([
+    { key: "canonicalName", label: "Name", type: "text" },
+    { key: "entityTypeName", label: "Type", type: "text" },
+    { key: "descriptionPreview", label: "Description", type: "text" },
+    { key: "createdAt", label: "Created", type: "date-time" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()([
+    "canonicalName",
+    "entityTypeName",
+    "descriptionPreview",
+  ]),
+  sortableFields: rowFieldKeysFor<ListItem>()([
+    "canonicalName",
+    "entityTypeName",
+    "createdAt",
+  ]),
+  actions: { create: false, update: false, delete: false, view: true },
+} satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for entities list/detail mapping.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { ListRow } from "./list-mapper";
+import {
+  ENTITY_DESCRIPTION_PREVIEW_MAX,
+  mapRowToDetailItem,
+  mapRowToListItem,
+  truncateDescriptionPreview,
+} from "./list-mapper";
+
+describe("truncateDescriptionPreview", () => {
+  it("returns null for null input", () => {
+    expect(truncateDescriptionPreview(null, 10)).toBeNull();
+  });
+
+  it("truncates long descriptions with ellipsis", () => {
+    const long = "x".repeat(ENTITY_DESCRIPTION_PREVIEW_MAX + 10);
+    const out = truncateDescriptionPreview(
+      long,
+      ENTITY_DESCRIPTION_PREVIEW_MAX,
+    );
+    expect(out).toHaveLength(ENTITY_DESCRIPTION_PREVIEW_MAX + 1);
+    expect(out?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("mapRowToListItem", () => {
+  it("maps type name and ISO timestamps", () => {
+    const createdAt = new Date("2024-04-01T12:00:00.000Z");
+    const updatedAt = new Date("2024-04-02T12:00:00.000Z");
+    const row = {
+      id: "ent-1",
+      typeId: "type-1",
+      canonicalName: "Example Co",
+      description: "Short",
+      metadata: null,
+      createdAt,
+      updatedAt,
+      type: { name: "ORG" },
+    } as ListRow;
+
+    const item = mapRowToListItem(row);
+
+    expect(item.canonicalName).toBe("Example Co");
+    expect(item.entityTypeName).toBe("ORG");
+    expect(item.descriptionPreview).toBe("Short");
+    expect(item.createdAt).toBe("2024-04-01T12:00:00.000Z");
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("includes metadata and type id", () => {
+    const createdAt = new Date("2024-04-01T00:00:00.000Z");
+    const updatedAt = new Date("2024-04-02T00:00:00.000Z");
+    const row = {
+      id: "ent-2",
+      typeId: "type-9",
+      canonicalName: "Other",
+      description: null,
+      metadata: { tier: 1 },
+      createdAt,
+      updatedAt,
+      type: { name: "PERSON" },
+    } as ListRow;
+
+    const detail = mapRowToDetailItem(row);
+
+    expect(detail.typeId).toBe("type-9");
+    expect(detail.metadata).toEqual({ tier: 1 });
+    expect(detail.entityTypeName).toBe("PERSON");
+    expect(detail.description).toBeNull();
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
@@ -1,0 +1,86 @@
+/**
+ * Prisma `include` for entity list/detail rows and mappers to list items and detail payloads.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/** Max characters of `description` included in list rows (full text on GET by id). */
+export const ENTITY_DESCRIPTION_PREVIEW_MAX = 200;
+
+/**
+ * `include` passed to `entity.findMany` / `findUnique` for list and detail views.
+ */
+export const listInclude = {
+  type: {
+    select: {
+      name: true,
+    },
+  },
+} satisfies Prisma.EntityInclude;
+
+/**
+ * Prisma row shape for `entity.findMany` when loading the list view.
+ */
+export type ListRow = Prisma.EntityGetPayload<{
+  include: typeof listInclude;
+}>;
+
+/**
+ * Truncates plain text for a list preview (ellipsis when longer than max).
+ *
+ * @param description - Raw `Entity.description` or null.
+ * @param max - Maximum characters before truncation.
+ * @returns Preview string or null when input is null.
+ */
+export const truncateDescriptionPreview = (
+  description: string | null,
+  max: number,
+): string | null => {
+  if (description === null) {
+    return null;
+  }
+  if (description.length <= max) {
+    return description;
+  }
+  return `${description.slice(0, max)}…`;
+};
+
+/**
+ * Maps an entity row (with type) to the JSON list item.
+ *
+ * @param row - Row from `prisma.entity.findMany` using {@link listInclude}.
+ * @returns Serializable list row for the domain API.
+ */
+export const mapRowToListItem = (row: ListRow) => ({
+  id: row.id,
+  canonicalName: row.canonicalName,
+  entityTypeName: row.type.name,
+  descriptionPreview: truncateDescriptionPreview(
+    row.description,
+    ENTITY_DESCRIPTION_PREVIEW_MAX,
+  ),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON list item type; derived from {@link mapRowToListItem}. */
+export type ListItem = ReturnType<typeof mapRowToListItem>;
+
+/**
+ * Maps an entity row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entity.findUnique` using {@link listInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: ListRow) => ({
+  id: row.id,
+  typeId: row.typeId,
+  entityTypeName: row.type.name,
+  canonicalName: row.canonicalName,
+  description: row.description,
+  metadata: row.metadata,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entities/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/resource-definition.ts
@@ -1,0 +1,21 @@
+/**
+ * Wires the entities Hono app and manifest page into the central `hermesDashboardResources` registry.
+ */
+
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  entitiesDashboardPage,
+  entitiesHermesPathSegment,
+} from "./dashboard-page";
+import { entitiesRoutes } from "./routes";
+
+/**
+ * Hermes dashboard registration for canonical KG entities (routes + manifest page).
+ */
+export const entitiesHermesDashboardResource = defineHermesDashboardResource({
+  resourceKey: "entities",
+  pathSegment: entitiesHermesPathSegment,
+  order: 32,
+  routes: entitiesRoutes,
+  dashboardPage: entitiesDashboardPage,
+});

--- a/apps/mediapulse/domain-api/src/resources/entities/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/routes.ts
@@ -1,0 +1,119 @@
+/**
+ * HTTP handlers for canonical KG entities: paginated list and read-only GET by id (Hermes detail view).
+ */
+
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma } from "@mediapulse/database";
+import { Hono } from "hono";
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
+import { parsePagination } from "../../lib/list-pagination";
+import {
+  listInclude,
+  mapRowToDetailItem,
+  mapRowToListItem,
+} from "./list-mapper";
+import { entitiesHermesPathSegment } from "./dashboard-page";
+
+/**
+ * Maps table-v1 `sortBy` query values to a Prisma `orderBy` for {@link Entity}.
+ *
+ * @param sortBy - Column key from the dashboard manifest (`sortableFields`).
+ * @param sortDir - Ascending or descending.
+ */
+const resolveEntityListOrderBy = (
+  sortBy: string | undefined,
+  sortDir: Prisma.SortOrder,
+): Prisma.EntityOrderByWithRelationInput => {
+  switch (sortBy) {
+    case "canonicalName":
+      return { canonicalName: sortDir };
+    case "createdAt":
+      return { createdAt: sortDir };
+    case "entityTypeName":
+      return { type: { name: sortDir } };
+    default:
+      return { createdAt: "desc" };
+  }
+};
+
+/**
+ * Hermes `table-v1` API for knowledge-graph entities (list + read-only detail).
+ */
+export const entitiesRoutes = new Hono();
+
+/** Paginated list of entities for the Hermes dashboard (search `q`; sort `sortBy` / `sortDir`). */
+entitiesRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const query = c.req.query("q")?.trim();
+  const sortBy = c.req.query("sortBy");
+  const sortDir: Prisma.SortOrder =
+    c.req.query("sortDir") === "desc" ? "desc" : "asc";
+  const skip = (page - 1) * pageSize;
+
+  const where = query
+    ? ({
+        OR: [
+          { canonicalName: { contains: query, mode: "insensitive" as const } },
+          { description: { contains: query, mode: "insensitive" as const } },
+          {
+            type: {
+              name: { contains: query, mode: "insensitive" as const },
+            },
+          },
+        ],
+      } satisfies Prisma.EntityWhereInput)
+    : undefined;
+
+  const orderBy = resolveEntityListOrderBy(sortBy, sortDir);
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.EntityFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.entity.findMany(findManyArgs),
+    prisma.entity.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+/**
+ * Table-v1 metadata for Hermes. Registered **before** `GET /:id` so `/meta` is not captured as an id
+ * (see {@link buildMetaPayloadForPathSegment}).
+ */
+entitiesRoutes.get("/meta", (c) => {
+  const meta = buildMetaPayloadForPathSegment(entitiesHermesPathSegment);
+  if (!meta) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+  return c.json(meta);
+});
+
+/** Returns one entity by id for the Hermes read-only detail page. */
+entitiesRoutes.get("/:id", async (c) => {
+  const row = await prisma.entity.findUnique({
+    where: { id: c.req.param("id") },
+    include: listInclude,
+  } satisfies Prisma.EntityFindUniqueArgs);
+
+  if (!row) {
+    return c.json({ message: "Entity not found" }, 404);
+  }
+
+  return c.json(mapRowToDetailItem(row));
+});

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
@@ -1,0 +1,47 @@
+/**
+ * Hermes `table-v1` manifest for knowledge-graph entity relations (read-only list + detail).
+ */
+
+import type { DashboardPageInput } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const entityRelationsHermesPathSegment = "entity-relations" as const;
+
+/** Hermes `table-v1` manifest page for KG entity relations (edges). */
+export const entityRelationsDashboardPage = {
+  id: entityRelationsHermesPathSegment,
+  label: "Entity relations",
+  description: "Directed typed edges between canonical entities (read-only).",
+  pathSegment: entityRelationsHermesPathSegment,
+  template: "table-v1" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(entityRelationsHermesPathSegment),
+  order: 33,
+  columns: columnsFor<ListItem>()([
+    { key: "fromEntityName", label: "From", type: "text" },
+    { key: "toEntityName", label: "To", type: "text" },
+    { key: "relationTypeName", label: "Relation type", type: "text" },
+    { key: "weight", label: "Weight", type: "text" },
+    { key: "lastSeenAt", label: "Last seen", type: "date-time" },
+    { key: "createdAt", label: "Created", type: "date-time" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()([
+    "fromEntityName",
+    "toEntityName",
+    "relationTypeName",
+  ]),
+  sortableFields: rowFieldKeysFor<ListItem>()([
+    "fromEntityName",
+    "toEntityName",
+    "relationTypeName",
+    "weight",
+    "lastSeenAt",
+    "createdAt",
+  ]),
+  actions: { create: false, update: false, delete: false, view: true },
+} satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for entity-relations list/detail mapping.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { ListRow } from "./list-mapper";
+import { mapRowToDetailItem, mapRowToListItem } from "./list-mapper";
+
+describe("mapRowToListItem", () => {
+  it("maps joined names and timestamps", () => {
+    const lastSeenAt = new Date("2024-08-01T00:00:00.000Z");
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const row = {
+      id: "rel-1",
+      fromEntityId: "e-a",
+      toEntityId: "e-b",
+      relationTypeId: "rt-1",
+      weight: 0.75,
+      lastSeenAt,
+      createdAt,
+      fromEntity: { id: "e-a", canonicalName: "Parent Inc" },
+      toEntity: { id: "e-b", canonicalName: "Child LLC" },
+      relationType: { name: "SUBSIDIARY_OF" },
+    } as ListRow;
+
+    const item = mapRowToListItem(row);
+
+    expect(item.fromEntityName).toBe("Parent Inc");
+    expect(item.toEntityName).toBe("Child LLC");
+    expect(item.relationTypeName).toBe("SUBSIDIARY_OF");
+    expect(item.weight).toBe(0.75);
+    expect(item.lastSeenAt).toBe("2024-08-01T00:00:00.000Z");
+    expect(item.createdAt).toBe("2024-07-01T00:00:00.000Z");
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("includes foreign key ids", () => {
+    const lastSeenAt = new Date("2024-08-01T00:00:00.000Z");
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const row = {
+      id: "rel-2",
+      fromEntityId: "from",
+      toEntityId: "to",
+      relationTypeId: "rtype",
+      weight: 1,
+      lastSeenAt,
+      createdAt,
+      fromEntity: { id: "from", canonicalName: "A" },
+      toEntity: { id: "to", canonicalName: "B" },
+      relationType: { name: "LINKED" },
+    } as ListRow;
+
+    const detail = mapRowToDetailItem(row);
+
+    expect(detail.fromEntityId).toBe("from");
+    expect(detail.toEntityId).toBe("to");
+    expect(detail.relationTypeId).toBe("rtype");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * Prisma `include` for entity-relation list/detail rows and mappers to list and detail JSON.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/**
+ * `include` passed to `entityRelation.findMany` / `findUnique` for list and detail views.
+ */
+export const listInclude = {
+  fromEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  toEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  relationType: {
+    select: {
+      name: true,
+    },
+  },
+} satisfies Prisma.EntityRelationInclude;
+
+/**
+ * Prisma row shape for `entityRelation.findMany` when loading the list view.
+ */
+export type ListRow = Prisma.EntityRelationGetPayload<{
+  include: typeof listInclude;
+}>;
+
+/**
+ * Maps an entity-relation row to the JSON list item.
+ *
+ * @param row - Row from `prisma.entityRelation.findMany` using {@link listInclude}.
+ * @returns Serializable list row for the domain API.
+ */
+export const mapRowToListItem = (row: ListRow) => ({
+  id: row.id,
+  fromEntityName: row.fromEntity.canonicalName,
+  toEntityName: row.toEntity.canonicalName,
+  relationTypeName: row.relationType.name,
+  weight: row.weight,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON list item type; derived from {@link mapRowToListItem}. */
+export type ListItem = ReturnType<typeof mapRowToListItem>;
+
+/**
+ * Maps an entity-relation row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entityRelation.findUnique` using {@link listInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: ListRow) => ({
+  id: row.id,
+  fromEntityId: row.fromEntityId,
+  toEntityId: row.toEntityId,
+  relationTypeId: row.relationTypeId,
+  fromEntityName: row.fromEntity.canonicalName,
+  toEntityName: row.toEntity.canonicalName,
+  relationTypeName: row.relationType.name,
+  weight: row.weight,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/resource-definition.ts
@@ -1,0 +1,22 @@
+/**
+ * Wires the entity-relations Hono app and manifest page into the central `hermesDashboardResources` registry.
+ */
+
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  entityRelationsDashboardPage,
+  entityRelationsHermesPathSegment,
+} from "./dashboard-page";
+import { entityRelationsRoutes } from "./routes";
+
+/**
+ * Hermes dashboard registration for KG entity relations (routes + manifest page).
+ */
+export const entityRelationsHermesDashboardResource =
+  defineHermesDashboardResource({
+    resourceKey: "entityRelations",
+    pathSegment: entityRelationsHermesPathSegment,
+    order: 33,
+    routes: entityRelationsRoutes,
+    dashboardPage: entityRelationsDashboardPage,
+  });

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP handlers for KG entity relations: paginated list and read-only GET by id (Hermes detail view).
+ */
+
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma } from "@mediapulse/database";
+import { Hono } from "hono";
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
+import { parsePagination } from "../../lib/list-pagination";
+import {
+  listInclude,
+  mapRowToDetailItem,
+  mapRowToListItem,
+} from "./list-mapper";
+import { entityRelationsHermesPathSegment } from "./dashboard-page";
+
+/**
+ * Maps table-v1 `sortBy` query values to a Prisma `orderBy` for {@link EntityRelation}.
+ *
+ * @param sortBy - Column key from the dashboard manifest (`sortableFields`).
+ * @param sortDir - Ascending or descending.
+ */
+const resolveEntityRelationListOrderBy = (
+  sortBy: string | undefined,
+  sortDir: Prisma.SortOrder,
+): Prisma.EntityRelationOrderByWithRelationInput => {
+  switch (sortBy) {
+    case "lastSeenAt":
+      return { lastSeenAt: sortDir };
+    case "createdAt":
+      return { createdAt: sortDir };
+    case "weight":
+      return { weight: sortDir };
+    case "fromEntityName":
+      return { fromEntity: { canonicalName: sortDir } };
+    case "toEntityName":
+      return { toEntity: { canonicalName: sortDir } };
+    case "relationTypeName":
+      return { relationType: { name: sortDir } };
+    default:
+      return { lastSeenAt: "desc" };
+  }
+};
+
+/**
+ * Hermes `table-v1` API for entity relations (list + read-only detail).
+ */
+export const entityRelationsRoutes = new Hono();
+
+/** Paginated list of entity relations for the Hermes dashboard (search `q`; sort `sortBy` / `sortDir`). */
+entityRelationsRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const query = c.req.query("q")?.trim();
+  const sortBy = c.req.query("sortBy");
+  const sortDir: Prisma.SortOrder =
+    c.req.query("sortDir") === "desc" ? "desc" : "asc";
+  const skip = (page - 1) * pageSize;
+
+  const where = query
+    ? ({
+        OR: [
+          {
+            fromEntity: {
+              canonicalName: { contains: query, mode: "insensitive" as const },
+            },
+          },
+          {
+            toEntity: {
+              canonicalName: { contains: query, mode: "insensitive" as const },
+            },
+          },
+          {
+            relationType: {
+              name: { contains: query, mode: "insensitive" as const },
+            },
+          },
+        ],
+      } satisfies Prisma.EntityRelationWhereInput)
+    : undefined;
+
+  const orderBy = resolveEntityRelationListOrderBy(sortBy, sortDir);
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.EntityRelationFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.entityRelation.findMany(findManyArgs),
+    prisma.entityRelation.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+/**
+ * Table-v1 metadata for Hermes. Registered **before** `GET /:id` so `/meta` is not captured as an id
+ * (see {@link buildMetaPayloadForPathSegment}).
+ */
+entityRelationsRoutes.get("/meta", (c) => {
+  const meta = buildMetaPayloadForPathSegment(entityRelationsHermesPathSegment);
+  if (!meta) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+  return c.json(meta);
+});
+
+/** Returns one entity relation by id for the Hermes read-only detail page. */
+entityRelationsRoutes.get("/:id", async (c) => {
+  const row = await prisma.entityRelation.findUnique({
+    where: { id: c.req.param("id") },
+    include: listInclude,
+  } satisfies Prisma.EntityRelationFindUniqueArgs);
+
+  if (!row) {
+    return c.json({ message: "Entity relation not found" }, 404);
+  }
+
+  return c.json(mapRowToDetailItem(row));
+});


### PR DESCRIPTION
## Summary

Expose canonical knowledge-graph **Entity** and **EntityRelation** data in the Hermes MediaPulse integration as read-only `table-v1` pages (paginated list, table metadata, and per-row detail), so operators can inspect KG instances without using SQL or separate tools.

## Related issues

Closes #279

## Important changes

- Register two new Hermes dashboard resources in domain-api: `entities` and `entity-relations`, each with list + `/meta` + `GET /:id` backed by Prisma queries with typed includes and list mappers.
- Extend the Hermes routing contract test so `HermesDashboardResource` exposes stable path segments for the new tables.

## Other changes

- Add focused Vitest coverage for the new list/detail mappers.

## Key files to review

- `apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts` — wires new resources into the manifest and route mounts.
- `apps/mediapulse/domain-api/src/resources/entities/routes.ts` and `entity-relations/routes.ts` — pagination, search, sort, and read-only detail responses.
- `apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts` and `entity-relations/dashboard-page.ts` — Hermes `table-v1` column and action metadata.

## How to test

1. From the repo root, run `pnpm code-quality` and confirm it exits successfully.
2. Run domain-api tests only: `pnpm --filter @mediapulse/domain-api test` (or the package’s `test:coverage` script) and confirm new mapper and routing tests pass.
3. With domain-api and Hermes running against a database that contains `Entity` / `EntityRelation` rows, open Hermes → MediaPulse integration and confirm **Entities** and **Entity relations** appear in the sidebar, lists load, and row detail opens.
