### PR TITLE
Skip known collection URLs before fetch and mint two-hour invocation JWTs

### DIFF
--- a/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
@@ -8,6 +8,14 @@ import { HERMES_INTERNAL_TOKEN_SUBJECT, issueToken } from "./issue-token";
 
 const mockFindFirst = vi.fn();
 
+const { issueTokenTestEnv } = vi.hoisted(() => ({
+  issueTokenTestEnv: {
+    AGENT_AUTH_JWT_SECRET: "test-secret-at-least-16-chars",
+    HERMES_INTERNAL_API_KEY: "internal-preset-key-for-tests",
+    HERMES_INTERNAL_API_KEY_PREVIOUS: "",
+  },
+}));
+
 vi.mock("@hermes/orchestration-database", () => ({
   prisma: {
     encryptedPayload: {
@@ -16,17 +24,16 @@ vi.mock("@hermes/orchestration-database", () => ({
   },
 }));
 
-const originalEnv = process.env;
 vi.mock("@hermes/env", () => ({
   env: {
     get AGENT_AUTH_JWT_SECRET() {
-      return process.env.AGENT_AUTH_JWT_SECRET ?? "";
+      return issueTokenTestEnv.AGENT_AUTH_JWT_SECRET;
     },
     get HERMES_INTERNAL_API_KEY() {
-      return process.env.HERMES_INTERNAL_API_KEY ?? "";
+      return issueTokenTestEnv.HERMES_INTERNAL_API_KEY;
     },
     get HERMES_INTERNAL_API_KEY_PREVIOUS() {
-      return process.env.HERMES_INTERNAL_API_KEY_PREVIOUS ?? "";
+      return issueTokenTestEnv.HERMES_INTERNAL_API_KEY_PREVIOUS;
     },
   },
 }));
@@ -38,17 +45,13 @@ describe("issueToken route", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    process.env = {
-      ...originalEnv,
-      AGENT_AUTH_JWT_SECRET: "test-secret-at-least-16-chars",
-      HERMES_INTERNAL_API_KEY: "internal-preset-key-for-tests",
-      HERMES_INTERNAL_API_KEY_PREVIOUS: "",
-    };
+    issueTokenTestEnv.AGENT_AUTH_JWT_SECRET = "test-secret-at-least-16-chars";
+    issueTokenTestEnv.HERMES_INTERNAL_API_KEY = "internal-preset-key-for-tests";
+    issueTokenTestEnv.HERMES_INTERNAL_API_KEY_PREVIOUS = "";
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    process.env = originalEnv;
   });
 
   it("returns 401 when Authorization header is missing", async () => {
@@ -62,7 +65,7 @@ describe("issueToken route", () => {
   });
 
   it("returns 503 when AGENT_AUTH_JWT_SECRET is not set", async () => {
-    delete process.env.AGENT_AUTH_JWT_SECRET;
+    issueTokenTestEnv.AGENT_AUTH_JWT_SECRET = "";
     const res = await app.request("http://localhost/api/token", {
       method: "POST",
       headers: { Authorization: "Bearer some-key" },
@@ -92,7 +95,8 @@ describe("issueToken route", () => {
   });
 
   it("returns 200 with JWT when Bearer matches HERMES_INTERNAL_API_KEY_PREVIOUS", async () => {
-    process.env.HERMES_INTERNAL_API_KEY_PREVIOUS = "previous-internal-key";
+    issueTokenTestEnv.HERMES_INTERNAL_API_KEY_PREVIOUS =
+      "previous-internal-key";
 
     const res = await app.request("http://localhost/api/token", {
       method: "POST",

--- a/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
@@ -86,7 +86,7 @@ describe("issueToken route", () => {
     expect(body).toHaveProperty("token");
     expect(typeof body.token).toBe("string");
     expect(body.token.split(".")).toHaveLength(3);
-    expect(body).toEqual(expect.objectContaining({ expiresIn: 900 }));
+    expect(body).toEqual(expect.objectContaining({ expiresIn: 7200 }));
     const claims = decodeJwt(body.token as string);
     expect(claims.sub).toBe(HERMES_INTERNAL_TOKEN_SUBJECT);
   });

--- a/apps/hermes/agent-auth-api/src/routes/issue-token.ts
+++ b/apps/hermes/agent-auth-api/src/routes/issue-token.ts
@@ -4,7 +4,7 @@ import * as crypto from "crypto";
 import { SignJWT } from "jose";
 import type { Context } from "hono";
 
-const TOKEN_EXPIRY_SECONDS = 900; // 15 minutes
+const TOKEN_EXPIRY_SECONDS = 7200; // 2 hours
 const JWT_ISSUER = "agent-auth-api";
 const JWT_AUDIENCE = "agent-invocation";
 

--- a/apps/hermes/agent-auth-api/src/routes/issue-token.ts
+++ b/apps/hermes/agent-auth-api/src/routes/issue-token.ts
@@ -1,4 +1,5 @@
 import { env } from "@hermes/env";
+import type { Prisma } from "@hermes/orchestration-database/client";
 import { prisma } from "@hermes/orchestration-database";
 import * as crypto from "crypto";
 import { SignJWT } from "jose";
@@ -110,13 +111,17 @@ export async function issueToken(context: Context) {
     }
 
     const hash = crypto.createHash("sha256").update(rawKey).digest("hex");
-    const payloadRow = await prisma.encryptedPayload.findFirst({
+    const encryptedPayloadLookupArgs = {
       where: {
         credentialSha256Hex: hash,
         domainIntegrationId: { not: null },
       },
       include: { domainIntegration: true },
-    });
+    } satisfies Prisma.EncryptedPayloadFindFirstArgs;
+
+    const payloadRow = await prisma.encryptedPayload.findFirst(
+      encryptedPayloadLookupArgs,
+    );
 
     if (!payloadRow?.domainIntegration) {
       return context.json({ error: "Invalid or inactive API key" }, 401);

--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -19,6 +19,10 @@ const dataCollectionPath = agentDataApiPathname(
   AGENT_DATA_API_DEFAULT_VERSION,
   "dataCollection",
 );
+const dataCollectionExistingUrlsPath = agentDataApiPathname(
+  AGENT_DATA_API_DEFAULT_VERSION,
+  "dataCollectionExistingUrls",
+);
 const deliveryPath = agentDataApiPathname(
   AGENT_DATA_API_DEFAULT_VERSION,
   "delivery",
@@ -511,6 +515,90 @@ describe("agent-data-api", () => {
             searchQueryId: SEARCH_QUERY_ID,
           },
         ],
+      });
+    });
+  });
+
+  describe(`POST ${dataCollectionExistingUrlsPath}`, () => {
+    it("returns 401 without Authorization header", async () => {
+      const { app } = await import("./index.js");
+      const res = await app.request(
+        `http://localhost${dataCollectionExistingUrlsPath}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            tickerId: TICKER_ID,
+            urls: ["https://example.com"],
+          }),
+        },
+      );
+      expect(res.status).toBe(401);
+    }, 20_000);
+
+    it("returns 400 when body validation fails (missing urls)", async () => {
+      const { app } = await import("./index.js");
+      const res = await app.request(
+        `http://localhost${dataCollectionExistingUrlsPath}`,
+        {
+          method: "POST",
+          headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+          body: JSON.stringify({ tickerId: TICKER_ID }),
+        },
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 200 with empty existingUrls when urls is empty", async () => {
+      const { prisma } = await getDatabase();
+
+      const { app } = await import("./index.js");
+      const res = await app.request(
+        `http://localhost${dataCollectionExistingUrlsPath}`,
+        {
+          method: "POST",
+          headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+          body: JSON.stringify({ tickerId: TICKER_ID, urls: [] }),
+        },
+      );
+      const body = (await res.json()) as { existingUrls: string[] };
+
+      expect(res.status).toBe(200);
+      expect(body.existingUrls).toEqual([]);
+      expect(prisma.dataSource.findMany).not.toHaveBeenCalled();
+    });
+
+    it("returns 200 with URLs that exist for the ticker", async () => {
+      const { prisma } = await getDatabase();
+      vi.mocked(prisma.dataSource.findMany).mockResolvedValue([
+        { url: "https://exists.example/a" },
+        { url: "https://exists.example/a" },
+      ] as never);
+
+      const { app } = await import("./index.js");
+      const res = await app.request(
+        `http://localhost${dataCollectionExistingUrlsPath}`,
+        {
+          method: "POST",
+          headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+          body: JSON.stringify({
+            tickerId: TICKER_ID,
+            urls: ["https://exists.example/a", "https://new.example/b"],
+          }),
+        },
+      );
+      const body = (await res.json()) as { existingUrls: string[] };
+
+      expect(res.status).toBe(200);
+      expect(body.existingUrls).toEqual(["https://exists.example/a"]);
+      expect(prisma.dataSource.findMany).toHaveBeenCalledWith({
+        where: {
+          tickerId: TICKER_ID,
+          url: {
+            in: ["https://exists.example/a", "https://new.example/b"],
+          },
+        },
+        select: { url: true },
       });
     });
   });

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -15,6 +15,7 @@ import {
   getContentGeneration,
   postContentGeneration,
 } from "./routes/content-generation.js";
+import { postDataCollectionExistingUrls } from "./routes/data-collection-existing-urls.js";
 import {
   getDataCollection,
   postDataCollection,
@@ -73,6 +74,9 @@ const routeHandlers = {
   dataCollection: {
     get: getDataCollection,
     post: postDataCollection,
+  },
+  dataCollectionExistingUrls: {
+    post: postDataCollectionExistingUrls,
   },
   dataCollectionRun: {
     get: getDataCollectionRun,

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.test.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.test.ts
@@ -1,0 +1,88 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@mediapulse/database", () => ({
+  prisma: {
+    dataSource: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import { prisma } from "@mediapulse/database";
+
+import { postDataCollectionExistingUrls } from "./data-collection-existing-urls";
+
+const TICKER_ID = "11111111-1111-4111-a111-111111111111";
+
+describe("postDataCollectionExistingUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 200 with empty existingUrls without querying when urls is empty", async () => {
+    const app = new Hono();
+    app.post("/test", postDataCollectionExistingUrls);
+
+    const res = await app.request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tickerId: TICKER_ID, urls: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ existingUrls: [] });
+    expect(prisma.dataSource.findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 with URLs returned by prisma for the ticker", async () => {
+    vi.mocked(prisma.dataSource.findMany).mockResolvedValue([
+      { url: "https://exists.example" },
+      { url: "https://exists.example" },
+    ] as never);
+
+    const app = new Hono();
+    app.post("/test", postDataCollectionExistingUrls);
+
+    const res = await app.request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        tickerId: TICKER_ID,
+        urls: ["https://exists.example", "https://new.example"],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { existingUrls: string[] };
+    expect(body.existingUrls).toEqual(["https://exists.example"]);
+    expect(prisma.dataSource.findMany).toHaveBeenCalledWith({
+      where: {
+        tickerId: TICKER_ID,
+        url: {
+          in: ["https://exists.example", "https://new.example"],
+        },
+      },
+      select: { url: true },
+    });
+  });
+
+  it("returns 400 when body fails schema validation", async () => {
+    const app = new Hono();
+    app.post("/test", postDataCollectionExistingUrls);
+
+    const res = await app.request("http://localhost/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tickerId: TICKER_ID }),
+    });
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts
@@ -1,0 +1,42 @@
+import { Context } from "hono";
+
+import { postDataCollectionExistingUrlsBodySchema } from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+import type { Prisma } from "@mediapulse/database";
+import { prisma } from "@mediapulse/database";
+
+/**
+ * Returns which of the given URLs already have a `data_source` row for the ticker (exact URL match).
+ *
+ * @param context - Hono context; JSON body `{ tickerId, urls }`.
+ * @returns JSON `{ existingUrls }` (unique subset of requested URLs found in DB).
+ */
+export async function postDataCollectionExistingUrls(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed =
+      await postDataCollectionExistingUrlsBodySchema.parseAsync(body);
+    const uniqueRequested = [...new Set(parsed.urls)];
+
+    if (uniqueRequested.length === 0) {
+      return context.json({ existingUrls: [] }, 200);
+    }
+
+    const findArgs = {
+      where: {
+        tickerId: parsed.tickerId,
+        url: { in: uniqueRequested },
+      },
+      select: { url: true },
+    } satisfies Prisma.DataSourceFindManyArgs;
+
+    const rows = await prisma.dataSource.findMany(findArgs);
+    const existingUrls = [...new Set(rows.map((row) => row.url))];
+
+    return context.json({ existingUrls }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -25,6 +25,7 @@ const { performWebSearchMock, performWebFetchMock } = vi.hoisted(() => ({
 
 const getMock = vi.fn();
 const postMock = vi.fn();
+const existingUrlsCreateMock = vi.fn();
 const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
 
@@ -34,6 +35,9 @@ vi.mock("@workspace/agent-data-api-client", () => {
       dataCollection: {
         get: getMock,
         create: postMock,
+      },
+      dataCollectionExistingUrls: {
+        create: existingUrlsCreateMock,
       },
       dataCollectionRun: {
         create: runCreateMock,
@@ -86,6 +90,7 @@ describe("data-collection agent (HTTP)", () => {
     vi.clearAllMocks();
     performWebSearchMock.mockResolvedValue(defaultSearchSuccess);
     performWebFetchMock.mockResolvedValue(defaultFetchSuccess);
+    existingUrlsCreateMock.mockResolvedValue({ existingUrls: [] });
   });
 
   afterEach(() => {

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -49,6 +49,7 @@ vi.mock("@workspace/logger", () => ({
 
 const getMock = vi.fn();
 const createMock = vi.fn();
+const existingUrlsCreateMock = vi.fn();
 const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
 
@@ -57,6 +58,9 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     dataCollection: {
       get: getMock,
       create: createMock,
+    },
+    dataCollectionExistingUrls: {
+      create: existingUrlsCreateMock,
     },
     dataCollectionRun: {
       create: runCreateMock,
@@ -118,6 +122,7 @@ describe("runDataCollection", () => {
       data: [{ id: "sq-1", text: "test query", tickerId: TICKER_ID }],
     });
     createMock.mockResolvedValue("{}");
+    existingUrlsCreateMock.mockResolvedValue({ existingUrls: [] });
   });
 
   afterEach(() => {
@@ -146,6 +151,10 @@ describe("runDataCollection", () => {
       token: "Bearer test-token",
     });
     expect(getMock).toHaveBeenCalledWith({ tickerId: TICKER_ID });
+    expect(existingUrlsCreateMock).toHaveBeenCalledWith({
+      tickerId: TICKER_ID,
+      urls: ["http://example.com"],
+    });
     expect(createMock).toHaveBeenCalledWith([
       {
         url: "http://example.com",
@@ -166,6 +175,33 @@ describe("runDataCollection", () => {
         }),
       }),
     );
+  });
+
+  it("skips web fetch for URLs already returned by dataCollectionExistingUrls", async () => {
+    existingUrlsCreateMock.mockResolvedValueOnce({
+      existingUrls: ["http://example.com"],
+    });
+    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+
+    const result = await runDataCollection(
+      createContext({
+        config: {
+          ...baseConfig,
+          runPolicy: {
+            minSuccessfulSources: 0,
+            failOnZeroSuccess: false,
+          },
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(existingUrlsCreateMock).toHaveBeenCalledWith({
+      tickerId: TICKER_ID,
+      urls: ["http://example.com"],
+    });
+    expect(performWebFetch).toHaveBeenCalledWith([], expect.anything());
+    expect(createMock).not.toHaveBeenCalled();
   });
 
   it("passes time window fields to dataCollection.get when input includes timeWindow", async () => {

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -9,6 +9,7 @@ import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
 import { performWebFetch } from "./utilities/web-fetch";
 import { performWebSearch } from "./utilities/web-search";
+import { resolveExistingDataSourceUrls } from "./utilities/resolve-existing-data-source-urls";
 import {
   deriveRunStatus,
   type RunCounters,
@@ -105,7 +106,28 @@ export async function runDataCollection(
     "web search stage finished",
   );
 
-  const fetchAttemptResults = await performWebFetch(searchSuccesses, {
+  const candidateUrls = searchSuccesses.map((hit) => hit.url);
+  const existingUrlSet = await resolveExistingDataSourceUrls(
+    input.tickerId,
+    candidateUrls,
+    (body) => dataApiClient.dataCollectionExistingUrls.create(body),
+  );
+  const searchSuccessesForFetch = searchSuccesses.filter(
+    (hit) => !existingUrlSet.has(hit.url),
+  );
+  const skippedExistingUrlCount =
+    searchSuccesses.length - searchSuccessesForFetch.length;
+  if (skippedExistingUrlCount > 0) {
+    log.info(
+      {
+        skippedExistingUrlCount,
+        searchHitCount: searchSuccesses.length,
+      },
+      "skipped web fetch for URLs already stored as data sources",
+    );
+  }
+
+  const fetchAttemptResults = await performWebFetch(searchSuccessesForFetch, {
     config: webFetchConfig,
     logger: log,
   });

--- a/apps/mediapulse/agents/data-collection/src/utilities/resolve-existing-data-source-urls.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/resolve-existing-data-source-urls.test.ts
@@ -1,0 +1,71 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DATA_COLLECTION_EXISTING_URLS_MAX } from "@workspace/agent-data-api-contract";
+
+import {
+  resolveExistingDataSourceUrls,
+  type LookupExistingDataSourceUrls,
+} from "./resolve-existing-data-source-urls";
+
+describe("resolveExistingDataSourceUrls", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns empty set when there are no candidate URLs", async () => {
+    const lookup = vi.fn();
+
+    const result = await resolveExistingDataSourceUrls(
+      "ticker-1",
+      [],
+      lookup as LookupExistingDataSourceUrls,
+    );
+
+    expect(result.size).toBe(0);
+    expect(lookup).not.toHaveBeenCalled();
+  });
+
+  it("merges existing URLs from a single lookup chunk", async () => {
+    const lookup = vi.fn().mockResolvedValue({
+      existingUrls: ["https://a.example", "https://b.example"],
+    });
+
+    const result = await resolveExistingDataSourceUrls(
+      "ticker-1",
+      ["https://a.example", "https://c.example", "https://a.example"],
+      lookup as LookupExistingDataSourceUrls,
+    );
+
+    expect(lookup).toHaveBeenCalledTimes(1);
+    expect(lookup).toHaveBeenCalledWith({
+      tickerId: "ticker-1",
+      urls: ["https://a.example", "https://c.example"],
+    });
+    expect(result.has("https://a.example")).toBe(true);
+    expect(result.has("https://b.example")).toBe(true);
+    expect(result.has("https://c.example")).toBe(false);
+  });
+
+  it("chunks requests when candidate count exceeds max", async () => {
+    const urls = Array.from(
+      { length: DATA_COLLECTION_EXISTING_URLS_MAX + 1 },
+      (_, i) => `https://example.com/p/${i}`,
+    );
+    const lookup = vi.fn().mockResolvedValue({
+      existingUrls: [],
+    });
+
+    await resolveExistingDataSourceUrls(
+      "ticker-1",
+      urls,
+      lookup as LookupExistingDataSourceUrls,
+    );
+
+    expect(lookup).toHaveBeenCalledTimes(2);
+    expect(lookup.mock.calls[0]?.[0].urls).toHaveLength(
+      DATA_COLLECTION_EXISTING_URLS_MAX,
+    );
+    expect(lookup.mock.calls[1]?.[0].urls).toHaveLength(1);
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/resolve-existing-data-source-urls.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/resolve-existing-data-source-urls.ts
@@ -1,0 +1,41 @@
+import {
+  DATA_COLLECTION_EXISTING_URLS_MAX,
+  type PostDataCollectionExistingUrlsBody,
+  type PostDataCollectionExistingUrlsResponse,
+} from "@workspace/agent-data-api-contract";
+
+/** Typed Agent Data API POST for existing URL lookup (SDK `dataCollectionExistingUrls.create`). */
+export type LookupExistingDataSourceUrls = (
+  body: PostDataCollectionExistingUrlsBody,
+) => Promise<PostDataCollectionExistingUrlsResponse>;
+
+/**
+ * Resolves which candidate URLs already have a `data_source` row for the ticker, batching requests
+ * to respect {@link DATA_COLLECTION_EXISTING_URLS_MAX}.
+ *
+ * @param tickerId - Ticker id passed to the lookup API.
+ * @param candidateUrls - URLs from web search (may contain duplicates).
+ * @param lookupExistingUrls - Injected lookup (production: SDK `create`).
+ * @returns Set of URLs that already exist (exact string match).
+ */
+export async function resolveExistingDataSourceUrls(
+  tickerId: string,
+  candidateUrls: readonly string[],
+  lookupExistingUrls: LookupExistingDataSourceUrls,
+): Promise<Set<string>> {
+  const unique = [...new Set(candidateUrls)];
+  const existing = new Set<string>();
+
+  for (let i = 0; i < unique.length; i += DATA_COLLECTION_EXISTING_URLS_MAX) {
+    const chunk = unique.slice(i, i + DATA_COLLECTION_EXISTING_URLS_MAX);
+    const { existingUrls } = await lookupExistingUrls({
+      tickerId,
+      urls: chunk,
+    });
+    for (const url of existingUrls) {
+      existing.add(url);
+    }
+  }
+
+  return existing;
+}

--- a/dev-docs/docs/hermes/apps/agent-auth-api.mdx
+++ b/dev-docs/docs/hermes/apps/agent-auth-api.mdx
@@ -6,23 +6,23 @@ icon: Key
 
 ## Purpose
 
-agent-auth-api is a Hono server that issues **short-lived JWT tokens** for agent invocation and exposes **JWT verification** for other services. **Agents, agent-data-api, and agent-registry-api** verify the **same invocation JWT** via `POST /api/verify` (see `@workspace/agent-auth-client` `verifyTokenViaAuthApi`). Long-lived **domain integration** secrets are stored in the orchestration DB as **SHA-256 hash + ciphertext** on `EncryptedPayload`; Hermes mints JWTs with `sub` set to **`domain_integration.id`**.
+agent-auth-api is a Hono server that issues **time-limited JWT tokens** (currently **2 hours** lifetime) for agent invocation and exposes **JWT verification** for other services. **Agents, agent-data-api, and agent-registry-api** verify the **same invocation JWT** via `POST /api/verify` (see `@workspace/agent-auth-client` `verifyTokenViaAuthApi`). Long-lived **domain integration** secrets are stored in the orchestration DB as **SHA-256 hash + ciphertext** on `EncryptedPayload`; Hermes mints JWTs with `sub` set to **`domain_integration.id`**.
 
 ## Features
 
 - **POST /api/verify** — **JWT-only** invocation verification. Accepts `Authorization: Bearer <jwt>`. Verifies signature and expiry. Used by agents to verify that the caller (Hermes/hermes-worker) is authorized. Requires `AGENT_AUTH_JWT_SECRET`.
-- **POST /api/token** — Issue a short-lived JWT (e.g. 15 min). Accepts **`Authorization: Bearer <HERMES_INTERNAL_API_KEY>`** (preset shared with Hermes dashboard and worker; timing-safe compare to env) **or** a **domain integration** API key whose SHA-256 hex matches `encrypted_payload.credential_sha256_hex` (JWT `sub` is `domain_integration.id`). During key rotation it also accepts **`HERMES_INTERNAL_API_KEY_PREVIOUS`** when set. Requires `AGENT_AUTH_JWT_SECRET` and, for the preset path, `HERMES_INTERNAL_API_KEY`. Hermes dashboard and worker use the preset only to mint JWTs; they never send it to agents.
+- **POST /api/token** — Issue a time-limited JWT (currently **2 hours**). Accepts **`Authorization: Bearer <HERMES_INTERNAL_API_KEY>`** (preset shared with Hermes dashboard and worker; timing-safe compare to env) **or** a **domain integration** API key whose SHA-256 hex matches `encrypted_payload.credential_sha256_hex` (JWT `sub` is `domain_integration.id`). During key rotation it also accepts **`HERMES_INTERNAL_API_KEY_PREVIOUS`** when set. Requires `AGENT_AUTH_JWT_SECRET` and, for the preset path, `HERMES_INTERNAL_API_KEY`. Hermes dashboard and worker use the preset only to mint JWTs; they never send it to agents.
 
 ## Key routes
 
-| Method | Path          | Description                  |
-| ------ | ------------- | ---------------------------- |
-| POST   | `/api/verify` | Verify JWT (invocation only) |
-| POST   | `/api/token`  | Issue short-lived JWT        |
+| Method | Path          | Description                   |
+| ------ | ------------- | ----------------------------- |
+| POST   | `/api/verify` | Verify JWT (invocation only)  |
+| POST   | `/api/token`  | Issue invocation JWT (2h TTL) |
 
 ## Environment
 
-- **AGENT_AUTH_JWT_SECRET** (required) — Secret for signing and verifying short-lived JWTs. Required for POST /api/token and POST /api/verify. Use a long random value (e.g. 32+ chars) in production.
+- **AGENT_AUTH_JWT_SECRET** (required) — Secret for signing and verifying invocation JWTs. Required for POST /api/token and POST /api/verify. Use a long random value (e.g. 32+ chars) in production.
 - **HERMES_INTERNAL_API_KEY** — Preset bearer for Hermes dashboard/worker token minting (same value those services use). Optional only if you never use the preset path (not recommended for normal Hermes deployments).
 - **HERMES_INTERNAL_API_KEY_PREVIOUS** (optional) — Temporary previous preset used only during key rotation so `/api/token` can accept both old and new internal Bearer values during rollout.
 - **TEMP_ADMIN_USERNAME** / **TEMP_ADMIN_PASSWORD** — Still required by `@hermes/env` for Hermes apps that share the schema; agent-auth-api does not expose HTTP Basic API-key CRUD on this service.

--- a/dev-docs/docs/integration/communication.mdx
+++ b/dev-docs/docs/integration/communication.mdx
@@ -44,7 +44,7 @@ Agent->>HermesOrWorker: 200 response
 **Steps:**
 
 1. **Hermes** (manual run) or **hermes-worker** (scheduled run) loads the **domain integration** credential for the pipeline (or uses **`HERMES_INTERNAL_API_KEY`** where applicable) and calls **agent-auth-api** `POST /api/token` with `Authorization: Bearer <secret>`.
-2. **agent-auth-api** matches the bearer token to the preset or a **domain_integration** key hash, signs a JWT with `AGENT_AUTH_JWT_SECRET`, and returns `{ token, expiresIn }` (e.g. 15 minutes).
+2. **agent-auth-api** matches the bearer token to the preset or a **domain_integration** key hash, signs a JWT with `AGENT_AUTH_JWT_SECRET`, and returns `{ token, expiresIn }` (currently **2 hours**).
 3. Hermes/hermes-worker **caches** the JWT and uses it for all agent requests until close to expiry, then fetches a new one.
 4. For each pipeline step, the caller sends `POST` to the agent URL with `Authorization: Bearer <jwt>` and the step input/config.
    - **hermes-worker** (scheduled runs) also sends correlation headers: `X-Job-Id`, `X-Execution-Id`, and schedule context `X-Schedule-Id`, `X-Schedule-Execution-Id`, `X-Pipeline-Step-Id` (see `invokeAgentPost` in `@hermes/scheduler`). Agents built with `@workspace/agent-runtime` receive those schedule/step ids on `run` as optional `context.hermesCorrelation` when those headers are present. Manual dashboard pipeline runs do not send the schedule headers unless extended later.
@@ -52,7 +52,7 @@ Agent->>HermesOrWorker: 200 response
 6. **agent-auth-api** `POST /api/verify` is **JWT-only**: it verifies signature and expiry. If the token is not a JWT or is invalid, it returns 401. The agent rejects the request unless it gets 200.
 7. The agent runs its logic and returns the result.
 
-**Important:** The internal preset key is only ever sent to agent-auth-api. Agents only ever see the JWT, so a leaked JWT expires in minutes. Rotate **`HERMES_INTERNAL_API_KEY`** at deploy time if it is compromised.
+**Important:** The internal preset key is only ever sent to agent-auth-api. Agents only ever see the JWT, so a leaked JWT expires within the configured TTL (see agent-auth-api issuance). Rotate **`HERMES_INTERNAL_API_KEY`** at deploy time if it is compromised.
 
 ---
 

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -14,7 +14,7 @@ agent-data-api is the **HTTP persistence layer between agents and the database**
 
 - **Bearer auth** — Requests must send `Authorization: Bearer <jwt>` (the same short-lived invocation JWT Hermes sends to agents). Verified with agent-auth-api `POST /api/verify` via `verifyTokenViaAuthApi`; agents forward the `Authorization` header from their run context to the SDK.
 - **Content generation** — Stores and loads generated newsletter-style output so downstream steps can reuse it without reshaping ad hoc payloads.
-- **Data collection** — Stores and loads crawled or gathered source material (pages, feeds, etc.) so collection and later stages see the same structured snapshot.
+- **Data collection** — Stores and loads crawled or gathered source material (pages, feeds, etc.) so collection and later stages see the same structured snapshot. A companion **existing URLs** POST lets the data-collection agent skip web fetch for URLs already persisted for a ticker (exact URL match).
 - **Analysis** — Loads unanalyzed (or full re-score) `DataSource` rows plus KG vocabulary (`entityTypes`, `relationTypes`, `existingEntities`) for the article-analysis agent, and accepts POST payloads that upsert entities, relations, `article_entity`, and `article_relevance` for a ticker. Optional GET bounds (`start`, `end`, ISO 8601) filter `DataSource.createdAt` **server-side** (FR1 / FR2 eligibility windows) so bounded runs do not download an unbounded history.
 - **Delivery** — Loads the latest newsletter for a ticker, **subscriber emails** and **`userTickerId`** from enabled `user_ticker` rows, plus **`deliveredUserTickerIds`** (existing checkpoints for idempotent replays). When there is no newsletter, **GET returns 200** with `newsletter: null`, `subscribers: []`, and empty checkpoint ids (agents skip without treating the call as an error). **POST** records a **`newsletter_delivery_checkpoint`** after a successful send (`userTickerId`, `newsletterId`, optional Resend id).
 - **Delivery run** — **POST** persists one diagnostic run and per-recipient rows (including optional **`runSkipReason`**, Hermes **`jobId` / `hermesExecutionId` / `hermesScheduleId`**, and per-recipient **`errorCategory`**). **GET** lists runs with optional filters (`tickerId`, `outcome`, `start`, `end` — each of `start` / `end` applies **`createdAt` `gte` / `lte` independently** when provided). Used by the delivery agent for Hermes-visible outcomes (`success`, `skipped`, `failed`, `partial_success`, `skipped_all_already_delivered`). The Mediapulse Hermes **Delivery runs** table supports the same filters via query string (`tickerId`, `outcome`, `start`, `end`) in addition to search (`q`) and sort.
@@ -23,7 +23,7 @@ agent-data-api is the **HTTP persistence layer between agents and the database**
 
 ## Key routes
 
-Agents should not call these HTTP paths directly. In agent code, use `@workspace/agent-data-api-client` and call SDK namespaces such as `contentGeneration`, `dataCollection`, `analysis`, and `delivery`. The SDK provides typed methods for each endpoint and validates responses with shared schemas.
+Agents should not call these HTTP paths directly. In agent code, use `@workspace/agent-data-api-client` and call SDK namespaces such as `contentGeneration`, `dataCollection`, `dataCollectionExistingUrls`, `analysis`, and `delivery`. The SDK provides typed methods for each endpoint and validates responses with shared schemas.
 
 | Method | Path                                 | Description                                                           |
 | ------ | ------------------------------------ | --------------------------------------------------------------------- |
@@ -31,6 +31,7 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | POST   | `/api/v1/content-generation`         | Store content-generation payload                                      |
 | GET    | `/api/v1/data-collection`            | Get data-collection data                                              |
 | POST   | `/api/v1/data-collection`            | Store data-collection payload                                         |
+| POST   | `/api/v1/data-collection-existing-urls` | List which candidate URLs already exist for a ticker (`data_source`, exact URL) |
 | GET    | `/api/v1/analysis`                   | Get analysis context (sources + KG vocabulary) for a ticker         |
 | POST   | `/api/v1/analysis`                   | Persist analysis results (entities, relations, mentions, relevance)   |
 | GET    | `/api/v1/delivery`                   | Get delivery payload (nullable newsletter, subscribers + checkpoints) |
@@ -42,6 +43,14 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | GET    | `/api/v1/query-analysis`                  | Get query-analysis context by ticker           |
 | POST   | `/api/v1/query-analysis`                  | Store and activate a versioned query set       |
 
+
+### Data collection existing URLs (`/api/v1/data-collection-existing-urls`)
+
+Implemented in `apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts`. Schemas live in `@workspace/agent-data-api-contract` (`data-collection.ts`).
+
+- **POST** — Body (`postDataCollectionExistingUrlsBodySchema`): `tickerId` (required), `urls` (array of URL strings, max 500 per request). Response: `existingUrls` — unique URLs from the request that already have a `data_source` row for that ticker (exact string match on `url`).
+
+From agents, use the SDK namespace **`dataCollectionExistingUrls`**: **`create`** for POST. The data-collection agent batches calls when search returns more than 500 distinct URLs.
 
 ### Analysis (`/api/v1/analysis`)
 

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -25,32 +25,41 @@ agent-data-api is the **HTTP persistence layer between agents and the database**
 
 Agents should not call these HTTP paths directly. In agent code, use `@workspace/agent-data-api-client` and call SDK namespaces such as `contentGeneration`, `dataCollection`, `dataCollectionExistingUrls`, `analysis`, and `delivery`. The SDK provides typed methods for each endpoint and validates responses with shared schemas.
 
-| Method | Path                                 | Description                                                           |
-| ------ | ------------------------------------ | --------------------------------------------------------------------- |
-| GET    | `/api/v1/content-generation`         | Get content-generation data (e.g. by tickerId)                        |
-| POST   | `/api/v1/content-generation`         | Store content-generation payload                                      |
-| GET    | `/api/v1/data-collection`            | Get data-collection data                                              |
-| POST   | `/api/v1/data-collection`            | Store data-collection payload                                         |
+| Method | Path                                    | Description                                                                     |
+| ------ | --------------------------------------- | ------------------------------------------------------------------------------- |
+| GET    | `/api/v1/content-generation`            | Get content-generation data (e.g. by tickerId)                                  |
+| POST   | `/api/v1/content-generation`            | Store content-generation payload                                                |
+| GET    | `/api/v1/data-collection`               | Get data-collection data                                                        |
+| POST   | `/api/v1/data-collection`               | Store data-collection payload                                                   |
 | POST   | `/api/v1/data-collection-existing-urls` | List which candidate URLs already exist for a ticker (`data_source`, exact URL) |
-| GET    | `/api/v1/analysis`                   | Get analysis context (sources + KG vocabulary) for a ticker         |
-| POST   | `/api/v1/analysis`                   | Persist analysis results (entities, relations, mentions, relevance)   |
-| GET    | `/api/v1/delivery`                   | Get delivery payload (nullable newsletter, subscribers + checkpoints) |
-| POST   | `/api/v1/delivery`                   | Upsert delivery checkpoint after successful send                      |
-| GET    | `/api/v1/delivery-run`               | List delivery diagnostic runs (filters optional)                      |
-| POST   | `/api/v1/delivery-run`               | Persist one delivery run + recipient outcomes                         |
-| POST   | `/api/v1/user-registration-register` | Process a new or returning subscription (optional immediate confirmation) |
-| POST   | `/api/v1/user-registration-confirm`  | Confirm a pending subscription (used for double opt-in from web signups) |
-| GET    | `/api/v1/query-analysis`                  | Get query-analysis context by ticker           |
-| POST   | `/api/v1/query-analysis`                  | Store and activate a versioned query set       |
+| GET    | `/api/v1/analysis`                      | Get analysis context (sources + KG vocabulary) for a ticker                     |
+| POST   | `/api/v1/analysis`                      | Persist analysis results (entities, relations, mentions, relevance)             |
+| GET    | `/api/v1/delivery`                      | Get delivery payload (nullable newsletter, subscribers + checkpoints)           |
+| POST   | `/api/v1/delivery`                      | Upsert delivery checkpoint after successful send                                |
+| GET    | `/api/v1/delivery-run`                  | List delivery diagnostic runs (filters optional)                                |
+| POST   | `/api/v1/delivery-run`                  | Persist one delivery run + recipient outcomes                                   |
+| POST   | `/api/v1/user-registration-register`    | Process a new or returning subscription (optional immediate confirmation)       |
+| POST   | `/api/v1/user-registration-confirm`     | Confirm a pending subscription (used for double opt-in from web signups)        |
+| GET    | `/api/v1/query-analysis`                | Get query-analysis context by ticker                                            |
+| POST   | `/api/v1/query-analysis`                | Store and activate a versioned query set                                        |
 
+### Data collection existing URLs (`POST /api/v1/data-collection-existing-urls`)
 
-### Data collection existing URLs (`/api/v1/data-collection-existing-urls`)
+Implemented in `apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts`. Zod schemas and the **`DATA_COLLECTION_EXISTING_URLS_MAX`** constant (500) live in `@workspace/agent-data-api-contract` (`data-collection.ts`); the manifest resource key is **`dataCollectionExistingUrls`**, so the same route exists under **`/api/v2/data-collection-existing-urls`** when callers pin `version: "v2"` on the SDK.
 
-Implemented in `apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts`. Schemas live in `@workspace/agent-data-api-contract` (`data-collection.ts`).
+- **POST** — Body (`postDataCollectionExistingUrlsBodySchema`): **`tickerId`** (required, non-empty string), **`urls`** (required array of URL strings, each valid URL, at most **`DATA_COLLECTION_EXISTING_URLS_MAX`** entries per request). Response (`postDataCollectionExistingUrlsResponseSchema`): **`existingUrls`** — deduplicated list of strings from **`urls`** that already have at least one `data_source` row for that **`tickerId`** (exact match on the stored `url` column; no normalization).
+- **Empty list** — If **`urls`** is `[]`, the handler returns **`200`** with **`{ "existingUrls": [] }`** and does not query Prisma for an empty `IN` clause.
+- **Errors** — **`401`** without a valid bearer JWT (same as other versioned routes). Invalid JSON body or Zod validation failures return **`400`** with `message: "Bad Request"` and **`errors`** (via shared `internalError` handling), consistent with other POST handlers.
 
-- **POST** — Body (`postDataCollectionExistingUrlsBodySchema`): `tickerId` (required), `urls` (array of URL strings, max 500 per request). Response: `existingUrls` — unique URLs from the request that already have a `data_source` row for that ticker (exact string match on `url`).
+From agents, use the SDK namespace **`dataCollectionExistingUrls`**: **`create`** for POST. The data-collection agent dedupes candidate URLs, then chunks requests so each POST stays within **`DATA_COLLECTION_EXISTING_URLS_MAX`**.
 
-From agents, use the SDK namespace **`dataCollectionExistingUrls`**: **`create`** for POST. The data-collection agent batches calls when search returns more than 500 distinct URLs.
+```ts
+const { existingUrls } = await dataApiClient.dataCollectionExistingUrls.create({
+  tickerId,
+  urls: ["https://news.example/a", "https://news.example/b"],
+});
+// existingUrls is a subset of urls that already exist in data_source for this ticker
+```
 
 ### Analysis (`/api/v1/analysis`)
 

--- a/packages/shared/agent-auth-client/src/agent-token-client.ts
+++ b/packages/shared/agent-auth-client/src/agent-token-client.ts
@@ -49,7 +49,8 @@ export function createAgentTokenClient(deps: AgentTokenClientDeps): {
     }
     const data = (await res.json()) as { token?: string; expiresIn?: number };
     const token = data.token;
-    const expiresIn = typeof data.expiresIn === "number" ? data.expiresIn : 900;
+    const expiresIn =
+      typeof data.expiresIn === "number" ? data.expiresIn : 7200;
     if (!token || typeof token !== "string") {
       throw new Error("Agent auth API did not return a token");
     }

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -72,6 +72,39 @@ describe("createAgentDataApiClient", () => {
     );
   });
 
+  it("posts data-collection-existing-urls payload and parses response", async () => {
+    const postFn = vi.fn().mockResolvedValue({
+      body: JSON.stringify({
+        existingUrls: ["https://exists.example"],
+      }),
+      statusCode: 200,
+    });
+    const client = createAgentDataApiClient({
+      baseUrl: "http://agent-data-api",
+      token: "Bearer sdk-token",
+      postFn,
+    });
+
+    const result = await client.dataCollectionExistingUrls.create({
+      tickerId: "11111111-1111-4111-a111-111111111111",
+      urls: ["https://exists.example", "https://new.example"],
+    });
+
+    expect(postFn).toHaveBeenCalledWith(
+      `http://agent-data-api${agentDataApiPathname(AGENT_DATA_API_DEFAULT_VERSION, "dataCollectionExistingUrls")}`,
+      expect.objectContaining({
+        json: {
+          tickerId: "11111111-1111-4111-a111-111111111111",
+          urls: ["https://exists.example", "https://new.example"],
+        },
+        headers: expect.objectContaining({
+          Authorization: "Bearer sdk-token",
+        }),
+      }),
+    );
+    expect(result.existingUrls).toEqual(["https://exists.example"]);
+  });
+
   it("posts content-generation payload and parses response", async () => {
     // Setup
     const postFn = vi.fn().mockResolvedValue({

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -15,6 +15,8 @@ import {
   dataCollectionBodySchema,
   dataCollectionQuerySchema,
   getDataCollectionResponseSchema,
+  postDataCollectionExistingUrlsBodySchema,
+  postDataCollectionExistingUrlsResponseSchema,
   postDataCollectionResponseSchema,
 } from "./data-collection.js";
 import {
@@ -162,6 +164,20 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: dataCollectionBodySchema,
         response: postDataCollectionResponseSchema,
+      },
+    },
+  },
+  dataCollectionExistingUrls: {
+    v1: {
+      post: {
+        body: postDataCollectionExistingUrlsBodySchema,
+        response: postDataCollectionExistingUrlsResponseSchema,
+      },
+    },
+    v2: {
+      post: {
+        body: postDataCollectionExistingUrlsBodySchema,
+        response: postDataCollectionExistingUrlsResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/data-collection.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection.ts
@@ -31,6 +31,24 @@ export const postDataCollectionResponseSchema = z.object({
   message: z.string(),
 });
 
+/** Max URLs per existing-url lookup request (data-collection agent batching). */
+export const DATA_COLLECTION_EXISTING_URLS_MAX = 500;
+
+/**
+ * Body for POST `/data-collection-existing-urls`: which ticker and which candidate URLs to check.
+ */
+export const postDataCollectionExistingUrlsBodySchema = z.object({
+  tickerId: z.string().trim().min(1),
+  urls: z.array(z.string().url()).max(DATA_COLLECTION_EXISTING_URLS_MAX),
+});
+
+/**
+ * Response: subset of requested URLs that already have a `data_source` row for the ticker (exact URL match).
+ */
+export const postDataCollectionExistingUrlsResponseSchema = z.object({
+  existingUrls: z.array(z.string()),
+});
+
 export type DataCollectionBody = z.infer<typeof dataCollectionBodySchema>;
 export type DataCollectionQuery = z.infer<typeof dataCollectionQuerySchema>;
 export type GetDataCollectionResponse = z.infer<
@@ -38,4 +56,10 @@ export type GetDataCollectionResponse = z.infer<
 >;
 export type PostDataCollectionResponse = z.infer<
   typeof postDataCollectionResponseSchema
+>;
+export type PostDataCollectionExistingUrlsBody = z.infer<
+  typeof postDataCollectionExistingUrlsBodySchema
+>;
+export type PostDataCollectionExistingUrlsResponse = z.infer<
+  typeof postDataCollectionExistingUrlsResponseSchema
 >;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -37,13 +37,18 @@ export {
   type PostContentGenerationResponse,
 } from "./content-generation.js";
 export {
+  DATA_COLLECTION_EXISTING_URLS_MAX,
   dataCollectionBodySchema,
   dataCollectionQuerySchema,
   getDataCollectionResponseSchema,
+  postDataCollectionExistingUrlsBodySchema,
+  postDataCollectionExistingUrlsResponseSchema,
   postDataCollectionResponseSchema,
   type DataCollectionBody,
   type DataCollectionQuery,
   type GetDataCollectionResponse,
+  type PostDataCollectionExistingUrlsBody,
+  type PostDataCollectionExistingUrlsResponse,
   type PostDataCollectionResponse,
 } from "./data-collection.js";
 export {


### PR DESCRIPTION
## Summary

This PR stops the data-collection agent from re-fetching URLs we already stored for the same ticker, and it bumps the Hermes-issued invocation JWT from fifteen minutes to two hours so a single pipeline step is less likely to outlive the token mid-run.

## Related issues

Closes #297

## Important changes

- New agent-data-api route `POST /api/v1/data-collection-existing-urls` (contract + manifest + handler): given `tickerId` and a list of URLs, returns which strings already exist on `data_source` for that ticker.
- Data-collection agent calls that endpoint in batches (500 URL cap per request), drops matching hits before `performWebFetch`, and logs how many were skipped.
- agent-auth-api now signs invocation JWTs with a **7200** second lifetime; the shared token client’s fallback `expiresIn` matches when the JSON omits the field.

## Other changes

- Dev-docs for agent-data-api, agent-auth-api, and integration communication updated to describe the new route and TTL.

## Key files to review

- `apps/mediapulse/agent-data-api/src/routes/data-collection-existing-urls.ts` — Prisma lookup and response shape.
- `apps/mediapulse/agents/data-collection/src/run.ts` — where prefetch runs relative to search vs fetch.
- `apps/hermes/agent-auth-api/src/routes/issue-token.ts` — single constant driving `exp` and JSON `expiresIn`.

## How to test

1. From repo root: `pnpm code-quality` (already green on this branch).
2. After deploy, mint a token from `POST /api/token` and confirm the JSON `expiresIn` is **7200** and decoded `exp` is about two hours ahead.
3. Run data collection for a ticker that already has sources: logs should show skipped existing URLs and agent-data-api should not see duplicate fetches for those exact URLs.
