### PR TITLE
Update prd-to-tickets to include PRD URLs

### DIFF
--- a/.cursor/skills/prd-to-tickets/SKILL.md
+++ b/.cursor/skills/prd-to-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-to-tickets
-description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. **Ticket summaries and narrative sections are humanized** per the humanizer skill (`.cursor/skills/humanizer/SKILL.md`). When work will ship as stacked PRs with horizontal splits (UI before API), tickets should document feature-flag gating and enabling order. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
+description: Breaks a Product Requirements Document (PRD) into actionable implementation tickets (issues) as markdown files with titles, priority, scope, acceptance criteria, and traceability to PRD requirement IDs. Adds deterministic `prd_url` links when the source is resolvable (including `prds` branch links) with a clear unresolved fallback. **By default writes files under `~/.cursor/plans/tickets/`** (override when the user gives another directory). Uses a **representative ticket prefix** (not generic `TICKET-`) and a **shared group slug/label** so related tickets stay filterable. **Ticket summaries and narrative sections are humanized** per the humanizer skill (`.cursor/skills/humanizer/SKILL.md`). When work will ship as stacked PRs with horizontal splits (UI before API), tickets should document feature-flag gating and enabling order. Use when turning a PRD into work items, GitHub issues, Linear-style tasks, sprint tickets, or when the user asks for tickets from a PRD or feature spec.
 ---
 
 # PRD → Tickets
@@ -60,7 +60,7 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 2. **Set `ticket_prefix`, `group_slug`, and `group_label` once** for the whole batch (after deriving from the PRD title unless the user supplied them).
 3. **One ticket per implementable slice** — prefer vertical slices (end-to-end user value) when the PRD allows; otherwise one ticket per **REQ** or per **user story** with clear AC.
 4. **Do not** merge unrelated requirements into one ticket; **do** merge duplicate or overlapping bullets from the PRD into a single ticket with a clear combined AC.
-5. **Traceability:** Each ticket must reference the PRD (`prd_source:` with file path or `"inline PRD"`) and **requirement IDs** when present (`prd_refs: [REQ-001, …]`).
+5. **Traceability:** Each ticket must reference the PRD (`prd_source:` with file path or `"inline PRD"`), include a clickable `prd_url:` when resolvable, and include **requirement IDs** when present (`prd_refs: [REQ-001, …]`).
 6. **Dependencies:** If the PRD orders work, add a **Depends on:** section using **same-batch ids** (`HERMES-ADM-PWRESET-001`) or REQ ids where tickets are not yet numbered.
 7. **Stacked / horizontal splits:** If the user plans **Git Town stacked PRs** and separates layers (e.g. UI ticket before API ticket), add the optional **Stacked delivery** section to affected tickets and specify **feature-flag** expectations so merged-but-incomplete work does not surface to users ([git-town-stacked-changes](../git-town-stacked-changes/SKILL.md)).
 8. **Non-goals:** Do not create tickets for items explicitly out of scope unless the user asks to “include deferred items” as a separate backlog file.
@@ -70,6 +70,20 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 
 - **`{ticket_prefix}-{NNN}-{short-slug}.md`** (e.g. `HERMES-ADM-PWRESET-002-session-credential-version.md`).
 - Slug: lowercase, hyphens, max ~50 chars, derived from the ticket title.
+
+## PRD URL resolution (required when possible)
+
+Add `prd_url` to frontmatter whenever you can resolve a stable source link:
+
+1. **If `prd_source` is already an HTTP(S) URL**, copy it to `prd_url` unchanged.
+2. **If `prd_source` is a path to a PRD file that exists in the `prds` branch**, set:
+   - `prd_url: https://github.com/hyperjumptech/mediapulse/blob/prds/<prd-file>.md`
+   - Use the PRD file basename (for example `article-analysis-agent-prd.md`).
+3. **If the URL cannot be resolved**, keep `prd_source` as-is and set:
+   - `prd_url: unresolved`
+   - In `## Notes`, add one concise line explaining the fallback (for example: `PRD URL unresolved; source is local-only: /tmp/foo.prd.md`).
+
+The goal is deterministic links when a source is known, without blocking ticket generation when it is not.
 
 ## Ticket file template
 
