### PR TITLE
Build @workspace/utils before user-registration agent Docker turbo step

### DIFF
--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -7,7 +7,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build && pnpm --filter=@workspace/utils run build
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose
 
 # Stage 2: run the built bundle only


### PR DESCRIPTION
## Summary

The user-registration agent image was failing during `bun build` because `@workspace/utils` ships compiled `dist/` entrypoints. The Dockerfile already ran `tsc` for `@workspace/agent-auth-client` but skipped utils, so Bun could not resolve the package in CI. This adds the same pre-build step we already use on the delivery and data-collection agent images.

## Related issues

Closes #310

## Important changes

- Builder stage now runs `pnpm --filter=@workspace/utils run build` chained after the auth client build, before `turbo build` for the agent.

## Other changes

- None.

## Key files to review

- `apps/mediapulse/agents/user-registration/Dockerfile` — single `RUN` line change; should match delivery/data-collection Dockerfiles.

## How to test

1. From repo root after `pnpm install`: `pnpm --filter=@workspace/agent-auth-client run build && pnpm --filter=@workspace/utils run build && pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose` — expect success and a bundled `dist/server.js`.
2. Optional: build the agent Docker image the same way CI does and confirm the builder stage completes past the previous `@workspace/utils` resolution error.
