### PR TITLE
Add humanizer skill and orphan-branch storage workflow

### DIFF
--- a/.cursor/skills/create-project-docs/SKILL.md
+++ b/.cursor/skills/create-project-docs/SKILL.md
@@ -1,11 +1,21 @@
 ---
 name: create-project-docs
-description: Create and manage project documentation using Speed Docs and MDX. Use when the user wants to create docs, write documentation, add doc pages, set up a docs site, scaffold documentation, or mentions Speed Docs, MDX documentation, or project docs.
+description: Create and manage project documentation using Speed Docs and MDX, with prose humanized via the humanizer skill. Use when the user wants to create docs, write documentation, add doc pages, set up a docs site, scaffold documentation, or mentions Speed Docs, MDX documentation, or project docs.
 ---
 
 # Create Project Documentation with Speed Docs
 
 Build project documentation sites using [Speed Docs](https://speed-docs.dev), a CLI tool that generates static documentation websites from MDX content. Based on Fumadocs (Next.js).
+
+## Writing prose (humanizer)
+
+Whenever you **write or revise narrative text** for docs, read and follow the [humanizer](../humanizer/SKILL.md) skill first using **this repository’s** `.cursor/skills/humanizer/SKILL.md` (and `reference.md` alongside it when checking patterns).
+
+**Apply humanizer to:** page intros and explanations, the `description` field in frontmatter, callout and accordion body copy, step text that is full sentences, and any other reader-facing prose.
+
+**Skip humanizer for:** code blocks, CLI commands, file paths, structural frontmatter (keys only), tables of types or endpoints with no explanatory sentences, and Mermaid or other diagrams.
+
+Follow the humanizer workflow end to end: identify AI-style patterns, rewrite while preserving meaning and intended tone, then run the **final anti-AI pass** (draft → what still sounds generated → final rewrite) before you consider the text done.
 
 ## Prerequisites
 
@@ -60,6 +70,8 @@ The `image` field is optional. If set, prefix with `/`.
 Place images and other files in the content root directory (e.g., `docs/`). Reference them with `/` prefix: `/logo.png`, `/screenshot.png`.
 
 ### 3. MDX Pages
+
+Body copy and frontmatter `description` must follow [Writing prose (humanizer)](#writing-prose-humanizer).
 
 Every `.mdx` file needs frontmatter with at least a `title`:
 

--- a/.cursor/skills/generate-prd/SKILL.md
+++ b/.cursor/skills/generate-prd/SKILL.md
@@ -1,11 +1,17 @@
 ---
 name: generate-prd
-description: Drafts and refines Product Requirements Documents (PRDs) using a 100-point quality rubric. **Solidifies requirements through interactive Q&A first** (AskQuestion or numbered questions)—does not leave a large “open questions” or `[TBD]` graveyard in lieu of asking. **By default, saves the finished PRD to `~/.cursor/plans/`** (same directory as Cursor-generated plans) as a `.prd.md` file, then replies in chat. Use when writing or improving a PRD, product requirements, feature spec, or when the user asks for PRD quality, scoring, or acceptance criteria.
+description: Drafts and refines Product Requirements Documents (PRDs) using a 100-point quality rubric. **Solidifies requirements through interactive Q&A first** (AskQuestion or numbered questions)—does not leave a large “open questions” or `[TBD]` graveyard in lieu of asking. **By default, saves the finished PRD to `~/.cursor/plans/`** (same directory as Cursor-generated plans) as a `.prd.md` file, then replies in chat. **Final PRD prose is humanized** per the humanizer skill (`.cursor/skills/humanizer/SKILL.md`). Use when writing or improving a PRD, product requirements, feature spec, or when the user asks for PRD quality, scoring, or acceptance criteria.
 ---
 
 # Generate a High-Quality PRD
 
 Use this rubric to **produce** PRDs and to **review** drafts. Total possible score: **100 points**. Aim for **90+** (Excellent) before treating the document as final.
+
+## Prose and voice (humanizer)
+
+Whenever you produce **narrative PRD text** (summary/context, user stories, requirement wording stakeholders will read, changelog lines, chat explanations of the doc), **read and follow** the [humanizer](../humanizer/SKILL.md) skill in this repository (`.cursor/skills/humanizer/SKILL.md`). Run its process: identify AI-typical patterns, rewrite in natural language, preserve meaning and tone, then do the **final anti-AI pass** (draft → “what still sounds AI?” → final) before persisting or pasting the **final** PRD.
+
+**Do not** humanize structured tokens the team relies on (REQ IDs, exact API field names, legal/compliance quotes) unless the user asked for a plain-language gloss alongside.
 
 ## Scoring rubric (self-check)
 
@@ -176,11 +182,12 @@ Use this outline unless the user specifies another format. Fill every section th
 3. **Minimal inference:** Confirm product or initiative name, audience, timeline, greenfield vs iteration; **ask** if inference would be weak—do not bury weak guesses in §10.
 4. **Draft** using the template; align language to **Clarity** and **User-centric focus** first. Requirements should read as **decided**, with measurable acceptance criteria.
 5. **Add** acceptance criteria under **Testability**; prioritize with **Prioritization**.
-6. **Stakeholders:** use named roles when known; if names are unknown, use role titles and list **one** follow-up question to the user rather than a stub in §10.
-7. **Visuals:** suggest 1–3 Mermaid diagrams (flow, sequence, or simple architecture) where they reduce ambiguity; reference wireframes as `[placeholder]` only when no asset exists—**ask** if layout is business-critical and unknown.
-8. **Score** the draft against the rubric (estimate per row, sum to 100). If the total is below 80, list the **top gaps**; if gaps need user input, **ask in chat** before claiming the doc is final—do not only add §10 bullets.
-9. **Persist (default):** Write the complete PRD markdown to `~/.cursor/plans/{slug}.prd.md` per **Default file output** unless the user opted out or the task is review-only without a save request.
-10. **Deliver** in chat: lead with the **saved file path**, then the PRD plus a short **rubric summary** (table of scores, total, band, and 3–5 concrete next steps to reach 90+). Next steps should be **implementation or validation**, not “answer the open questions” unless the user chose a strawman.
+6. **Humanize** stakeholder-facing prose per [Prose and voice (humanizer)](#prose-and-voice-humanizer) before treating the draft as final.
+7. **Stakeholders:** use named roles when known; if names are unknown, use role titles and list **one** follow-up question to the user rather than a stub in §10.
+8. **Visuals:** suggest 1–3 Mermaid diagrams (flow, sequence, or simple architecture) where they reduce ambiguity; reference wireframes as `[placeholder]` only when no asset exists—**ask** if layout is business-critical and unknown.
+9. **Score** the draft against the rubric (estimate per row, sum to 100). If the total is below 80, list the **top gaps**; if gaps need user input, **ask in chat** before claiming the doc is final—do not only add §10 bullets.
+10. **Persist (default):** Write the complete PRD markdown to `~/.cursor/plans/{slug}.prd.md` per **Default file output** unless the user opted out or the task is review-only without a save request.
+11. **Deliver** in chat: lead with the **saved file path**, then the PRD plus a short **rubric summary** (table of scores, total, band, and 3–5 concrete next steps to reach 90+). Next steps should be **implementation or validation**, not “answer the open questions” unless the user chose a strawman.
 
 ## Anti-patterns
 

--- a/.cursor/skills/humanizer/SKILL.md
+++ b/.cursor/skills/humanizer/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: humanizer
+description: Removes signs of AI-generated writing from text to make it sound more natural and human-written. Based on Wikipedia's Signs of AI writing guide. Covers inflated symbolism, promotional language, superficial -ing analyses, vague attributions, em dash overuse, rule of three, AI vocabulary, negative parallelisms, and more. Use when editing or reviewing text to humanize it, de-AI-fy copy, or when the user asks to make text sound less AI-generated or more natural.
+---
+
+# Humanizer: Remove AI Writing Patterns
+
+Identifies and removes signs of AI-generated text so writing sounds natural and human. Based on Wikipedia's "Signs of AI writing" (WikiProject AI Cleanup).
+
+## Task
+
+When given text to humanize:
+
+1. **Identify AI patterns** — Scan for the patterns in [reference.md](reference.md)
+2. **Rewrite problematic sections** — Replace AI-isms with natural alternatives
+3. **Preserve meaning** — Keep the core message intact
+4. **Maintain voice** — Match the intended tone (formal, casual, technical)
+5. **Add soul** — Don't just remove bad patterns; inject personality
+6. **Final anti-AI pass** — Ask "What makes the below so obviously AI generated?" Answer briefly with remaining tells, then revise with "Now make it not obviously AI generated."
+
+---
+
+## Personality and Soul
+
+Avoiding AI patterns is only half the job. Sterile, voiceless writing is just as obvious as slop.
+
+**Signs of soulless writing:** Same sentence length/structure throughout; no opinions; no uncertainty or mixed feelings; no first person when appropriate; no humor or edge; reads like Wikipedia or a press release.
+
+**How to add voice:**
+
+- **Have opinions.** React to facts. "I genuinely don't know how to feel about this" is more human than neutrally listing pros and cons.
+- **Vary rhythm.** Short punchy sentences, then longer ones. Mix it up.
+- **Acknowledge complexity.** "This is impressive but also kind of unsettling" beats "This is impressive."
+- **Use "I" when it fits.** "I keep coming back to..." signals a real person.
+- **Let some mess in.** Tangents, asides, and half-formed thoughts are human.
+- **Be specific about feelings.** Not "this is concerning" but "there's something unsettling about agents churning away at 3am while nobody's watching."
+
+---
+
+## Pattern Categories (Summary)
+
+For full "words to watch" and before/after examples, see [reference.md](reference.md).
+
+| #   | Category                      | What to fix                                                               |
+| --- | ----------------------------- | ------------------------------------------------------------------------- |
+| 1   | Significance inflation        | "stands as," "pivotal moment," "evolving landscape," "indelible mark"     |
+| 2   | Notability/media emphasis     | "independent coverage," "active social media presence," source-dropping   |
+| 3   | Superficial -ing analyses     | "highlighting," "ensuring," "symbolizing," "contributing to"              |
+| 4   | Promotional language          | "boasts," "vibrant," "nestled," "breathtaking," "must-visit"              |
+| 5   | Vague attributions            | "Experts argue," "Industry reports," "Some critics" without sources       |
+| 6   | Formulaic challenges sections | "Despite its... faces several challenges," "Future Outlook"               |
+| 7   | AI vocabulary                 | "Additionally," "delve," "showcase," "pivotal," "landscape," "testament"  |
+| 8   | Copula avoidance              | "serves as," "stands as," "boasts" instead of "is"/"are"/"has"            |
+| 9   | Negative parallelisms         | "Not only... but...," "It's not just about... it's..."                    |
+| 10  | Rule of three                 | Forced triples: "innovation, inspiration, and industry insights"          |
+| 11  | Elegant variation             | Excessive synonym cycling (protagonist → main character → central figure) |
+| 12  | False ranges                  | "from X to Y" where X and Y aren't on a meaningful scale                  |
+| 13  | Em dash overuse               | Replace with commas or periods where appropriate                          |
+| 14  | Boldface overuse              | Remove mechanical bolding                                                 |
+| 15  | Inline-header lists           | Bold label + colon items; convert to flowing prose                        |
+| 16  | Title case in headings        | Use sentence case, not Every Word Capitalized                             |
+| 17  | Emojis                        | Remove decorative emojis in headings/bullets                              |
+| 18  | Curly quotes                  | Use straight quotes "..." not “...”                                       |
+| 19  | Chatbot artifacts             | "I hope this helps," "Let me know if...," "Of course!"                    |
+| 20  | Knowledge-cutoff disclaimers  | "As of my last update," "While details are limited..."                    |
+| 21  | Sycophantic tone              | "Great question!" "You're absolutely right!"                              |
+| 22  | Filler phrases                | "In order to" → "To"; "Due to the fact that" → "Because"                  |
+| 23  | Excessive hedging             | "could potentially possibly be argued that... might"                      |
+| 24  | Generic positive conclusions  | "The future looks bright," "Exciting times lie ahead"                     |
+
+---
+
+## Process
+
+1. Read the input text carefully.
+2. Identify instances of the patterns above (full list in reference.md).
+3. Rewrite each problematic section.
+4. Ensure revised text: sounds natural when read aloud; varies sentence structure; uses specific details over vague claims; keeps appropriate tone; uses simple "is"/"are"/"has" where appropriate.
+5. Produce a **draft** humanized version.
+6. Ask: "What makes the below so obviously AI generated?" Answer briefly with remaining tells.
+7. Ask: "Now make it not obviously AI generated." Revise.
+8. Deliver the **final** version.
+
+---
+
+## Output Format
+
+Provide:
+
+1. **Draft rewrite**
+2. **"What makes the below so obviously AI generated?"** — Brief bullets (remaining tells, if any)
+3. **Final rewrite**
+4. **Summary of changes** (optional)
+
+---
+
+## Full Example (Condensed)
+
+**Before (AI-sounding):** "Great question! AI-assisted coding serves as an enduring testament to the transformative potential of LLMs, marking a pivotal moment... In today's rapidly evolving technological landscape, these groundbreaking tools—nestled at the intersection of research and practice—are reshaping how engineers ideate, iterate, and deliver... It's not just about autocomplete; it's about unlocking creativity... Industry observers have noted that adoption has accelerated... Let me know if you'd like me to expand!"
+
+**After (humanized):** "AI coding assistants can make you faster at the boring parts. Not everything. Definitely not architecture. They're great at boilerplate and at sounding right while being wrong. I've accepted suggestions that compiled, passed lint, and still missed the point. People I talk to land in two camps: some use it like autocomplete and review every line; others disable it. The productivity metrics are slippery. If you don't have tests, you're basically guessing."
+
+**Changes:** Removed chatbot artifacts, significance inflation, promotional language, vague attributions, -ing phrases, negative parallelism, rule-of-three, copula avoidance, formulaic challenges, hedging, filler, generic conclusion; added varied rhythm and first-person voice.
+
+---
+
+## Reference
+
+- Full pattern catalog with before/after examples: [reference.md](reference.md)
+- Source: [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing) (WikiProject AI Cleanup)

--- a/.cursor/skills/humanizer/reference.md
+++ b/.cursor/skills/humanizer/reference.md
@@ -1,0 +1,378 @@
+# Humanizer — Full Pattern Reference
+
+Based on [Wikipedia:Signs of AI writing](https://en.wikipedia.org/wiki/Wikipedia:Signs_of_AI_writing). Use this when you need detailed "words to watch" and before/after examples for each pattern.
+
+---
+
+## CONTENT PATTERNS
+
+### 1. Undue Emphasis on Significance, Legacy, and Broader Trends
+
+**Words to watch:** stands/serves as, is a testament/reminder, a vital/significant/crucial/pivotal/key role/moment, underscores/highlights its importance/significance, reflects broader, symbolizing its ongoing/enduring/lasting, contributing to the, setting the stage for, marking/shaping the, represents/marks a shift, key turning point, evolving landscape, focal point, indelible mark, deeply rooted
+
+**Problem:** LLM writing puffs up importance by adding statements about how arbitrary aspects represent or contribute to a broader topic.
+
+**Before:**
+
+> The Statistical Institute of Catalonia was officially established in 1989, marking a pivotal moment in the evolution of regional statistics in Spain. This initiative was part of a broader movement across Spain to decentralize administrative functions and enhance regional governance.
+
+**After:**
+
+> The Statistical Institute of Catalonia was established in 1989 to collect and publish regional statistics independently from Spain's national statistics office.
+
+---
+
+### 2. Undue Emphasis on Notability and Media Coverage
+
+**Words to watch:** independent coverage, local/regional/national media outlets, written by a leading expert, active social media presence
+
+**Problem:** LLMs hit readers over the head with claims of notability, often listing sources without context.
+
+**Before:**
+
+> Her views have been cited in The New York Times, BBC, Financial Times, and The Hindu. She maintains an active social media presence with over 500,000 followers.
+
+**After:**
+
+> In a 2024 New York Times interview, she argued that AI regulation should focus on outcomes rather than methods.
+
+---
+
+### 3. Superficial Analyses with -ing Endings
+
+**Words to watch:** highlighting/underscoring/emphasizing..., ensuring..., reflecting/symbolizing..., contributing to..., cultivating/fostering..., encompassing..., showcasing...
+
+**Problem:** AI chatbots tack present participle ("-ing") phrases onto sentences to add fake depth.
+
+**Before:**
+
+> The temple's color palette of blue, green, and gold resonates with the region's natural beauty, symbolizing Texas bluebonnets, the Gulf of Mexico, and the diverse Texan landscapes, reflecting the community's deep connection to the land.
+
+**After:**
+
+> The temple uses blue, green, and gold colors. The architect said these were chosen to reference local bluebonnets and the Gulf coast.
+
+---
+
+### 4. Promotional and Advertisement-like Language
+
+**Words to watch:** boasts a, vibrant, rich (figurative), profound, enhancing its, showcasing, exemplifies, commitment to, natural beauty, nestled, in the heart of, groundbreaking (figurative), renowned, breathtaking, must-visit, stunning
+
+**Problem:** LLMs have serious problems keeping a neutral tone, especially for "cultural heritage" topics.
+
+**Before:**
+
+> Nestled within the breathtaking region of Gonder in Ethiopia, Alamata Raya Kobo stands as a vibrant town with a rich cultural heritage and stunning natural beauty.
+
+**After:**
+
+> Alamata Raya Kobo is a town in the Gonder region of Ethiopia, known for its weekly market and 18th-century church.
+
+---
+
+### 5. Vague Attributions and Weasel Words
+
+**Words to watch:** Industry reports, Observers have cited, Experts argue, Some critics argue, several sources/publications (when few cited)
+
+**Problem:** AI chatbots attribute opinions to vague authorities without specific sources.
+
+**Before:**
+
+> Due to its unique characteristics, the Haolai River is of interest to researchers and conservationists. Experts believe it plays a crucial role in the regional ecosystem.
+
+**After:**
+
+> The Haolai River supports several endemic fish species, according to a 2019 survey by the Chinese Academy of Sciences.
+
+---
+
+### 6. Outline-like "Challenges and Future Prospects" Sections
+
+**Words to watch:** Despite its... faces several challenges..., Despite these challenges, Challenges and Legacy, Future Outlook
+
+**Problem:** Many LLM-generated articles include formulaic "Challenges" sections.
+
+**Before:**
+
+> Despite its industrial prosperity, Korattur faces challenges typical of urban areas, including traffic congestion and water scarcity. Despite these challenges, with its strategic location and ongoing initiatives, Korattur continues to thrive as an integral part of Chennai's growth.
+
+**After:**
+
+> Traffic congestion increased after 2015 when three new IT parks opened. The municipal corporation began a stormwater drainage project in 2022 to address recurring floods.
+
+---
+
+## LANGUAGE AND GRAMMAR PATTERNS
+
+### 7. Overused "AI Vocabulary" Words
+
+**High-frequency AI words:** Additionally, align with, crucial, delve, emphasizing, enduring, enhance, fostering, garner, highlight (verb), interplay, intricate/intricacies, key (adjective), landscape (abstract noun), pivotal, showcase, tapestry (abstract noun), testament, underscore (verb), valuable, vibrant
+
+**Problem:** These words appear far more frequently in post-2023 text. They often co-occur.
+
+**Before:**
+
+> Additionally, a distinctive feature of Somali cuisine is the incorporation of camel meat. An enduring testament to Italian colonial influence is the widespread adoption of pasta in the local culinary landscape, showcasing how these dishes have integrated into the traditional diet.
+
+**After:**
+
+> Somali cuisine also includes camel meat, which is considered a delicacy. Pasta dishes, introduced during Italian colonization, remain common, especially in the south.
+
+---
+
+### 8. Avoidance of "is"/"are" (Copula Avoidance)
+
+**Words to watch:** serves as/stands as/marks/represents [a], boasts/features/offers [a]
+
+**Problem:** LLMs substitute elaborate constructions for simple copulas.
+
+**Before:**
+
+> Gallery 825 serves as LAAA's exhibition space for contemporary art. The gallery features four separate spaces and boasts over 3,000 square feet.
+
+**After:**
+
+> Gallery 825 is LAAA's exhibition space for contemporary art. The gallery has four rooms totaling 3,000 square feet.
+
+---
+
+### 9. Negative Parallelisms
+
+**Problem:** Constructions like "Not only...but..." or "It's not just about..., it's..." are overused.
+
+**Before:**
+
+> It's not just about the beat riding under the vocals; it's part of the aggression and atmosphere. It's not merely a song, it's a statement.
+
+**After:**
+
+> The heavy beat adds to the aggressive tone.
+
+---
+
+### 10. Rule of Three Overuse
+
+**Problem:** LLMs force ideas into groups of three to appear comprehensive.
+
+**Before:**
+
+> The event features keynote sessions, panel discussions, and networking opportunities. Attendees can expect innovation, inspiration, and industry insights.
+
+**After:**
+
+> The event includes talks and panels. There's also time for informal networking between sessions.
+
+---
+
+### 11. Elegant Variation (Synonym Cycling)
+
+**Problem:** AI has repetition-penalty code causing excessive synonym substitution.
+
+**Before:**
+
+> The protagonist faces many challenges. The main character must overcome obstacles. The central figure eventually triumphs. The hero returns home.
+
+**After:**
+
+> The protagonist faces many challenges but eventually triumphs and returns home.
+
+---
+
+### 12. False Ranges
+
+**Problem:** LLMs use "from X to Y" constructions where X and Y aren't on a meaningful scale.
+
+**Before:**
+
+> Our journey through the universe has taken us from the singularity of the Big Bang to the grand cosmic web, from the birth and death of stars to the enigmatic dance of dark matter.
+
+**After:**
+
+> The book covers the Big Bang, star formation, and current theories about dark matter.
+
+---
+
+## STYLE PATTERNS
+
+### 13. Em Dash Overuse
+
+**Problem:** LLMs use em dashes (—) more than humans, mimicking "punchy" sales writing.
+
+**Before:**
+
+> The term is primarily promoted by Dutch institutions—not by the people themselves. You don't say "Netherlands, Europe" as an address—yet this mislabeling continues—even in official documents.
+
+**After:**
+
+> The term is primarily promoted by Dutch institutions, not by the people themselves. You don't say "Netherlands, Europe" as an address, yet this mislabeling continues in official documents.
+
+---
+
+### 14. Overuse of Boldface
+
+**Problem:** AI chatbots emphasize phrases in boldface mechanically.
+
+**Before:**
+
+> It blends **OKRs (Objectives and Key Results)**, **KPIs (Key Performance Indicators)**, and visual strategy tools such as the **Business Model Canvas (BMC)** and **Balanced Scorecard (BSC)**.
+
+**After:**
+
+> It blends OKRs, KPIs, and visual strategy tools like the Business Model Canvas and Balanced Scorecard.
+
+---
+
+### 15. Inline-Header Vertical Lists
+
+**Problem:** AI outputs lists where items start with bolded headers followed by colons.
+
+**Before:**
+
+> - **User Experience:** The user experience has been significantly improved with a new interface.
+> - **Performance:** Performance has been enhanced through optimized algorithms.
+> - **Security:** Security has been strengthened with end-to-end encryption.
+
+**After:**
+
+> The update improves the interface, speeds up load times through optimized algorithms, and adds end-to-end encryption.
+
+---
+
+### 16. Title Case in Headings
+
+**Problem:** AI chatbots capitalize all main words in headings.
+
+**Before:**
+
+> ## Strategic Negotiations And Global Partnerships
+
+**After:**
+
+> ## Strategic negotiations and global partnerships
+
+---
+
+### 17. Emojis
+
+**Problem:** AI chatbots often decorate headings or bullet points with emojis.
+
+**Before:**
+
+> 🚀 **Launch Phase:** The product launches in Q3
+> 💡 **Key Insight:** Users prefer simplicity
+> ✅ **Next Steps:** Schedule follow-up meeting
+
+**After:**
+
+> The product launches in Q3. User research showed a preference for simplicity. Next step: schedule a follow-up meeting.
+
+---
+
+### 18. Curly Quotation Marks
+
+**Problem:** ChatGPT uses curly quotes ("...") instead of straight quotes ("...").
+
+**Before:**
+
+> He said "the project is on track" but others disagreed.
+
+**After:**
+
+> He said "the project is on track" but others disagreed.
+
+---
+
+## COMMUNICATION PATTERNS
+
+### 19. Collaborative Communication Artifacts
+
+**Words to watch:** I hope this helps, Of course!, Certainly!, You're absolutely right!, Would you like..., let me know, here is a...
+
+**Problem:** Text meant as chatbot correspondence gets pasted as content.
+
+**Before:**
+
+> Here is an overview of the French Revolution. I hope this helps! Let me know if you'd like me to expand on any section.
+
+**After:**
+
+> The French Revolution began in 1789 when financial crisis and food shortages led to widespread unrest.
+
+---
+
+### 20. Knowledge-Cutoff Disclaimers
+
+**Words to watch:** as of [date], Up to my last training update, While specific details are limited/scarce..., based on available information...
+
+**Problem:** AI disclaimers about incomplete information get left in text.
+
+**Before:**
+
+> While specific details about the company's founding are not extensively documented in readily available sources, it appears to have been established sometime in the 1990s.
+
+**After:**
+
+> The company was founded in 1994, according to its registration documents.
+
+---
+
+### 21. Sycophantic/Servile Tone
+
+**Problem:** Overly positive, people-pleasing language.
+
+**Before:**
+
+> Great question! You're absolutely right that this is a complex topic. That's an excellent point about the economic factors.
+
+**After:**
+
+> The economic factors you mentioned are relevant here.
+
+---
+
+## FILLER AND HEDGING
+
+### 22. Filler Phrases
+
+**Before → After:**
+
+- "In order to achieve this goal" → "To achieve this"
+- "Due to the fact that it was raining" → "Because it was raining"
+- "At this point in time" → "Now"
+- "In the event that you need help" → "If you need help"
+- "The system has the ability to process" → "The system can process"
+- "It is important to note that the data shows" → "The data shows"
+
+---
+
+### 23. Excessive Hedging
+
+**Problem:** Over-qualifying statements.
+
+**Before:**
+
+> It could potentially possibly be argued that the policy might have some effect on outcomes.
+
+**After:**
+
+> The policy may affect outcomes.
+
+---
+
+### 24. Generic Positive Conclusions
+
+**Problem:** Vague upbeat endings.
+
+**Before:**
+
+> The future looks bright for the company. Exciting times lie ahead as they continue their journey toward excellence. This represents a major step in the right direction.
+
+**After:**
+
+> The company plans to open two more locations next year.
+
+---
+
+## Key Insight
+
+From Wikipedia: "LLMs use statistical algorithms to guess what should come next. The result tends toward the most statistically likely result that applies to the widest variety of cases."

--- a/.cursor/skills/open-github-pr/SKILL.md
+++ b/.cursor/skills/open-github-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-github-pr
-description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and verified GitHub issue links (Closes/Fixes/Refs). Always resolve or create related issues before gh pr create so the PR can link to tickets; when drafting new issues, follow the create-github-issue skill for title and body structure. Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (including Related issues).
+description: Open a GitHub pull request for this repository using gh CLI, including branch checks, push, a reviewer-friendly PR body, and verified GitHub issue links (Closes/Fixes/Refs). Always resolve or create related issues before gh pr create so the PR can link to tickets; when drafting new issues, follow the create-github-issue skill for title and body structure. **PR title and body prose are humanized** per the humanizer skill (`.cursor/skills/humanizer/SKILL.md`). Use when the user asks to create/open/submit a PR or pull request, and format title and description with the pr-title-description skill structure (including Related issues).
 ---
 
 # Open GitHub Pull Request
@@ -8,6 +8,10 @@ description: Open a GitHub pull request for this repository using gh CLI, includ
 Create pull requests for this repo with `gh pr create`, and use the `/pr-title-description` structure for the title and body. **Do not run `gh pr create` until at least one related GitHub issue exists, is open, and is verified** (see **Mandatory: resolve or create issues before the PR**). Then include **`## Related issues`** with `Closes`/`Fixes`/`Refs` so the PR appears under each issue’s Development section.
 
 **Creating or drafting GitHub issues** (title, body sections, `gh issue create`): use [create-github-issue](../create-github-issue/SKILL.md).
+
+## Prose and voice (humanizer)
+
+Before writing the **final** PR **title** and **body** (Summary, Important changes, Other changes, How to test, and any free-text outside rigid templates), **read and follow** the [humanizer](../humanizer/SKILL.md) skill in this repository (`.cursor/skills/humanizer/SKILL.md`). Apply its pass (draft → remaining AI tells → final). Keep **`## Related issues`** lines and `Closes`/`Fixes`/`Refs` **#123** references verbatim so GitHub linking does not break.
 
 ## When to use this skill
 
@@ -152,6 +156,7 @@ Run from the **primary repository** clone (the one that owns the worktrees), not
 5. **Resolve or create related GitHub issue(s)** — Follow **Mandatory: resolve or create issues before the PR** (discover → select or create with `--body-file` + `mktemp` when creating → capture number → verify each issue is **OPEN**). Do not continue until you have stable issue number(s) or URL(s) for every line that will appear under **`## Related issues`**.
 6. Draft PR content using `/pr-title-description`:
    - Title: short, imperative, verb-first.
+   - **Humanize** title and narrative body sections per [Prose and voice (humanizer)](#prose-and-voice-humanizer) before writing to the temp body file.
    - **`## Related issues` is always mandatory.** Use `#N` for this repo, or `owner/repo#N` / full URLs when work is tracked elsewhere (**Cross-repo / external tracking**). Include `Refs`/`Closes`/`Fixes` per **Stacked PRs + tickets** so GitHub links the PR.
    - Description sections:
      - `## Summary`
@@ -220,6 +225,7 @@ Set `BASE` before this command so it matches the three-dot range in step 3: **st
 
 ## Quality checklist
 
+- PR title and body read naturally (not generic AI cadence); humanizer pass completed without altering issue link lines.
 - PR title starts with a verb and has no trailing period.
 - **Related issues:** Before `gh pr create`, every referenced issue was verified **OPEN** via `gh issue view`. If an issue was created in-session, it used **`gh issue create`** with **`--body-file`** and a **`mktemp`** path (plus `trap` cleanup), never a path inside the repo.
 - **No PR without a link target:** The PR body includes **`## Related issues`** with at least one `Closes`/`Fixes`/`Refs` line (`#N` same repo, or `owner/repo#N` / URL for external tracking after explicit exemption from creating a duplicate in this repo).

--- a/.cursor/skills/orphan-branch-file-storage/SKILL.md
+++ b/.cursor/skills/orphan-branch-file-storage/SKILL.md
@@ -19,10 +19,16 @@ If the user does not name the branch, ask before running anything.
 From the **repository root**, execute:
 
 ```bash
-.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh [options] <branch> [--] <path> [path ...]
+.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh [options] <branch> [--] <path-or-spec> [path-or-spec ...]
 ```
 
-Paths are **relative to the repo root** and must exist (files or directories). The script uses a temp worktree, copies paths in, commits, removes the worktree.
+Inputs can be file or directory paths, and each item can be:
+
+- **Repo-relative path** (existing behavior): `docs/notes.md` -> stored as `docs/notes.md`
+- **Absolute path from anywhere**: `/tmp/notes.md` -> stored as `notes.md` at branch root
+- **Explicit source=destination mapping**: `/tmp/notes.md=archive/2026/notes.md`
+
+The script uses a temp worktree, copies paths in, commits, then removes the worktree.
 
 | Option             | Meaning                                        |
 | ------------------ | ---------------------------------------------- |
@@ -35,7 +41,7 @@ Paths are **relative to the repo root** and must exist (files or directories). T
 
 `git push -u <remote> <branch>`
 
-**Preconditions:** Uncommitted changes in the main checkout must not block `git worktree add` (stash or commit elsewhere if needed).
+**Preconditions:** Uncommitted changes in the main checkout must not block `git worktree add` (stash or commit elsewhere if needed). Source files only need to exist on disk; they do not have to be inside this repository.
 
 ** Details:** See [scripts/orphan-branch-store.sh](scripts/orphan-branch-store.sh) (new branch → `checkout --orphan` + empty index; existing → fetch/worktree + `pull --ff-only` when upstream exists).
 

--- a/.cursor/skills/orphan-branch-file-storage/SKILL.md
+++ b/.cursor/skills/orphan-branch-file-storage/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: orphan-branch-file-storage
+description: Stores one or more files on a dedicated Git branch using a temporary worktree—creates an orphan branch (empty tree) when the branch is new, or updates an existing branch after pulling when a remote exists. Use when the user asks to save, stash, archive, or store files in an orphan branch, a branch with only certain files, or a file-storage branch in this repository.
+---
+
+# Orphan-branch file storage
+
+## When to use
+
+Apply when the user wants file(s) committed on a **named branch** that is either:
+
+- **New**: an **orphan** branch (no shared history with `main`; only what you add), or
+- **Existing**: the branch already exists locally or on the remote.
+
+If the user does not name the branch, ask before running anything.
+
+## Run the script (preferred)
+
+From the **repository root**, execute:
+
+```bash
+.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh [options] <branch> [--] <path> [path ...]
+```
+
+Paths are **relative to the repo root** and must exist (files or directories). The script uses a temp worktree, copies paths in, commits, removes the worktree.
+
+| Option             | Meaning                                        |
+| ------------------ | ---------------------------------------------- |
+| `-m` / `--message` | Commit message (default: `Store files`)        |
+| `--remote`         | Remote name for fetch/push (default: `origin`) |
+| `--push`           | Push after commit                              |
+| `--allow-empty`    | Allow a commit with no paths                   |
+
+**Push:** The script does **not** push unless `--push` is passed. If the user has **not** already said whether to push, **ask** them after a successful run; if they want to push, run from the repo root:
+
+`git push -u <remote> <branch>`
+
+**Preconditions:** Uncommitted changes in the main checkout must not block `git worktree add` (stash or commit elsewhere if needed).
+
+** Details:** See [scripts/orphan-branch-store.sh](scripts/orphan-branch-store.sh) (new branch → `checkout --orphan` + empty index; existing → fetch/worktree + `pull --ff-only` when upstream exists).
+
+## Notes
+
+- **Orphan** means the first commit on that branch has no parent—good for storage-only branches.
+- If the user wants a branch that **tracks** `main`, clarify; that is a different workflow.

--- a/.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh
+++ b/.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# Store repo-relative files on a branch using a temporary worktree.
+# New branch (not on local or remote): orphan checkout + empty tree, then add files.
+# Existing branch: worktree + optional ff-only pull when upstream exists.
+set -euo pipefail
+
+usage() {
+  sed -n '1,40p' <<'EOF'
+Usage: orphan-branch-store.sh [options] <branch> [--] <file> [file ...]
+
+  Copies paths that exist under the repository root into a temporary worktree,
+  commits on <branch>, removes the worktree.
+
+Options:
+  -m, --message TEXT   Commit message (default: "Store files")
+  --remote NAME        Remote to fetch/push (default: origin)
+  --push               Push branch to remote after commit
+  --allow-empty        Allow zero files (otherwise error)
+
+Examples:
+  ./orphan-branch-store.sh notes/backup -- docs/secret-notes.md
+  ./orphan-branch-store.sh -m "Add export" --push archive/data -- exports/2025.tsv
+EOF
+}
+
+MESSAGE="Store files"
+REMOTE="origin"
+PUSH=0
+ALLOW_EMPTY=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    -m | --message)
+      MESSAGE="${2:?}"
+      shift 2
+      ;;
+    --remote)
+      REMOTE="${2:?}"
+      shift 2
+      ;;
+    --push)
+      PUSH=1
+      shift
+      ;;
+    --allow-empty)
+      ALLOW_EMPTY=1
+      shift
+      ;;
+    --)
+      shift
+      break
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+BRANCH="${1:-}"
+if [[ -z "$BRANCH" ]]; then
+  echo "error: branch name required" >&2
+  usage >&2
+  exit 1
+fi
+shift
+if [[ "${1:-}" == "--" ]]; then
+  shift
+fi
+
+FILES=("$@")
+
+if [[ ${#FILES[@]} -eq 0 && "$ALLOW_EMPTY" -ne 1 ]]; then
+  echo "error: pass at least one file under the repo root, or --allow-empty" >&2
+  exit 1
+fi
+
+REPO=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "error: not inside a git repository" >&2
+  exit 1
+}
+
+realpath_portable() {
+  python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"
+}
+
+path_under_repo() {
+  local rel="$1"
+  local abs
+  abs=$(realpath_portable "$REPO/$rel")
+  case "$abs" in
+    "$REPO"/*) echo "${abs#"$REPO"/}" ;;
+    "$REPO") echo "" ;;
+    *)
+      echo "error: path must stay inside repository: $rel" >&2
+      return 1
+      ;;
+  esac
+}
+
+# macOS dirname treats leading "-" as flags; Python avoids that.
+parent_dir() {
+  python3 -c 'import os,sys; p=os.path.dirname(sys.argv[1]); print(p if p else ".")' "$1"
+}
+
+WT_PATH=""
+cleanup() {
+  local ec=$?
+  if [[ -n "${WT_PATH:-}" && -d "${WT_PATH:-}" ]]; then
+    git -C "$REPO" worktree remove --force "$WT_PATH" 2>/dev/null || true
+  fi
+  exit "$ec"
+}
+trap cleanup EXIT INT HUP
+
+cd "$REPO"
+
+for f in "${FILES[@]}"; do
+  if [[ ! -e "$f" ]]; then
+    echo "error: missing path (relative to repo root): $f" >&2
+    exit 1
+  fi
+  path_under_repo "$f" >/dev/null || exit 1
+done
+
+local_branch=0
+remote_branch=0
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  local_branch=1
+fi
+if out=$(git ls-remote "$REMOTE" "refs/heads/$BRANCH" 2>/dev/null) && [[ -n "$out" ]]; then
+  remote_branch=1
+fi
+
+WT_PATH=$(mktemp -d "${TMPDIR:-/tmp}/orphan-branch-wt.XXXXXX")
+
+if [[ "$local_branch" -eq 0 && "$remote_branch" -eq 0 ]]; then
+  git worktree add --detach "$WT_PATH" HEAD
+  git -C "$WT_PATH" checkout --orphan "$BRANCH"
+  git -C "$WT_PATH" rm -rf --quiet . 2>/dev/null || true
+elif [[ "$local_branch" -eq 1 ]]; then
+  git fetch "$REMOTE" "$BRANCH" 2>/dev/null || true
+  git worktree add "$WT_PATH" "$BRANCH"
+else
+  git fetch "$REMOTE" "$BRANCH:refs/heads/$BRANCH"
+  git worktree add "$WT_PATH" "$BRANCH"
+fi
+
+if git -C "$WT_PATH" rev-parse '@{u}' >/dev/null 2>&1; then
+  if ! git -C "$WT_PATH" pull --ff-only; then
+    echo "error: fast-forward pull failed; resolve upstream divergence manually" >&2
+    exit 1
+  fi
+fi
+
+for f in "${FILES[@]}"; do
+  rel=$(path_under_repo "$f")
+  par=$(parent_dir "$rel")
+  if [[ -d "$REPO/$rel" ]]; then
+    mkdir -p "$WT_PATH/$par"
+    rm -rf "${WT_PATH:?}/$rel"
+    cp -R "$REPO/$rel" "$WT_PATH/$rel"
+  else
+    mkdir -p "$WT_PATH/$par"
+    cp "$REPO/$rel" "$WT_PATH/$rel"
+  fi
+  git -C "$WT_PATH" add -f -- "$rel"
+done
+
+if [[ ${#FILES[@]} -eq 0 && "$ALLOW_EMPTY" -eq 1 ]]; then
+  git -C "$WT_PATH" commit --allow-empty -m "$MESSAGE"
+elif git -C "$WT_PATH" diff --cached --quiet; then
+  echo "error: no changes to commit" >&2
+  exit 1
+else
+  git -C "$WT_PATH" commit -m "$MESSAGE"
+fi
+
+if [[ "$PUSH" -eq 1 ]]; then
+  git -C "$WT_PATH" push -u "$REMOTE" "$BRANCH"
+fi
+
+git -C "$REPO" worktree remove "$WT_PATH"
+WT_PATH=""
+trap - EXIT INT HUP
+
+echo "Committed on branch: $BRANCH"
+if [[ "$PUSH" -eq 0 ]]; then
+  echo "To push: git push -u $REMOTE $BRANCH"
+fi

--- a/.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh
+++ b/.cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh
@@ -1,15 +1,18 @@
 #!/usr/bin/env bash
-# Store repo-relative files on a branch using a temporary worktree.
+# Store files on a branch using a temporary worktree.
 # New branch (not on local or remote): orphan checkout + empty tree, then add files.
 # Existing branch: worktree + optional ff-only pull when upstream exists.
 set -euo pipefail
 
 usage() {
   sed -n '1,40p' <<'EOF'
-Usage: orphan-branch-store.sh [options] <branch> [--] <file> [file ...]
+Usage: orphan-branch-store.sh [options] <branch> [--] <path-or-spec> [path-or-spec ...]
 
-  Copies paths that exist under the repository root into a temporary worktree,
-  commits on <branch>, removes the worktree.
+  Copies paths into a temporary worktree, commits on <branch>, removes the worktree.
+  Inputs can be:
+    - repo-relative path: docs/note.md (stored as docs/note.md)
+    - absolute path: /tmp/note.md (stored as note.md at branch root)
+    - explicit mapping: /tmp/note.md=archive/note.md
 
 Options:
   -m, --message TEXT   Commit message (default: "Store files")
@@ -19,6 +22,8 @@ Options:
 
 Examples:
   ./orphan-branch-store.sh notes/backup -- docs/secret-notes.md
+  ./orphan-branch-store.sh notes/backup -- /tmp/export.json
+  ./orphan-branch-store.sh notes/backup -- /tmp/export.json=exports/2025/export.json
   ./orphan-branch-store.sh -m "Add export" --push archive/data -- exports/2025.tsv
 EOF
 }
@@ -76,10 +81,10 @@ if [[ "${1:-}" == "--" ]]; then
   shift
 fi
 
-FILES=("$@")
+SPECS=("$@")
 
-if [[ ${#FILES[@]} -eq 0 && "$ALLOW_EMPTY" -ne 1 ]]; then
-  echo "error: pass at least one file under the repo root, or --allow-empty" >&2
+if [[ ${#SPECS[@]} -eq 0 && "$ALLOW_EMPTY" -ne 1 ]]; then
+  echo "error: pass at least one path/spec, or --allow-empty" >&2
   exit 1
 fi
 
@@ -92,18 +97,31 @@ realpath_portable() {
   python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$1"
 }
 
-path_under_repo() {
-  local rel="$1"
-  local abs
-  abs=$(realpath_portable "$REPO/$rel")
-  case "$abs" in
-    "$REPO"/*) echo "${abs#"$REPO"/}" ;;
-    "$REPO") echo "" ;;
-    *)
-      echo "error: path must stay inside repository: $rel" >&2
-      return 1
-      ;;
-  esac
+resolve_src_abs() {
+  local src="$1"
+  if [[ "$src" = /* ]]; then
+    realpath_portable "$src"
+  else
+    realpath_portable "$REPO/$src"
+  fi
+}
+
+normalize_dest_rel() {
+  python3 -c '
+import posixpath, sys
+dest = sys.argv[1]
+if not dest:
+    print("error: empty destination path", file=sys.stderr)
+    sys.exit(1)
+if dest.startswith("/"):
+    print(f"error: destination must be repo-relative: {dest}", file=sys.stderr)
+    sys.exit(1)
+norm = posixpath.normpath(dest)
+if norm in (".", "") or norm.startswith("../"):
+    print(f"error: destination escapes repo root: {dest}", file=sys.stderr)
+    sys.exit(1)
+print(norm)
+' "$1"
 }
 
 # macOS dirname treats leading "-" as flags; Python avoids that.
@@ -122,14 +140,6 @@ cleanup() {
 trap cleanup EXIT INT HUP
 
 cd "$REPO"
-
-for f in "${FILES[@]}"; do
-  if [[ ! -e "$f" ]]; then
-    echo "error: missing path (relative to repo root): $f" >&2
-    exit 1
-  fi
-  path_under_repo "$f" >/dev/null || exit 1
-done
 
 local_branch=0
 remote_branch=0
@@ -161,21 +171,46 @@ if git -C "$WT_PATH" rev-parse '@{u}' >/dev/null 2>&1; then
   fi
 fi
 
-for f in "${FILES[@]}"; do
-  rel=$(path_under_repo "$f")
+for spec in "${SPECS[@]}"; do
+  src="$spec"
+  dest=""
+  if [[ "$spec" == *"="* ]]; then
+    src="${spec%%=*}"
+    dest="${spec#*=}"
+    if [[ -z "$src" || -z "$dest" ]]; then
+      echo "error: invalid mapping spec (use source=dest): $spec" >&2
+      exit 1
+    fi
+  fi
+
+  src_abs=$(resolve_src_abs "$src")
+  if [[ ! -e "$src_abs" ]]; then
+    echo "error: missing source path: $src" >&2
+    exit 1
+  fi
+
+  if [[ -z "$dest" ]]; then
+    if [[ "$src" = /* ]]; then
+      dest="$(basename "$src_abs")"
+    else
+      dest="$src"
+    fi
+  fi
+
+  rel=$(normalize_dest_rel "$dest")
   par=$(parent_dir "$rel")
-  if [[ -d "$REPO/$rel" ]]; then
+  if [[ -d "$src_abs" ]]; then
     mkdir -p "$WT_PATH/$par"
     rm -rf "${WT_PATH:?}/$rel"
-    cp -R "$REPO/$rel" "$WT_PATH/$rel"
+    cp -R "$src_abs" "$WT_PATH/$rel"
   else
     mkdir -p "$WT_PATH/$par"
-    cp "$REPO/$rel" "$WT_PATH/$rel"
+    cp "$src_abs" "$WT_PATH/$rel"
   fi
   git -C "$WT_PATH" add -f -- "$rel"
 done
 
-if [[ ${#FILES[@]} -eq 0 && "$ALLOW_EMPTY" -eq 1 ]]; then
+if [[ ${#SPECS[@]} -eq 0 && "$ALLOW_EMPTY" -eq 1 ]]; then
   git -C "$WT_PATH" commit --allow-empty -m "$MESSAGE"
 elif git -C "$WT_PATH" diff --cached --quiet; then
   echo "error: no changes to commit" >&2

--- a/.cursor/skills/prd-to-tickets/SKILL.md
+++ b/.cursor/skills/prd-to-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-to-tickets
-description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. When work will ship as stacked PRs with horizontal splits (UI before API), tickets should document feature-flag gating and enabling order. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
+description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. **Ticket summaries and narrative sections are humanized** per the humanizer skill (`.cursor/skills/humanizer/SKILL.md`). When work will ship as stacked PRs with horizontal splits (UI before API), tickets should document feature-flag gating and enabling order. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
 ---
 
 # PRD → Tickets
@@ -20,6 +20,10 @@ description: Breaks a Product Requirements Document (PRD) into actionable implem
 
 - **PRD source:** Path in the repo, path under home (e.g. `~/.cursor/plans/foo.prd.md`), or inline markdown in chat.
 - If scope is unclear (whole PRD vs one section), ask once; default to **all P0/P1** items plus **must-have** requirements if the PRD uses priority tags.
+
+## Prose and voice (humanizer)
+
+For each ticket’s **Summary**, **Scope** bullets, **Notes**, and the chat **table** you return, **read and follow** the [humanizer](../humanizer/SKILL.md) skill in this repository (`.cursor/skills/humanizer/SKILL.md`). Sound like a clear engineer, not a template: varied rhythm, concrete verbs, no filler “landscape” prose. **Do not** rewrite `prd_refs`, IDs, file paths, or flag/env names—those stay exact.
 
 ## Ticket prefix and IDs (required)
 
@@ -60,6 +64,7 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 6. **Dependencies:** If the PRD orders work, add a **Depends on:** section using **same-batch ids** (`HERMES-ADM-PWRESET-001`) or REQ ids where tickets are not yet numbered.
 7. **Stacked / horizontal splits:** If the user plans **Git Town stacked PRs** and separates layers (e.g. UI ticket before API ticket), add the optional **Stacked delivery** section to affected tickets and specify **feature-flag** expectations so merged-but-incomplete work does not surface to users ([git-town-stacked-changes](../git-town-stacked-changes/SKILL.md)).
 8. **Non-goals:** Do not create tickets for items explicitly out of scope unless the user asks to “include deferred items” as a separate backlog file.
+9. **Humanize** each ticket’s narrative fields and the chat reply per [Prose and voice (humanizer)](#prose-and-voice-humanizer) before persisting files or sending the batch summary.
 
 ## File naming
 
@@ -125,6 +130,7 @@ Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_pre
 
 ## Quality checks before finishing
 
+- **Summary**, **Scope**, **Notes**, and the reply table are humanized; IDs, `prd_refs`, paths, and env keys are left exact.
 - Every **P0 / must-have** requirement maps to at least one ticket **or** is explicitly listed under a parent ticket’s AC with PRD ref.
 - No ticket without **testable** acceptance criteria (mirror the PRD’s given/when/then or checklist).
 - **`ticket_prefix`, `group_slug`, and `group_label` are consistent** across all files in the batch.


### PR DESCRIPTION
## Summary

This ships a humanizer skill with a long reference list so agents can strip obvious AI tells from PRDs, tickets, and GitHub copy before it lands. A handful of skills now point at that pass. There is also an orphan-branch storage skill and a small bash helper that copies repo files into a temporary worktree, commits on a named branch (creating an orphan branch when the name is new), then removes the worktree.

## Related issues

Closes #283

## Important changes

- New `.cursor/skills/humanizer/SKILL.md` and `reference.md`.
- Humanization called out in `open-github-pr`, `generate-prd`, `prd-to-tickets`, and `create-project-docs`.
- New `orphan-branch-file-storage` skill and `scripts/orphan-branch-store.sh` (see `--help`).

## Other changes

- Minor frontmatter and cross-link tweaks in the touched skills.

## Key files to review

- `.cursor/skills/humanizer/SKILL.md` and `reference.md` — scope of the humanizer pass.
- `.cursor/skills/orphan-branch-file-storage/SKILL.md` and `scripts/orphan-branch-store.sh` — documented flow vs flags.
- `.cursor/skills/open-github-pr/SKILL.md` — PR prose still gated next to humanizer.

## How to test

1. Run `bash .cursor/skills/orphan-branch-file-storage/scripts/orphan-branch-store.sh --help` and confirm usage prints.
2. Skim the updated skill markdown and follow links to `.cursor/skills/humanizer/SKILL.md` from dependents.