@@ -84,6 +98,7 @@ group_label: Hermes admin password reset
 title: [Imperative, concise title]
 priority: P0 | P1 | P2
 prd_source: [path or "inline"]
+prd_url: [https URL or "unresolved"]
 prd_refs: [REQ-001, REQ-002]
 status: draft
 ---
@@ -124,6 +139,8 @@ See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for impleme
 ## Notes
 
 [APIs, flags, analytics, migration, rollout — only if PRD calls for it.]
+
+When `prd_url` is `unresolved`, include one fallback line explaining why.
 ```
 
 Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_prefix` / `group_slug` / `group_label` for the run. The one-line **Group** line under the H1 is optional but helps plain-markdown readers.
@@ -131,6 +148,7 @@ Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_pre
 ## Quality checks before finishing
 
 - **Summary**, **Scope**, **Notes**, and the reply table are humanized; IDs, `prd_refs`, paths, and env keys are left exact.
+- `prd_url` exists on every ticket and is clickable when resolvable (`https://github.com/hyperjumptech/mediapulse/blob/prds/<prd-file>.md` for `prds` branch sources); unresolved cases clearly keep fallback metadata.
 - Every **P0 / must-have** requirement maps to at least one ticket **or** is explicitly listed under a parent ticket’s AC with PRD ref.
 - No ticket without **testable** acceptance criteria (mirror the PRD’s given/when/then or checklist).
 - **`ticket_prefix`, `group_slug`, and `group_label` are consistent** across all files in the batch.

--- a/.cursor/skills/prd-to-tickets/SKILL.md
+++ b/.cursor/skills/prd-to-tickets/SKILL.md
@@ -60,7 +60,7 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 2. **Set `ticket_prefix`, `group_slug`, and `group_label` once** for the whole batch (after deriving from the PRD title unless the user supplied them).
 3. **One ticket per implementable slice** — prefer vertical slices (end-to-end user value) when the PRD allows; otherwise one ticket per **REQ** or per **user story** with clear AC.
 4. **Do not** merge unrelated requirements into one ticket; **do** merge duplicate or overlapping bullets from the PRD into a single ticket with a clear combined AC.
-5. **Traceability:** Each ticket must reference the PRD (`prd_source:` with file path or `"inline PRD"`), include a clickable `prd_url:` when resolvable, and include **requirement IDs** when present (`prd_refs: [REQ-001, …]`).
+5. **Traceability:** Each ticket must reference the PRD (`prd_source:` with file path or `"inline PRD"`), include `prd_url:` in frontmatter, include a **PRD link section in the markdown body right after Dependencies**, and include **requirement IDs** when present (`prd_refs: [REQ-001, …]`).
 6. **Dependencies:** If the PRD orders work, add a **Depends on:** section using **same-batch ids** (`HERMES-ADM-PWRESET-001`) or REQ ids where tickets are not yet numbered.
 7. **Stacked / horizontal splits:** If the user plans **Git Town stacked PRs** and separates layers (e.g. UI ticket before API ticket), add the optional **Stacked delivery** section to affected tickets and specify **feature-flag** expectations so merged-but-incomplete work does not surface to users ([git-town-stacked-changes](../git-town-stacked-changes/SKILL.md)).
 8. **Non-goals:** Do not create tickets for items explicitly out of scope unless the user asks to “include deferred items” as a separate backlog file.
@@ -73,7 +73,7 @@ Every ticket in the **same PRD batch** shares metadata so tools can filter or ta
 
 ## PRD URL resolution (required when possible)
 
-Add `prd_url` to frontmatter whenever you can resolve a stable source link:
+Resolve `prd_url` in frontmatter whenever you can resolve a stable source link:
 
 1. **If `prd_source` is already an HTTP(S) URL**, copy it to `prd_url` unchanged.
 2. **If `prd_source` is a path to a PRD file that exists in the `prds` branch**, set:
@@ -81,7 +81,9 @@ Add `prd_url` to frontmatter whenever you can resolve a stable source link:
    - Use the PRD file basename (for example `article-analysis-agent-prd.md`).
 3. **If the URL cannot be resolved**, keep `prd_source` as-is and set:
    - `prd_url: unresolved`
