### PR TITLE
Add Copy JSON for masked enqueue diagnostics

### DIFF
--- a/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.test.tsx
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.test.tsx
@@ -49,6 +49,9 @@ describe("EnqueueDiagnosticsPanel", () => {
     expect(
       screen.getByText(/No detailed enqueue error was recorded/i),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Copy enqueue diagnostics JSON" }),
+    ).not.toBeInTheDocument();
   });
 
   it("renders invalid payload message for non-array errors", () => {
@@ -102,6 +105,29 @@ describe("EnqueueDiagnosticsPanel", () => {
     expect(
       screen.queryByRole("heading", { name: "Correlation" }),
     ).not.toBeInTheDocument();
+  });
+
+  it("copies masked diagnostics JSON when Copy JSON is used", () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <EnqueueDiagnosticsPanel
+        enqueueStatus="failed"
+        errors={[{ message: "one", timestamp: "2026-01-01T00:00:00.000Z" }]}
+      />,
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Copy enqueue diagnostics JSON" }),
+    );
+    expect(writeText).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(writeText.mock.calls[0][0] as string) as {
+      errors: unknown[];
+    };
+    expect(Array.isArray(payload.errors)).toBe(true);
+    expect(payload.errors).toHaveLength(1);
+    expect(payload.errors[0]).toMatchObject({ message: "one" });
   });
 
   it("renders Correlation and copies request id", async () => {

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.test.tsx
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.test.tsx
@@ -122,7 +122,13 @@ describe("EnqueueDiagnosticsPanel", () => {
       screen.getByRole("button", { name: "Copy enqueue diagnostics JSON" }),
     );
     expect(writeText).toHaveBeenCalledTimes(1);
-    const payload = JSON.parse(writeText.mock.calls[0][0] as string) as {
+    const firstCall = writeText.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    const rawJson = firstCall![0];
+    if (typeof rawJson !== "string") {
+      expect.fail("clipboard writeText expected a string payload");
+    }
+    const payload = JSON.parse(rawJson) as {
       errors: unknown[];
     };
     expect(Array.isArray(payload.errors)).toBe(true);

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.tsx
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { Copy } from "lucide-react";
-import { useCallback, useState } from "react";
 
 import { Button } from "@workspace/ui/components/button";
 import type { HermesEnqueueCorrelation } from "@hermes/scheduler/enqueue-diagnostics-correlation";
 
 import type { EnqueueDiagnosticEntry } from "@/lib/enqueue-diagnostics";
 
+import {
+  useClipboardCopyFeedback,
+  useKeyedClipboardCopyFeedback,
+} from "./use-enqueue-diagnostics-clipboard";
 import { useEnqueueDiagnosticsPanelViewModel } from "./use-enqueue-diagnostics-panel";
 
 export type EnqueueDiagnosticsPanelProps = {
@@ -41,17 +44,7 @@ const CorrelationSubsectionInner = ({
 }: {
   rows: Array<{ key: string; label: string; value: string }>;
 }) => {
-  const [copiedKey, setCopiedKey] = useState<string | null>(null);
-
-  const onCopy = useCallback(async (key: string, text: string) => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopiedKey(key);
-      window.setTimeout(() => setCopiedKey(null), 2000);
-    } catch {
-      setCopiedKey(null);
-    }
-  }, []);
+  const { copiedKey, copyForKey } = useKeyedClipboardCopyFeedback();
 
   return (
     <div className="mt-4 rounded-md border border-border/80 bg-muted/40 p-3">
@@ -76,7 +69,7 @@ const CorrelationSubsectionInner = ({
                 variant="outline"
                 size="sm"
                 className="shrink-0 gap-1.5"
-                onClick={() => void onCopy(key, value)}
+                onClick={() => void copyForKey(key, value)}
                 aria-label={`Copy ${label}`}
               >
                 <Copy className="size-3.5" aria-hidden />
@@ -91,17 +84,7 @@ const CorrelationSubsectionInner = ({
 };
 
 const CopyDiagnosticsJsonButton = ({ copyJson }: { copyJson: string }) => {
-  const [copied, setCopied] = useState(false);
-
-  const onCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(copyJson);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      setCopied(false);
-    }
-  }, [copyJson]);
+  const { copied, copy } = useClipboardCopyFeedback(copyJson);
 
   return (
     <Button
@@ -109,7 +92,7 @@ const CopyDiagnosticsJsonButton = ({ copyJson }: { copyJson: string }) => {
       variant="outline"
       size="sm"
       className="shrink-0 gap-1.5 self-start sm:self-auto"
-      onClick={() => void onCopy()}
+      onClick={() => void copy()}
       aria-label="Copy enqueue diagnostics JSON"
     >
       <Copy className="size-3.5" aria-hidden />

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.tsx
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.tsx
@@ -90,6 +90,49 @@ const CorrelationSubsectionInner = ({
   );
 };
 
+const CopyDiagnosticsJsonButton = ({ copyJson }: { copyJson: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(copyJson);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }, [copyJson]);
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      className="shrink-0 gap-1.5 self-start sm:self-auto"
+      onClick={() => void onCopy()}
+      aria-label="Copy enqueue diagnostics JSON"
+    >
+      <Copy className="size-3.5" aria-hidden />
+      {copied ? "Copied" : "Copy JSON"}
+    </Button>
+  );
+};
+
+const EnqueueDiagnosticsSectionHeader = ({
+  copyJson,
+}: {
+  copyJson?: string;
+}) => (
+  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-3">
+    <h2 id="enqueue-diagnostics-heading" className="text-lg font-medium">
+      Enqueue diagnostics
+    </h2>
+    {copyJson != null && copyJson !== "" ? (
+      <CopyDiagnosticsJsonButton copyJson={copyJson} />
+    ) : null}
+  </div>
+);
+
 const CorrelationSubsection = ({
   correlation,
 }: {
@@ -144,9 +187,7 @@ export const EnqueueDiagnosticsPanel = ({
         role="region"
         aria-labelledby="enqueue-diagnostics-heading"
       >
-        <h2 id="enqueue-diagnostics-heading" className="text-lg font-medium">
-          Enqueue diagnostics
-        </h2>
+        <EnqueueDiagnosticsSectionHeader copyJson={view.copyJson} />
         {view.correlation ? (
           <CorrelationSubsection correlation={view.correlation} />
         ) : null}
@@ -175,9 +216,7 @@ export const EnqueueDiagnosticsPanel = ({
         role="region"
         aria-labelledby="enqueue-diagnostics-heading"
       >
-        <h2 id="enqueue-diagnostics-heading" className="text-lg font-medium">
-          Enqueue diagnostics
-        </h2>
+        <EnqueueDiagnosticsSectionHeader />
         {view.correlation ? (
           <CorrelationSubsection correlation={view.correlation} />
         ) : null}
@@ -201,9 +240,7 @@ export const EnqueueDiagnosticsPanel = ({
       role="region"
       aria-labelledby="enqueue-diagnostics-heading"
     >
-      <h2 id="enqueue-diagnostics-heading" className="text-lg font-medium">
-        Enqueue diagnostics
-      </h2>
+      <EnqueueDiagnosticsSectionHeader copyJson={view.copyJson} />
       {view.correlation ? (
         <CorrelationSubsection correlation={view.correlation} />
       ) : null}

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-clipboard.test.ts
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-clipboard.test.ts
@@ -1,0 +1,42 @@
+/** @vitest-environment jsdom */
+import { renderHook, act } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  useClipboardCopyFeedback,
+  useKeyedClipboardCopyFeedback,
+} from "./use-enqueue-diagnostics-clipboard";
+
+describe("useKeyedClipboardCopyFeedback", () => {
+  it("writes text and sets copiedKey", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { result } = renderHook(() => useKeyedClipboardCopyFeedback());
+
+    await act(async () => {
+      await result.current.copyForKey("a", "hello");
+    });
+
+    expect(writeText).toHaveBeenCalledWith("hello");
+    expect(result.current.copiedKey).toBe("a");
+  });
+});
+
+describe("useClipboardCopyFeedback", () => {
+  it("writes the bound text and toggles copied", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    const { result } = renderHook(() =>
+      useClipboardCopyFeedback('{"errors":[]}'),
+    );
+
+    await act(async () => {
+      await result.current.copy();
+    });
+
+    expect(writeText).toHaveBeenCalledWith('{"errors":[]}');
+    expect(result.current.copied).toBe(true);
+  });
+});

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-clipboard.ts
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-clipboard.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+/**
+ * Clipboard copy with per-row "Copied" feedback (correlation ids, etc.).
+ */
+export const useKeyedClipboardCopyFeedback = () => {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+
+  const copyForKey = useCallback(async (key: string, text: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopiedKey(key);
+      window.setTimeout(() => setCopiedKey(null), 2000);
+    } catch {
+      setCopiedKey(null);
+    }
+  }, []);
+
+  return { copiedKey, copyForKey };
+};
+
+/**
+ * Clipboard copy for a single string with short "Copied" feedback.
+ */
+export const useClipboardCopyFeedback = (text: string) => {
+  const [copied, setCopied] = useState(false);
+
+  const copy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  }, [text]);
+
+  return { copied, copy };
+};

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-panel.test.ts
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-panel.test.ts
@@ -2,6 +2,8 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { SECRET_MASK } from "@/lib/mask-json-secrets";
+
 import { useEnqueueDiagnosticsPanelViewModel } from "./use-enqueue-diagnostics-panel";
 
 describe("useEnqueueDiagnosticsPanelViewModel", () => {
@@ -21,6 +23,12 @@ describe("useEnqueueDiagnosticsPanelViewModel", () => {
       throw new Error("expected invalid");
     expect(result.current.payloadPreview).toContain('"x"');
     expect(result.current.panelClass).toContain("destructive");
+    const parsed = JSON.parse(result.current.copyJson) as {
+      errors?: unknown;
+      hermesEnqueueCorrelation?: unknown;
+    };
+    expect(parsed.errors).toEqual({ x: 1 });
+    expect(parsed.hermesEnqueueCorrelation).toBeUndefined();
   });
 
   it("returns empty when errors array is empty", () => {
@@ -28,6 +36,7 @@ describe("useEnqueueDiagnosticsPanelViewModel", () => {
       useEnqueueDiagnosticsPanelViewModel("failed", []),
     );
     expect(result.current).toMatchObject({ status: "empty" });
+    expect(result.current).not.toHaveProperty("copyJson");
   });
 
   it("returns entries when diagnostics are present", () => {
@@ -41,6 +50,13 @@ describe("useEnqueueDiagnosticsPanelViewModel", () => {
       throw new Error("expected entries");
     expect(result.current.entries).toHaveLength(1);
     expect(result.current.entries[0]?.message).toBe("m");
+    const parsed = JSON.parse(result.current.copyJson) as {
+      errors?: unknown[];
+      hermesEnqueueCorrelation?: unknown;
+    };
+    expect(parsed.errors).toHaveLength(1);
+    expect(parsed.errors?.[0]).toMatchObject({ message: "m" });
+    expect(parsed.hermesEnqueueCorrelation).toBeUndefined();
   });
 
   it("includes correlation from metadata on entries view", () => {
@@ -57,6 +73,17 @@ describe("useEnqueueDiagnosticsPanelViewModel", () => {
       status: "entries",
       correlation: { requestId: "r1", workerTickId: "7" },
     });
+    if (result.current.status !== "entries")
+      throw new Error("expected entries");
+    const parsed = JSON.parse(result.current.copyJson) as {
+      errors?: unknown[];
+      hermesEnqueueCorrelation?: { requestId?: string; workerTickId?: string };
+    };
+    expect(parsed.hermesEnqueueCorrelation).toEqual({
+      requestId: "r1",
+      workerTickId: "7",
+    });
+    expect(parsed.errors).toHaveLength(1);
   });
 
   it("includes correlation on invalid errors view", () => {
@@ -71,5 +98,26 @@ describe("useEnqueueDiagnosticsPanelViewModel", () => {
     if (result.current.status !== "invalid")
       throw new Error("expected invalid");
     expect(result.current.correlation).toEqual({ requestId: "corr-invalid" });
+    const parsed = JSON.parse(result.current.copyJson) as {
+      errors?: unknown;
+      hermesEnqueueCorrelation?: { requestId?: string };
+    };
+    expect(parsed.hermesEnqueueCorrelation).toEqual({
+      requestId: "corr-invalid",
+    });
+    expect(parsed.errors).toEqual({ not: "array" });
+  });
+
+  it("masks secrets in copyJson for invalid errors", () => {
+    const { result } = renderHook(() =>
+      useEnqueueDiagnosticsPanelViewModel("failed", {
+        nested: { apiKey: "secret-value" },
+      }),
+    );
+    expect(result.current.status).toBe("invalid");
+    if (result.current.status !== "invalid")
+      throw new Error("expected invalid");
+    expect(result.current.copyJson).toContain(SECRET_MASK);
+    expect(result.current.copyJson).not.toContain("secret-value");
   });
 });

--- a/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-panel.ts
+++ b/apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-panel.ts
@@ -21,6 +21,7 @@ export type EnqueueDiagnosticsPanelViewModel =
       status: "invalid";
       panelClass: string;
       payloadPreview: string;
+      copyJson: string;
       correlation?: HermesEnqueueCorrelation;
     }
   | {
@@ -32,6 +33,7 @@ export type EnqueueDiagnosticsPanelViewModel =
       status: "entries";
       panelClass: string;
       entries: EnqueueDiagnosticEntry[];
+      copyJson: string;
       correlation?: HermesEnqueueCorrelation;
     };
 
@@ -39,6 +41,18 @@ const panelClassForPartial = (isPartial: boolean): string =>
   isPartial
     ? "rounded-md border border-amber-600/40 bg-amber-500/5 p-4 text-foreground"
     : "rounded-md border border-destructive/40 bg-destructive/5 p-4 text-foreground";
+
+const maskedDiagnosticsExportJson = (
+  errorsValue: unknown,
+  correlation: HermesEnqueueCorrelation | undefined,
+): string => {
+  const payload: Record<string, unknown> = {};
+  if (correlation) {
+    payload.hermesEnqueueCorrelation = correlation;
+  }
+  payload.errors = errorsValue;
+  return safeJsonStringify(payload);
+};
 
 /**
  * Derives everything the enqueue diagnostics panel needs from `enqueueStatus` and raw
@@ -63,10 +77,12 @@ export const useEnqueueDiagnosticsPanelViewModel = (
     const normalized = normalizeEnqueueErrorsPayload(maskedErrors);
 
     if (normalized.kind === "invalid") {
+      const errorsForExport = maskSecretsInJson(normalized.raw);
       return {
         status: "invalid",
         panelClass,
-        payloadPreview: safeJsonStringify(maskSecretsInJson(normalized.raw)),
+        payloadPreview: safeJsonStringify(errorsForExport),
+        copyJson: maskedDiagnosticsExportJson(errorsForExport, correlation),
         ...(correlation ? { correlation } : {}),
       };
     }
@@ -87,6 +103,7 @@ export const useEnqueueDiagnosticsPanelViewModel = (
       status: "entries",
       panelClass,
       entries: sorted,
+      copyJson: maskedDiagnosticsExportJson(sorted, correlation),
       ...(correlation ? { correlation } : {}),
     };
   }, [enqueueStatus, errors, metadata]);


### PR DESCRIPTION
## Summary

Operators debugging enqueue failures can paste the exact masked diagnostics blob into Slack or a ticket without retyping the page. The enqueue diagnostics panel now has a header Copy JSON control whenever there is something worth exporting (invalid errors JSON shape, or a non-empty error list). Clipboard text is pretty-printed JSON: masked `errors` using the same pipeline as the list and preview, plus `hermesEnqueueCorrelation` when execution metadata includes it. When there are no detailed enqueue errors, the button stays hidden.

## Related issues

Closes #296

## Important changes

- `copyJson` on the view model for `invalid` and `entries` branches, built from the same masking and sorting logic as the UI.
- Small header row with copy affordance and short-lived Copied feedback.

## Other changes

- Vitest coverage for JSON shape, secret masking in exports, correlation fields, and empty-state behavior.

## Key files to review

- `apps/hermes/dashboard/components/enqueue-diagnostics/use-enqueue-diagnostics-panel.ts` — when `copyJson` is produced and how the export object is assembled.
- `apps/hermes/dashboard/components/enqueue-diagnostics/enqueue-diagnostics-panel.tsx` — copy button wiring and empty vs invalid vs entries layout.

## How to test

1. From `apps/hermes/dashboard`, run `pnpm exec vitest run -c vitest.config.mjs components/enqueue-diagnostics`.
2. In the app, open a failed or partial execution that shows enqueue diagnostics; use Copy JSON and confirm pasted text parses and matches what you see (including redacted secrets).
3. Confirm executions with an empty diagnostics message do not show Copy JSON.
