### PR TITLE
Hermes dashboard: per-route tests for enqueue diagnostics on execution detail

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { HttpTriggerExecutionDetail } from "@/lib/http-triggers";
+
+const getHttpTriggerExecutionDetailMock = vi.fn();
+const notFoundMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  notFound: () => notFoundMock(),
+}));
+
+vi.mock("@/lib/http-triggers", () => ({
+  getHttpTriggerExecutionDetail: (...args: unknown[]) =>
+    getHttpTriggerExecutionDetailMock(...args),
+}));
+
+vi.mock("@/lib/mask-json-secrets", () => ({
+  maskHttpTriggerExecutionDetailForDisplay: (detail: unknown) => detail,
+}));
+
+vi.mock("@/lib/compute-execution-elapsed", () => ({
+  computePipelineWallElapsed: vi
+    .fn()
+    .mockReturnValue({ kind: "unknown" as const }),
+  formatPipelineElapsedLabel: vi.fn().mockReturnValue("—"),
+}));
+
+vi.mock("@/lib/format-invocation-error", () => ({
+  formatInvocationErrorSummary: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/components/schedule-execution-invocations-table", () => ({
+  ScheduleExecutionInvocationsTable: () => (
+    <div data-testid="invocations-stub">Invocations</div>
+  ),
+}));
+
+import HttpTriggerExecutionDetailPage from "./page";
+
+const ROUTE_ENQUEUE_ERROR_MESSAGE = "HTTP_TRIGGER_ROUTE_ENQUEUE_FAIL";
+
+const minimalFailedDetail = (): HttpTriggerExecutionDetail => ({
+  execution: {
+    id: "exec-http-1",
+    executionTime: new Date("2026-04-21T12:00:00.000Z"),
+    enqueueStatus: "failed",
+    runStatus: "pending",
+    effectiveExecutionConfig: null,
+    jobsCreated: 0,
+    jobsEnqueued: 0,
+    succeededInvocationCount: 0,
+    failedInvocationCount: 0,
+    errors: [
+      {
+        message: ROUTE_ENQUEUE_ERROR_MESSAGE,
+        timestamp: "2026-04-21T12:00:01.000Z",
+      },
+    ],
+    metadata: null,
+    createdAt: new Date("2026-04-21T12:00:00.000Z"),
+  },
+  pipeline: null,
+  trigger: { id: "trig-1", name: "Test trigger" },
+  stepExecutions: [],
+  invocations: [],
+});
+
+describe("HttpTriggerExecutionDetailPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getHttpTriggerExecutionDetailMock.mockReset();
+    notFoundMock.mockReset();
+  });
+
+  it("renders enqueue diagnostics region with persisted errors for failed enqueue", async () => {
+    getHttpTriggerExecutionDetailMock.mockResolvedValue(minimalFailedDetail());
+
+    const ui = await HttpTriggerExecutionDetailPage({
+      params: Promise.resolve({
+        id: "trig-1",
+        executionId: "exec-http-1",
+      }),
+    });
+    render(ui as React.ReactElement);
+
+    expect(
+      await screen.findByRole("region", { name: /enqueue diagnostics/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(ROUTE_ENQUEUE_ERROR_MESSAGE),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ManualPipelineExecutionDetail } from "@/lib/pipeline-executions";
+
+const getManualPipelineExecutionDetailMock = vi.fn();
+const notFoundMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  notFound: () => notFoundMock(),
+}));
+
+vi.mock("@/lib/pipeline-executions", () => ({
+  getManualPipelineExecutionDetail: (...args: unknown[]) =>
+    getManualPipelineExecutionDetailMock(...args),
+}));
+
+vi.mock("@/lib/mask-json-secrets", () => ({
+  maskSecretsInJson: (value: unknown) => value,
+}));
+
+vi.mock("@/lib/compute-execution-elapsed", () => ({
+  computePipelineWallElapsed: vi
+    .fn()
+    .mockReturnValue({ kind: "unknown" as const }),
+  formatPipelineElapsedLabel: vi.fn().mockReturnValue("—"),
+}));
+
+vi.mock("@/lib/format-invocation-error", () => ({
+  formatInvocationErrorSummary: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/components/schedule-execution-invocations-table", () => ({
+  ScheduleExecutionInvocationsTable: () => (
+    <div data-testid="invocations-stub">Invocations</div>
+  ),
+}));
+
+import PipelineExecutionDetailPage from "./page";
+
+const ROUTE_ENQUEUE_ERROR_MESSAGE = "MANUAL_PIPELINE_ROUTE_ENQUEUE_FAIL";
+
+const minimalFailedDetail = (): ManualPipelineExecutionDetail => ({
+  execution: {
+    id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    executionTime: new Date("2026-04-21T12:00:00.000Z"),
+    enqueueStatus: "failed",
+    runStatus: "pending",
+    effectiveExecutionConfig: null,
+    jobsCreated: 0,
+    jobsEnqueued: 0,
+    succeededInvocationCount: 0,
+    failedInvocationCount: 0,
+    errors: [
+      {
+        message: ROUTE_ENQUEUE_ERROR_MESSAGE,
+        timestamp: "2026-04-21T12:00:01.000Z",
+      },
+    ],
+    createdAt: new Date("2026-04-21T12:00:00.000Z"),
+  },
+  pipeline: { id: "pipe-1", name: "Test pipeline" },
+  stepExecutions: [],
+  invocations: [],
+});
+
+describe("PipelineExecutionDetailPage (manual execution)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getManualPipelineExecutionDetailMock.mockReset();
+    notFoundMock.mockReset();
+  });
+
+  it("renders enqueue diagnostics region with persisted errors for failed enqueue", async () => {
+    getManualPipelineExecutionDetailMock.mockResolvedValue(
+      minimalFailedDetail(),
+    );
+
+    const ui = await PipelineExecutionDetailPage({
+      params: Promise.resolve({
+        id: "pipe-1",
+        executionId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+      }),
+    });
+    render(ui as React.ReactElement);
+
+    expect(
+      await screen.findByRole("region", { name: /enqueue diagnostics/i }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText(ROUTE_ENQUEUE_ERROR_MESSAGE),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ScheduleExecutionDetail } from "@/lib/schedules";
+
+const getScheduleExecutionDetailMock = vi.fn();
+const notFoundMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  notFound: () => notFoundMock(),
+}));
+
+vi.mock("@/lib/schedules", () => ({
+  getScheduleExecutionDetail: (...args: unknown[]) =>
+    getScheduleExecutionDetailMock(...args),
+}));
+
+vi.mock("@/lib/mask-json-secrets", () => ({
+  maskScheduleExecutionDetailForDisplay: (detail: unknown) => detail,
+}));
+
+vi.mock("@/lib/compute-execution-elapsed", () => ({
+  computePipelineWallElapsed: vi
+    .fn()
+    .mockReturnValue({ kind: "unknown" as const }),
+  formatPipelineElapsedLabel: vi.fn().mockReturnValue("—"),
+}));
+
+vi.mock("@/lib/format-invocation-error", () => ({
+  formatInvocationErrorSummary: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/components/schedule-execution-invocations-table", () => ({
+  ScheduleExecutionInvocationsTable: () => (
+    <div data-testid="invocations-stub">Invocations</div>
+  ),
+}));
+
+import ScheduleExecutionDetailPage from "./page";
+
+const ROUTE_ENQUEUE_ERROR_MESSAGE = "SCHEDULE_ROUTE_ENQUEUE_FAIL";
+
+const minimalFailedDetail = (): ScheduleExecutionDetail => ({
+  execution: {
+    id: "exec-schedule-1",
+    executionTime: new Date("2026-04-21T12:00:00.000Z"),
+    enqueueStatus: "failed",
+    runStatus: "pending",
+    effectiveExecutionConfig: null,
+    jobsCreated: 0,
+    jobsEnqueued: 0,
+    succeededInvocationCount: 0,
+    failedInvocationCount: 0,
+    errors: [
+      {
+        message: ROUTE_ENQUEUE_ERROR_MESSAGE,
+        timestamp: "2026-04-21T12:00:01.000Z",
+      },
+    ],
+    createdAt: new Date("2026-04-21T12:00:00.000Z"),
+  },
+  pipeline: null,
+  schedule: { id: "sched-1", name: "Test schedule" },
+  stepExecutions: [],
+  invocations: [],
+});
+
+describe("ScheduleExecutionDetailPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    getScheduleExecutionDetailMock.mockReset();
+    notFoundMock.mockReset();
+  });
+
+  it("renders enqueue diagnostics region with persisted errors for failed enqueue", async () => {
+    getScheduleExecutionDetailMock.mockResolvedValue(minimalFailedDetail());
+
+    const ui = await ScheduleExecutionDetailPage({
+      params: Promise.resolve({
+        id: "sched-1",
+        executionId: "exec-schedule-1",
+      }),
+    });
+    render(ui as React.ReactElement);
+
+    const region = await screen.findByRole("region", {
+      name: /enqueue diagnostics/i,
+    });
+    expect(region).toBeInTheDocument();
+    expect(
+      await screen.findByText(ROUTE_ENQUEUE_ERROR_MESSAGE),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
+    expect(screen.getByText("failed")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds **per-route Vitest coverage** so each Hermes execution detail page is proven to render the shared enqueue diagnostics region when `enqueueStatus` is `failed` and JSON `errors` are present. Wiring was already on `main` from ENQ-DIAG-001; this closes the proof requirement in #291.

## Important changes

- `page.test.tsx` co-located with schedule, HTTP trigger, and manual pipeline **execution detail** routes, each mocking its loader + masking helpers and asserting `role="region"` and the fixture error message.

## How to test

- `cd apps/hermes/dashboard && pnpm test --testNamePattern "renders enqueue diagnostics region"`

## Related issues

Fixes https://github.com/hyperjumptech/mediapulse/issues/291
