### PR TITLE
Clarify Hermes invocation path and manual run counters on execution detail

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
@@ -94,5 +94,7 @@ describe("HttpTriggerExecutionDetailPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText(/Invocation transport:/)).toBeInTheDocument();
+    expect(screen.getByText(/Hermes worker \+ DataQueue/)).toBeInTheDocument();
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
 import { getHttpTriggerExecutionDetail } from "@/lib/http-triggers";
+import { getHermesExecutionInvokeTransportBlurb } from "@/lib/hermes-execution-invoke-transport";
 import { maskHttpTriggerExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 
 /**
@@ -42,6 +43,8 @@ export default async function HttpTriggerExecutionDetailPage({
   );
 
   const detail = maskHttpTriggerExecutionDetailForDisplay(rawDetail);
+  const invokeTransport =
+    getHermesExecutionInvokeTransportBlurb("http-trigger");
 
   return (
     <div className="flex flex-col gap-6">
@@ -101,6 +104,11 @@ export default async function HttpTriggerExecutionDetailPage({
           {detail.execution.succeededInvocationCount} /{" "}
           {detail.execution.failedInvocationCount}
         </p>
+        <p>
+          <span className="text-muted-foreground">Invocation transport:</span>{" "}
+          {invokeTransport.headline}
+        </p>
+        <p className="text-muted-foreground">{invokeTransport.detail}</p>
       </section>
 
       <EnqueueDiagnosticsPanel

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
@@ -95,5 +95,7 @@ describe("PipelineExecutionDetailPage (manual execution)", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText(/Invocation transport:/)).toBeInTheDocument();
+    expect(screen.getByText(/Dashboard HTTP/)).toBeInTheDocument();
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
@@ -18,6 +18,10 @@ import {
   formatPipelineElapsedLabel,
 } from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
+import {
+  formatManualExecutionMetadataHints,
+  getHermesExecutionInvokeTransportBlurb,
+} from "@/lib/hermes-execution-invoke-transport";
 import { maskManualPipelineExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 import { getManualPipelineExecutionDetail } from "@/lib/pipeline-executions";
 
@@ -46,6 +50,11 @@ export default async function PipelineExecutionDetailPage({
   );
 
   const detail = maskManualPipelineExecutionDetailForDisplay(rawDetail);
+  const invokeTransport =
+    getHermesExecutionInvokeTransportBlurb("manual-pipeline");
+  const metadataHints = formatManualExecutionMetadataHints(
+    detail.execution.metadata,
+  );
 
   return (
     <div className="flex flex-col gap-6">
@@ -91,6 +100,18 @@ export default async function PipelineExecutionDetailPage({
           {detail.execution.succeededInvocationCount} /{" "}
           {detail.execution.failedInvocationCount}
         </p>
+        <p>
+          <span className="text-muted-foreground">Invocation transport:</span>{" "}
+          {invokeTransport.headline}
+        </p>
+        <p className="text-muted-foreground">{invokeTransport.detail}</p>
+        {metadataHints.length > 0 ? (
+          <ul className="list-inside list-disc text-muted-foreground">
+            {metadataHints.map((line) => (
+              <li key={line}>{line}</li>
+            ))}
+          </ul>
+        ) : null}
       </section>
 
       <EnqueueDiagnosticsPanel

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -99,6 +99,27 @@ describe("detailFromAgentErrorBody", () => {
     expect(detailFromAgentErrorBody('{"message":"No data"}')).toBe("No data");
     expect(detailFromAgentErrorBody({ message: "No data" })).toBe("No data");
   });
+
+  it("adds a gateway hint for 502/503/504 when the body is empty", () => {
+    expect(detailFromAgentErrorBody(null, { statusCode: 502 })).toContain(
+      "Bad gateway or upstream error",
+    );
+    expect(detailFromAgentErrorBody(undefined, { statusCode: 503 })).toContain(
+      "reverse proxy",
+    );
+    expect(detailFromAgentErrorBody("", { statusCode: 504 })).toContain(
+      "load balancer",
+    );
+  });
+
+  it("does not replace a concrete message for 502", () => {
+    expect(
+      detailFromAgentErrorBody(
+        { message: "Rate limited" },
+        { statusCode: 502 },
+      ),
+    ).toBe("Rate limited");
+  });
 });
 
 describe("createRunPipelineHandler", () => {

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -41,6 +41,12 @@ const bodyValidator = z.object({
 const RUN_PIPELINE_LOG_PREFIX = "[hermes-dashboard:run-pipeline]";
 
 /**
+ * Request timeout for each manual agent POST, aligned with Hermes worker
+ * `defaultTimeoutMs` (see `apps/hermes/worker/src/job-handlers.ts`).
+ */
+const MANUAL_INVOKE_AGENT_REQUEST_TIMEOUT_MS = 300_000;
+
+/**
  * Logs run-pipeline diagnostics to stderr (visible in dashboard server logs).
  *
  * @param phase - Stage that failed or produced a warning (e.g. token, planning, agent-http).
@@ -81,34 +87,66 @@ export const responseValidator = z.object({
   failedInvocationCount: z.number(),
 });
 
+/** Optional HTTP status when normalizing a non-OK agent response. */
+export type DetailFromAgentErrorContext = {
+  statusCode?: number;
+};
+
+const isGatewayStatusCode = (code: number | undefined): boolean =>
+  code === 502 || code === 503 || code === 504;
+
+const upgradeUnknownDetailForGateway = (
+  detail: string,
+  statusCode: number | undefined,
+): string => {
+  if (!isGatewayStatusCode(statusCode)) return detail;
+  const isUnknownEmpty =
+    detail === "Unknown error (empty response body)" ||
+    detail === "Unknown error (see agent logs)";
+  if (!isUnknownEmpty) return detail;
+  return "Bad gateway or upstream error with an empty or non-JSON body. Often this is a reverse proxy or load balancer timing out or resetting the connection to the agent; check upstream idle limits and agent health (for scheduled runs, also confirm the worker-to-agent path, not only DataQueue).";
+};
+
 /**
  * Builds a short human-readable detail from an agent error response body (JSON object or string).
  *
  * @param body - Parsed or raw body from `got` when `throwHttpErrors` is false.
- * @returns Message for dashboard users (agent `message` field when present).
+ * @param context - When `statusCode` is 502/503/504 and the body is empty, adds an operator hint for proxy timeouts.
  */
-export const detailFromAgentErrorBody = (body: unknown): string => {
+export const detailFromAgentErrorBody = (
+  body: unknown,
+  context?: DetailFromAgentErrorContext,
+): string => {
+  let detail: string;
   if (body === null || body === undefined) {
-    return "Unknown error (empty response body)";
-  }
-  if (typeof body === "string") {
+    detail = "Unknown error (empty response body)";
+  } else if (typeof body === "string") {
     const trimmed = body.trim();
-    if (!trimmed) return "Unknown error (empty response body)";
-    try {
-      const parsed = JSON.parse(trimmed) as { message?: unknown };
-      if (typeof parsed.message === "string" && parsed.message.length > 0) {
-        return parsed.message;
+    if (!trimmed) {
+      detail = "Unknown error (empty response body)";
+    } else {
+      try {
+        const parsed = JSON.parse(trimmed) as { message?: unknown };
+        if (typeof parsed.message === "string" && parsed.message.length > 0) {
+          detail = parsed.message;
+        } else {
+          detail =
+            trimmed.length > 300 ? `${trimmed.slice(0, 300)}...` : trimmed;
+        }
+      } catch {
+        detail = trimmed.length > 300 ? `${trimmed.slice(0, 300)}...` : trimmed;
       }
-    } catch {
-      // Not JSON.
     }
-    return trimmed.length > 300 ? `${trimmed.slice(0, 300)}...` : trimmed;
-  }
-  if (typeof body === "object" && !Array.isArray(body)) {
+  } else if (typeof body === "object" && !Array.isArray(body)) {
     const msg = (body as { message?: unknown }).message;
-    if (typeof msg === "string" && msg.length > 0) return msg;
+    detail =
+      typeof msg === "string" && msg.length > 0
+        ? msg
+        : "Unknown error (see agent logs)";
+  } else {
+    detail = "Unknown error (see agent logs)";
   }
-  return "Unknown error (see agent logs)";
+  return upgradeUnknownDetailForGateway(detail, context?.statusCode);
 };
 
 /**
@@ -428,6 +466,7 @@ export const createRunPipelineHandler = ({
                 Authorization: `Bearer ${jwt}`,
               },
               throwHttpErrors: false,
+              timeout: { request: MANUAL_INVOKE_AGENT_REQUEST_TIMEOUT_MS },
             });
             const response = agentResponse as {
               ok?: boolean;
@@ -539,7 +578,13 @@ export const createRunPipelineHandler = ({
               continue;
             }
 
-            const detail = detailFromAgentErrorBody(response.body);
+            const statusCodeNum =
+              typeof response.statusCode === "number"
+                ? response.statusCode
+                : undefined;
+            const detail = detailFromAgentErrorBody(response.body, {
+              statusCode: statusCodeNum,
+            });
             const code = response.statusCode ?? "unknown";
             logRunPipelineIssue(
               "agent-http",

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
@@ -95,5 +95,7 @@ describe("ScheduleExecutionDetailPage", () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/Enqueue status:/)).toBeInTheDocument();
     expect(screen.getByText("failed")).toBeInTheDocument();
+    expect(screen.getByText(/Invocation transport:/)).toBeInTheDocument();
+    expect(screen.getByText(/Hermes worker \+ DataQueue/)).toBeInTheDocument();
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
@@ -18,6 +18,7 @@ import {
   formatPipelineElapsedLabel,
 } from "@/lib/compute-execution-elapsed";
 import { formatInvocationErrorSummary } from "@/lib/format-invocation-error";
+import { getHermesExecutionInvokeTransportBlurb } from "@/lib/hermes-execution-invoke-transport";
 import { maskScheduleExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 import { getScheduleExecutionDetail } from "@/lib/schedules";
 
@@ -45,6 +46,7 @@ export default async function ScheduleExecutionDetailPage({
     rawDetail.execution.runStatus,
   );
   const detail = maskScheduleExecutionDetailForDisplay(rawDetail);
+  const invokeTransport = getHermesExecutionInvokeTransportBlurb("schedule");
 
   return (
     <div className="flex flex-col gap-6">
@@ -104,6 +106,11 @@ export default async function ScheduleExecutionDetailPage({
           {detail.execution.succeededInvocationCount} /{" "}
           {detail.execution.failedInvocationCount}
         </p>
+        <p>
+          <span className="text-muted-foreground">Invocation transport:</span>{" "}
+          {invokeTransport.headline}
+        </p>
+        <p className="text-muted-foreground">{invokeTransport.detail}</p>
       </section>
 
       <EnqueueDiagnosticsPanel

--- a/apps/hermes/dashboard/lib/get-manual-pipeline-execution-detail.test.ts
+++ b/apps/hermes/dashboard/lib/get-manual-pipeline-execution-detail.test.ts
@@ -1,0 +1,181 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const findFirstMock = vi.fn();
+
+vi.mock("@hermes/orchestration-database", () => ({
+  prisma: {
+    manualPipelineExecution: {
+      findFirst: (...args: unknown[]) => findFirstMock(...args),
+    },
+  },
+}));
+
+import { getManualPipelineExecutionDetail } from "./pipeline-executions";
+
+describe("getManualPipelineExecutionDetail", () => {
+  afterEach(() => {
+    findFirstMock.mockReset();
+  });
+
+  it("derives invocation counts and step rollups from agent_job_execution rows", async () => {
+    const stepId = "step-1";
+    findFirstMock.mockResolvedValue({
+      id: "exec-1",
+      executionTime: new Date("2026-04-21T12:00:00.000Z"),
+      enqueueStatus: "success",
+      runStatus: "running",
+      effectiveExecutionConfig: {
+        schemaVersion: 1,
+        stepRollupPolicy: "strict",
+        stepOrder: "sequential",
+        continueSequentialAfterPartial: false,
+      },
+      jobsCreated: 2,
+      jobsEnqueued: 2,
+      succeededInvocationCount: 0,
+      failedInvocationCount: 0,
+      errors: null,
+      metadata: { source: "dashboard" },
+      createdAt: new Date("2026-04-21T12:00:00.000Z"),
+      pipeline: { id: "pipe-1", name: "P" },
+      manualPipelineStepExecutions: [
+        {
+          pipelineStepId: stepId,
+          expectedInvocationCount: 2,
+          succeededCount: 0,
+          failedCount: 0,
+          rollupStatus: "running",
+          pipelineStep: {
+            id: stepId,
+            order: 0,
+            agentId: "article-analysis",
+            agentVersion: "1.0.0",
+          },
+        },
+      ],
+      agentJobExecutions: [
+        {
+          jobId: "j1",
+          status: "failed",
+          agentId: "article-analysis",
+          pipelineStepId: stepId,
+          params: {},
+          invocationConfig: null,
+          error: { code: 502 },
+          agentResponse: null,
+          semanticStatus: "failure",
+          enqueuedAt: new Date("2026-04-21T12:00:00.000Z"),
+          startedAt: new Date("2026-04-21T12:00:01.000Z"),
+          completedAt: new Date("2026-04-21T12:00:02.000Z"),
+          dataQueueAttempts: null,
+          dataQueueMaxAttempts: null,
+        },
+        {
+          jobId: "j2",
+          status: "running",
+          agentId: "article-analysis",
+          pipelineStepId: stepId,
+          params: {},
+          invocationConfig: null,
+          error: null,
+          agentResponse: null,
+          semanticStatus: null,
+          enqueuedAt: new Date("2026-04-21T12:00:00.000Z"),
+          startedAt: new Date("2026-04-21T12:00:03.000Z"),
+          completedAt: null,
+          dataQueueAttempts: null,
+          dataQueueMaxAttempts: null,
+        },
+      ],
+    });
+
+    const detail = await getManualPipelineExecutionDetail("pipe-1", "exec-1");
+
+    expect(detail).not.toBeNull();
+    expect(detail!.execution.succeededInvocationCount).toBe(0);
+    expect(detail!.execution.failedInvocationCount).toBe(1);
+    const step = detail!.stepExecutions[0];
+    expect(step?.succeededCount).toBe(0);
+    expect(step?.failedCount).toBe(1);
+    expect(step?.rollupStatus).toBe("running");
+  });
+
+  it("computes terminal step rollup when all jobs finished", async () => {
+    const stepId = "step-1";
+    findFirstMock.mockResolvedValue({
+      id: "exec-2",
+      executionTime: new Date("2026-04-21T12:00:00.000Z"),
+      enqueueStatus: "success",
+      runStatus: "succeeded",
+      effectiveExecutionConfig: {
+        schemaVersion: 1,
+        stepRollupPolicy: "strict",
+        stepOrder: "sequential",
+        continueSequentialAfterPartial: false,
+      },
+      jobsCreated: 2,
+      jobsEnqueued: 2,
+      succeededInvocationCount: 2,
+      failedInvocationCount: 0,
+      errors: null,
+      metadata: null,
+      createdAt: new Date("2026-04-21T12:00:00.000Z"),
+      pipeline: { id: "pipe-1", name: "P" },
+      manualPipelineStepExecutions: [
+        {
+          pipelineStepId: stepId,
+          expectedInvocationCount: 2,
+          succeededCount: 2,
+          failedCount: 0,
+          rollupStatus: "success",
+          pipelineStep: {
+            id: stepId,
+            order: 0,
+            agentId: "a",
+            agentVersion: "1.0.0",
+          },
+        },
+      ],
+      agentJobExecutions: [
+        {
+          jobId: "j1",
+          status: "completed",
+          agentId: "a",
+          pipelineStepId: stepId,
+          params: {},
+          invocationConfig: null,
+          error: null,
+          agentResponse: {},
+          semanticStatus: "success",
+          enqueuedAt: new Date("2026-04-21T12:00:00.000Z"),
+          startedAt: new Date("2026-04-21T12:00:01.000Z"),
+          completedAt: new Date("2026-04-21T12:00:02.000Z"),
+          dataQueueAttempts: null,
+          dataQueueMaxAttempts: null,
+        },
+        {
+          jobId: "j2",
+          status: "completed",
+          agentId: "a",
+          pipelineStepId: stepId,
+          params: {},
+          invocationConfig: null,
+          error: null,
+          agentResponse: {},
+          semanticStatus: "success",
+          enqueuedAt: new Date("2026-04-21T12:00:00.000Z"),
+          startedAt: new Date("2026-04-21T12:00:01.000Z"),
+          completedAt: new Date("2026-04-21T12:00:02.000Z"),
+          dataQueueAttempts: null,
+          dataQueueMaxAttempts: null,
+        },
+      ],
+    });
+
+    const detail = await getManualPipelineExecutionDetail("pipe-1", "exec-2");
+    expect(detail!.execution.succeededInvocationCount).toBe(2);
+    expect(detail!.execution.failedInvocationCount).toBe(0);
+    expect(detail!.stepExecutions[0]?.rollupStatus).toBe("success");
+  });
+});

--- a/apps/hermes/dashboard/lib/hermes-execution-invoke-transport.test.ts
+++ b/apps/hermes/dashboard/lib/hermes-execution-invoke-transport.test.ts
@@ -1,0 +1,35 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  formatManualExecutionMetadataHints,
+  getHermesExecutionInvokeTransportBlurb,
+} from "./hermes-execution-invoke-transport";
+
+describe("getHermesExecutionInvokeTransportBlurb", () => {
+  it("states dashboard HTTP for manual pipeline runs", () => {
+    const b = getHermesExecutionInvokeTransportBlurb("manual-pipeline");
+    expect(b.headline).toContain("Dashboard HTTP");
+    expect(b.detail).toContain("DataQueue");
+  });
+
+  it("states worker + DataQueue for schedules and HTTP triggers", () => {
+    expect(
+      getHermesExecutionInvokeTransportBlurb("schedule").headline,
+    ).toContain("worker");
+    expect(
+      getHermesExecutionInvokeTransportBlurb("http-trigger").headline,
+    ).toContain("worker");
+  });
+});
+
+describe("formatManualExecutionMetadataHints", () => {
+  it("includes dashboard source and request id when present", () => {
+    const lines = formatManualExecutionMetadataHints({
+      source: "dashboard",
+      hermesEnqueueCorrelation: { requestId: "req-abc" },
+    });
+    expect(lines.some((l) => l.includes("Dashboard"))).toBe(true);
+    expect(lines.some((l) => l.includes("req-abc"))).toBe(true);
+  });
+});

--- a/apps/hermes/dashboard/lib/hermes-execution-invoke-transport.ts
+++ b/apps/hermes/dashboard/lib/hermes-execution-invoke-transport.ts
@@ -1,0 +1,72 @@
+import { parseHermesEnqueueCorrelationFromMetadata } from "@hermes/scheduler/enqueue-diagnostics-correlation";
+
+/**
+ * Which Hermes execution detail page is rendering (drives invocation-transport copy).
+ */
+export type HermesExecutionDetailPageKind =
+  | "manual-pipeline"
+  | "schedule"
+  | "http-trigger";
+
+export type HermesExecutionInvokeTransportBlurb = {
+  /** Short label for the summary grid. */
+  headline: string;
+  /** One or two sentences for operators (DataQueue vs dashboard HTTP). */
+  detail: string;
+};
+
+/**
+ * Explains how agent jobs are invoked for this execution type so operators do not
+ * mis-attribute behaviour to DataQueue when using dashboard manual runs.
+ */
+export const getHermesExecutionInvokeTransportBlurb = (
+  kind: HermesExecutionDetailPageKind,
+): HermesExecutionInvokeTransportBlurb => {
+  if (kind === "manual-pipeline") {
+    return {
+      headline: "Dashboard HTTP (no DataQueue)",
+      detail:
+        "Manual runs invoke agents with synchronous HTTP POSTs from the Hermes dashboard server. The Hermes worker and DataQueue are not used. A row can stay “running” for a long time while the dashboard waits for the agent HTTP response to finish.",
+    };
+  }
+  if (kind === "schedule") {
+    return {
+      headline: "Hermes worker + DataQueue",
+      detail:
+        "Scheduled runs enqueue `invoke_agent` jobs on DataQueue. The worker POSTs to each agent using the schedule timeout (default five minutes unless the schedule overrides `timeout`).",
+    };
+  }
+  return {
+    headline: "Hermes worker + DataQueue",
+    detail:
+      "HTTP-triggered runs enqueue `invoke_agent` jobs on DataQueue, same as schedules. Inspect worker logs and DataQueue job state when invocations retry or stall.",
+  };
+};
+
+/**
+ * Optional sublines from masked manual execution metadata (`source`, correlation ids).
+ */
+export const formatManualExecutionMetadataHints = (
+  metadata: unknown,
+): string[] => {
+  const root =
+    metadata !== null &&
+    typeof metadata === "object" &&
+    !Array.isArray(metadata)
+      ? (metadata as Record<string, unknown>)
+      : null;
+  const lines: string[] = [];
+  const source = root?.source;
+  if (typeof source === "string" && source.trim() !== "") {
+    lines.push(
+      source === "dashboard"
+        ? "Started from: Dashboard (Run pipeline)"
+        : `Started from: ${source}`,
+    );
+  }
+  const correlation = parseHermesEnqueueCorrelationFromMetadata(metadata);
+  if (correlation?.requestId) {
+    lines.push(`Request id: ${correlation.requestId}`);
+  }
+  return lines;
+};

--- a/apps/hermes/dashboard/lib/pipeline-executions.ts
+++ b/apps/hermes/dashboard/lib/pipeline-executions.ts
@@ -1,5 +1,7 @@
 import type { Prisma } from "@hermes/orchestration-database";
 import { prisma } from "@hermes/orchestration-database";
+import { parseEffectiveExecutionConfig } from "@hermes/scheduler/execution-config";
+import { computeStepRollupFromCounts } from "@hermes/scheduler/schedule-rollup";
 
 import {
   computePipelineWallElapsed,
@@ -297,6 +299,92 @@ const attachPipelineExecutionElapsedLabels = async (
   });
 };
 
+type AgentJobStatusLite = {
+  status: string;
+  pipelineStepId: string | null;
+};
+
+const loadExecutionConfigForManualDetail = (
+  raw: unknown,
+): ReturnType<typeof parseEffectiveExecutionConfig> => {
+  try {
+    if (raw !== null && typeof raw === "object" && !Array.isArray(raw)) {
+      return parseEffectiveExecutionConfig(raw as Record<string, unknown>);
+    }
+  } catch {
+    // Invalid config JSON — fall back to defaults.
+  }
+  return parseEffectiveExecutionConfig({});
+};
+
+const deriveManualInvocationCountsFromJobs = (
+  jobs: ReadonlyArray<{ status: string }>,
+): { succeededInvocationCount: number; failedInvocationCount: number } => {
+  let succeededInvocationCount = 0;
+  let failedInvocationCount = 0;
+  for (const job of jobs) {
+    if (job.status === "completed") {
+      succeededInvocationCount += 1;
+    } else if (job.status === "failed") {
+      failedInvocationCount += 1;
+    }
+  }
+  return { succeededInvocationCount, failedInvocationCount };
+};
+
+/**
+ * Recomputes per-step counts and rollups from `agent_job_execution` rows so the manual
+ * execution detail header and steps table stay accurate while the dashboard run-pipeline
+ * handler is still in progress (parent row counters are only finalized after all jobs).
+ */
+const deriveManualStepExecutionsFromJobs = <
+  T extends {
+    pipelineStepId: string;
+    expectedInvocationCount: number;
+    succeededCount: number;
+    failedCount: number;
+    rollupStatus: string;
+  },
+>(
+  steps: T[],
+  jobs: ReadonlyArray<AgentJobStatusLite>,
+  stepRollupPolicy: ReturnType<
+    typeof parseEffectiveExecutionConfig
+  >["stepRollupPolicy"],
+): T[] => {
+  return steps.map((step) => {
+    const forStep = jobs.filter(
+      (j) => j.pipelineStepId === step.pipelineStepId,
+    );
+    const succeededCount = forStep.filter(
+      (j) => j.status === "completed",
+    ).length;
+    const failedCount = forStep.filter((j) => j.status === "failed").length;
+    const hasNonTerminal = forStep.some(
+      (j) => j.status === "pending" || j.status === "running",
+    );
+    if (hasNonTerminal) {
+      return {
+        ...step,
+        succeededCount,
+        failedCount,
+        rollupStatus: "running",
+      };
+    }
+    const terminal = computeStepRollupFromCounts(
+      succeededCount,
+      failedCount,
+      stepRollupPolicy,
+    );
+    return {
+      ...step,
+      succeededCount,
+      failedCount,
+      rollupStatus: terminal,
+    };
+  });
+};
+
 export type ManualPipelineExecutionDetail = {
   execution: {
     id: string;
@@ -393,6 +481,32 @@ export const getManualPipelineExecutionDetail = async (
   });
   if (!row) return null;
 
+  const executionConfig = loadExecutionConfigForManualDetail(
+    row.effectiveExecutionConfig,
+  );
+  const jobRows = row.agentJobExecutions;
+  const { succeededInvocationCount, failedInvocationCount } =
+    deriveManualInvocationCountsFromJobs(jobRows);
+
+  const stepExecutionsBase = row.manualPipelineStepExecutions
+    .map((item) => ({
+      pipelineStepId: item.pipelineStepId,
+      stepOrder: item.pipelineStep.order,
+      agentId: item.pipelineStep.agentId,
+      agentVersion: item.pipelineStep.agentVersion,
+      expectedInvocationCount: item.expectedInvocationCount,
+      succeededCount: item.succeededCount,
+      failedCount: item.failedCount,
+      rollupStatus: item.rollupStatus,
+    }))
+    .sort((left, right) => left.stepOrder - right.stepOrder);
+
+  const stepExecutions = deriveManualStepExecutionsFromJobs(
+    stepExecutionsBase,
+    jobRows,
+    executionConfig.stepRollupPolicy,
+  );
+
   return {
     execution: {
       id: row.id,
@@ -402,25 +516,14 @@ export const getManualPipelineExecutionDetail = async (
       effectiveExecutionConfig: row.effectiveExecutionConfig,
       jobsCreated: row.jobsCreated,
       jobsEnqueued: row.jobsEnqueued,
-      succeededInvocationCount: row.succeededInvocationCount,
-      failedInvocationCount: row.failedInvocationCount,
+      succeededInvocationCount,
+      failedInvocationCount,
       errors: row.errors,
       metadata: row.metadata,
       createdAt: row.createdAt,
     },
     pipeline: row.pipeline,
-    stepExecutions: row.manualPipelineStepExecutions
-      .map((item) => ({
-        pipelineStepId: item.pipelineStepId,
-        stepOrder: item.pipelineStep.order,
-        agentId: item.pipelineStep.agentId,
-        agentVersion: item.pipelineStep.agentVersion,
-        expectedInvocationCount: item.expectedInvocationCount,
-        succeededCount: item.succeededCount,
-        failedCount: item.failedCount,
-        rollupStatus: item.rollupStatus,
-      }))
-      .sort((left, right) => left.stepOrder - right.stepOrder),
+    stepExecutions,
     invocations: row.agentJobExecutions.map((job) => ({
       jobId: job.jobId,
       status: job.status,

--- a/packages/hermes/scheduler/package.json
+++ b/packages/hermes/scheduler/package.json
@@ -7,7 +7,9 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./enqueue-diagnostics-correlation": "./src/enqueue-diagnostics-correlation.ts"
+    "./enqueue-diagnostics-correlation": "./src/enqueue-diagnostics-correlation.ts",
+    "./execution-config": "./src/execution-config.ts",
+    "./schedule-rollup": "./src/schedule-rollup.ts"
   },
   "scripts": {
     "lint": "eslint \"src/**/*.ts\"",


### PR DESCRIPTION
## Summary

Manual pipeline runs were hard to reason about from the execution page alone: the top-level success/fail counters only updated after every job finished, so a long agent call looked like 0/0 even when rows below already showed failures. There was also no copy explaining that those runs use the dashboard server as the HTTP client (no DataQueue), which sent people looking in the wrong place when something hung.

This PR fixes that drift by deriving manual counts and step rollups from `agent_job_execution`, adds a short "invocation transport" blurb on all three execution detail surfaces, aligns manual `got.post` with the worker default 300s timeout, and tightens empty-body 502/503/504 messaging for proxy timeouts.

## Related issues

Closes #312

## Important changes

- Manual execution detail: live succeeded/failed counts and step rollups from job rows; optional metadata lines for dashboard-initiated runs.
- All execution detail pages: short transport note (dashboard HTTP vs worker + DataQueue).
- Manual run-pipeline: `timeout.request` 300000 ms on each agent POST; richer gateway error text when the body is empty.

## Other changes

- `@hermes/scheduler` exposes `./execution-config` and `./schedule-rollup` so the dashboard can import rollup helpers without pulling the full package entry (keeps Vitest from tripping over Prisma env).

## Key files to review

- `apps/hermes/dashboard/lib/pipeline-executions.ts` — derivation logic for manual detail.
- `apps/hermes/dashboard/lib/hermes-execution-invoke-transport.ts` — copy + metadata hints.
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — timeout and `detailFromAgentErrorBody` context.

## How to test

1. From `apps/hermes/dashboard`, run `pnpm test` (expect all green).
2. From repo root, run `pnpm format:check`.
3. Optional: open a manual pipeline execution that is still `running` with some terminal jobs and confirm the header counts match the invocations table; open a schedule execution and confirm the transport line mentions DataQueue.
