### PR TITLE
Emit run summary for article-analysis relevance validation and chunk parse failures

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -175,6 +175,27 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.entityReuseRatio).toBe(0.5);
     expect(payload.avgExtractionLatencyMs).toBe(150);
     expect(payload.llmTotalTokens).toBe(30);
+    expect(payload.schemaValidationFailureCount).toBe(3);
+    expect(payload.failureCountsByKind).toEqual({
+      llm: 1,
+      vocabulary: 1,
+      schemaValidation: 3,
+      persistenceHttp: 1,
+      persistenceOther: 1,
+    });
+    expect(payload.stageMetrics).toEqual({
+      extract: {
+        articlesProcessed: 3,
+        articlesSucceeded: 2,
+        articlesFailedExtraction: 2,
+      },
+      scorePrepare: { schemaValidationFailures: 3 },
+      persist: {
+        postChunkFailures: 2,
+        articlesScored: 2,
+        articlesSelected: 1,
+      },
+    });
   });
 
   it("omits LLM usage keys when usage is null", () => {
@@ -202,6 +223,27 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     });
     expect("llmTotalTokens" in payload).toBe(false);
     expect(payload.scoreFailureCount).toBe(0);
+    expect(payload.schemaValidationFailureCount).toBe(0);
+    expect(payload.failureCountsByKind).toEqual({
+      llm: 0,
+      vocabulary: 0,
+      schemaValidation: 0,
+      persistenceHttp: 0,
+      persistenceOther: 0,
+    });
+    expect(payload.stageMetrics).toEqual({
+      extract: {
+        articlesProcessed: 1,
+        articlesSucceeded: 1,
+        articlesFailedExtraction: 0,
+      },
+      scorePrepare: { schemaValidationFailures: 0 },
+      persist: {
+        postChunkFailures: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      },
+    });
   });
 
   it("embeds failure reason and safe error for top-level failures", () => {

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -237,6 +237,10 @@ export type ArticleAnalysisRunSummaryInput = {
 /**
  * Builds a single JSON-safe object for one structured info log line.
  *
+ * Includes **`stageMetrics`** (extract / scorePrepare / persist) and **`failureCountsByKind`**
+ * so LLM, vocabulary, schema or row validation, and HTTP persistence failures stay separable
+ * in metrics backends (MP-ART-ANALYSIS-008).
+ *
  * @param input - Counters and aggregates at end of run (or failure path).
  * @returns Payload to pass as first argument to `log.info`.
  */
@@ -265,6 +269,12 @@ export const buildArticleAnalysisRunSummaryPayload = (
     postByKind[p.chunkKind] += 1;
     postByCategory[p.errorCategory] += 1;
   }
+
+  const schemaValidationFailureCount =
+    input.relevanceRowValidationFailures +
+    input.chunkParseCounts.entityRelationChunkParseErrors +
+    input.chunkParseCounts.articleEntityChunkParseErrors +
+    input.chunkParseCounts.articleRelevanceChunkParseErrors;
 
   const denom = input.entitiesCreated + input.entitiesReused;
   const entityReuseRatio = denom > 0 ? input.entitiesReused / denom : null;
@@ -295,6 +305,29 @@ export const buildArticleAnalysisRunSummaryPayload = (
       input.chunkParseCounts.articleEntityChunkParseErrors,
     chunkParseErrorsArticleRelevance:
       input.chunkParseCounts.articleRelevanceChunkParseErrors,
+    schemaValidationFailureCount,
+    failureCountsByKind: {
+      llm: llmFails,
+      vocabulary: vocabFails,
+      schemaValidation: schemaValidationFailureCount,
+      persistenceHttp: postByCategory.agent_data_api_http,
+      persistenceOther: postByCategory.unknown,
+    },
+    stageMetrics: {
+      extract: {
+        articlesProcessed: input.articlesProcessed,
+        articlesSucceeded: input.extractionSuccessCount,
+        articlesFailedExtraction: input.extractionFailures.length,
+      },
+      scorePrepare: {
+        schemaValidationFailures: schemaValidationFailureCount,
+      },
+      persist: {
+        postChunkFailures: input.postFailures.length,
+        articlesScored: input.articlesScored,
+        articlesSelected: input.articlesSelected,
+      },
+    },
     postFailureCount: input.postFailures.length,
     postFailuresByChunkKind: postByKind,
     postFailuresByErrorCategory: postByCategory,

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -985,8 +985,10 @@ describe("run", () => {
     );
   });
 
-  it("does not log raw article content in structured info payloads", async () => {
+  it("does not log raw article content, bearer token, or API key in default log payloads", async () => {
     const secretBody = "DO_NOT_LOG_THIS_ARTICLE_BODY_SECRET";
+    const bearer = "Bearer DO_NOT_LOG_THIS_AGENT_TOKEN";
+    const apiKey = "sk-DO_NOT_LOG_THIS_OPENAI_KEY";
     analysisGet.mockResolvedValue({
       dataSources: [
         {
@@ -1029,11 +1031,23 @@ describe("run", () => {
         articlesSelected: 1,
       });
 
-    await run(runContext({ input: { tickerId: "ticker-1" } }));
+    await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { openaiApiKey: apiKey },
+        token: bearer,
+      }),
+    );
 
-    const payloads = mockLog.info.mock.calls.map((c) => JSON.stringify(c[0]));
-    for (const p of payloads) {
+    const allPayloads = [
+      ...mockLog.info.mock.calls,
+      ...mockLog.warn.mock.calls,
+      ...mockLog.error.mock.calls,
+    ].map((c) => JSON.stringify(c[0]));
+    for (const p of allPayloads) {
       expect(p).not.toContain(secretBody);
+      expect(p).not.toContain(bearer);
+      expect(p).not.toContain(apiKey);
     }
   });
 

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -580,6 +580,25 @@ describe("run", () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("validation failed before selection");
+
+    const validationSummary = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { semanticFailureReason?: string }).semanticFailureReason ===
+          "relevance_row_validation",
+    );
+    expect(validationSummary).toBeDefined();
+    expect((validationSummary?.[0] as { outcome: string }).outcome).toBe(
+      "failure",
+    );
+    expect((validationSummary?.[0] as { event?: string }).event).toBe(
+      ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(
+      (validationSummary?.[0] as { relevanceRowValidationFailures: number })
+        .relevanceRowValidationFailures,
+    ).toBeGreaterThan(0);
   });
 
   it("fails run when relevance chunk parse errors are reported", async () => {
@@ -628,6 +647,23 @@ describe("run", () => {
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("relevance chunk parse failed");
+
+    const parseSummary = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { semanticFailureReason?: string }).semanticFailureReason ===
+          "relevance_chunk_parse",
+    );
+    expect(parseSummary).toBeDefined();
+    expect((parseSummary?.[0] as { outcome: string }).outcome).toBe("failure");
+    expect((parseSummary?.[0] as { event?: string }).event).toBe(
+      ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(
+      (parseSummary?.[0] as { chunkParseErrorsArticleRelevance: number })
+        .chunkParseErrorsArticleRelevance,
+    ).toBeGreaterThan(0);
   });
 
   it("returns failure when analysis GET throws", async () => {
@@ -943,7 +979,7 @@ describe("run", () => {
       {
         dataSourceId: DS_ID,
         stage: "llm",
-        message: "provider timeout",
+        err: { type: "Error", message: "provider timeout" },
       },
       expect.any(String),
     );

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -598,7 +598,7 @@ export const run = async ({
           {
             dataSourceId: source.id,
             stage: "llm",
-            message,
+            err: toSafeLogError(err),
           },
           "article-analysis LLM extraction failed for source; skipping",
         );
@@ -938,6 +938,29 @@ export const run = async ({
         }
       }
       if (relevanceValidationErrors.length > 0) {
+        emitRunSummary({
+          outcome: "failure",
+          articlesProcessed: batch.length,
+          extractionSuccessCount,
+          extractionFailures,
+          relevanceRowValidationFailures,
+          chunkParseCounts: { ...chunkParseCounts },
+          postFailures,
+          entitiesCreated,
+          entitiesReused,
+          relationsCreated,
+          articlesScored: articlesScoredTotal,
+          articlesSelected: articlesSelectedTotal,
+          relevanceAggregate: null,
+          llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+          extractionLatencyMsTotal,
+          extractionCalls,
+          runStatusLabel: deriveArticleAnalysisRunStatusLabel(
+            extractionFailures.length,
+            postFailures.length,
+          ),
+          semanticFailureReason: "relevance_row_validation",
+        });
         return {
           success: false,
           message:
@@ -982,6 +1005,29 @@ export const run = async ({
           },
           "article-analysis relevance chunk build reported parse issues",
         );
+        emitRunSummary({
+          outcome: "failure",
+          articlesProcessed: batch.length,
+          extractionSuccessCount,
+          extractionFailures,
+          relevanceRowValidationFailures,
+          chunkParseCounts: { ...chunkParseCounts },
+          postFailures,
+          entitiesCreated,
+          entitiesReused,
+          relationsCreated,
+          articlesScored: articlesScoredTotal,
+          articlesSelected: articlesSelectedTotal,
+          relevanceAggregate: null,
+          llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
+          extractionLatencyMsTotal,
+          extractionCalls,
+          runStatusLabel: deriveArticleAnalysisRunStatusLabel(
+            extractionFailures.length,
+            postFailures.length,
+          ),
+          semanticFailureReason: "relevance_chunk_parse",
+        });
         return {
           success: false,
           message: "article-analysis relevance chunk parse failed",

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -53,7 +53,7 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 | Area | Fields (examples) |
 | ---- | ----------------- |
 | Correlation | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present |
-| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**) |
+| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**, pre-POST **`relevance_row_validation`**, relevance chunk build **`relevance_chunk_parse`**) |
 | Extraction | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`** |
 | Validation | **`relevanceRowValidationFailures`** (pre-POST row checks), **`chunkParseErrors*`** (entity/relation chunks, `articleEntities`, `articleRelevances` chunk-build / Zod issues) |
 | Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -54,8 +54,9 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 | ---- | ----------------- |
 | Correlation | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present |
 | Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**, pre-POST **`relevance_row_validation`**, relevance chunk build **`relevance_chunk_parse`**) |
+| Stages | **`stageMetrics.extract`** (`articlesProcessed`, `articlesSucceeded`, `articlesFailedExtraction`), **`stageMetrics.scorePrepare.schemaValidationFailures`**, **`stageMetrics.persist`** (`postChunkFailures`, `articlesScored`, `articlesSelected`) |
 | Extraction | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`** |
-| Validation | **`relevanceRowValidationFailures`** (pre-POST row checks), **`chunkParseErrors*`** (entity/relation chunks, `articleEntities`, `articleRelevances` chunk-build / Zod issues) |
+| Validation | **`relevanceRowValidationFailures`**, **`chunkParseErrors*`**, rolled-up **`schemaValidationFailureCount`**; **`failureCountsByKind`** splits **`llm`**, **`vocabulary`**, **`schemaValidation`**, **`persistenceHttp`**, **`persistenceOther`** from POST failures |
 | Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |
 | KG tallies | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected` |
 | Relevance stats | When relevance rows were built: `relevanceRowCount`, `scoreMin` / `scoreMax` / `scoreMean`, **`scoreBuckets`**, **`breakdownVersion`** (or `mixed`), **`breakdownKeyMeans`** / mins / maxes over canonical keys |


### PR DESCRIPTION
## Summary

Relevance row validation and relevance chunk parse failures returned `success: false` without emitting `article_analysis.run.summary`, so log pipelines that only watch that event never saw those outcomes. The agent now logs the same structured summary on those exits, with two new `semanticFailureReason` values you can filter on. LLM extraction skip warnings log `err: toSafeLogError(err)` instead of a raw `message` field, matching the POST failure logs.

## Related issues

Refs #272

## Important changes

- Call `emitRunSummary` before the early returns for relevance validation errors and for relevance chunk build parse errors, with `outcome: "failure"`, `semanticFailureReason` of `relevance_row_validation` or `relevance_chunk_parse`, and `runStatusLabel` from `deriveArticleAnalysisRunStatusLabel`.

## Other changes

- Document those `semanticFailureReason` values in the article-analysis observability section of dev-docs.
- Extend `run.test.ts` to assert the summary payload on both failure paths; update the LLM extraction warn test for the safe error shape.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — where summaries fire and what fields are passed on the two failure paths.
- `apps/mediapulse/agents/article-analysis/src/run.test.ts` — assertions on `mockLog.info` summary fields and the LLM warn payload.

## How to test

1. From `apps/mediapulse/agents/article-analysis`, run `pnpm test`.
2. Confirm `pnpm type:check` passes in that package.
