### PR TITLE
Add Hermes execution cancellation

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions-table.tsx
@@ -11,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@workspace/ui/components/table";
+import { HermesExecutionCancelButton } from "@/components/hermes-execution-cancel-button";
 import type { HttpTriggerExecutionRow } from "@/lib/http-triggers";
 
 const executionDetailHref = (triggerId: string, executionId: string) =>
@@ -39,13 +40,14 @@ export const ExecutionsTable = ({
               Invocations (success / fail)
             </TableHead>
             <TableHead className="w-[90px]">Detail</TableHead>
+            <TableHead className="w-[120px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {executions.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={7}
                 className="text-center text-muted-foreground"
               >
                 No executions yet.
@@ -88,6 +90,16 @@ export const ExecutionsTable = ({
                     >
                       View
                     </Link>
+                  </TableCell>
+                  <TableCell>
+                    <HermesExecutionCancelButton
+                      target={{
+                        kind: "httpTrigger",
+                        httpTriggerId: triggerId,
+                        httpTriggerExecutionId: execution.id,
+                      }}
+                      runStatus={execution.runStatus}
+                    />
                   </TableCell>
                 </TableRow>
               );

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.test.tsx
@@ -9,6 +9,7 @@ const notFoundMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   notFound: () => notFoundMock(),
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("@/lib/http-triggers", () => ({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/[id]/executions/[executionId]/page.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableRow,
 } from "@workspace/ui/components/table";
+import { HermesExecutionCancelButton } from "@/components/hermes-execution-cancel-button";
 import { EnqueueDiagnosticsPanel } from "@/components/enqueue-diagnostics";
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
 import {
@@ -57,25 +58,35 @@ export default async function HttpTriggerExecutionDetailPage({
           Back to HTTP trigger
         </Link>
       </div>
-      <div>
-        <h1 className="break-all text-2xl font-semibold text-foreground">
-          Execution {detail.execution.id}
-        </h1>
-        <p className="text-muted-foreground">
-          {detail.trigger.name}
-          {detail.pipeline ? (
-            <>
-              {" · "}
-              <Link
-                href={`/dashboard/pipelines/${detail.pipeline.id}`}
-                className="inline-flex items-center gap-1 underline-offset-4 hover:text-foreground hover:underline"
-              >
-                <GitBranch className="size-4 shrink-0" aria-hidden />
-                {detail.pipeline.name}
-              </Link>
-            </>
-          ) : null}
-        </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="break-all text-2xl font-semibold text-foreground">
+            Execution {detail.execution.id}
+          </h1>
+          <p className="text-muted-foreground">
+            {detail.trigger.name}
+            {detail.pipeline ? (
+              <>
+                {" · "}
+                <Link
+                  href={`/dashboard/pipelines/${detail.pipeline.id}`}
+                  className="inline-flex items-center gap-1 underline-offset-4 hover:text-foreground hover:underline"
+                >
+                  <GitBranch className="size-4 shrink-0" aria-hidden />
+                  {detail.pipeline.name}
+                </Link>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <HermesExecutionCancelButton
+          target={{
+            kind: "httpTrigger",
+            httpTriggerId: triggerId,
+            httpTriggerExecutionId: executionId,
+          }}
+          runStatus={detail.execution.runStatus}
+        />
       </div>
 
       <section className="grid gap-2 text-sm">

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.test.ts
@@ -1,0 +1,75 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createCancelHttpTriggerExecutionHandler } from "./route.post.config";
+
+const mockDashboardUser = {
+  id: "user-1",
+  name: "A",
+  email: "a@b.com",
+} as const;
+
+vi.mock("@/lib/hermes-job-queue", () => ({
+  getHermesJobQueue: vi.fn(() => ({})),
+}));
+
+describe("createCancelHttpTriggerExecutionHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns not found when the execution is missing", async () => {
+    const db = {
+      httpTriggerExecution: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const handler = createCancelHttpTriggerExecutionHandler({
+      db: db as never,
+      cancelExecution: vi.fn(),
+    });
+
+    const result = await handler({
+      body: {
+        httpTriggerId: "00000000-0000-4000-8000-000000000010",
+        httpTriggerExecutionId: "00000000-0000-4000-8000-000000000020",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "HTTP trigger execution not found",
+    );
+  });
+
+  it("returns ok when cancel succeeds", async () => {
+    const cancelExecution = vi.fn().mockResolvedValue({ ok: true });
+    const db = {
+      httpTriggerExecution: {
+        findFirst: vi.fn().mockResolvedValue({ id: "ex1" }),
+      },
+    };
+    const handler = createCancelHttpTriggerExecutionHandler({
+      db: db as never,
+      cancelExecution,
+    });
+
+    const result = await handler({
+      body: {
+        httpTriggerId: "00000000-0000-4000-8000-000000000010",
+        httpTriggerExecutionId: "00000000-0000-4000-8000-000000000020",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(true);
+    expect((result as { data?: { ok: boolean } }).data?.ok).toBe(true);
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
@@ -1,0 +1,80 @@
+import { prisma } from "@hermes/orchestration-database";
+import {
+  cancelHttpTriggerExecution,
+  type CancelHttpTriggerExecutionResult,
+} from "@hermes/scheduler";
+import {
+  createRequestValidator,
+  errorResponse,
+  type HandlerFunc,
+  successResponse,
+} from "route-action-gen/lib";
+import { z } from "zod";
+
+import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { getHermesJobQueue } from "@/lib/hermes-job-queue";
+
+const bodyValidator = z.object({
+  httpTriggerId: z.string().uuid(),
+  httpTriggerExecutionId: z.string().uuid(),
+});
+
+export const requestValidator = createRequestValidator({
+  body: bodyValidator,
+  user: requireDashboardSessionForRoute,
+});
+
+export const responseValidator = z.object({
+  ok: z.literal(true),
+});
+
+type CancelHttpTriggerExecutionHandler = HandlerFunc<
+  typeof requestValidator,
+  typeof responseValidator,
+  undefined
+>;
+
+type Dependencies = {
+  db?: typeof prisma;
+  cancelExecution?: (
+    db: typeof prisma,
+    queue: ReturnType<typeof getHermesJobQueue>,
+    httpTriggerExecutionId: string,
+  ) => Promise<CancelHttpTriggerExecutionResult>;
+};
+
+/**
+ * Creates handler that cancels an HTTP trigger execution (DataQueue + orchestration).
+ */
+export const createCancelHttpTriggerExecutionHandler = ({
+  db = prisma,
+  cancelExecution = cancelHttpTriggerExecution,
+}: Dependencies = {}): CancelHttpTriggerExecutionHandler => {
+  return async (data) => {
+    const { httpTriggerId, httpTriggerExecutionId } = data.body;
+    const execution = await db.httpTriggerExecution.findFirst({
+      where: { id: httpTriggerExecutionId, httpTriggerId },
+      select: { id: true },
+    });
+    if (!execution) {
+      return errorResponse("HTTP trigger execution not found");
+    }
+
+    const result = await cancelExecution(
+      db,
+      getHermesJobQueue(),
+      httpTriggerExecutionId,
+    );
+    if (!result.ok) {
+      if (result.reason === "already_terminal") {
+        return errorResponse("Execution is already finished");
+      }
+      return errorResponse("HTTP trigger execution not found");
+    }
+
+    return successResponse({ ok: true as const });
+  };
+};
+
+export const handler: CancelHttpTriggerExecutionHandler =
+  createCancelHttpTriggerExecutionHandler();

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.test.ts
@@ -1,0 +1,17 @@
+/** @vitest-environment node */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe("http-triggers cancel-execution route.ts", () => {
+  it("re-exports the generated route entrypoint", () => {
+    const routePath = join(__dirname, "route.ts");
+    expect(readFileSync(routePath, "utf8")).toContain(
+      'export * from "./.generated/route"',
+    );
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.ts
@@ -1,0 +1,1 @@
+export * from "./.generated/route";

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.test.tsx
@@ -9,6 +9,7 @@ const notFoundMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   notFound: () => notFoundMock(),
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("@/lib/pipeline-executions", () => ({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/executions/[executionId]/page.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@workspace/ui/components/table";
 
+import { HermesExecutionCancelButton } from "@/components/hermes-execution-cancel-button";
 import { EnqueueDiagnosticsPanel } from "@/components/enqueue-diagnostics";
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
 import {
@@ -67,11 +68,21 @@ export default async function PipelineExecutionDetailPage({
           Back to pipeline
         </Link>
       </div>
-      <div>
-        <h1 className="text-2xl font-semibold text-foreground">
-          Execution {detail.execution.id.slice(0, 8)}...
-        </h1>
-        <p className="text-muted-foreground">{detail.pipeline.name}</p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">
+            Execution {detail.execution.id.slice(0, 8)}...
+          </h1>
+          <p className="text-muted-foreground">{detail.pipeline.name}</p>
+        </div>
+        <HermesExecutionCancelButton
+          target={{
+            kind: "manual",
+            pipelineId,
+            manualExecutionId: executionId,
+          }}
+          runStatus={detail.execution.runStatus}
+        />
       </div>
 
       <section className="grid gap-2 text-sm">

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.test.ts
@@ -1,0 +1,99 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createCancelManualExecutionHandler } from "./route.post.config";
+
+const mockDashboardUser = {
+  id: "user-1",
+  name: "A",
+  email: "a@b.com",
+} as const;
+
+const pipelineId = "00000000-0000-4000-8000-000000000010";
+const manualExecutionId = "00000000-0000-4000-8000-000000000020";
+
+describe("createCancelManualExecutionHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns not found when the execution is missing", async () => {
+    const db = {
+      manualPipelineExecution: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const handler = createCancelManualExecutionHandler({
+      db: db as never,
+    });
+
+    const result = await handler({
+      body: { pipelineId, manualExecutionId },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Manual execution not found",
+    );
+  });
+
+  it("returns not allowed when the session user did not start the run", async () => {
+    const db = {
+      manualPipelineExecution: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: manualExecutionId,
+          metadata: { initiatedByUserId: "other-user" },
+        }),
+      },
+    };
+    const handler = createCancelManualExecutionHandler({
+      db: db as never,
+    });
+
+    const result = await handler({
+      body: { pipelineId, manualExecutionId },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Not allowed to cancel this execution",
+    );
+  });
+
+  it("calls abortLocal and returns ok when mark cancelled succeeds", async () => {
+    const abortLocal = vi.fn();
+    const markCancelled = vi.fn().mockResolvedValue({ ok: true });
+    const db = {
+      manualPipelineExecution: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: manualExecutionId,
+          metadata: { initiatedByUserId: "user-1" },
+        }),
+      },
+    };
+    const handler = createCancelManualExecutionHandler({
+      db: db as never,
+      markCancelled,
+      abortLocal,
+    });
+
+    const result = await handler({
+      body: { pipelineId, manualExecutionId },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(true);
+    expect(abortLocal).toHaveBeenCalledWith(manualExecutionId);
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
@@ -1,0 +1,88 @@
+import { prisma } from "@hermes/orchestration-database";
+import {
+  createRequestValidator,
+  errorResponse,
+  type HandlerFunc,
+  successResponse,
+} from "route-action-gen/lib";
+import { z } from "zod";
+
+import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { abortManualPipelineRunIfLocal } from "@/lib/manual-pipeline-run-abort";
+import { markManualPipelineExecutionCancelled } from "@hermes/scheduler";
+
+const bodyValidator = z.object({
+  pipelineId: z.string().uuid(),
+  manualExecutionId: z.string().uuid(),
+});
+
+export const requestValidator = createRequestValidator({
+  body: bodyValidator,
+  user: requireDashboardSessionForRoute,
+});
+
+export const responseValidator = z.object({
+  ok: z.literal(true),
+});
+
+type CancelManualExecutionHandler = HandlerFunc<
+  typeof requestValidator,
+  typeof responseValidator,
+  undefined
+>;
+
+type Dependencies = {
+  db?: typeof prisma;
+  markCancelled?: typeof markManualPipelineExecutionCancelled;
+};
+
+/**
+ * Marks a manual pipeline run as cancelled and best-effort aborts local HTTP.
+ */
+export const createCancelManualExecutionHandler = ({
+  db = prisma,
+  markCancelled = markManualPipelineExecutionCancelled,
+}: Dependencies = {}): CancelManualExecutionHandler => {
+  return async (data) => {
+    const { pipelineId, manualExecutionId } = data.body;
+    const sessionUserId = data.user.id;
+
+    const execution = await db.manualPipelineExecution.findFirst({
+      where: { id: manualExecutionId, pipelineId },
+      select: {
+        id: true,
+        metadata: true,
+      },
+    });
+    if (!execution) {
+      return errorResponse("Manual execution not found");
+    }
+
+    const meta = execution.metadata;
+    const initiatedBy =
+      meta != null &&
+      typeof meta === "object" &&
+      !Array.isArray(meta) &&
+      typeof (meta as Record<string, unknown>).initiatedByUserId === "string"
+        ? ((meta as Record<string, unknown>).initiatedByUserId as string)
+        : null;
+    if (initiatedBy !== sessionUserId) {
+      return errorResponse("Not allowed to cancel this execution");
+    }
+
+    const result = await markCancelled(db, manualExecutionId);
+    if (!result.ok) {
+      if (result.reason === "already_terminal") {
+        return errorResponse("Execution is already finished");
+      }
+      return errorResponse("Manual execution not found");
+    }
+
+    abortManualPipelineRunIfLocal(manualExecutionId);
+
+    return successResponse({ ok: true as const });
+  };
+};
+
+export const handler: CancelManualExecutionHandler =
+  createCancelManualExecutionHandler();

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
@@ -34,6 +34,7 @@ type CancelManualExecutionHandler = HandlerFunc<
 type Dependencies = {
   db?: typeof prisma;
   markCancelled?: typeof markManualPipelineExecutionCancelled;
+  abortLocal?: (manualExecutionId: string) => void;
 };
 
 /**
@@ -42,6 +43,7 @@ type Dependencies = {
 export const createCancelManualExecutionHandler = ({
   db = prisma,
   markCancelled = markManualPipelineExecutionCancelled,
+  abortLocal = abortManualPipelineRunIfLocal,
 }: Dependencies = {}): CancelManualExecutionHandler => {
   return async (data) => {
     const { pipelineId, manualExecutionId } = data.body;
@@ -78,7 +80,7 @@ export const createCancelManualExecutionHandler = ({
       return errorResponse("Manual execution not found");
     }
 
-    abortManualPipelineRunIfLocal(manualExecutionId);
+    abortLocal(manualExecutionId);
 
     return successResponse({ ok: true as const });
   };

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.test.ts
@@ -1,0 +1,17 @@
+/** @vitest-environment node */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe("pipelines cancel-manual-execution route.ts", () => {
+  it("re-exports the generated route entrypoint", () => {
+    const routePath = join(__dirname, "route.ts");
+    expect(readFileSync(routePath, "utf8")).toContain(
+      'export * from "./.generated/route"',
+    );
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.ts
@@ -1,0 +1,1 @@
+export * from "./.generated/route";

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -42,6 +42,7 @@ const request = (body: { pipelineId: string }) =>
 const createExecutionPersistenceStubs = () => ({
   manualPipelineExecution: {
     create: vi.fn().mockResolvedValue({ id: "manual-exec-1" }),
+    findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
     update: vi.fn().mockResolvedValue(undefined),
   },
   manualPipelineStepExecution: {

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -13,6 +13,7 @@ import {
   computeExecutionRunStatusFromStepRollups,
   computeStepRollupFromCounts,
   diagnosticFromCaughtError,
+  finalizeManualPipelineExecutionAfterCooperativeCancel,
   mergeExecutionConfig,
   parseAgentResponseEnvelope,
   planPipelineInvocations,
@@ -31,6 +32,10 @@ import { z } from "zod";
 
 import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
 import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-inputs-for-manual-pipeline";
+import {
+  clearManualPipelineRunAbortController,
+  registerManualPipelineRunAbortController,
+} from "@/lib/manual-pipeline-run-abort";
 import { validatePipeline } from "@/lib/validate-pipeline";
 
 const bodyValidator = z.object({
@@ -83,7 +88,7 @@ export const responseValidator = z.object({
   ok: z.literal(true),
   invocationsRun: z.number(),
   executionId: z.string().uuid(),
-  runStatus: z.enum(["succeeded", "partial", "failed"]),
+  runStatus: z.enum(["succeeded", "partial", "failed", "cancelled"]),
   failedInvocationCount: z.number(),
 });
 
@@ -417,254 +422,320 @@ export const createRunPipelineHandler = ({
 
       const errors: EnqueueDiagnosticEntry[] = [...planning.errors];
 
-      for (const wave of waveList) {
-        for (const job of wave) {
-          const step = pipeline.steps.find(
-            (item) => item.id === job.pipelineStepId,
-          );
-          if (!step) {
-            logRunPipelineIssue(
-              "agent-invoke",
-              pipeline.id,
-              "Planned job references missing pipeline step",
-              {
-                jobId: job.jobId,
-                pipelineStepId: job.pipelineStepId,
-                agentId: job.agentId,
-              },
+      const abortSignal = registerManualPipelineRunAbortController(
+        execution.id,
+      );
+      const processedJobIds = new Set<string>();
+      const plannedJobsForCancel = plannedJobs.map((j) => ({
+        jobId: j.jobId,
+        pipelineStepId: j.pipelineStepId,
+      }));
+      let cooperativeCancel = false;
+
+      try {
+        invokeLoop: for (const wave of waveList) {
+          for (const job of wave) {
+            const cancelRow = await db.manualPipelineExecution.findUnique({
+              where: { id: execution.id },
+              select: { cancelledAt: true },
+            });
+            if (cancelRow?.cancelledAt) {
+              cooperativeCancel = true;
+              break invokeLoop;
+            }
+
+            const step = pipeline.steps.find(
+              (item) => item.id === job.pipelineStepId,
             );
-            errors.push({
-              message: `Missing pipeline step ${job.pipelineStepId} (job ${job.jobId})`,
-              timestamp: now().toISOString(),
-              phase: "transaction",
-              pipelineStepId: job.pipelineStepId,
-              code: "MISSING_PIPELINE_STEP",
-            });
-            continue;
-          }
-
-          await db.agentJobExecution.create({
-            data: {
-              jobId: job.jobId,
-              agentId: job.agentId,
-              manualExecutionId: execution.id,
-              pipelineId: pipeline.id,
-              pipelineStepId: step.id,
-              status: "running",
-              enqueuedAt: executionTime,
-              startedAt: now(),
-              params: job.input as Prisma.InputJsonValue,
-              invocationConfig: job.config as Prisma.InputJsonValue,
-            },
-          });
-
-          try {
-            const agentResponse = await post(job.endpointUrl, {
-              json: { input: job.input, config: job.config },
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${jwt}`,
-              },
-              throwHttpErrors: false,
-              timeout: { request: MANUAL_INVOKE_AGENT_REQUEST_TIMEOUT_MS },
-            });
-            const response = agentResponse as {
-              ok?: boolean;
-              statusCode?: number;
-              body?: unknown;
-            };
-            if (response.ok === true) {
-              const { raw: rawBody, isEmpty: isEmptyBody } =
-                agentHttpBodyToRawString(response.body);
-              const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
-              if (!parsed.ok) {
-                const detail = parsed.error.message;
-                logRunPipelineIssue(
-                  "agent-envelope",
-                  pipeline.id,
-                  "Agent HTTP 200 but response body is not a valid Hermes envelope",
-                  {
-                    jobId: job.jobId,
-                    pipelineStepId: step.id,
-                    agentId: step.agentId,
-                    agentVersion: step.agentVersion,
-                    endpointUrl: job.endpointUrl,
-                    code: parsed.error.code,
-                    detail,
-                  },
-                );
-                const stats = stepStats.get(step.id);
-                if (stats) stats.failedCount += 1;
-                errors.push({
-                  message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                  timestamp: now().toISOString(),
-                  phase: "transaction",
-                  pipelineStepId: step.id,
-                  code: `AGENT_ENVELOPE_INVALID:${parsed.error.code}`,
-                });
-                await db.agentJobExecution.update({
-                  where: { jobId: job.jobId },
-                  data: {
-                    status: "failed",
-                    completedAt: now(),
-                    error: {
-                      message: detail,
-                      code: parsed.error.code,
-                      jobId: job.jobId,
-                      retryable: false,
-                    },
-                    agentResponse: Prisma.DbNull,
-                    semanticStatus: "failure",
-                  },
-                });
-                continue;
-              }
-              if (parsed.envelope.status === "failure") {
-                const detail =
-                  parsed.envelope.message ?? "Agent reported semantic failure";
-                logRunPipelineIssue(
-                  "agent-semantic",
-                  pipeline.id,
-                  "Agent returned HTTP 200 with envelope status failure",
-                  {
-                    jobId: job.jobId,
-                    pipelineStepId: step.id,
-                    agentId: step.agentId,
-                    agentVersion: step.agentVersion,
-                    endpointUrl: job.endpointUrl,
-                    detail,
-                  },
-                );
-                const stats = stepStats.get(step.id);
-                if (stats) stats.failedCount += 1;
-                errors.push({
-                  message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                  timestamp: now().toISOString(),
-                  phase: "transaction",
-                  pipelineStepId: step.id,
-                  code: "AGENT_SEMANTIC_FAILURE",
-                });
-                await db.agentJobExecution.update({
-                  where: { jobId: job.jobId },
-                  data: {
-                    status: "failed",
-                    completedAt: now(),
-                    error: {
-                      message: detail,
-                      retryable: false,
-                      semantic: true,
-                      jobId: job.jobId,
-                    },
-                    agentResponse:
-                      parsed.envelope as unknown as Prisma.InputJsonValue,
-                    semanticStatus: "failure",
-                  },
-                });
-                continue;
-              }
-              const stats = stepStats.get(step.id);
-              if (stats) stats.succeededCount += 1;
-              await db.agentJobExecution.update({
-                where: { jobId: job.jobId },
-                data: {
-                  status: "completed",
-                  completedAt: now(),
-                  error: Prisma.DbNull,
-                  agentResponse:
-                    parsed.envelope as unknown as Prisma.InputJsonValue,
-                  semanticStatus: "success",
+            if (!step) {
+              logRunPipelineIssue(
+                "agent-invoke",
+                pipeline.id,
+                "Planned job references missing pipeline step",
+                {
+                  jobId: job.jobId,
+                  pipelineStepId: job.pipelineStepId,
+                  agentId: job.agentId,
                 },
+              );
+              errors.push({
+                message: `Missing pipeline step ${job.pipelineStepId} (job ${job.jobId})`,
+                timestamp: now().toISOString(),
+                phase: "transaction",
+                pipelineStepId: job.pipelineStepId,
+                code: "MISSING_PIPELINE_STEP",
               });
               continue;
             }
 
-            const statusCodeNum =
-              typeof response.statusCode === "number"
-                ? response.statusCode
-                : undefined;
-            const detail = detailFromAgentErrorBody(response.body, {
-              statusCode: statusCodeNum,
-            });
-            const code = response.statusCode ?? "unknown";
-            logRunPipelineIssue(
-              "agent-http",
-              pipeline.id,
-              "Agent HTTP response was not OK",
-              {
-                jobId: job.jobId,
-                pipelineStepId: step.id,
-                agentId: step.agentId,
-                agentVersion: step.agentVersion,
-                endpointUrl: job.endpointUrl,
-                statusCode: code,
-                detail,
-              },
-            );
-            const stats = stepStats.get(step.id);
-            if (stats) stats.failedCount += 1;
-            errors.push({
-              message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-              timestamp: now().toISOString(),
-              phase: "transaction",
-              pipelineStepId: step.id,
-              code: `AGENT_HTTP_${String(code)}`,
-            });
-            await db.agentJobExecution.update({
-              where: { jobId: job.jobId },
+            await db.agentJobExecution.create({
               data: {
-                status: "failed",
-                completedAt: now(),
-                error: {
-                  detail,
-                  code,
-                  jobId: job.jobId,
-                },
-                agentResponse:
-                  (response.body as Prisma.InputJsonValue | undefined) ??
-                  Prisma.DbNull,
-                semanticStatus: "failure",
+                jobId: job.jobId,
+                agentId: job.agentId,
+                manualExecutionId: execution.id,
+                pipelineId: pipeline.id,
+                pipelineStepId: step.id,
+                status: "running",
+                enqueuedAt: executionTime,
+                startedAt: now(),
+                params: job.input as Prisma.InputJsonValue,
+                invocationConfig: job.config as Prisma.InputJsonValue,
               },
             });
-          } catch (err) {
-            const detail = err instanceof Error ? err.message : String(err);
-            logRunPipelineIssue(
-              "agent-http",
-              pipeline.id,
-              "Agent HTTP request threw (network/DNS/TLS/timeout)",
-              {
-                jobId: job.jobId,
-                pipelineStepId: step.id,
-                agentId: step.agentId,
-                agentVersion: step.agentVersion,
-                endpointUrl: job.endpointUrl,
-                detail,
-              },
-              err,
-            );
-            const stats = stepStats.get(step.id);
-            if (stats) stats.failedCount += 1;
-            errors.push(
-              diagnosticFromCaughtError(err, {
+
+            try {
+              const agentResponse = await post(job.endpointUrl, {
+                json: { input: job.input, config: job.config },
+                headers: {
+                  "Content-Type": "application/json",
+                  Authorization: `Bearer ${jwt}`,
+                },
+                throwHttpErrors: false,
+                timeout: { request: MANUAL_INVOKE_AGENT_REQUEST_TIMEOUT_MS },
+                signal: abortSignal,
+              });
+              const response = agentResponse as {
+                ok?: boolean;
+                statusCode?: number;
+                body?: unknown;
+              };
+              if (response.ok === true) {
+                const { raw: rawBody, isEmpty: isEmptyBody } =
+                  agentHttpBodyToRawString(response.body);
+                const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
+                if (!parsed.ok) {
+                  const detail = parsed.error.message;
+                  logRunPipelineIssue(
+                    "agent-envelope",
+                    pipeline.id,
+                    "Agent HTTP 200 but response body is not a valid Hermes envelope",
+                    {
+                      jobId: job.jobId,
+                      pipelineStepId: step.id,
+                      agentId: step.agentId,
+                      agentVersion: step.agentVersion,
+                      endpointUrl: job.endpointUrl,
+                      code: parsed.error.code,
+                      detail,
+                    },
+                  );
+                  const stats = stepStats.get(step.id);
+                  if (stats) stats.failedCount += 1;
+                  errors.push({
+                    message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
+                    timestamp: now().toISOString(),
+                    phase: "transaction",
+                    pipelineStepId: step.id,
+                    code: `AGENT_ENVELOPE_INVALID:${parsed.error.code}`,
+                  });
+                  await db.agentJobExecution.update({
+                    where: { jobId: job.jobId },
+                    data: {
+                      status: "failed",
+                      completedAt: now(),
+                      error: {
+                        message: detail,
+                        code: parsed.error.code,
+                        jobId: job.jobId,
+                        retryable: false,
+                      },
+                      agentResponse: Prisma.DbNull,
+                      semanticStatus: "failure",
+                    },
+                  });
+                  processedJobIds.add(job.jobId);
+                  continue;
+                }
+                if (parsed.envelope.status === "failure") {
+                  const detail =
+                    parsed.envelope.message ??
+                    "Agent reported semantic failure";
+                  logRunPipelineIssue(
+                    "agent-semantic",
+                    pipeline.id,
+                    "Agent returned HTTP 200 with envelope status failure",
+                    {
+                      jobId: job.jobId,
+                      pipelineStepId: step.id,
+                      agentId: step.agentId,
+                      agentVersion: step.agentVersion,
+                      endpointUrl: job.endpointUrl,
+                      detail,
+                    },
+                  );
+                  const stats = stepStats.get(step.id);
+                  if (stats) stats.failedCount += 1;
+                  errors.push({
+                    message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
+                    timestamp: now().toISOString(),
+                    phase: "transaction",
+                    pipelineStepId: step.id,
+                    code: "AGENT_SEMANTIC_FAILURE",
+                  });
+                  await db.agentJobExecution.update({
+                    where: { jobId: job.jobId },
+                    data: {
+                      status: "failed",
+                      completedAt: now(),
+                      error: {
+                        message: detail,
+                        retryable: false,
+                        semantic: true,
+                        jobId: job.jobId,
+                      },
+                      agentResponse:
+                        parsed.envelope as unknown as Prisma.InputJsonValue,
+                      semanticStatus: "failure",
+                    },
+                  });
+                  processedJobIds.add(job.jobId);
+                  continue;
+                }
+                const stats = stepStats.get(step.id);
+                if (stats) stats.succeededCount += 1;
+                await db.agentJobExecution.update({
+                  where: { jobId: job.jobId },
+                  data: {
+                    status: "completed",
+                    completedAt: now(),
+                    error: Prisma.DbNull,
+                    agentResponse:
+                      parsed.envelope as unknown as Prisma.InputJsonValue,
+                    semanticStatus: "success",
+                  },
+                });
+                processedJobIds.add(job.jobId);
+                continue;
+              }
+
+              const statusCodeNum =
+                typeof response.statusCode === "number"
+                  ? response.statusCode
+                  : undefined;
+              const detail = detailFromAgentErrorBody(response.body, {
+                statusCode: statusCodeNum,
+              });
+              const code = response.statusCode ?? "unknown";
+              logRunPipelineIssue(
+                "agent-http",
+                pipeline.id,
+                "Agent HTTP response was not OK",
+                {
+                  jobId: job.jobId,
+                  pipelineStepId: step.id,
+                  agentId: step.agentId,
+                  agentVersion: step.agentVersion,
+                  endpointUrl: job.endpointUrl,
+                  statusCode: code,
+                  detail,
+                },
+              );
+              const stats = stepStats.get(step.id);
+              if (stats) stats.failedCount += 1;
+              errors.push({
+                message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
+                timestamp: now().toISOString(),
                 phase: "transaction",
                 pipelineStepId: step.id,
-                messagePrefix: `Agent HTTP threw (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-              }),
-            );
-            await db.agentJobExecution.update({
-              where: { jobId: job.jobId },
-              data: {
-                status: "failed",
-                completedAt: now(),
-                error: {
-                  detail,
-                  code: "unknown",
-                  jobId: job.jobId,
+                code: `AGENT_HTTP_${String(code)}`,
+              });
+              await db.agentJobExecution.update({
+                where: { jobId: job.jobId },
+                data: {
+                  status: "failed",
+                  completedAt: now(),
+                  error: {
+                    detail,
+                    code,
+                    jobId: job.jobId,
+                  },
+                  agentResponse:
+                    (response.body as Prisma.InputJsonValue | undefined) ??
+                    Prisma.DbNull,
+                  semanticStatus: "failure",
                 },
-                semanticStatus: "failure",
-              },
-            });
+              });
+              processedJobIds.add(job.jobId);
+            } catch (err) {
+              if (abortSignal.aborted) {
+                cooperativeCancel = true;
+                break invokeLoop;
+              }
+              const detail = err instanceof Error ? err.message : String(err);
+              logRunPipelineIssue(
+                "agent-http",
+                pipeline.id,
+                "Agent HTTP request threw (network/DNS/TLS/timeout)",
+                {
+                  jobId: job.jobId,
+                  pipelineStepId: step.id,
+                  agentId: step.agentId,
+                  agentVersion: step.agentVersion,
+                  endpointUrl: job.endpointUrl,
+                  detail,
+                },
+                err,
+              );
+              const stats = stepStats.get(step.id);
+              if (stats) stats.failedCount += 1;
+              errors.push(
+                diagnosticFromCaughtError(err, {
+                  phase: "transaction",
+                  pipelineStepId: step.id,
+                  messagePrefix: `Agent HTTP threw (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
+                }),
+              );
+              await db.agentJobExecution.update({
+                where: { jobId: job.jobId },
+                data: {
+                  status: "failed",
+                  completedAt: now(),
+                  error: {
+                    detail,
+                    code: "unknown",
+                    jobId: job.jobId,
+                  },
+                  semanticStatus: "failure",
+                },
+              });
+              processedJobIds.add(job.jobId);
+            }
           }
         }
+      } finally {
+        clearManualPipelineRunAbortController(execution.id);
+      }
+
+      if (cooperativeCancel) {
+        await finalizeManualPipelineExecutionAfterCooperativeCancel(db, {
+          manualExecutionId: execution.id,
+          plannedJobs: plannedJobsForCancel,
+          processedJobIds,
+        });
+        const finalRow = await db.manualPipelineExecution.findUnique({
+          where: { id: execution.id },
+          select: {
+            runStatus: true,
+            succeededInvocationCount: true,
+            failedInvocationCount: true,
+          },
+        });
+        const rs = finalRow?.runStatus;
+        const runStatusLabel =
+          rs === ScheduleRunStatus.cancelled
+            ? ("cancelled" as const)
+            : rs === ScheduleRunStatus.partial
+              ? ("partial" as const)
+              : rs === ScheduleRunStatus.succeeded
+                ? ("succeeded" as const)
+                : ("failed" as const);
+        return successResponse({
+          ok: true as const,
+          invocationsRun: processedJobIds.size,
+          executionId: execution.id,
+          runStatus: runStatusLabel,
+          failedInvocationCount: finalRow?.failedInvocationCount ?? 0,
+        });
       }
 
       const stepRollups: StepRollupTerminal[] = [];

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.test.tsx
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 import { ExecutionsTable } from "./executions-table";
 import type { ScheduleExecutionRow } from "@/lib/schedules";
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
 vi.mock("next/link", () => ({
   default: ({
     children,

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "@workspace/ui/components/table";
 import { format } from "date-fns";
 
+import { HermesExecutionCancelButton } from "@/components/hermes-execution-cancel-button";
 import type { ScheduleExecutionRow } from "@/lib/schedules";
 
 type ExecutionsTableProps = {
@@ -49,13 +50,14 @@ export const ExecutionsTable = ({
               Invocations (success / fail)
             </TableHead>
             <TableHead className="w-[90px]">Detail</TableHead>
+            <TableHead className="w-[120px]">Actions</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
           {executions.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={6}
+                colSpan={7}
                 className="text-center text-muted-foreground"
               >
                 No executions yet.
@@ -99,6 +101,16 @@ export const ExecutionsTable = ({
                     >
                       View
                     </Link>
+                  </TableCell>
+                  <TableCell>
+                    <HermesExecutionCancelButton
+                      target={{
+                        kind: "schedule",
+                        scheduleId,
+                        scheduleExecutionId: execution.id,
+                      }}
+                      runStatus={execution.runStatus}
+                    />
                   </TableCell>
                 </TableRow>
               );

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.test.tsx
@@ -9,6 +9,7 @@ const notFoundMock = vi.fn();
 
 vi.mock("next/navigation", () => ({
   notFound: () => notFoundMock(),
+  useRouter: () => ({ refresh: vi.fn() }),
 }));
 
 vi.mock("@/lib/schedules", () => ({

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
@@ -11,6 +11,7 @@ import {
   TableRow,
 } from "@workspace/ui/components/table";
 
+import { HermesExecutionCancelButton } from "@/components/hermes-execution-cancel-button";
 import { EnqueueDiagnosticsPanel } from "@/components/enqueue-diagnostics";
 import { ScheduleExecutionInvocationsTable } from "@/components/schedule-execution-invocations-table";
 import {
@@ -59,25 +60,35 @@ export default async function ScheduleExecutionDetailPage({
           Back to schedule
         </Link>
       </div>
-      <div>
-        <h1 className="break-all text-2xl font-semibold text-foreground">
-          Execution {detail.execution.id}
-        </h1>
-        <p className="text-muted-foreground">
-          {detail.schedule.name}
-          {detail.pipeline ? (
-            <>
-              {" · "}
-              <Link
-                href={`/dashboard/pipelines/${detail.pipeline.id}`}
-                className="inline-flex items-center gap-1 underline-offset-4 hover:text-foreground hover:underline"
-              >
-                <GitBranch className="size-4 shrink-0" aria-hidden />
-                {detail.pipeline.name}
-              </Link>
-            </>
-          ) : null}
-        </p>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="break-all text-2xl font-semibold text-foreground">
+            Execution {detail.execution.id}
+          </h1>
+          <p className="text-muted-foreground">
+            {detail.schedule.name}
+            {detail.pipeline ? (
+              <>
+                {" · "}
+                <Link
+                  href={`/dashboard/pipelines/${detail.pipeline.id}`}
+                  className="inline-flex items-center gap-1 underline-offset-4 hover:text-foreground hover:underline"
+                >
+                  <GitBranch className="size-4 shrink-0" aria-hidden />
+                  {detail.pipeline.name}
+                </Link>
+              </>
+            ) : null}
+          </p>
+        </div>
+        <HermesExecutionCancelButton
+          target={{
+            kind: "schedule",
+            scheduleId,
+            scheduleExecutionId: executionId,
+          }}
+          runStatus={detail.execution.runStatus}
+        />
       </div>
 
       <section className="grid gap-2 text-sm">

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.test.ts
@@ -1,0 +1,107 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createCancelScheduleExecutionHandler } from "./route.post.config";
+
+const mockDashboardUser = {
+  id: "user-1",
+  name: "A",
+  email: "a@b.com",
+} as const;
+
+vi.mock("@/lib/hermes-job-queue", () => ({
+  getHermesJobQueue: vi.fn(() => ({})),
+}));
+
+describe("createCancelScheduleExecutionHandler", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns not found when the execution is missing", async () => {
+    const db = {
+      scheduleExecution: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const handler = createCancelScheduleExecutionHandler({
+      db: db as never,
+      cancelExecution: vi.fn(),
+    });
+
+    const result = await handler({
+      body: {
+        scheduleId: "00000000-0000-4000-8000-000000000010",
+        scheduleExecutionId: "00000000-0000-4000-8000-000000000020",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Schedule execution not found",
+    );
+  });
+
+  it("returns error when cancel reports already terminal", async () => {
+    const cancelExecution = vi.fn().mockResolvedValue({
+      ok: false,
+      reason: "already_terminal",
+    });
+    const db = {
+      scheduleExecution: {
+        findFirst: vi.fn().mockResolvedValue({ id: "ex1" }),
+      },
+    };
+    const handler = createCancelScheduleExecutionHandler({
+      db: db as never,
+      cancelExecution,
+    });
+
+    const result = await handler({
+      body: {
+        scheduleId: "00000000-0000-4000-8000-000000000010",
+        scheduleExecutionId: "00000000-0000-4000-8000-000000000020",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Execution is already finished",
+    );
+  });
+
+  it("returns ok when cancel succeeds", async () => {
+    const cancelExecution = vi.fn().mockResolvedValue({ ok: true });
+    const db = {
+      scheduleExecution: {
+        findFirst: vi.fn().mockResolvedValue({ id: "ex1" }),
+      },
+    };
+    const handler = createCancelScheduleExecutionHandler({
+      db: db as never,
+      cancelExecution,
+    });
+
+    const result = await handler({
+      body: {
+        scheduleId: "00000000-0000-4000-8000-000000000010",
+        scheduleExecutionId: "00000000-0000-4000-8000-000000000020",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    expect(result.status).toBe(true);
+    expect((result as { data?: { ok: boolean } }).data?.ok).toBe(true);
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
@@ -1,0 +1,80 @@
+import { prisma } from "@hermes/orchestration-database";
+import {
+  cancelScheduleExecution,
+  type CancelScheduleExecutionResult,
+} from "@hermes/scheduler";
+import {
+  createRequestValidator,
+  errorResponse,
+  type HandlerFunc,
+  successResponse,
+} from "route-action-gen/lib";
+import { z } from "zod";
+
+import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { getHermesJobQueue } from "@/lib/hermes-job-queue";
+
+const bodyValidator = z.object({
+  scheduleId: z.string().uuid(),
+  scheduleExecutionId: z.string().uuid(),
+});
+
+export const requestValidator = createRequestValidator({
+  body: bodyValidator,
+  user: requireDashboardSessionForRoute,
+});
+
+export const responseValidator = z.object({
+  ok: z.literal(true),
+});
+
+type CancelScheduleExecutionHandler = HandlerFunc<
+  typeof requestValidator,
+  typeof responseValidator,
+  undefined
+>;
+
+type Dependencies = {
+  db?: typeof prisma;
+  cancelExecution?: (
+    db: typeof prisma,
+    queue: ReturnType<typeof getHermesJobQueue>,
+    scheduleExecutionId: string,
+  ) => Promise<CancelScheduleExecutionResult>;
+};
+
+/**
+ * Creates handler that cancels a schedule execution (DataQueue + orchestration).
+ */
+export const createCancelScheduleExecutionHandler = ({
+  db = prisma,
+  cancelExecution = cancelScheduleExecution,
+}: Dependencies = {}): CancelScheduleExecutionHandler => {
+  return async (data) => {
+    const { scheduleId, scheduleExecutionId } = data.body;
+    const execution = await db.scheduleExecution.findFirst({
+      where: { id: scheduleExecutionId, scheduleId },
+      select: { id: true },
+    });
+    if (!execution) {
+      return errorResponse("Schedule execution not found");
+    }
+
+    const result = await cancelExecution(
+      db,
+      getHermesJobQueue(),
+      scheduleExecutionId,
+    );
+    if (!result.ok) {
+      if (result.reason === "already_terminal") {
+        return errorResponse("Execution is already finished");
+      }
+      return errorResponse("Schedule execution not found");
+    }
+
+    return successResponse({ ok: true as const });
+  };
+};
+
+export const handler: CancelScheduleExecutionHandler =
+  createCancelScheduleExecutionHandler();

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.test.ts
@@ -1,0 +1,17 @@
+/** @vitest-environment node */
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe("schedules cancel-execution route.ts", () => {
+  it("re-exports the generated route entrypoint", () => {
+    const routePath = join(__dirname, "route.ts");
+    expect(readFileSync(routePath, "utf8")).toContain(
+      'export * from "./.generated/route"',
+    );
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.ts
@@ -1,0 +1,1 @@
+export * from "./.generated/route";

--- a/apps/hermes/dashboard/components/hermes-execution-cancel-button.test.tsx
+++ b/apps/hermes/dashboard/components/hermes-execution-cancel-button.test.tsx
@@ -1,0 +1,79 @@
+/** @vitest-environment jsdom */
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { HermesExecutionCancelButton } from "./hermes-execution-cancel-button";
+
+const routerRefreshMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefreshMock,
+  }),
+}));
+
+vi.mock("@workspace/ui/components/button", () => ({
+  Button: ({
+    children,
+    type,
+    disabled,
+    onClick,
+  }: React.PropsWithChildren<{
+    type?: string;
+    disabled?: boolean;
+    onClick?: () => void;
+  }>) => (
+    <button type={type as "button"} disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+}));
+
+const scheduleTarget = {
+  kind: "schedule" as const,
+  scheduleId: "00000000-0000-4000-8000-000000000001",
+  scheduleExecutionId: "00000000-0000-4000-8000-000000000002",
+};
+
+describe("HermesExecutionCancelButton", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    routerRefreshMock.mockReset();
+  });
+
+  it("renders nothing when the run cannot be cancelled", () => {
+    render(
+      <HermesExecutionCancelButton
+        target={scheduleTarget}
+        runStatus="succeeded"
+      />,
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("posts cancel and refreshes when clicked for a pending run", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <HermesExecutionCancelButton
+        target={scheduleTarget}
+        runStatus="pending"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Cancel run/i }));
+
+    await waitFor(() => {
+      expect(routerRefreshMock).toHaveBeenCalled();
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/dashboard/schedules/actions/cancel-execution",
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
+++ b/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useRouter } from "next/navigation";
+
 import { Button } from "@workspace/ui/components/button";
 
 import {
@@ -21,8 +23,9 @@ export const HermesExecutionCancelButton = ({
   target,
   runStatus,
 }: HermesExecutionCancelButtonProps) => {
+  const router = useRouter();
   const { isLoading, canCancel, requestCancel } =
-    useHermesExecutionCancelButton(target, runStatus);
+    useHermesExecutionCancelButton(target, runStatus, () => router.refresh());
 
   if (!canCancel) {
     return null;

--- a/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
+++ b/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
@@ -1,49 +1,13 @@
 "use client";
 
-import { useRouter } from "next/navigation";
-import { useCallback, useState } from "react";
-
 import { Button } from "@workspace/ui/components/button";
 
-type CancelTarget =
-  | { kind: "schedule"; scheduleId: string; scheduleExecutionId: string }
-  | {
-      kind: "httpTrigger";
-      httpTriggerId: string;
-      httpTriggerExecutionId: string;
-    }
-  | { kind: "manual"; pipelineId: string; manualExecutionId: string };
+import {
+  type CancelTarget,
+  useHermesExecutionCancelButton,
+} from "@/hooks/use-hermes-execution-cancel-button";
 
-const cancelUrl = (target: CancelTarget): string => {
-  switch (target.kind) {
-    case "schedule":
-      return "/dashboard/schedules/actions/cancel-execution";
-    case "httpTrigger":
-      return "/dashboard/http-triggers/actions/cancel-execution";
-    case "manual":
-      return "/dashboard/pipelines/actions/cancel-manual-execution";
-  }
-};
-
-const cancelBody = (target: CancelTarget): Record<string, string> => {
-  switch (target.kind) {
-    case "schedule":
-      return {
-        scheduleId: target.scheduleId,
-        scheduleExecutionId: target.scheduleExecutionId,
-      };
-    case "httpTrigger":
-      return {
-        httpTriggerId: target.httpTriggerId,
-        httpTriggerExecutionId: target.httpTriggerExecutionId,
-      };
-    case "manual":
-      return {
-        pipelineId: target.pipelineId,
-        manualExecutionId: target.manualExecutionId,
-      };
-  }
-};
+export type { CancelTarget } from "@/hooks/use-hermes-execution-cancel-button";
 
 type HermesExecutionCancelButtonProps = {
   target: CancelTarget;
@@ -57,31 +21,8 @@ export const HermesExecutionCancelButton = ({
   target,
   runStatus,
 }: HermesExecutionCancelButtonProps) => {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const canCancel = runStatus === "pending" || runStatus === "running";
-
-  const onClick = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const response = await fetch(cancelUrl(target), {
-        method: "POST",
-        credentials: "include",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(cancelBody(target)),
-      });
-      if (!response.ok) {
-        const body = (await response.json()) as { message?: string };
-        throw new Error(body.message ?? "Cancel failed");
-      }
-      router.refresh();
-    } catch (e) {
-      const message = e instanceof Error ? e.message : "Cancel failed";
-      window.alert(message);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [router, target]);
+  const { isLoading, canCancel, requestCancel } =
+    useHermesExecutionCancelButton(target, runStatus);
 
   if (!canCancel) {
     return null;
@@ -93,7 +34,7 @@ export const HermesExecutionCancelButton = ({
       variant="outline"
       size="sm"
       disabled={isLoading}
-      onClick={() => void onClick()}
+      onClick={requestCancel}
     >
       {isLoading ? "Cancelling…" : "Cancel run"}
     </Button>

--- a/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
+++ b/apps/hermes/dashboard/components/hermes-execution-cancel-button.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+import { Button } from "@workspace/ui/components/button";
+
+type CancelTarget =
+  | { kind: "schedule"; scheduleId: string; scheduleExecutionId: string }
+  | {
+      kind: "httpTrigger";
+      httpTriggerId: string;
+      httpTriggerExecutionId: string;
+    }
+  | { kind: "manual"; pipelineId: string; manualExecutionId: string };
+
+const cancelUrl = (target: CancelTarget): string => {
+  switch (target.kind) {
+    case "schedule":
+      return "/dashboard/schedules/actions/cancel-execution";
+    case "httpTrigger":
+      return "/dashboard/http-triggers/actions/cancel-execution";
+    case "manual":
+      return "/dashboard/pipelines/actions/cancel-manual-execution";
+  }
+};
+
+const cancelBody = (target: CancelTarget): Record<string, string> => {
+  switch (target.kind) {
+    case "schedule":
+      return {
+        scheduleId: target.scheduleId,
+        scheduleExecutionId: target.scheduleExecutionId,
+      };
+    case "httpTrigger":
+      return {
+        httpTriggerId: target.httpTriggerId,
+        httpTriggerExecutionId: target.httpTriggerExecutionId,
+      };
+    case "manual":
+      return {
+        pipelineId: target.pipelineId,
+        manualExecutionId: target.manualExecutionId,
+      };
+  }
+};
+
+type HermesExecutionCancelButtonProps = {
+  target: CancelTarget;
+  runStatus: string;
+};
+
+/**
+ * Cancels a schedule, HTTP trigger, or manual pipeline execution when still `pending` or `running`.
+ */
+export const HermesExecutionCancelButton = ({
+  target,
+  runStatus,
+}: HermesExecutionCancelButtonProps) => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const canCancel = runStatus === "pending" || runStatus === "running";
+
+  const onClick = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await fetch(cancelUrl(target), {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(cancelBody(target)),
+      });
+      if (!response.ok) {
+        const body = (await response.json()) as { message?: string };
+        throw new Error(body.message ?? "Cancel failed");
+      }
+      router.refresh();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Cancel failed";
+      window.alert(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [router, target]);
+
+  if (!canCancel) {
+    return null;
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={isLoading}
+      onClick={() => void onClick()}
+    >
+      {isLoading ? "Cancelling…" : "Cancel run"}
+    </Button>
+  );
+};

--- a/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.test.ts
+++ b/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment jsdom */
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  type CancelTarget,
+  useHermesExecutionCancelButton,
+} from "./use-hermes-execution-cancel-button";
+
+const routerRefreshMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    refresh: routerRefreshMock,
+  }),
+}));
+
+const scheduleTarget: CancelTarget = {
+  kind: "schedule",
+  scheduleId: "00000000-0000-4000-8000-000000000001",
+  scheduleExecutionId: "00000000-0000-4000-8000-000000000002",
+};
+
+describe("useHermesExecutionCancelButton", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    routerRefreshMock.mockReset();
+  });
+
+  it("sets canCancel false when run is not pending or running", () => {
+    const { result } = renderHook(() =>
+      useHermesExecutionCancelButton(scheduleTarget, "succeeded"),
+    );
+    expect(result.current.canCancel).toBe(false);
+  });
+
+  it("sets canCancel true for pending runs", () => {
+    const { result } = renderHook(() =>
+      useHermesExecutionCancelButton(scheduleTarget, "pending"),
+    );
+    expect(result.current.canCancel).toBe(true);
+  });
+
+  it("POSTs to the schedule cancel route and refreshes on success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useHermesExecutionCancelButton(scheduleTarget, "running"),
+    );
+
+    await act(async () => {
+      result.current.requestCancel();
+    });
+
+    await waitFor(() => {
+      expect(routerRefreshMock).toHaveBeenCalled();
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/dashboard/schedules/actions/cancel-execution",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          scheduleId: scheduleTarget.scheduleId,
+          scheduleExecutionId: scheduleTarget.scheduleExecutionId,
+        }),
+      }),
+    );
+  });
+
+  it("alerts when the server returns an error body", async () => {
+    const alertMock = vi.fn();
+    vi.stubGlobal("alert", alertMock);
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: false,
+      json: async () => ({ message: "Execution is already finished" }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() =>
+      useHermesExecutionCancelButton(scheduleTarget, "running"),
+    );
+
+    await act(async () => {
+      result.current.requestCancel();
+    });
+
+    await waitFor(() => {
+      expect(alertMock).toHaveBeenCalledWith("Execution is already finished");
+    });
+    expect(routerRefreshMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.test.ts
+++ b/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.test.ts
@@ -7,13 +7,7 @@ import {
   useHermesExecutionCancelButton,
 } from "./use-hermes-execution-cancel-button";
 
-const routerRefreshMock = vi.fn();
-
-vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    refresh: routerRefreshMock,
-  }),
-}));
+const refreshMock = vi.fn();
 
 const scheduleTarget: CancelTarget = {
   kind: "schedule",
@@ -25,19 +19,19 @@ describe("useHermesExecutionCancelButton", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
-    routerRefreshMock.mockReset();
+    refreshMock.mockReset();
   });
 
   it("sets canCancel false when run is not pending or running", () => {
     const { result } = renderHook(() =>
-      useHermesExecutionCancelButton(scheduleTarget, "succeeded"),
+      useHermesExecutionCancelButton(scheduleTarget, "succeeded", refreshMock),
     );
     expect(result.current.canCancel).toBe(false);
   });
 
   it("sets canCancel true for pending runs", () => {
     const { result } = renderHook(() =>
-      useHermesExecutionCancelButton(scheduleTarget, "pending"),
+      useHermesExecutionCancelButton(scheduleTarget, "pending", refreshMock),
     );
     expect(result.current.canCancel).toBe(true);
   });
@@ -50,7 +44,7 @@ describe("useHermesExecutionCancelButton", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { result } = renderHook(() =>
-      useHermesExecutionCancelButton(scheduleTarget, "running"),
+      useHermesExecutionCancelButton(scheduleTarget, "running", refreshMock),
     );
 
     await act(async () => {
@@ -58,7 +52,7 @@ describe("useHermesExecutionCancelButton", () => {
     });
 
     await waitFor(() => {
-      expect(routerRefreshMock).toHaveBeenCalled();
+      expect(refreshMock).toHaveBeenCalled();
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
@@ -83,7 +77,7 @@ describe("useHermesExecutionCancelButton", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { result } = renderHook(() =>
-      useHermesExecutionCancelButton(scheduleTarget, "running"),
+      useHermesExecutionCancelButton(scheduleTarget, "running", refreshMock),
     );
 
     await act(async () => {
@@ -93,6 +87,6 @@ describe("useHermesExecutionCancelButton", () => {
     await waitFor(() => {
       expect(alertMock).toHaveBeenCalledWith("Execution is already finished");
     });
-    expect(routerRefreshMock).not.toHaveBeenCalled();
+    expect(refreshMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.ts
+++ b/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.ts
@@ -1,4 +1,3 @@
-import { useRouter } from "next/navigation";
 import { useCallback, useState } from "react";
 
 /** Identifies which Hermes execution type is being cancelled and its ids. */
@@ -53,12 +52,14 @@ export type UseHermesExecutionCancelButtonResult = {
 
 /**
  * Owns loading state and the cancel POST for schedule, HTTP trigger, or manual executions.
+ *
+ * @param refresh - Called after a successful cancel (typically `router.refresh()` from the host component).
  */
 export const useHermesExecutionCancelButton = (
   target: CancelTarget,
   runStatus: string,
+  refresh: () => void,
 ): UseHermesExecutionCancelButtonResult => {
-  const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const canCancel = runStatus === "pending" || runStatus === "running";
 
@@ -76,7 +77,7 @@ export const useHermesExecutionCancelButton = (
           const body = (await response.json()) as { message?: string };
           throw new Error(body.message ?? "Cancel failed");
         }
-        router.refresh();
+        refresh();
       } catch (e) {
         const message = e instanceof Error ? e.message : "Cancel failed";
         window.alert(message);
@@ -84,7 +85,7 @@ export const useHermesExecutionCancelButton = (
         setIsLoading(false);
       }
     })();
-  }, [router, target]);
+  }, [refresh, target]);
 
   return { isLoading, canCancel, requestCancel };
 };

--- a/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.ts
+++ b/apps/hermes/dashboard/hooks/use-hermes-execution-cancel-button.ts
@@ -1,0 +1,90 @@
+import { useRouter } from "next/navigation";
+import { useCallback, useState } from "react";
+
+/** Identifies which Hermes execution type is being cancelled and its ids. */
+export type CancelTarget =
+  | { kind: "schedule"; scheduleId: string; scheduleExecutionId: string }
+  | {
+      kind: "httpTrigger";
+      httpTriggerId: string;
+      httpTriggerExecutionId: string;
+    }
+  | { kind: "manual"; pipelineId: string; manualExecutionId: string };
+
+const cancelUrl = (target: CancelTarget): string => {
+  switch (target.kind) {
+    case "schedule":
+      return "/dashboard/schedules/actions/cancel-execution";
+    case "httpTrigger":
+      return "/dashboard/http-triggers/actions/cancel-execution";
+    case "manual":
+      return "/dashboard/pipelines/actions/cancel-manual-execution";
+  }
+};
+
+const cancelBody = (target: CancelTarget): Record<string, string> => {
+  switch (target.kind) {
+    case "schedule":
+      return {
+        scheduleId: target.scheduleId,
+        scheduleExecutionId: target.scheduleExecutionId,
+      };
+    case "httpTrigger":
+      return {
+        httpTriggerId: target.httpTriggerId,
+        httpTriggerExecutionId: target.httpTriggerExecutionId,
+      };
+    case "manual":
+      return {
+        pipelineId: target.pipelineId,
+        manualExecutionId: target.manualExecutionId,
+      };
+  }
+};
+
+export type UseHermesExecutionCancelButtonResult = {
+  /** True while the cancel POST is in flight. */
+  isLoading: boolean;
+  /** Cancel is only offered for non-terminal runs. */
+  canCancel: boolean;
+  /** Starts the cancel request (fire-and-forget safe). */
+  requestCancel: () => void;
+};
+
+/**
+ * Owns loading state and the cancel POST for schedule, HTTP trigger, or manual executions.
+ */
+export const useHermesExecutionCancelButton = (
+  target: CancelTarget,
+  runStatus: string,
+): UseHermesExecutionCancelButtonResult => {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const canCancel = runStatus === "pending" || runStatus === "running";
+
+  const requestCancel = useCallback(() => {
+    void (async () => {
+      setIsLoading(true);
+      try {
+        const response = await fetch(cancelUrl(target), {
+          method: "POST",
+          credentials: "include",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(cancelBody(target)),
+        });
+        if (!response.ok) {
+          const body = (await response.json()) as { message?: string };
+          throw new Error(body.message ?? "Cancel failed");
+        }
+        router.refresh();
+      } catch (e) {
+        const message = e instanceof Error ? e.message : "Cancel failed";
+        window.alert(message);
+      } finally {
+        setIsLoading(false);
+      }
+    })();
+  }, [router, target]);
+
+  return { isLoading, canCancel, requestCancel };
+};

--- a/apps/hermes/dashboard/lib/hermes-job-queue.ts
+++ b/apps/hermes/dashboard/lib/hermes-job-queue.ts
@@ -1,3 +1,4 @@
+import type { InvokeAgentJobPayload } from "@hermes/scheduler";
 import { initJobQueue } from "@nicnocquee/dataqueue";
 import { env } from "@hermes/env";
 
@@ -5,6 +6,8 @@ type DashboardJobPayloadMap = {
   execute_http_trigger: {
     httpTriggerExecutionId: string;
   };
+  /** Typed for queue control APIs; dashboard only enqueues `execute_http_trigger` today. */
+  invoke_agent: InvokeAgentJobPayload;
 };
 
 let queue: ReturnType<typeof initJobQueue<DashboardJobPayloadMap>> | null =

--- a/apps/hermes/dashboard/lib/manual-pipeline-run-abort.test.ts
+++ b/apps/hermes/dashboard/lib/manual-pipeline-run-abort.test.ts
@@ -1,0 +1,39 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  abortManualPipelineRunIfLocal,
+  clearManualPipelineRunAbortController,
+  registerManualPipelineRunAbortController,
+} from "./manual-pipeline-run-abort";
+
+describe("manual-pipeline-run-abort", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the same AbortSignal when registering twice for one execution id", () => {
+    const id = "00000000-0000-4000-8000-0000000000a1";
+    const a = registerManualPipelineRunAbortController(id);
+    const b = registerManualPipelineRunAbortController(id);
+    expect(a).toBe(b);
+    clearManualPipelineRunAbortController(id);
+  });
+
+  it("fires abort on the registered signal", () => {
+    const id = "00000000-0000-4000-8000-0000000000a2";
+    const signal = registerManualPipelineRunAbortController(id);
+    const listener = vi.fn();
+    signal.addEventListener("abort", listener);
+    abortManualPipelineRunIfLocal(id);
+    expect(listener).toHaveBeenCalled();
+    clearManualPipelineRunAbortController(id);
+  });
+
+  it("does nothing when abort is called after clear", () => {
+    const id = "00000000-0000-4000-8000-0000000000a3";
+    registerManualPipelineRunAbortController(id);
+    clearManualPipelineRunAbortController(id);
+    expect(() => abortManualPipelineRunIfLocal(id)).not.toThrow();
+  });
+});

--- a/apps/hermes/dashboard/lib/manual-pipeline-run-abort.ts
+++ b/apps/hermes/dashboard/lib/manual-pipeline-run-abort.ts
@@ -1,0 +1,38 @@
+/**
+ * Best-effort in-process abort handles for manual pipeline runs. Only affects `got.post`
+ * when cancel is invoked on the same Node process as the run.
+ */
+const abortControllers = new Map<string, AbortController>();
+
+/**
+ * Registers an {@link AbortController} for a manual execution and returns its signal for HTTP.
+ */
+export const registerManualPipelineRunAbortController = (
+  manualExecutionId: string,
+): AbortSignal => {
+  const existing = abortControllers.get(manualExecutionId);
+  if (existing) {
+    return existing.signal;
+  }
+  const ac = new AbortController();
+  abortControllers.set(manualExecutionId, ac);
+  return ac.signal;
+};
+
+/**
+ * Aborts an in-flight manual run HTTP request when the controller was registered locally.
+ */
+export const abortManualPipelineRunIfLocal = (
+  manualExecutionId: string,
+): void => {
+  abortControllers.get(manualExecutionId)?.abort();
+};
+
+/**
+ * Removes the abort controller when the run finishes or errors.
+ */
+export const clearManualPipelineRunAbortController = (
+  manualExecutionId: string,
+): void => {
+  abortControllers.delete(manualExecutionId);
+};

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -17,6 +17,12 @@ const mockPrisma = vi.hoisted(() => ({
     update: vi.fn().mockResolvedValue(undefined),
     updateMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
+  scheduleExecution: {
+    findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
+  },
+  httpTriggerExecution: {
+    findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
+  },
   domainIntegration: {
     findFirst: vi.fn().mockResolvedValue({
       baseUrl: "https://mediapulse-domain.example",
@@ -35,6 +41,7 @@ vi.mock("@hermes/orchestration-database", () => ({
     running: "running",
     completed: "completed",
     failed: "failed",
+    cancelled: "cancelled",
   },
   DomainIntegrationStatus: {
     pending: "pending",
@@ -397,6 +404,12 @@ describe("jobHandlers", () => {
       mockPrisma.agentJobExecution.update.mockClear();
       mockPrisma.agentJobExecution.updateMany.mockClear();
       mockPrisma.agentJobExecution.updateMany.mockResolvedValue({ count: 1 });
+      mockPrisma.scheduleExecution.findUnique.mockResolvedValue({
+        cancelledAt: null,
+      });
+      mockPrisma.httpTriggerExecution.findUnique.mockResolvedValue({
+        cancelledAt: null,
+      });
     });
 
     it("claims pending row, calls invokeAgentPost, and applies completion on 2xx success envelope", async () => {
@@ -448,6 +461,26 @@ describe("jobHandlers", () => {
           scheduleExecutionId: payload.scheduleExecutionId,
           terminal: expect.objectContaining({
             status: AgentJobExecutionStatus.completed,
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("applies cancelled completion and skips HTTP when parent schedule execution is cancelled", async () => {
+      mockPrisma.scheduleExecution.findUnique.mockResolvedValueOnce({
+        cancelledAt: new Date(),
+      });
+
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
+
+      expect(invokeAgentPost).not.toHaveBeenCalled();
+      expect(applyInvocationCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: payload.jobId,
+          scheduleExecutionId: payload.scheduleExecutionId,
+          terminal: expect.objectContaining({
+            status: AgentJobExecutionStatus.cancelled,
           }),
         }),
         expect.any(Object),

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -404,6 +404,37 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       return;
     }
 
+    const parentExecution = payload.scheduleExecutionId
+      ? await orchestrationPrisma.scheduleExecution.findUnique({
+          where: { id: payload.scheduleExecutionId },
+          select: { cancelledAt: true },
+        })
+      : await orchestrationPrisma.httpTriggerExecution.findUnique({
+          where: { id: payload.httpTriggerExecutionId! },
+          select: { cancelledAt: true },
+        });
+
+    if (parentExecution?.cancelledAt) {
+      await applyInvocationCompletion(
+        {
+          jobId: payload.jobId,
+          scheduleExecutionId: payload.scheduleExecutionId,
+          httpTriggerExecutionId: payload.httpTriggerExecutionId,
+          pipelineStepId: payload.pipelineStepId,
+          terminal: {
+            status: AgentJobExecutionStatus.cancelled,
+            error: {
+              cancelled: true,
+              message: "Execution was cancelled before agent invoke",
+              retryable: false,
+            },
+          },
+        },
+        completionDeps,
+      );
+      return;
+    }
+
     const httpClient = createHttpClient(signal);
     const authToken = await getJwtForDomainIntegration(
       payload.domainIntegrationId,
@@ -427,6 +458,30 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
     );
 
     if (postResult.kind === "transport_error") {
+      const aborted =
+        signal.aborted ||
+        postResult.error.name === "AbortError" ||
+        /abort/i.test(postResult.error.message);
+      if (aborted) {
+        await applyInvocationCompletion(
+          {
+            jobId: payload.jobId,
+            scheduleExecutionId: payload.scheduleExecutionId,
+            httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            pipelineStepId: payload.pipelineStepId,
+            terminal: {
+              status: AgentJobExecutionStatus.cancelled,
+              error: {
+                cancelled: true,
+                message: "Agent invoke aborted (cancelled or signal)",
+                retryable: false,
+              },
+            },
+          },
+          completionDeps,
+        );
+        return;
+      }
       logger.error(
         {
           err: postResult.error,
@@ -442,6 +497,27 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
         errorToThrow: postResult.error,
       });
     } else {
+      if (signal.aborted) {
+        await applyInvocationCompletion(
+          {
+            jobId: payload.jobId,
+            scheduleExecutionId: payload.scheduleExecutionId,
+            httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            pipelineStepId: payload.pipelineStepId,
+            terminal: {
+              status: AgentJobExecutionStatus.cancelled,
+              error: {
+                cancelled: true,
+                message: "Agent invoke aborted after response (cancelled)",
+                retryable: false,
+              },
+            },
+          },
+          completionDeps,
+        );
+        return;
+      }
+
       const { statusCode, rawBody, isEmptyBody } = postResult.response;
 
       if (statusCode >= 500) {

--- a/packages/hermes/orchestration-database/prisma/migrations/20260422092857_add_execution_cancellation/migration.sql
+++ b/packages/hermes/orchestration-database/prisma/migrations/20260422092857_add_execution_cancellation/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+ALTER TYPE "AgentJobExecutionStatus" ADD VALUE 'cancelled';
+
+-- AlterEnum
+ALTER TYPE "ScheduleRunStatus" ADD VALUE 'cancelled';
+
+-- AlterTable
+ALTER TABLE "http_trigger_execution" ADD COLUMN     "cancelled_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "manual_pipeline_execution" ADD COLUMN     "cancelled_at" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "schedule_execution" ADD COLUMN     "cancelled_at" TIMESTAMP(3);

--- a/packages/hermes/orchestration-database/prisma/schema.prisma
+++ b/packages/hermes/orchestration-database/prisma/schema.prisma
@@ -225,6 +225,7 @@ enum ScheduleRunStatus {
   succeeded
   partial
   failed
+  cancelled
 }
 
 /// Aggregated outcome for invocations under one pipeline step within a schedule execution.
@@ -243,6 +244,7 @@ enum AgentJobExecutionStatus {
   running
   completed
   failed
+  cancelled
 }
 
 model Schedule {
@@ -286,6 +288,7 @@ model ScheduleExecution {
   failedInvocationCount    Int                   @default(0) @map("failed_invocation_count")
   errors                   Json?
   metadata                 Json?
+  cancelledAt              DateTime?             @map("cancelled_at")
   createdAt                DateTime              @default(now()) @map("created_at")
 
   schedule               Schedule                @relation(fields: [scheduleId], references: [id], onDelete: Cascade)
@@ -371,6 +374,7 @@ model HttpTriggerExecution {
   failedInvocationCount    Int                   @default(0) @map("failed_invocation_count")
   errors                   Json?
   metadata                 Json?
+  cancelledAt              DateTime?             @map("cancelled_at")
   createdAt                DateTime              @default(now()) @map("created_at")
 
   httpTrigger               HttpTrigger                @relation(fields: [httpTriggerId], references: [id], onDelete: Cascade)
@@ -411,6 +415,7 @@ model ManualPipelineExecution {
   failedInvocationCount    Int                   @default(0) @map("failed_invocation_count")
   errors                   Json?
   metadata                 Json?
+  cancelledAt              DateTime?             @map("cancelled_at")
   createdAt                DateTime              @default(now()) @map("created_at")
 
   pipeline                     Pipeline                      @relation(fields: [pipelineId], references: [id], onDelete: Cascade)

--- a/packages/hermes/scheduler/src/apply-invocation-completion.ts
+++ b/packages/hermes/scheduler/src/apply-invocation-completion.ts
@@ -15,6 +15,10 @@ import {
   computeStepRollupFromCounts,
   type StepRollupTerminal,
 } from "./schedule-rollup";
+import {
+  resolveRunStatusForSettledCancelledExecution,
+  resolveStepRollupPrismaAfterInvocation,
+} from "./cancel-execution";
 
 export type InvocationCompletionInput = {
   jobId: string;
@@ -31,6 +35,10 @@ export type InvocationCompletionInput = {
         error: Prisma.InputJsonValue;
         agentResponse?: Prisma.InputJsonValue;
         semanticStatus?: string | null;
+      }
+    | {
+        status: typeof AgentJobExecutionStatus.cancelled;
+        error: Prisma.InputJsonValue;
       };
 };
 
@@ -92,6 +100,7 @@ export const applyInvocationCompletion = async (
         select: {
           id: true,
           runStatus: true,
+          cancelledAt: true,
           effectiveExecutionConfig: true,
         },
       })
@@ -101,6 +110,7 @@ export const applyInvocationCompletion = async (
           select: {
             id: true,
             runStatus: true,
+            cancelledAt: true,
             effectiveExecutionConfig: true,
           },
         })
@@ -130,23 +140,45 @@ export const applyInvocationCompletion = async (
   );
 
   const isSuccess = input.terminal.status === AgentJobExecutionStatus.completed;
-  const agentData =
-    input.terminal.status === AgentJobExecutionStatus.completed
-      ? {
-          status: AgentJobExecutionStatus.completed,
-          completedAt: new Date(),
-          error: Prisma.DbNull,
-          agentResponse: input.terminal
-            .envelope as unknown as Prisma.InputJsonValue,
-          semanticStatus: input.terminal.envelope.status,
-        }
-      : {
-          status: AgentJobExecutionStatus.failed,
-          completedAt: new Date(),
-          error: input.terminal.error,
-          agentResponse: input.terminal.agentResponse ?? Prisma.DbNull,
-          semanticStatus: input.terminal.semanticStatus ?? null,
-        };
+  const isCancelled =
+    input.terminal.status === AgentJobExecutionStatus.cancelled;
+
+  let agentData: {
+    status: AgentJobExecutionStatus;
+    completedAt: Date;
+    error: Prisma.InputJsonValue | typeof Prisma.DbNull;
+    agentResponse: Prisma.InputJsonValue | typeof Prisma.DbNull;
+    semanticStatus: string | null;
+  };
+
+  if (input.terminal.status === AgentJobExecutionStatus.completed) {
+    agentData = {
+      status: AgentJobExecutionStatus.completed,
+      completedAt: new Date(),
+      error: Prisma.DbNull,
+      agentResponse: input.terminal
+        .envelope as unknown as Prisma.InputJsonValue,
+      semanticStatus: input.terminal.envelope.status,
+    };
+  } else if (isCancelled) {
+    agentData = {
+      status: AgentJobExecutionStatus.cancelled,
+      completedAt: new Date(),
+      error: input.terminal.error,
+      agentResponse: Prisma.DbNull,
+      semanticStatus: null,
+    };
+  } else if (input.terminal.status === AgentJobExecutionStatus.failed) {
+    agentData = {
+      status: AgentJobExecutionStatus.failed,
+      completedAt: new Date(),
+      error: input.terminal.error,
+      agentResponse: input.terminal.agentResponse ?? Prisma.DbNull,
+      semanticStatus: input.terminal.semanticStatus ?? null,
+    };
+  } else {
+    throw new Error("applyInvocationCompletion: unsupported terminal status");
+  }
 
   const execCountInc = isSuccess
     ? { succeededInvocationCount: { increment: 1 } }
@@ -200,7 +232,7 @@ export const applyInvocationCompletion = async (
 
     const inc = isSuccess
       ? { succeededCount: { increment: 1 } }
-      : { failedCount: { increment: 1 } };
+      : { failedCount: { increment: 1 } }; // failed + user-cancelled terminal both increment failedCount on the step row
 
     const updated =
       executionKind === "schedule"
@@ -232,21 +264,52 @@ export const applyInvocationCompletion = async (
       return;
     }
 
-    const rollupTerminal = computeStepRollupFromCounts(
-      updated.succeededCount,
-      updated.failedCount,
-      config.stepRollupPolicy,
-    );
+    const executionCancelledAt =
+      executionKind === "schedule"
+        ? await tx.scheduleExecution.findUnique({
+            where: { id: input.scheduleExecutionId! },
+            select: { cancelledAt: true },
+          })
+        : await tx.httpTriggerExecution.findUnique({
+            where: { id: input.httpTriggerExecutionId! },
+            select: { cancelledAt: true },
+          });
+
+    const stepJobsForRollup =
+      executionKind === "schedule"
+        ? await tx.agentJobExecution.findMany({
+            where: {
+              scheduleExecutionId: input.scheduleExecutionId!,
+              pipelineStepId: input.pipelineStepId,
+            },
+            select: { status: true, error: true },
+          })
+        : await tx.agentJobExecution.findMany({
+            where: {
+              httpTriggerExecutionId: input.httpTriggerExecutionId!,
+              pipelineStepId: input.pipelineStepId,
+            },
+            select: { status: true, error: true },
+          });
+
+    const rollupPrisma = resolveStepRollupPrismaAfterInvocation({
+      cancelledAt: executionCancelledAt?.cancelledAt ?? null,
+      stepJobs: stepJobsForRollup,
+      succeededCount: updated.succeededCount,
+      failedCount: updated.failedCount,
+      expectedInvocationCount: updated.expectedInvocationCount,
+      policy: config.stepRollupPolicy,
+    });
 
     if (executionKind === "schedule") {
       await tx.scheduleStepExecution.update({
         where: { id: stepRow.id },
-        data: { rollupStatus: stepRollupTerminalToPrisma(rollupTerminal) },
+        data: { rollupStatus: rollupPrisma },
       });
     } else {
       await tx.httpTriggerStepExecution.update({
         where: { id: stepRow.id },
-        data: { rollupStatus: stepRollupTerminalToPrisma(rollupTerminal) },
+        data: { rollupStatus: rollupPrisma },
       });
     }
 
@@ -276,13 +339,36 @@ export const applyInvocationCompletion = async (
       return;
     }
 
-    const stepTerminals: StepRollupTerminal[] = allSteps.map((s) =>
-      prismaRollupToTerminal(s.rollupStatus),
-    );
-    const run = computeExecutionRunStatusFromStepRollups(
-      stepTerminals,
-      config.stepRollupPolicy,
-    );
+    const executionRow =
+      executionKind === "schedule"
+        ? await tx.scheduleExecution.findUnique({
+            where: { id: input.scheduleExecutionId! },
+            select: { cancelledAt: true },
+          })
+        : await tx.httpTriggerExecution.findUnique({
+            where: { id: input.httpTriggerExecutionId! },
+            select: { cancelledAt: true },
+          });
+
+    const allJobs =
+      executionKind === "schedule"
+        ? await tx.agentJobExecution.findMany({
+            where: { scheduleExecutionId: input.scheduleExecutionId! },
+            select: { status: true, error: true },
+          })
+        : await tx.agentJobExecution.findMany({
+            where: { httpTriggerExecutionId: input.httpTriggerExecutionId! },
+            select: { status: true, error: true },
+          });
+
+    const run = executionRow?.cancelledAt
+      ? resolveRunStatusForSettledCancelledExecution(allJobs)
+      : runStatusToPrisma(
+          computeExecutionRunStatusFromStepRollups(
+            allSteps.map((s) => prismaRollupToTerminal(s.rollupStatus)),
+            config.stepRollupPolicy,
+          ),
+        );
 
     if (executionKind === "schedule") {
       await tx.scheduleExecution.updateMany({
@@ -292,7 +378,7 @@ export const applyInvocationCompletion = async (
             in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
           },
         },
-        data: { runStatus: runStatusToPrisma(run) },
+        data: { runStatus: run },
       });
     } else {
       await tx.httpTriggerExecution.updateMany({
@@ -302,24 +388,11 @@ export const applyInvocationCompletion = async (
             in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
           },
         },
-        data: { runStatus: runStatusToPrisma(run) },
+        data: { runStatus: run },
       });
     }
   });
 };
-
-function stepRollupTerminalToPrisma(
-  r: StepRollupTerminal,
-): ScheduleStepRollupStatus {
-  switch (r) {
-    case "success":
-      return ScheduleStepRollupStatus.success;
-    case "partial":
-      return ScheduleStepRollupStatus.partial;
-    case "failed":
-      return ScheduleStepRollupStatus.failed;
-  }
-}
 
 function prismaRollupToTerminal(
   r: ScheduleStepRollupStatus,

--- a/packages/hermes/scheduler/src/apply-invocation-completion.ts
+++ b/packages/hermes/scheduler/src/apply-invocation-completion.ts
@@ -12,7 +12,6 @@ import {
 } from "./execution-config";
 import {
   computeExecutionRunStatusFromStepRollups,
-  computeStepRollupFromCounts,
   type StepRollupTerminal,
 } from "./schedule-rollup";
 import {

--- a/packages/hermes/scheduler/src/cancel-execution.test.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.test.ts
@@ -1,0 +1,47 @@
+/** @vitest-environment node */
+import {
+  AgentJobExecutionStatus,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+import { describe, expect, it } from "vitest";
+import {
+  errorIndicatesUserCancel,
+  resolveRunStatusForSettledCancelledExecution,
+} from "./cancel-execution";
+
+describe("cancel-execution", () => {
+  it("resolveRunStatusForSettledCancelledExecution returns cancelled when all jobs are cancelled", () => {
+    const jobs = [
+      { status: AgentJobExecutionStatus.cancelled, error: null },
+      { status: AgentJobExecutionStatus.cancelled, error: null },
+    ];
+    expect(resolveRunStatusForSettledCancelledExecution(jobs)).toBe(
+      ScheduleRunStatus.cancelled,
+    );
+  });
+
+  it("resolveRunStatusForSettledCancelledExecution returns partial when some completed and some cancelled", () => {
+    const jobs = [
+      { status: AgentJobExecutionStatus.completed, error: null },
+      { status: AgentJobExecutionStatus.cancelled, error: null },
+    ];
+    expect(resolveRunStatusForSettledCancelledExecution(jobs)).toBe(
+      ScheduleRunStatus.partial,
+    );
+  });
+
+  it("resolveRunStatusForSettledCancelledExecution returns failed when an agent failure exists", () => {
+    const jobs = [
+      { status: AgentJobExecutionStatus.failed, error: { message: "boom" } },
+      { status: AgentJobExecutionStatus.cancelled, error: null },
+    ];
+    expect(resolveRunStatusForSettledCancelledExecution(jobs)).toBe(
+      ScheduleRunStatus.failed,
+    );
+  });
+
+  it("errorIndicatesUserCancel detects structured cancel errors", () => {
+    expect(errorIndicatesUserCancel({ cancelled: true })).toBe(true);
+    expect(errorIndicatesUserCancel({ message: "x" })).toBe(false);
+  });
+});

--- a/packages/hermes/scheduler/src/cancel-execution.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.ts
@@ -1,0 +1,899 @@
+import {
+  AgentJobExecutionStatus,
+  Prisma,
+  ScheduleRunStatus,
+  ScheduleStepRollupStatus,
+  type PrismaClient,
+} from "@hermes/orchestration-database";
+import {
+  computeStepRollupFromCounts,
+  type StepRollupTerminal,
+} from "./schedule-rollup";
+import {
+  parseEffectiveExecutionConfig,
+  type ExecutionConfig,
+} from "./execution-config";
+
+/** Minimal DataQueue surface used to drop pending `invoke_agent` work by Hermes tags. */
+export type HermesDataQueueForCancel = {
+  cancelAllUpcomingJobs: (filter: {
+    tags: { values: string[]; mode: "all" };
+  }) => Promise<unknown>;
+};
+
+const userCancelError = (): Prisma.InputJsonValue =>
+  ({
+    cancelled: true,
+    message: "Execution was cancelled",
+    retryable: false,
+  }) as Prisma.InputJsonValue;
+
+export function errorIndicatesUserCancel(error: unknown): boolean {
+  if (error == null || typeof error !== "object" || Array.isArray(error)) {
+    return false;
+  }
+  return (error as Record<string, unknown>).cancelled === true;
+}
+
+/**
+ * Resolves parent `ScheduleRunStatus` once every `AgentJobExecution` for the execution is terminal
+ * and `cancelledAt` was set (user requested cancellation).
+ */
+export type StepJobRollupInput = {
+  status: AgentJobExecutionStatus;
+  error: Prisma.JsonValue | null;
+};
+
+/**
+ * Computes per-step rollup Prisma status after an invocation completes, respecting
+ * user-cancelled invocations when `cancelledAt` is set on the parent execution.
+ */
+export function resolveStepRollupPrismaAfterInvocation(args: {
+  cancelledAt: Date | null;
+  stepJobs: StepJobRollupInput[];
+  succeededCount: number;
+  failedCount: number;
+  expectedInvocationCount: number;
+  policy: ExecutionConfig["stepRollupPolicy"];
+}): ScheduleStepRollupStatus {
+  const {
+    cancelledAt,
+    stepJobs,
+    succeededCount,
+    failedCount,
+    expectedInvocationCount,
+    policy,
+  } = args;
+
+  if (
+    cancelledAt &&
+    stepJobs.length > 0 &&
+    succeededCount + failedCount >= expectedInvocationCount
+  ) {
+    const allUserCancel = stepJobs.every(
+      (j) =>
+        j.status === AgentJobExecutionStatus.cancelled ||
+        (j.status === AgentJobExecutionStatus.failed &&
+          errorIndicatesUserCancel(j.error)),
+    );
+    if (allUserCancel) {
+      return ScheduleStepRollupStatus.cancelled;
+    }
+  }
+
+  const rollupTerminal = computeStepRollupFromCounts(
+    succeededCount,
+    failedCount,
+    policy,
+  );
+  return stepRollupTerminalToPrisma(rollupTerminal);
+}
+
+export function resolveRunStatusForSettledCancelledExecution(
+  jobs: Array<{
+    status: AgentJobExecutionStatus;
+    error: Prisma.JsonValue | null;
+  }>,
+): ScheduleRunStatus {
+  const hasCompleted = jobs.some(
+    (j) => j.status === AgentJobExecutionStatus.completed,
+  );
+  const hasAgentFailure = jobs.some(
+    (j) =>
+      j.status === AgentJobExecutionStatus.failed &&
+      !errorIndicatesUserCancel(j.error),
+  );
+  const hasUserCancel =
+    jobs.some((j) => j.status === AgentJobExecutionStatus.cancelled) ||
+    jobs.some(
+      (j) =>
+        j.status === AgentJobExecutionStatus.failed &&
+        errorIndicatesUserCancel(j.error),
+    );
+
+  if (hasAgentFailure) {
+    return ScheduleRunStatus.failed;
+  }
+  if (hasCompleted && hasUserCancel) {
+    return ScheduleRunStatus.partial;
+  }
+  if (hasCompleted) {
+    return ScheduleRunStatus.succeeded;
+  }
+  if (
+    jobs.length > 0 &&
+    jobs.every(
+      (j) =>
+        j.status === AgentJobExecutionStatus.cancelled ||
+        (j.status === AgentJobExecutionStatus.failed &&
+          errorIndicatesUserCancel(j.error)),
+    )
+  ) {
+    return ScheduleRunStatus.cancelled;
+  }
+  return ScheduleRunStatus.failed;
+}
+
+function defaultExecutionConfig(): ExecutionConfig {
+  return {
+    schemaVersion: 1,
+    stepRollupPolicy: "strict",
+    stepOrder: "sequential",
+    continueSequentialAfterPartial: false,
+  };
+}
+
+function loadExecutionConfig(
+  raw: Prisma.JsonValue | null | undefined,
+): ExecutionConfig {
+  try {
+    const obj =
+      raw != null && typeof raw === "object" && !Array.isArray(raw)
+        ? (raw as Record<string, unknown>)
+        : {};
+    return parseEffectiveExecutionConfig(obj);
+  } catch {
+    return defaultExecutionConfig();
+  }
+}
+
+function stepRollupTerminalToPrisma(
+  r: StepRollupTerminal,
+): ScheduleStepRollupStatus {
+  switch (r) {
+    case "success":
+      return ScheduleStepRollupStatus.success;
+    case "partial":
+      return ScheduleStepRollupStatus.partial;
+    case "failed":
+      return ScheduleStepRollupStatus.failed;
+  }
+}
+
+async function reconcileStepRollupsForScheduleExecution(
+  tx: Prisma.TransactionClient,
+  scheduleExecutionId: string,
+  policy: ExecutionConfig["stepRollupPolicy"],
+): Promise<StepRollupTerminal[]> {
+  const jobs = await tx.agentJobExecution.findMany({
+    where: { scheduleExecutionId },
+    select: {
+      pipelineStepId: true,
+      status: true,
+      error: true,
+    },
+  });
+  const jobsByStep = new Map<string, typeof jobs>();
+  for (const j of jobs) {
+    const pid = j.pipelineStepId;
+    if (!pid) continue;
+    const list = jobsByStep.get(pid) ?? [];
+    list.push(j);
+    jobsByStep.set(pid, list);
+  }
+
+  const steps = await tx.scheduleStepExecution.findMany({
+    where: { scheduleExecutionId },
+  });
+
+  const stepTerminals: StepRollupTerminal[] = [];
+
+  for (const step of steps) {
+    const stepJobs = jobsByStep.get(step.pipelineStepId) ?? [];
+    const e = step.expectedInvocationCount;
+    const s = step.succeededCount;
+    const f = step.failedCount;
+    if (s + f < e) {
+      await tx.scheduleStepExecution.update({
+        where: { id: step.id },
+        data: {
+          succeededCount: s,
+          failedCount: f,
+          rollupStatus:
+            s + f > 0
+              ? ScheduleStepRollupStatus.running
+              : ScheduleStepRollupStatus.pending,
+        },
+      });
+      continue;
+    }
+
+    const allUserCancel =
+      stepJobs.length > 0 &&
+      stepJobs.every(
+        (j) =>
+          j.status === AgentJobExecutionStatus.cancelled ||
+          (j.status === AgentJobExecutionStatus.failed &&
+            errorIndicatesUserCancel(j.error)),
+      );
+
+    const rollupPrisma = allUserCancel
+      ? ScheduleStepRollupStatus.cancelled
+      : stepRollupTerminalToPrisma(computeStepRollupFromCounts(s, f, policy));
+
+    await tx.scheduleStepExecution.update({
+      where: { id: step.id },
+      data: {
+        succeededCount: s,
+        failedCount: f,
+        rollupStatus: rollupPrisma,
+      },
+    });
+    stepTerminals.push(prismaRollupToStepTerminalForParentRun(rollupPrisma));
+  }
+
+  return stepTerminals;
+}
+
+async function reconcileStepRollupsForHttpTriggerExecution(
+  tx: Prisma.TransactionClient,
+  httpTriggerExecutionId: string,
+  policy: ExecutionConfig["stepRollupPolicy"],
+): Promise<StepRollupTerminal[]> {
+  const jobs = await tx.agentJobExecution.findMany({
+    where: { httpTriggerExecutionId },
+    select: {
+      pipelineStepId: true,
+      status: true,
+      error: true,
+    },
+  });
+  const jobsByStep = new Map<string, typeof jobs>();
+  for (const j of jobs) {
+    const pid = j.pipelineStepId;
+    if (!pid) continue;
+    const list = jobsByStep.get(pid) ?? [];
+    list.push(j);
+    jobsByStep.set(pid, list);
+  }
+
+  const steps = await tx.httpTriggerStepExecution.findMany({
+    where: { httpTriggerExecutionId },
+  });
+
+  const stepTerminals: StepRollupTerminal[] = [];
+
+  for (const step of steps) {
+    const stepJobs = jobsByStep.get(step.pipelineStepId) ?? [];
+    const e = step.expectedInvocationCount;
+    const s = step.succeededCount;
+    const f = step.failedCount;
+    if (s + f < e) {
+      await tx.httpTriggerStepExecution.update({
+        where: { id: step.id },
+        data: {
+          succeededCount: s,
+          failedCount: f,
+          rollupStatus:
+            s + f > 0
+              ? ScheduleStepRollupStatus.running
+              : ScheduleStepRollupStatus.pending,
+        },
+      });
+      continue;
+    }
+
+    const allUserCancel =
+      stepJobs.length > 0 &&
+      stepJobs.every(
+        (j) =>
+          j.status === AgentJobExecutionStatus.cancelled ||
+          (j.status === AgentJobExecutionStatus.failed &&
+            errorIndicatesUserCancel(j.error)),
+      );
+
+    const rollupPrisma = allUserCancel
+      ? ScheduleStepRollupStatus.cancelled
+      : stepRollupTerminalToPrisma(computeStepRollupFromCounts(s, f, policy));
+
+    await tx.httpTriggerStepExecution.update({
+      where: { id: step.id },
+      data: {
+        succeededCount: s,
+        failedCount: f,
+        rollupStatus: rollupPrisma,
+      },
+    });
+    stepTerminals.push(prismaRollupToStepTerminalForParentRun(rollupPrisma));
+  }
+
+  return stepTerminals;
+}
+
+function prismaRollupToStepTerminalForParentRun(
+  r: ScheduleStepRollupStatus,
+): StepRollupTerminal {
+  switch (r) {
+    case ScheduleStepRollupStatus.success:
+      return "success";
+    case ScheduleStepRollupStatus.partial:
+      return "partial";
+    case ScheduleStepRollupStatus.cancelled:
+    case ScheduleStepRollupStatus.failed:
+    case ScheduleStepRollupStatus.skipped:
+    case ScheduleStepRollupStatus.running:
+    case ScheduleStepRollupStatus.pending:
+    default:
+      return "failed";
+  }
+}
+
+export type CancelScheduleExecutionResult =
+  | { ok: true; scheduleExecutionId: string }
+  | { ok: false; reason: "not_found" | "already_terminal" };
+
+export type CancelHttpTriggerExecutionResult =
+  | { ok: true; httpTriggerExecutionId: string }
+  | { ok: false; reason: "not_found" | "already_terminal" };
+
+/**
+ * Cancels a schedule execution: drops queued `invoke_agent` jobs by tag, marks pending
+ * invocations cancelled, reconciles step rollups, and sets parent `runStatus` when no
+ * invocations remain `running`.
+ */
+export const cancelScheduleExecution = async (
+  db: PrismaClient,
+  queue: HermesDataQueueForCancel,
+  scheduleExecutionId: string,
+): Promise<CancelScheduleExecutionResult> => {
+  const existing = await db.scheduleExecution.findUnique({
+    where: { id: scheduleExecutionId },
+    select: {
+      id: true,
+      runStatus: true,
+      effectiveExecutionConfig: true,
+      failedInvocationCount: true,
+      succeededInvocationCount: true,
+    },
+  });
+  if (!existing) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (
+    existing.runStatus !== ScheduleRunStatus.pending &&
+    existing.runStatus !== ScheduleRunStatus.running
+  ) {
+    return { ok: false, reason: "already_terminal" };
+  }
+
+  await queue.cancelAllUpcomingJobs({
+    tags: { values: [`scheduleExecution:${scheduleExecutionId}`], mode: "all" },
+  });
+
+  const now = new Date();
+  const policy = loadExecutionConfig(
+    existing.effectiveExecutionConfig,
+  ).stepRollupPolicy;
+
+  await db.$transaction(async (tx) => {
+    const pending = await tx.agentJobExecution.findMany({
+      where: {
+        scheduleExecutionId,
+        status: AgentJobExecutionStatus.pending,
+      },
+      select: { id: true, pipelineStepId: true },
+    });
+
+    const cancelledByStep = new Map<string, number>();
+    for (const row of pending) {
+      const pid = row.pipelineStepId;
+      if (!pid) continue;
+      cancelledByStep.set(pid, (cancelledByStep.get(pid) ?? 0) + 1);
+    }
+
+    if (pending.length > 0) {
+      await tx.agentJobExecution.updateMany({
+        where: {
+          scheduleExecutionId,
+          status: AgentJobExecutionStatus.pending,
+        },
+        data: {
+          status: AgentJobExecutionStatus.cancelled,
+          completedAt: now,
+          error: userCancelError(),
+        },
+      });
+    }
+
+    for (const [pipelineStepId, n] of cancelledByStep) {
+      await tx.scheduleStepExecution.updateMany({
+        where: { scheduleExecutionId, pipelineStepId },
+        data: { failedCount: { increment: n } },
+      });
+    }
+
+    const runningLeft = await tx.agentJobExecution.count({
+      where: {
+        scheduleExecutionId,
+        status: AgentJobExecutionStatus.running,
+      },
+    });
+
+    await tx.scheduleExecution.update({
+      where: { id: scheduleExecutionId },
+      data: {
+        cancelledAt: now,
+        failedInvocationCount: { increment: pending.length },
+      },
+    });
+
+    if (runningLeft > 0) {
+      return;
+    }
+
+    const stepTerminals = await reconcileStepRollupsForScheduleExecution(
+      tx,
+      scheduleExecutionId,
+      policy,
+    );
+    const stepsAfter = await tx.scheduleStepExecution.findMany({
+      where: { scheduleExecutionId },
+      select: {
+        expectedInvocationCount: true,
+        succeededCount: true,
+        failedCount: true,
+      },
+    });
+    const allStepsTerminal =
+      stepsAfter.length > 0 &&
+      stepsAfter.every(
+        (row) =>
+          row.succeededCount + row.failedCount >= row.expectedInvocationCount,
+      );
+    if (!allStepsTerminal) {
+      return;
+    }
+
+    const jobs = await tx.agentJobExecution.findMany({
+      where: { scheduleExecutionId },
+      select: { status: true, error: true },
+    });
+    const finalRun = resolveRunStatusForSettledCancelledExecution(jobs);
+
+    await tx.scheduleExecution.update({
+      where: { id: scheduleExecutionId },
+      data: { runStatus: finalRun },
+    });
+  });
+
+  return { ok: true, scheduleExecutionId };
+};
+
+/**
+ * Cancels an HTTP trigger execution (same semantics as {@link cancelScheduleExecution}).
+ */
+export const cancelHttpTriggerExecution = async (
+  db: PrismaClient,
+  queue: HermesDataQueueForCancel,
+  httpTriggerExecutionId: string,
+): Promise<CancelHttpTriggerExecutionResult> => {
+  const existing = await db.httpTriggerExecution.findUnique({
+    where: { id: httpTriggerExecutionId },
+    select: {
+      id: true,
+      runStatus: true,
+      effectiveExecutionConfig: true,
+    },
+  });
+  if (!existing) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (
+    existing.runStatus !== ScheduleRunStatus.pending &&
+    existing.runStatus !== ScheduleRunStatus.running
+  ) {
+    return { ok: false, reason: "already_terminal" };
+  }
+
+  await queue.cancelAllUpcomingJobs({
+    tags: {
+      values: [`httpTriggerExecution:${httpTriggerExecutionId}`],
+      mode: "all",
+    },
+  });
+
+  const now = new Date();
+  const policy = loadExecutionConfig(
+    existing.effectiveExecutionConfig,
+  ).stepRollupPolicy;
+
+  await db.$transaction(async (tx) => {
+    const pending = await tx.agentJobExecution.findMany({
+      where: {
+        httpTriggerExecutionId,
+        status: AgentJobExecutionStatus.pending,
+      },
+      select: { id: true, pipelineStepId: true },
+    });
+
+    const cancelledByStep = new Map<string, number>();
+    for (const row of pending) {
+      const pid = row.pipelineStepId;
+      if (!pid) continue;
+      cancelledByStep.set(pid, (cancelledByStep.get(pid) ?? 0) + 1);
+    }
+
+    if (pending.length > 0) {
+      await tx.agentJobExecution.updateMany({
+        where: {
+          httpTriggerExecutionId,
+          status: AgentJobExecutionStatus.pending,
+        },
+        data: {
+          status: AgentJobExecutionStatus.cancelled,
+          completedAt: now,
+          error: userCancelError(),
+        },
+      });
+    }
+
+    for (const [pipelineStepId, n] of cancelledByStep) {
+      await tx.httpTriggerStepExecution.updateMany({
+        where: { httpTriggerExecutionId, pipelineStepId },
+        data: { failedCount: { increment: n } },
+      });
+    }
+
+    const runningLeft = await tx.agentJobExecution.count({
+      where: {
+        httpTriggerExecutionId,
+        status: AgentJobExecutionStatus.running,
+      },
+    });
+
+    await tx.httpTriggerExecution.update({
+      where: { id: httpTriggerExecutionId },
+      data: {
+        cancelledAt: now,
+        failedInvocationCount: { increment: pending.length },
+      },
+    });
+
+    if (runningLeft > 0) {
+      return;
+    }
+
+    const stepTerminals = await reconcileStepRollupsForHttpTriggerExecution(
+      tx,
+      httpTriggerExecutionId,
+      policy,
+    );
+    const stepsAfter = await tx.httpTriggerStepExecution.findMany({
+      where: { httpTriggerExecutionId },
+      select: {
+        expectedInvocationCount: true,
+        succeededCount: true,
+        failedCount: true,
+      },
+    });
+    const allStepsTerminal =
+      stepsAfter.length > 0 &&
+      stepsAfter.every(
+        (row) =>
+          row.succeededCount + row.failedCount >= row.expectedInvocationCount,
+      );
+    if (!allStepsTerminal) {
+      return;
+    }
+
+    const jobs = await tx.agentJobExecution.findMany({
+      where: { httpTriggerExecutionId },
+      select: { status: true, error: true },
+    });
+    const finalRun = resolveRunStatusForSettledCancelledExecution(jobs);
+
+    await tx.httpTriggerExecution.update({
+      where: { id: httpTriggerExecutionId },
+      data: { runStatus: finalRun },
+    });
+  });
+
+  return { ok: true, httpTriggerExecutionId };
+};
+
+/**
+ * When a cancelled execution still had `running` jobs that have now finished, finalize
+ * parent `runStatus` and step rollups if every step is terminal.
+ */
+export const finalizeCancelledExecutionIfSettled = async (
+  db: PrismaClient,
+  args:
+    | { kind: "schedule"; scheduleExecutionId: string }
+    | { kind: "httpTrigger"; httpTriggerExecutionId: string },
+): Promise<void> => {
+  const isSchedule = args.kind === "schedule";
+  const executionId = isSchedule
+    ? args.scheduleExecutionId
+    : args.httpTriggerExecutionId;
+
+  const execution = isSchedule
+    ? await db.scheduleExecution.findUnique({
+        where: { id: executionId },
+        select: {
+          cancelledAt: true,
+          runStatus: true,
+          effectiveExecutionConfig: true,
+        },
+      })
+    : await db.httpTriggerExecution.findUnique({
+        where: { id: executionId },
+        select: {
+          cancelledAt: true,
+          runStatus: true,
+          effectiveExecutionConfig: true,
+        },
+      });
+
+  if (!execution?.cancelledAt) {
+    return;
+  }
+  if (
+    execution.runStatus !== ScheduleRunStatus.pending &&
+    execution.runStatus !== ScheduleRunStatus.running
+  ) {
+    return;
+  }
+
+  const runningCount = await db.agentJobExecution.count({
+    where: isSchedule
+      ? {
+          scheduleExecutionId: executionId,
+          status: AgentJobExecutionStatus.running,
+        }
+      : {
+          httpTriggerExecutionId: executionId,
+          status: AgentJobExecutionStatus.running,
+        },
+  });
+  if (runningCount > 0) {
+    return;
+  }
+
+  const policy = loadExecutionConfig(
+    execution.effectiveExecutionConfig,
+  ).stepRollupPolicy;
+
+  await db.$transaction(async (tx) => {
+    await (isSchedule
+      ? reconcileStepRollupsForScheduleExecution(tx, executionId, policy)
+      : reconcileStepRollupsForHttpTriggerExecution(tx, executionId, policy));
+
+    const stepsAfter = isSchedule
+      ? await tx.scheduleStepExecution.findMany({
+          where: { scheduleExecutionId: executionId },
+          select: {
+            expectedInvocationCount: true,
+            succeededCount: true,
+            failedCount: true,
+          },
+        })
+      : await tx.httpTriggerStepExecution.findMany({
+          where: { httpTriggerExecutionId: executionId },
+          select: {
+            expectedInvocationCount: true,
+            succeededCount: true,
+            failedCount: true,
+          },
+        });
+
+    const allStepsTerminal =
+      stepsAfter.length > 0 &&
+      stepsAfter.every(
+        (row) =>
+          row.succeededCount + row.failedCount >= row.expectedInvocationCount,
+      );
+    if (!allStepsTerminal) {
+      return;
+    }
+
+    const jobs = await tx.agentJobExecution.findMany({
+      where: isSchedule
+        ? { scheduleExecutionId: executionId }
+        : { httpTriggerExecutionId: executionId },
+      select: { status: true, error: true },
+    });
+
+    const pendingLeft = jobs.filter(
+      (j) => j.status === AgentJobExecutionStatus.pending,
+    ).length;
+    if (pendingLeft > 0) {
+      return;
+    }
+
+    const finalRun = resolveRunStatusForSettledCancelledExecution(jobs);
+
+    if (isSchedule) {
+      await tx.scheduleExecution.update({
+        where: { id: executionId },
+        data: { runStatus: finalRun },
+      });
+    } else {
+      await tx.httpTriggerExecution.update({
+        where: { id: executionId },
+        data: { runStatus: finalRun },
+      });
+    }
+  });
+};
+
+export type MarkManualPipelineCancelledResult =
+  | { ok: true }
+  | { ok: false; reason: "not_found" | "already_terminal" };
+
+/**
+ * Marks a manual dashboard pipeline run as user-cancelled (`cancelledAt`). The run loop
+ * should observe this and call {@link finalizeManualPipelineExecutionAfterCooperativeCancel}.
+ */
+export const markManualPipelineExecutionCancelled = async (
+  db: PrismaClient,
+  manualExecutionId: string,
+): Promise<MarkManualPipelineCancelledResult> => {
+  const row = await db.manualPipelineExecution.findUnique({
+    where: { id: manualExecutionId },
+    select: { runStatus: true },
+  });
+  if (!row) {
+    return { ok: false, reason: "not_found" };
+  }
+  if (row.runStatus !== ScheduleRunStatus.running) {
+    return { ok: false, reason: "already_terminal" };
+  }
+  await db.manualPipelineExecution.update({
+    where: { id: manualExecutionId },
+    data: { cancelledAt: new Date() },
+  });
+  return { ok: true };
+};
+
+export type PlannedJobForManualCancel = {
+  jobId: string;
+  pipelineStepId: string;
+};
+
+/**
+ * After a cooperative cancel break in the manual run loop: increments per-step `failedCount`
+ * for jobs that never started, cancels any remaining `running` rows, recomputes rollups, and
+ * sets parent `runStatus`.
+ */
+export const finalizeManualPipelineExecutionAfterCooperativeCancel = async (
+  db: PrismaClient,
+  args: {
+    manualExecutionId: string;
+    plannedJobs: PlannedJobForManualCancel[];
+    processedJobIds: ReadonlySet<string>;
+  },
+): Promise<void> => {
+  const { manualExecutionId, plannedJobs, processedJobIds } = args;
+  const execution = await db.manualPipelineExecution.findUnique({
+    where: { id: manualExecutionId },
+    select: { effectiveExecutionConfig: true, cancelledAt: true },
+  });
+  if (!execution?.cancelledAt) {
+    return;
+  }
+
+  const policy = loadExecutionConfig(
+    execution.effectiveExecutionConfig,
+  ).stepRollupPolicy;
+  const now = new Date();
+
+  await db.$transaction(async (tx) => {
+    const remainingByStep = new Map<string, number>();
+    for (const job of plannedJobs) {
+      if (processedJobIds.has(job.jobId)) {
+        continue;
+      }
+      const row = await tx.agentJobExecution.findUnique({
+        where: { jobId: job.jobId },
+        select: { id: true },
+      });
+      if (!row) {
+        remainingByStep.set(
+          job.pipelineStepId,
+          (remainingByStep.get(job.pipelineStepId) ?? 0) + 1,
+        );
+      }
+    }
+    for (const [pipelineStepId, n] of remainingByStep) {
+      await tx.manualPipelineStepExecution.updateMany({
+        where: { manualExecutionId, pipelineStepId },
+        data: { failedCount: { increment: n } },
+      });
+    }
+
+    await tx.agentJobExecution.updateMany({
+      where: { manualExecutionId, status: AgentJobExecutionStatus.running },
+      data: {
+        status: AgentJobExecutionStatus.cancelled,
+        completedAt: now,
+        error: userCancelError(),
+      },
+    });
+
+    const steps = await tx.manualPipelineStepExecution.findMany({
+      where: { manualExecutionId },
+    });
+    for (const step of steps) {
+      const s = step.succeededCount;
+      const f = step.failedCount;
+      const e = step.expectedInvocationCount;
+      if (e === 0) {
+        continue;
+      }
+      if (s + f < e) {
+        continue;
+      }
+      const stepJobs = await tx.agentJobExecution.findMany({
+        where: { manualExecutionId, pipelineStepId: step.pipelineStepId },
+        select: { status: true, error: true },
+      });
+      const allUserCancel =
+        stepJobs.length > 0 &&
+        stepJobs.every(
+          (j) =>
+            j.status === AgentJobExecutionStatus.cancelled ||
+            (j.status === AgentJobExecutionStatus.failed &&
+              errorIndicatesUserCancel(j.error)),
+        );
+      const rollupPrisma = allUserCancel
+        ? ScheduleStepRollupStatus.cancelled
+        : stepRollupTerminalToPrisma(computeStepRollupFromCounts(s, f, policy));
+      await tx.manualPipelineStepExecution.update({
+        where: {
+          manualExecutionId_pipelineStepId: {
+            manualExecutionId,
+            pipelineStepId: step.pipelineStepId,
+          },
+        },
+        data: { rollupStatus: rollupPrisma },
+      });
+    }
+
+    const jobs = await tx.agentJobExecution.findMany({
+      where: { manualExecutionId },
+      select: { status: true, error: true },
+    });
+    const succeededInvocationCount = jobs.filter(
+      (j) => j.status === AgentJobExecutionStatus.completed,
+    ).length;
+    const failedInvocationCount = jobs.filter(
+      (j) =>
+        j.status === AgentJobExecutionStatus.failed ||
+        j.status === AgentJobExecutionStatus.cancelled,
+    ).length;
+    const finalRun = resolveRunStatusForSettledCancelledExecution(jobs);
+
+    await tx.manualPipelineExecution.update({
+      where: { id: manualExecutionId },
+      data: {
+        runStatus: finalRun,
+        succeededInvocationCount,
+        failedInvocationCount,
+      },
+    });
+  });
+};
+
+/** @internal Exported for tests — maps step rollup row to coarse terminal for parent run math. */
+export const __testOnlyPrismaRollupToStepTerminalForParentRun =
+  prismaRollupToStepTerminalForParentRun;

--- a/packages/hermes/scheduler/src/cancel-execution.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.ts
@@ -447,7 +447,7 @@ export const cancelScheduleExecution = async (
       return;
     }
 
-    const stepTerminals = await reconcileStepRollupsForScheduleExecution(
+    await reconcileStepRollupsForScheduleExecution(
       tx,
       scheduleExecutionId,
       policy,
@@ -579,7 +579,7 @@ export const cancelHttpTriggerExecution = async (
       return;
     }
 
-    const stepTerminals = await reconcileStepRollupsForHttpTriggerExecution(
+    await reconcileStepRollupsForHttpTriggerExecution(
       tx,
       httpTriggerExecutionId,
       policy,

--- a/packages/hermes/scheduler/src/cancel-execution.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.ts
@@ -28,6 +28,9 @@ const userCancelError = (): Prisma.InputJsonValue =>
     retryable: false,
   }) as Prisma.InputJsonValue;
 
+/**
+ * Returns true when `error` is a structured user-cancel payload (`cancelled: true`).
+ */
 export function errorIndicatesUserCancel(error: unknown): boolean {
   if (error == null || typeof error !== "object" || Array.isArray(error)) {
     return false;
@@ -89,6 +92,9 @@ export function resolveStepRollupPrismaAfterInvocation(args: {
   return stepRollupTerminalToPrisma(rollupTerminal);
 }
 
+/**
+ * Derives the parent schedule run status after cancellation when every job is terminal.
+ */
 export function resolveRunStatusForSettledCancelledExecution(
   jobs: Array<{
     status: AgentJobExecutionStatus;

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -47,6 +47,21 @@ export {
   type InvocationCompletionInput,
 } from "./apply-invocation-completion";
 export {
+  cancelHttpTriggerExecution,
+  cancelScheduleExecution,
+  errorIndicatesUserCancel,
+  finalizeCancelledExecutionIfSettled,
+  finalizeManualPipelineExecutionAfterCooperativeCancel,
+  markManualPipelineExecutionCancelled,
+  resolveRunStatusForSettledCancelledExecution,
+  resolveStepRollupPrismaAfterInvocation,
+  type CancelHttpTriggerExecutionResult,
+  type CancelScheduleExecutionResult,
+  type HermesDataQueueForCancel,
+  type MarkManualPipelineCancelledResult,
+  type PlannedJobForManualCancel,
+} from "./cancel-execution";
+export {
   substituteVariables,
   substituteInString,
 } from "./substitute-variables";


### PR DESCRIPTION
## Summary

Hermes can now cancel pipeline executions that are still in flight or queued. Schedule and HTTP-trigger runs clear matching DataQueue jobs and reconcile Postgres so steps and parents land in a consistent cancelled state. Dashboard manual runs pick up `cancelledAt` between invocations and can abort an in-flight HTTP call on a best-effort basis.

## Related issues

Closes #323

## Important changes

- New Prisma enum values and `cancelledAt` on execution rows, plus migration `20260422092857_add_execution_cancellation`.
- Scheduler `cancelScheduleExecution` / `cancelHttpTriggerExecution` cancel tagged queue work and update related rows in one transaction; manual helpers finalize cooperative cancels.
- `apply-invocation-completion` handles terminal `cancelled` and rollups when an execution was cancelled vs completed normally.
- Worker `invoke_agent` skips the agent HTTP call when the parent execution is already cancelled after claim, and treats transport abort as user cancel where it matches known errors.
- Dashboard cancel POST routes for schedules, HTTP triggers, and manual runs; execution tables and detail pages expose Cancel; `run-pipeline` polls for cancel and wires `AbortController` through the invoke loop.

## Other changes

- Vitest coverage for `cancel-execution` and for the worker path that skips HTTP when the parent is cancelled.
- `hermes-job-queue` typing extended for queue control helpers used by cancel actions.

## Key files to review

- `packages/hermes/scheduler/src/cancel-execution.ts` — queue cancel + DB reconciliation paths.
- `packages/hermes/scheduler/src/apply-invocation-completion.ts` — cancelled completion and rollup behavior.
- `apps/hermes/worker/src/job-handlers.ts` — claim-time cancelled check and abort-aware invoke flow.
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — cooperative cancel loop and response `runStatus`.

## How to test

1. Apply the new migration on a dev database (`pnpm --filter @hermes/orchestration-database db:migrate:dev` or your usual migrate command).
2. Run `pnpm --filter @hermes/scheduler exec vitest run` and `pnpm --filter @hermes/worker exec vitest run` (or the repo equivalents) and confirm the new tests pass.
3. In the Hermes dashboard, start a schedule or HTTP execution (or a manual pipeline run), hit Cancel while it is pending or running, refresh, and confirm the UI shows a terminal cancelled state and queued work does not keep draining.
