### PR TITLE
Fix user-registration Docker next build

### DIFF
--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -22,6 +22,14 @@ COPY apps ./apps
 
 RUN pnpm install --frozen-lockfile
 
+# next build imports @mediapulse/database → default @mediapulse/env (t3) validates at module load.
+# Prisma client output is gitignored; match domain-api / agent-data-api image builds.
+ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
+ENV DOMAIN_INTEGRATION_API_KEY="docker-build-dummy"
+ENV DOMAIN_INTEGRATION_ID="docker-build-dummy"
+ENV AGENT_AUTH_API_URL="http://127.0.0.1:9/dummy"
+RUN pnpm --filter=@mediapulse/database run db:generate
+
 # next.config loads env files; provide an empty app-level .env for image builds.
 RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local && \
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local


### PR DESCRIPTION
## Summary

The user-registration Next image runs `next build` in a builder that had no database URL and no generated Prisma client. Loading `@mediapulse/database` triggers default `@mediapulse/env` validation, so CI/Fly failed with missing env vars. This PR adds the same build-time pattern we already use on other Mediapulse images: dummy `ENV` values for the fields t3 checks, then `pnpm --filter=@mediapulse/database run db:generate` before `next build`.

## Related issues

Closes #315

## Important changes

- Builder stage sets non-secret placeholder env for `MEDIAPULSE_DATABASE_URL`, `DOMAIN_INTEGRATION_API_KEY`, `DOMAIN_INTEGRATION_ID`, and `AGENT_AUTH_API_URL` so `next build` can import Prisma without tripping `@mediapulse/env`.
- Runs `db:generate` in the image build because `packages/mediapulse/database/client` is gitignored.

## Other changes

- None.

## Key files to review

- `apps/mediapulse/user-registration/Dockerfile` — order of `ENV`, `db:generate`, and `next build` relative to `pnpm install`.

## How to test

1. From repo root: `export MEDIAPULSE_DATABASE_URL=postgresql://localhost:5432/dummy DOMAIN_INTEGRATION_API_KEY=x DOMAIN_INTEGRATION_ID=x AGENT_AUTH_API_URL=http://127.0.0.1:9/x` then `pnpm --filter=@mediapulse/database run db:generate` and `pnpm --filter=@mediapulse/user-registration run build` — should finish without env validation errors.
2. Optional: `docker build -f apps/mediapulse/user-registration/Dockerfile .` from monorepo root (same context Fly uses) and confirm the builder step completes.