-   - In `## Notes`, add one concise line explaining the fallback (for example: `PRD URL unresolved; source is local-only: /tmp/foo.prd.md`).
+   - In the **PRD link body section** (after Dependencies), add one concise fallback line (for example: `PRD URL unresolved; source is local-only: /tmp/foo.prd.md`).
+
+Then mirror the same info in the ticket body under `## PRD link` immediately after `## Dependencies` so `/create-github-issue` output keeps the link even when frontmatter and title are stripped.
 
 The goal is deterministic links when a source is known, without blocking ticket generation when it is not.
 
@@ -126,6 +128,10 @@ status: draft
 - Depends on: [none | HERMES-ADM-PWRESET-xxx | REQ-xxx]
 - Blocks: …
 
+## PRD link
+
+- PRD: [https URL from `prd_url` or fallback line when unresolved]
+
 ## Stacked delivery (optional)
 
 Use when tickets will ship as **Git Town stacked PRs** and work is split so an **earlier** ticket is incomplete without a **later** one (e.g. UI in `…-002`, API in `…-003`):
@@ -140,7 +146,7 @@ See [git-town-stacked-changes](../git-town-stacked-changes/SKILL.md) for impleme
 
 [APIs, flags, analytics, migration, rollout — only if PRD calls for it.]
 
-When `prd_url` is `unresolved`, include one fallback line explaining why.
+When `prd_url` is `unresolved`, include one fallback line in `## PRD link` explaining why.
 ```
 
 Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_prefix` / `group_slug` / `group_label` for the run. The one-line **Group** line under the H1 is optional but helps plain-markdown readers.
@@ -149,6 +155,7 @@ Adjust the example `HERMES-ADM-PWRESET-*` values to match the actual `ticket_pre
 
 - **Summary**, **Scope**, **Notes**, and the reply table are humanized; IDs, `prd_refs`, paths, and env keys are left exact.
 - `prd_url` exists on every ticket and is clickable when resolvable (`https://github.com/hyperjumptech/mediapulse/blob/prds/<prd-file>.md` for `prds` branch sources); unresolved cases clearly keep fallback metadata.
+- `## PRD link` appears immediately after `## Dependencies` in every ticket body, and matches `prd_url` (or unresolved fallback text).
 - Every **P0 / must-have** requirement maps to at least one ticket **or** is explicitly listed under a parent ticket’s AC with PRD ref.
 - No ticket without **testable** acceptance criteria (mirror the PRD’s given/when/then or checklist).
 - **`ticket_prefix`, `group_slug`, and `group_label` are consistent** across all files in the batch.


### PR DESCRIPTION
## Summary

Update the `/prd-to-tickets` skill docs so generated tickets include a direct PRD link when the source is known. This makes requirement traceability faster for reviewers while keeping generation resilient when a link cannot be resolved.

## Related issues

Closes #285

## Important changes

- Add required `prd_url` guidance to `/prd-to-tickets` traceability rules.
- Define deterministic URL mapping for PRDs in the `prds` branch: `https://github.com/hyperjumptech/mediapulse/blob/prds/<prd-file>.md`.
- Document fallback behavior (`prd_url: unresolved` + short notes line) so ticket generation still succeeds without a resolvable link.

## Other changes

- Update the skill frontmatter description to mention deterministic PRD links and fallback behavior.
- Extend the ticket template and quality checklist to enforce `prd_url` presence and consistency.

## Key files to review

- `.cursor/skills/prd-to-tickets/SKILL.md` - Adds PRD URL resolution rules, ticket template field, and acceptance checks for link behavior.

## How to test

1. Run `/prd-to-tickets` using a PRD file that exists in the `prds` branch.
2. Confirm each generated ticket includes `prd_url` with `https://github.com/hyperjumptech/mediapulse/blob/prds/<prd-file>.md`.
3. Run `/prd-to-tickets` with an inline or local-only PRD source that cannot be resolved to GitHub.
4. Confirm generation still succeeds and each ticket includes `prd_url: unresolved` plus a short fallback note.
