### PR TITLE
Fix article-analysis OpenAI strict extraction schema

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildExtractionSystemContent,
   buildExtractionUserContent,
+  normalizeLlmExtractionWire,
   normalizeLlmUsageFromSdk,
 } from "./llm-extract-entities.js";
 
@@ -36,6 +37,56 @@ describe("buildExtractionUserContent", () => {
     expect(u).toContain("T");
     expect(u).toContain("Hello");
     expect(u).toContain("Body text");
+  });
+});
+
+describe("normalizeLlmExtractionWire", () => {
+  it("maps empty description and NONE sentiment to null", () => {
+    const out = normalizeLlmExtractionWire({
+      entities: [
+        {
+          canonicalName: "Acme",
+          typeId: TID,
+          description: "",
+          aliases: ["ACME"],
+        },
+      ],
+      relations: [],
+      articleMentions: [
+        {
+          entityName: "Acme",
+          mentionCount: 1,
+          confidence: 0.9,
+          sentiment: "NONE",
+        },
+      ],
+    });
+    expect(out.entities[0]?.description).toBeNull();
+    expect(out.articleMentions[0]?.sentiment).toBeNull();
+  });
+
+  it("preserves non-empty description and concrete sentiment", () => {
+    const out = normalizeLlmExtractionWire({
+      entities: [
+        {
+          canonicalName: "Acme",
+          typeId: TID,
+          description: "  HQ  ",
+          aliases: [],
+        },
+      ],
+      relations: [],
+      articleMentions: [
+        {
+          entityName: "Acme",
+          mentionCount: 1,
+          confidence: 0.5,
+          sentiment: "NEGATIVE",
+        },
+      ],
+    });
+    expect(out.entities[0]?.description).toBe("HQ");
+    expect(out.articleMentions[0]?.sentiment).toBe("NEGATIVE");
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -5,14 +5,13 @@ import { z } from "zod";
 
 const sentimentSchema = z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL"]);
 
-/** Structured extraction result validated by the AI SDK. */
-export const llmExtractionOutputSchema = z.object({
+const llmExtractionOpenAiWireSchema = z.object({
   entities: z.array(
     z.object({
       canonicalName: z.string().trim().min(1),
       typeId: z.string().uuid(),
-      description: z.string().optional(),
-      aliases: z.array(z.string().trim().min(1)).default([]),
+      description: z.string().max(4000),
+      aliases: z.array(z.string().trim().min(1)),
     }),
   ),
   relations: z.array(
@@ -22,20 +21,69 @@ export const llmExtractionOutputSchema = z.object({
       relationTypeId: z.string().uuid(),
     }),
   ),
-  /** Per-article entity mention signals (aligned with `postAnalysisBodySchema.articleEntities`, without `dataSourceId`). */
-  articleMentions: z
-    .array(
-      z.object({
-        entityName: z.string().trim().min(1),
-        mentionCount: z.number().int().positive(),
-        confidence: z.number().min(0).max(1),
-        sentiment: sentimentSchema.optional(),
-      }),
-    )
-    .default([]),
+  articleMentions: z.array(
+    z.object({
+      entityName: z.string().trim().min(1),
+      mentionCount: z.number().int().positive(),
+      confidence: z.number().min(0).max(1),
+      sentiment: z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL", "NONE"]),
+    }),
+  ),
+});
+
+export type LlmExtractionWireOutput = z.infer<
+  typeof llmExtractionOpenAiWireSchema
+>;
+
+/** Structured extraction result after normalizing wire values (null = absent). */
+export const llmExtractionOutputSchema = z.object({
+  entities: z.array(
+    z.object({
+      canonicalName: z.string().trim().min(1),
+      typeId: z.string().uuid(),
+      description: z.string().nullable(),
+      aliases: z.array(z.string().trim().min(1)),
+    }),
+  ),
+  relations: z.array(
+    z.object({
+      fromEntityName: z.string().trim().min(1),
+      toEntityName: z.string().trim().min(1),
+      relationTypeId: z.string().uuid(),
+    }),
+  ),
+  articleMentions: z.array(
+    z.object({
+      entityName: z.string().trim().min(1),
+      mentionCount: z.number().int().positive(),
+      confidence: z.number().min(0).max(1),
+      sentiment: sentimentSchema.nullable(),
+    }),
+  ),
 });
 
 export type LlmExtractionOutput = z.infer<typeof llmExtractionOutputSchema>;
+
+/**
+ * Maps OpenAI wire payload to the normalized extraction shape (null = none).
+ *
+ * @param wire - Parsed output from {@link llmExtractionOpenAiWireSchema}.
+ * @returns Validated normalized object for downstream pipeline code.
+ */
+export const normalizeLlmExtractionWire = (
+  wire: LlmExtractionWireOutput,
+): LlmExtractionOutput =>
+  llmExtractionOutputSchema.parse({
+    entities: wire.entities.map((e) => ({
+      ...e,
+      description: e.description.trim() === "" ? null : e.description.trim(),
+    })),
+    relations: wire.relations,
+    articleMentions: wire.articleMentions.map((m) => ({
+      ...m,
+      sentiment: m.sentiment === "NONE" ? null : m.sentiment,
+    })),
+  });
 
 /** Normalized token counts from the AI SDK (`generateObject` usage), if the provider reports them. */
 export type LlmExtractionUsage = {
@@ -51,10 +99,13 @@ export type LlmExtractionCallResult = {
 
 export type GenerateObjectForExtraction = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
-  schema: typeof llmExtractionOutputSchema;
+  schema: typeof llmExtractionOpenAiWireSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
-}) => Promise<LlmExtractionCallResult>;
+}) => Promise<{
+  object: LlmExtractionWireOutput;
+  usage: LlmExtractionUsage | null;
+}>;
 
 /**
  * Converts AI SDK `LanguageModelUsage` into compact counters; `null` when the provider omits usage.
@@ -108,7 +159,9 @@ export const buildExtractionSystemContent = (
     "Use ONLY entity typeId values listed under ENTITY TYPES and ONLY relationTypeId values under RELATION TYPES.",
     "Relation fromEntityName and toEntityName must match canonicalName strings of entities you output (not aliases).",
     "Prefer high-precision entities; omit uncertain extractions.",
-    "Also populate articleMentions: for entities in your entities array that appear in the article text, estimate mentionCount (positive integer), confidence (0–1), and optional sentiment POSITIVE | NEGATIVE | NEUTRAL.",
+    'Every entity must include description as a string; use an empty string "" when there is no short description.',
+    "Every entity must include aliases as an array (use [] when there are no aliases beyond canonicalName).",
+    "Also populate articleMentions: for entities in your entities array that appear in the article text, estimate mentionCount (positive integer), confidence (0–1), and sentiment POSITIVE | NEGATIVE | NEUTRAL, or NONE when not applicable.",
     "Each articleMentions.entityName must exactly match the canonicalName of one row in your entities array (same spelling as canonicalName).",
     "Return JSON object with keys entities, relations, and articleMentions (arrays; articleMentions may be empty).",
     "ENTITY TYPES (uuid — label):\n" + et,
@@ -153,10 +206,14 @@ export const extractEntitiesAndRelationsForSource = async (
   },
 ): Promise<LlmExtractionCallResult> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
-  return deps.generateObjectForExtraction({
+  const raw = await deps.generateObjectForExtraction({
     model: openai(params.model),
-    schema: llmExtractionOutputSchema,
+    schema: llmExtractionOpenAiWireSchema,
     maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
   });
+  return {
+    object: normalizeLlmExtractionWire(raw.object),
+    usage: raw.usage,
+  };
 };

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -42,11 +42,43 @@ vi.mock("@workspace/logger", () => ({
   },
 }));
 
-/** Wraps LLM output for mocks (`extractEntitiesAndRelationsForSource`). */
+/** Test-only LLM payload; omits keys the real model must supply as null for strict JSON Schema. */
+type LlmExtractionOutputMockInput = Omit<
+  Llm.LlmExtractionOutput,
+  "entities" | "articleMentions"
+> & {
+  entities: Array<
+    Omit<Llm.LlmExtractionOutput["entities"][number], "description"> & {
+      description?: string | null;
+    }
+  >;
+  articleMentions: Array<
+    Omit<Llm.LlmExtractionOutput["articleMentions"][number], "sentiment"> & {
+      sentiment?:
+        | Llm.LlmExtractionOutput["articleMentions"][number]["sentiment"]
+        | null;
+    }
+  >;
+};
+
+/** Wraps LLM output for mocks; fills omitted `description` / `sentiment` with null. */
 const llmResult = (
-  object: Llm.LlmExtractionOutput,
+  object: LlmExtractionOutputMockInput,
   usage: Llm.LlmExtractionUsage | null = null,
-): Llm.LlmExtractionCallResult => ({ object, usage });
+): Llm.LlmExtractionCallResult => ({
+  object: {
+    ...object,
+    entities: object.entities.map((e) => ({
+      ...e,
+      description: e.description ?? null,
+    })),
+    articleMentions: object.articleMentions.map((m) => ({
+      ...m,
+      sentiment: m.sentiment ?? null,
+    })),
+  } satisfies Llm.LlmExtractionOutput,
+  usage,
+});
 
 const TYPE_ID = "11111111-1111-4111-a111-111111111111";
 const REL_ID = "22222222-2222-4222-a222-222222222222";

--- a/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
+++ b/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
@@ -3,6 +3,8 @@ import type { DashboardPageInput } from "@hermes/domain-contract";
 import type { Hono } from "hono";
 import { dataSourcesHermesDashboardResource } from "../resources/data-sources/resource-definition";
 import { deliveryRunsHermesDashboardResource } from "../resources/delivery-runs/resource-definition";
+import { entitiesHermesDashboardResource } from "../resources/entities/resource-definition";
+import { entityRelationsHermesDashboardResource } from "../resources/entity-relations/resource-definition";
 import { entityTypesHermesDashboardResource } from "../resources/entity-types/resource-definition";
 import { mediapulseUsersHermesDashboardResource } from "../resources/mediapulse-users/resource-definition";
 import { relationTypesHermesDashboardResource } from "../resources/relation-types/resource-definition";
@@ -21,6 +23,8 @@ export const hermesDashboardResources = [
   mediapulseUsersHermesDashboardResource,
   entityTypesHermesDashboardResource,
   relationTypesHermesDashboardResource,
+  entitiesHermesDashboardResource,
+  entityRelationsHermesDashboardResource,
   dataSourcesHermesDashboardResource,
   searchQueriesHermesDashboardResource,
   deliveryRunsHermesDashboardResource,

--- a/apps/mediapulse/domain-api/src/http/hermes-dashboard-routing.test.ts
+++ b/apps/mediapulse/domain-api/src/http/hermes-dashboard-routing.test.ts
@@ -67,6 +67,8 @@ describe("Hermes dashboard routing contract", () => {
     // Assert — breaks if segments are renamed without updating mounts + manifest
     expect(HermesDashboardResource.tickers).toBe("tickers");
     expect(HermesDashboardResource.mediapulseUsers).toBe("mediapulse-users");
+    expect(HermesDashboardResource.entities).toBe("entities");
+    expect(HermesDashboardResource.entityRelations).toBe("entity-relations");
     expect(HermesDashboardResource.dataSources).toBe("data-sources");
     expect(HermesDashboardResource.deliveryRuns).toBe("delivery-runs");
     expect(hermesDashboardTableMountPath(HermesDashboardResource.tickers)).toBe(
@@ -75,5 +77,11 @@ describe("Hermes dashboard routing contract", () => {
     expect(
       hermesDashboardTableMountPath(HermesDashboardResource.dataSources),
     ).toBe("/hermes-dashboard/data-sources");
+    expect(
+      hermesDashboardTableMountPath(HermesDashboardResource.entities),
+    ).toBe("/hermes-dashboard/entities");
+    expect(
+      hermesDashboardTableMountPath(HermesDashboardResource.entityRelations),
+    ).toBe("/hermes-dashboard/entity-relations");
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
@@ -1,0 +1,43 @@
+/**
+ * Hermes `table-v1` manifest for canonical knowledge-graph entities (read-only list + detail).
+ */
+
+import type { DashboardPageInput } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const entitiesHermesPathSegment = "entities" as const;
+
+/** Hermes `table-v1` manifest page for KG entities. */
+export const entitiesDashboardPage = {
+  id: entitiesHermesPathSegment,
+  label: "Entities",
+  description:
+    "Canonical knowledge-graph entities extracted from articles (read-only).",
+  pathSegment: entitiesHermesPathSegment,
+  template: "table-v1" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(entitiesHermesPathSegment),
+  order: 32,
+  columns: columnsFor<ListItem>()([
+    { key: "canonicalName", label: "Name", type: "text" },
+    { key: "entityTypeName", label: "Type", type: "text" },
+    { key: "descriptionPreview", label: "Description", type: "text" },
+    { key: "createdAt", label: "Created", type: "date-time" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()([
+    "canonicalName",
+    "entityTypeName",
+    "descriptionPreview",
+  ]),
+  sortableFields: rowFieldKeysFor<ListItem>()([
+    "canonicalName",
+    "entityTypeName",
+    "createdAt",
+  ]),
+  actions: { create: false, update: false, delete: false, view: true },
+} satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for entities list/detail mapping.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { ListRow } from "./list-mapper";
+import {
+  ENTITY_DESCRIPTION_PREVIEW_MAX,
+  mapRowToDetailItem,
+  mapRowToListItem,
+  truncateDescriptionPreview,
+} from "./list-mapper";
+
+describe("truncateDescriptionPreview", () => {
+  it("returns null for null input", () => {
+    expect(truncateDescriptionPreview(null, 10)).toBeNull();
+  });
+
+  it("truncates long descriptions with ellipsis", () => {
+    const long = "x".repeat(ENTITY_DESCRIPTION_PREVIEW_MAX + 10);
+    const out = truncateDescriptionPreview(
+      long,
+      ENTITY_DESCRIPTION_PREVIEW_MAX,
+    );
+    expect(out).toHaveLength(ENTITY_DESCRIPTION_PREVIEW_MAX + 1);
+    expect(out?.endsWith("…")).toBe(true);
+  });
+});
+
+describe("mapRowToListItem", () => {
+  it("maps type name and ISO timestamps", () => {
+    const createdAt = new Date("2024-04-01T12:00:00.000Z");
+    const updatedAt = new Date("2024-04-02T12:00:00.000Z");
+    const row = {
+      id: "ent-1",
+      typeId: "type-1",
+      canonicalName: "Example Co",
+      description: "Short",
+      metadata: null,
+      createdAt,
+      updatedAt,
+      type: { name: "ORG" },
+    } as ListRow;
+
+    const item = mapRowToListItem(row);
+
+    expect(item.canonicalName).toBe("Example Co");
+    expect(item.entityTypeName).toBe("ORG");
+    expect(item.descriptionPreview).toBe("Short");
+    expect(item.createdAt).toBe("2024-04-01T12:00:00.000Z");
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("includes metadata and type id", () => {
+    const createdAt = new Date("2024-04-01T00:00:00.000Z");
+    const updatedAt = new Date("2024-04-02T00:00:00.000Z");
+    const row = {
+      id: "ent-2",
+      typeId: "type-9",
+      canonicalName: "Other",
+      description: null,
+      metadata: { tier: 1 },
+      createdAt,
+      updatedAt,
+      type: { name: "PERSON" },
+    } as ListRow;
+
+    const detail = mapRowToDetailItem(row);
+
+    expect(detail.typeId).toBe("type-9");
+    expect(detail.metadata).toEqual({ tier: 1 });
+    expect(detail.entityTypeName).toBe("PERSON");
+    expect(detail.description).toBeNull();
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
@@ -1,0 +1,86 @@
+/**
+ * Prisma `include` for entity list/detail rows and mappers to list items and detail payloads.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/** Max characters of `description` included in list rows (full text on GET by id). */
+export const ENTITY_DESCRIPTION_PREVIEW_MAX = 200;
+
+/**
+ * `include` passed to `entity.findMany` / `findUnique` for list and detail views.
+ */
+export const listInclude = {
+  type: {
+    select: {
+      name: true,
+    },
+  },
+} satisfies Prisma.EntityInclude;
+
+/**
+ * Prisma row shape for `entity.findMany` when loading the list view.
+ */
+export type ListRow = Prisma.EntityGetPayload<{
+  include: typeof listInclude;
+}>;
+
+/**
+ * Truncates plain text for a list preview (ellipsis when longer than max).
+ *
+ * @param description - Raw `Entity.description` or null.
+ * @param max - Maximum characters before truncation.
+ * @returns Preview string or null when input is null.
+ */
+export const truncateDescriptionPreview = (
+  description: string | null,
+  max: number,
+): string | null => {
+  if (description === null) {
+    return null;
+  }
+  if (description.length <= max) {
+    return description;
+  }
+  return `${description.slice(0, max)}…`;
+};
+
+/**
+ * Maps an entity row (with type) to the JSON list item.
+ *
+ * @param row - Row from `prisma.entity.findMany` using {@link listInclude}.
+ * @returns Serializable list row for the domain API.
+ */
+export const mapRowToListItem = (row: ListRow) => ({
+  id: row.id,
+  canonicalName: row.canonicalName,
+  entityTypeName: row.type.name,
+  descriptionPreview: truncateDescriptionPreview(
+    row.description,
+    ENTITY_DESCRIPTION_PREVIEW_MAX,
+  ),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON list item type; derived from {@link mapRowToListItem}. */
+export type ListItem = ReturnType<typeof mapRowToListItem>;
+
+/**
+ * Maps an entity row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entity.findUnique` using {@link listInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: ListRow) => ({
+  id: row.id,
+  typeId: row.typeId,
+  entityTypeName: row.type.name,
+  canonicalName: row.canonicalName,
+  description: row.description,
+  metadata: row.metadata,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entities/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/resource-definition.ts
@@ -1,0 +1,21 @@
+/**
+ * Wires the entities Hono app and manifest page into the central `hermesDashboardResources` registry.
+ */
+
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  entitiesDashboardPage,
+  entitiesHermesPathSegment,
+} from "./dashboard-page";
+import { entitiesRoutes } from "./routes";
+
+/**
+ * Hermes dashboard registration for canonical KG entities (routes + manifest page).
+ */
+export const entitiesHermesDashboardResource = defineHermesDashboardResource({
+  resourceKey: "entities",
+  pathSegment: entitiesHermesPathSegment,
+  order: 32,
+  routes: entitiesRoutes,
+  dashboardPage: entitiesDashboardPage,
+});

--- a/apps/mediapulse/domain-api/src/resources/entities/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/routes.ts
@@ -1,0 +1,119 @@
+/**
+ * HTTP handlers for canonical KG entities: paginated list and read-only GET by id (Hermes detail view).
+ */
+
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma } from "@mediapulse/database";
+import { Hono } from "hono";
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
+import { parsePagination } from "../../lib/list-pagination";
+import {
+  listInclude,
+  mapRowToDetailItem,
+  mapRowToListItem,
+} from "./list-mapper";
+import { entitiesHermesPathSegment } from "./dashboard-page";
+
+/**
+ * Maps table-v1 `sortBy` query values to a Prisma `orderBy` for {@link Entity}.
+ *
+ * @param sortBy - Column key from the dashboard manifest (`sortableFields`).
+ * @param sortDir - Ascending or descending.
+ */
+const resolveEntityListOrderBy = (
+  sortBy: string | undefined,
+  sortDir: Prisma.SortOrder,
+): Prisma.EntityOrderByWithRelationInput => {
+  switch (sortBy) {
+    case "canonicalName":
+      return { canonicalName: sortDir };
+    case "createdAt":
+      return { createdAt: sortDir };
+    case "entityTypeName":
+      return { type: { name: sortDir } };
+    default:
+      return { createdAt: "desc" };
+  }
+};
+
+/**
+ * Hermes `table-v1` API for knowledge-graph entities (list + read-only detail).
+ */
+export const entitiesRoutes = new Hono();
+
+/** Paginated list of entities for the Hermes dashboard (search `q`; sort `sortBy` / `sortDir`). */
+entitiesRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const query = c.req.query("q")?.trim();
+  const sortBy = c.req.query("sortBy");
+  const sortDir: Prisma.SortOrder =
+    c.req.query("sortDir") === "desc" ? "desc" : "asc";
+  const skip = (page - 1) * pageSize;
+
+  const where = query
+    ? ({
+        OR: [
+          { canonicalName: { contains: query, mode: "insensitive" as const } },
+          { description: { contains: query, mode: "insensitive" as const } },
+          {
+            type: {
+              name: { contains: query, mode: "insensitive" as const },
+            },
+          },
+        ],
+      } satisfies Prisma.EntityWhereInput)
+    : undefined;
+
+  const orderBy = resolveEntityListOrderBy(sortBy, sortDir);
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.EntityFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.entity.findMany(findManyArgs),
+    prisma.entity.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+/**
+ * Table-v1 metadata for Hermes. Registered **before** `GET /:id` so `/meta` is not captured as an id
+ * (see {@link buildMetaPayloadForPathSegment}).
+ */
+entitiesRoutes.get("/meta", (c) => {
+  const meta = buildMetaPayloadForPathSegment(entitiesHermesPathSegment);
+  if (!meta) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+  return c.json(meta);
+});
+
+/** Returns one entity by id for the Hermes read-only detail page. */
+entitiesRoutes.get("/:id", async (c) => {
+  const row = await prisma.entity.findUnique({
+    where: { id: c.req.param("id") },
+    include: listInclude,
+  } satisfies Prisma.EntityFindUniqueArgs);
+
+  if (!row) {
+    return c.json({ message: "Entity not found" }, 404);
+  }
+
+  return c.json(mapRowToDetailItem(row));
+});

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
@@ -1,0 +1,47 @@
+/**
+ * Hermes `table-v1` manifest for knowledge-graph entity relations (read-only list + detail).
+ */
+
+import type { DashboardPageInput } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const entityRelationsHermesPathSegment = "entity-relations" as const;
+
+/** Hermes `table-v1` manifest page for KG entity relations (edges). */
+export const entityRelationsDashboardPage = {
+  id: entityRelationsHermesPathSegment,
+  label: "Entity relations",
+  description: "Directed typed edges between canonical entities (read-only).",
+  pathSegment: entityRelationsHermesPathSegment,
+  template: "table-v1" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(entityRelationsHermesPathSegment),
+  order: 33,
+  columns: columnsFor<ListItem>()([
+    { key: "fromEntityName", label: "From", type: "text" },
+    { key: "toEntityName", label: "To", type: "text" },
+    { key: "relationTypeName", label: "Relation type", type: "text" },
+    { key: "weight", label: "Weight", type: "text" },
+    { key: "lastSeenAt", label: "Last seen", type: "date-time" },
+    { key: "createdAt", label: "Created", type: "date-time" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()([
+    "fromEntityName",
+    "toEntityName",
+    "relationTypeName",
+  ]),
+  sortableFields: rowFieldKeysFor<ListItem>()([
+    "fromEntityName",
+    "toEntityName",
+    "relationTypeName",
+    "weight",
+    "lastSeenAt",
+    "createdAt",
+  ]),
+  actions: { create: false, update: false, delete: false, view: true },
+} satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for entity-relations list/detail mapping.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { ListRow } from "./list-mapper";
+import { mapRowToDetailItem, mapRowToListItem } from "./list-mapper";
+
+describe("mapRowToListItem", () => {
+  it("maps joined names and timestamps", () => {
+    const lastSeenAt = new Date("2024-08-01T00:00:00.000Z");
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const row = {
+      id: "rel-1",
+      fromEntityId: "e-a",
+      toEntityId: "e-b",
+      relationTypeId: "rt-1",
+      weight: 0.75,
+      lastSeenAt,
+      createdAt,
+      fromEntity: { id: "e-a", canonicalName: "Parent Inc" },
+      toEntity: { id: "e-b", canonicalName: "Child LLC" },
+      relationType: { name: "SUBSIDIARY_OF" },
+    } as ListRow;
+
+    const item = mapRowToListItem(row);
+
+    expect(item.fromEntityName).toBe("Parent Inc");
+    expect(item.toEntityName).toBe("Child LLC");
+    expect(item.relationTypeName).toBe("SUBSIDIARY_OF");
+    expect(item.weight).toBe(0.75);
+    expect(item.lastSeenAt).toBe("2024-08-01T00:00:00.000Z");
+    expect(item.createdAt).toBe("2024-07-01T00:00:00.000Z");
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("includes foreign key ids", () => {
+    const lastSeenAt = new Date("2024-08-01T00:00:00.000Z");
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const row = {
+      id: "rel-2",
+      fromEntityId: "from",
+      toEntityId: "to",
+      relationTypeId: "rtype",
+      weight: 1,
+      lastSeenAt,
+      createdAt,
+      fromEntity: { id: "from", canonicalName: "A" },
+      toEntity: { id: "to", canonicalName: "B" },
+      relationType: { name: "LINKED" },
+    } as ListRow;
+
+    const detail = mapRowToDetailItem(row);
+
+    expect(detail.fromEntityId).toBe("from");
+    expect(detail.toEntityId).toBe("to");
+    expect(detail.relationTypeId).toBe("rtype");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
@@ -1,0 +1,76 @@
+/**
+ * Prisma `include` for entity-relation list/detail rows and mappers to list and detail JSON.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/**
+ * `include` passed to `entityRelation.findMany` / `findUnique` for list and detail views.
+ */
+export const listInclude = {
+  fromEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  toEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  relationType: {
+    select: {
+      name: true,
+    },
+  },
+} satisfies Prisma.EntityRelationInclude;
+
+/**
+ * Prisma row shape for `entityRelation.findMany` when loading the list view.
+ */
+export type ListRow = Prisma.EntityRelationGetPayload<{
+  include: typeof listInclude;
+}>;
+
+/**
+ * Maps an entity-relation row to the JSON list item.
+ *
+ * @param row - Row from `prisma.entityRelation.findMany` using {@link listInclude}.
+ * @returns Serializable list row for the domain API.
+ */
+export const mapRowToListItem = (row: ListRow) => ({
+  id: row.id,
+  fromEntityName: row.fromEntity.canonicalName,
+  toEntityName: row.toEntity.canonicalName,
+  relationTypeName: row.relationType.name,
+  weight: row.weight,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON list item type; derived from {@link mapRowToListItem}. */
+export type ListItem = ReturnType<typeof mapRowToListItem>;
+
+/**
+ * Maps an entity-relation row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entityRelation.findUnique` using {@link listInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: ListRow) => ({
+  id: row.id,
+  fromEntityId: row.fromEntityId,
+  toEntityId: row.toEntityId,
+  relationTypeId: row.relationTypeId,
+  fromEntityName: row.fromEntity.canonicalName,
+  toEntityName: row.toEntity.canonicalName,
+  relationTypeName: row.relationType.name,
+  weight: row.weight,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/resource-definition.ts
@@ -1,0 +1,22 @@
+/**
+ * Wires the entity-relations Hono app and manifest page into the central `hermesDashboardResources` registry.
+ */
+
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  entityRelationsDashboardPage,
+  entityRelationsHermesPathSegment,
+} from "./dashboard-page";
+import { entityRelationsRoutes } from "./routes";
+
+/**
+ * Hermes dashboard registration for KG entity relations (routes + manifest page).
+ */
+export const entityRelationsHermesDashboardResource =
+  defineHermesDashboardResource({
+    resourceKey: "entityRelations",
+    pathSegment: entityRelationsHermesPathSegment,
+    order: 33,
+    routes: entityRelationsRoutes,
+    dashboardPage: entityRelationsDashboardPage,
+  });

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
@@ -1,0 +1,133 @@
+/**
+ * HTTP handlers for KG entity relations: paginated list and read-only GET by id (Hermes detail view).
+ */
+
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma } from "@mediapulse/database";
+import { Hono } from "hono";
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
+import { parsePagination } from "../../lib/list-pagination";
+import {
+  listInclude,
+  mapRowToDetailItem,
+  mapRowToListItem,
+} from "./list-mapper";
+import { entityRelationsHermesPathSegment } from "./dashboard-page";
+
+/**
+ * Maps table-v1 `sortBy` query values to a Prisma `orderBy` for {@link EntityRelation}.
+ *
+ * @param sortBy - Column key from the dashboard manifest (`sortableFields`).
+ * @param sortDir - Ascending or descending.
+ */
+const resolveEntityRelationListOrderBy = (
+  sortBy: string | undefined,
+  sortDir: Prisma.SortOrder,
+): Prisma.EntityRelationOrderByWithRelationInput => {
+  switch (sortBy) {
+    case "lastSeenAt":
+      return { lastSeenAt: sortDir };
+    case "createdAt":
+      return { createdAt: sortDir };
+    case "weight":
+      return { weight: sortDir };
+    case "fromEntityName":
+      return { fromEntity: { canonicalName: sortDir } };
+    case "toEntityName":
+      return { toEntity: { canonicalName: sortDir } };
+    case "relationTypeName":
+      return { relationType: { name: sortDir } };
+    default:
+      return { lastSeenAt: "desc" };
+  }
+};
+
+/**
+ * Hermes `table-v1` API for entity relations (list + read-only detail).
+ */
+export const entityRelationsRoutes = new Hono();
+
+/** Paginated list of entity relations for the Hermes dashboard (search `q`; sort `sortBy` / `sortDir`). */
+entityRelationsRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const query = c.req.query("q")?.trim();
+  const sortBy = c.req.query("sortBy");
+  const sortDir: Prisma.SortOrder =
+    c.req.query("sortDir") === "desc" ? "desc" : "asc";
+  const skip = (page - 1) * pageSize;
+
+  const where = query
+    ? ({
+        OR: [
+          {
+            fromEntity: {
+              canonicalName: { contains: query, mode: "insensitive" as const },
+            },
+          },
+          {
+            toEntity: {
+              canonicalName: { contains: query, mode: "insensitive" as const },
+            },
+          },
+          {
+            relationType: {
+              name: { contains: query, mode: "insensitive" as const },
+            },
+          },
+        ],
+      } satisfies Prisma.EntityRelationWhereInput)
+    : undefined;
+
+  const orderBy = resolveEntityRelationListOrderBy(sortBy, sortDir);
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.EntityRelationFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.entityRelation.findMany(findManyArgs),
+    prisma.entityRelation.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+/**
+ * Table-v1 metadata for Hermes. Registered **before** `GET /:id` so `/meta` is not captured as an id
+ * (see {@link buildMetaPayloadForPathSegment}).
+ */
+entityRelationsRoutes.get("/meta", (c) => {
+  const meta = buildMetaPayloadForPathSegment(entityRelationsHermesPathSegment);
+  if (!meta) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+  return c.json(meta);
+});
+
+/** Returns one entity relation by id for the Hermes read-only detail page. */
+entityRelationsRoutes.get("/:id", async (c) => {
+  const row = await prisma.entityRelation.findUnique({
+    where: { id: c.req.param("id") },
+    include: listInclude,
+  } satisfies Prisma.EntityRelationFindUniqueArgs);
+
+  if (!row) {
+    return c.json({ message: "Entity relation not found" }, 404);
+  }
+
+  return c.json(mapRowToDetailItem(row));
+});

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -52,7 +52,8 @@ export const postAnalysisBodySchema = z.object({
       z.object({
         canonicalName: z.string().trim().min(1),
         typeId: z.string().uuid(),
-        description: z.string().optional(),
+        /** `null` allowed for LLM structured outputs; omit when absent. */
+        description: z.string().nullish(),
         aliases: z.array(z.string().trim().min(1)).default([]),
       }),
     )
@@ -73,7 +74,7 @@ export const postAnalysisBodySchema = z.object({
         entityName: z.string().trim().min(1),
         mentionCount: z.number().int().positive(),
         confidence: z.number().min(0).max(1),
-        sentiment: sentimentSchema.optional(),
+        sentiment: sentimentSchema.nullish(),
       }),
     )
     .default([]),


### PR DESCRIPTION
## Summary

Fixes article-analysis **OpenAI structured output** validation for `generateObject` by introducing a **wire Zod schema** (required `description` as string with `""` when empty, required `sentiment` including `NONE`) and **normalizing** to the existing pipeline types (`null` where absent). Relaxes the **agent-data-api contract** so POST bodies accept `null` / omitted values consistently.

`main` may already include the Hermes **Entities** / **Entity relations** read-only tables from prior work; this branch still carries that commit history, but the diff against current `main` is expected to be the article-analysis + contract files unless you are comparing an older base.

## Related issues

Closes #281

## Important changes

- `extractEntitiesAndRelationsForSource` now calls `generateObject` with `llmExtractionOpenAiWireSchema`, then `normalizeLlmExtractionWire` before vocabulary validation and merging.
- `postAnalysisBodySchema` entity `description` and article-entity `sentiment` use `nullish()` where appropriate for LLM-originated nulls.

## Other changes

- Vitest coverage for `normalizeLlmExtractionWire`; `run.test` `llmResult` helper comment tightened.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` — wire vs normalized schemas and normalization rules.
- `packages/shared/agent-data-api-contract/src/analysis.ts` — POST body nullish fields.

## How to test

1. Run `pnpm code-quality` from the repo root (passes on this branch).
2. Run `pnpm --filter @mediapulse/article-analysis test`.
3. Run article-analysis against OpenAI with a populated vocabulary; confirm logs no longer show `Missing 'description'` / invalid `response_format` schema errors for `entities.items`.
