### PR TITLE
Fix Hermes cancellation reliability for DataQueue and manual runs

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -35,6 +35,7 @@ import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-in
 import {
   clearManualPipelineRunAbortController,
   registerManualPipelineRunAbortController,
+  startManualExecutionCancelledPollFromDb,
 } from "@/lib/manual-pipeline-run-abort";
 import { validatePipeline } from "@/lib/validate-pipeline";
 
@@ -425,6 +426,10 @@ export const createRunPipelineHandler = ({
       const abortSignal = registerManualPipelineRunAbortController(
         execution.id,
       );
+      const stopCancelledPoll = startManualExecutionCancelledPollFromDb(
+        db,
+        execution.id,
+      );
       const processedJobIds = new Set<string>();
       const plannedJobsForCancel = plannedJobs.map((j) => ({
         jobId: j.jobId,
@@ -703,6 +708,7 @@ export const createRunPipelineHandler = ({
           }
         }
       } finally {
+        stopCancelledPoll();
         clearManualPipelineRunAbortController(execution.id);
       }
 

--- a/apps/hermes/dashboard/lib/manual-pipeline-run-abort.test.ts
+++ b/apps/hermes/dashboard/lib/manual-pipeline-run-abort.test.ts
@@ -5,6 +5,7 @@ import {
   abortManualPipelineRunIfLocal,
   clearManualPipelineRunAbortController,
   registerManualPipelineRunAbortController,
+  startManualExecutionCancelledPollFromDb,
 } from "./manual-pipeline-run-abort";
 
 describe("manual-pipeline-run-abort", () => {
@@ -35,5 +36,25 @@ describe("manual-pipeline-run-abort", () => {
     registerManualPipelineRunAbortController(id);
     clearManualPipelineRunAbortController(id);
     expect(() => abortManualPipelineRunIfLocal(id)).not.toThrow();
+  });
+
+  it("aborts the local signal on the first poll when cancelledAt is set", async () => {
+    const id = "00000000-0000-4000-8000-0000000000b1";
+    const signal = registerManualPipelineRunAbortController(id);
+    const listener = vi.fn();
+    signal.addEventListener("abort", listener);
+    const findUnique = vi
+      .fn()
+      .mockResolvedValue({ cancelledAt: new Date("2026-01-01T00:00:00.000Z") });
+    const stop = startManualExecutionCancelledPollFromDb(
+      { manualPipelineExecution: { findUnique } },
+      id,
+      50,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(listener).toHaveBeenCalled();
+    expect(findUnique).toHaveBeenCalled();
+    stop();
+    clearManualPipelineRunAbortController(id);
   });
 });

--- a/apps/hermes/dashboard/lib/manual-pipeline-run-abort.ts
+++ b/apps/hermes/dashboard/lib/manual-pipeline-run-abort.ts
@@ -36,3 +36,50 @@ export const clearManualPipelineRunAbortController = (
 ): void => {
   abortControllers.delete(manualExecutionId);
 };
+
+type ManualExecutionCancelPollDb = {
+  manualPipelineExecution: {
+    findUnique: (args: {
+      where: { id: string };
+      select: { cancelledAt: true };
+    }) => Promise<{ cancelledAt: Date | null } | null>;
+  };
+};
+
+const DEFAULT_CANCEL_POLL_MS = 400;
+
+/**
+ * Polls Postgres for `cancelledAt` on this execution and aborts the in-process HTTP signal when
+ * set. Needed when cancel is handled on another instance (in-memory abort is a no-op there) or
+ * while a long `got.post` is in flight (the invoke loop only checked between jobs before).
+ *
+ * Call the returned stopper from the same `finally` that clears the abort controller.
+ */
+export const startManualExecutionCancelledPollFromDb = (
+  db: ManualExecutionCancelPollDb,
+  manualExecutionId: string,
+  intervalMs: number = DEFAULT_CANCEL_POLL_MS,
+): (() => void) => {
+  const tick = async () => {
+    try {
+      const row = await db.manualPipelineExecution.findUnique({
+        where: { id: manualExecutionId },
+        select: { cancelledAt: true },
+      });
+      if (row?.cancelledAt) {
+        abortManualPipelineRunIfLocal(manualExecutionId);
+      }
+    } catch {
+      // ignore transient read errors; next tick retries
+    }
+  };
+
+  void tick();
+  const handle = setInterval(() => {
+    void tick();
+  }, intervalMs);
+
+  return () => {
+    clearInterval(handle);
+  };
+};

--- a/packages/hermes/scheduler/src/cancel-execution.test.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.test.ts
@@ -3,8 +3,9 @@ import {
   AgentJobExecutionStatus,
   ScheduleRunStatus,
 } from "@hermes/orchestration-database";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+  cancelTaggedHermesQueueJobs,
   errorIndicatesUserCancel,
   resolveRunStatusForSettledCancelledExecution,
 } from "./cancel-execution";
@@ -43,5 +44,44 @@ describe("cancel-execution", () => {
   it("errorIndicatesUserCancel detects structured cancel errors", () => {
     expect(errorIndicatesUserCancel({ cancelled: true })).toBe(true);
     expect(errorIndicatesUserCancel({ message: "x" })).toBe(false);
+  });
+});
+
+describe("cancelTaggedHermesQueueJobs", () => {
+  it("calls cancelAllUpcomingJobs then cancelJob for pending and waiting matches", async () => {
+    const cancelAllUpcomingJobs = vi.fn().mockResolvedValue(undefined);
+    const getJobsByTags = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { id: 10, status: "waiting" },
+        { id: 11, status: "cancelled" },
+        { id: 12, status: "pending" },
+      ])
+      .mockResolvedValueOnce([]);
+    const cancelJob = vi.fn().mockResolvedValue(undefined);
+
+    await cancelTaggedHermesQueueJobs(
+      { cancelAllUpcomingJobs, getJobsByTags, cancelJob },
+      "scheduleExecution:00000000-0000-4000-8000-000000000099",
+    );
+
+    expect(cancelAllUpcomingJobs).toHaveBeenCalledWith({
+      tags: {
+        values: ["scheduleExecution:00000000-0000-4000-8000-000000000099"],
+        mode: "all",
+      },
+    });
+    expect(cancelJob).toHaveBeenCalledWith(10);
+    expect(cancelJob).toHaveBeenCalledWith(12);
+    expect(cancelJob).not.toHaveBeenCalledWith(11);
+  });
+
+  it("skips getJobsByTags when optional methods are absent", async () => {
+    const cancelAllUpcomingJobs = vi.fn().mockResolvedValue(undefined);
+    await cancelTaggedHermesQueueJobs(
+      { cancelAllUpcomingJobs },
+      "scheduleExecution:x",
+    );
+    expect(cancelAllUpcomingJobs).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/hermes/scheduler/src/cancel-execution.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.ts
@@ -14,12 +14,59 @@ import {
   type ExecutionConfig,
 } from "./execution-config";
 
-/** Minimal DataQueue surface used to drop pending `invoke_agent` work by Hermes tags. */
+/** DataQueue surface used to cancel Hermes work by execution tag (pending + waiting). */
 export type HermesDataQueueForCancel = {
   cancelAllUpcomingJobs: (filter: {
     tags: { values: string[]; mode: "all" };
   }) => Promise<unknown>;
+  /**
+   * Optional but required in production: {@link cancelAllUpcomingJobs} only cancels `pending`
+   * rows; dependency-blocked jobs stay `waiting` and would otherwise still run.
+   */
+  getJobsByTags?: (
+    tags: string[],
+    mode?: "all" | "any" | "exact" | "none",
+    limit?: number,
+    offset?: number,
+  ) => Promise<Array<{ id: number; status: string }>>;
+  cancelJob?: (jobId: number) => Promise<unknown>;
 };
+
+/**
+ * Cancels all DataQueue jobs tagged with `tag` that are still `pending` or `waiting`.
+ * {@link HermesDataQueueForCancel.cancelAllUpcomingJobs} only hits `pending`, so this
+ * follows up with per-job cancellation for `waiting` dependency chains.
+ */
+export async function cancelTaggedHermesQueueJobs(
+  queue: HermesDataQueueForCancel,
+  tag: string,
+): Promise<void> {
+  await queue.cancelAllUpcomingJobs({
+    tags: { values: [tag], mode: "all" },
+  });
+
+  const getJobsByTags = queue.getJobsByTags;
+  const cancelJob = queue.cancelJob;
+  if (typeof getJobsByTags !== "function" || typeof cancelJob !== "function") {
+    return;
+  }
+
+  const tagArray = [tag];
+  const pageSize = 200;
+  const maxSweeps = 50;
+  for (let sweep = 0; sweep < maxSweeps; sweep += 1) {
+    const rows = await getJobsByTags(tagArray, "all", pageSize, 0);
+    const actionable = rows.filter(
+      (row) => row.status === "pending" || row.status === "waiting",
+    );
+    if (actionable.length === 0) {
+      break;
+    }
+    for (const row of actionable) {
+      await cancelJob(row.id);
+    }
+  }
+}
 
 const userCancelError = (): Prisma.InputJsonValue =>
   ({
@@ -382,9 +429,10 @@ export const cancelScheduleExecution = async (
     return { ok: false, reason: "already_terminal" };
   }
 
-  await queue.cancelAllUpcomingJobs({
-    tags: { values: [`scheduleExecution:${scheduleExecutionId}`], mode: "all" },
-  });
+  await cancelTaggedHermesQueueJobs(
+    queue,
+    `scheduleExecution:${scheduleExecutionId}`,
+  );
 
   const now = new Date();
   const policy = loadExecutionConfig(
@@ -511,12 +559,10 @@ export const cancelHttpTriggerExecution = async (
     return { ok: false, reason: "already_terminal" };
   }
 
-  await queue.cancelAllUpcomingJobs({
-    tags: {
-      values: [`httpTriggerExecution:${httpTriggerExecutionId}`],
-      mode: "all",
-    },
-  });
+  await cancelTaggedHermesQueueJobs(
+    queue,
+    `httpTriggerExecution:${httpTriggerExecutionId}`,
+  );
 
   const now = new Date();
   const policy = loadExecutionConfig(
@@ -761,7 +807,10 @@ export const markManualPipelineExecutionCancelled = async (
   if (!row) {
     return { ok: false, reason: "not_found" };
   }
-  if (row.runStatus !== ScheduleRunStatus.running) {
+  if (
+    row.runStatus !== ScheduleRunStatus.running &&
+    row.runStatus !== ScheduleRunStatus.pending
+  ) {
     return { ok: false, reason: "already_terminal" };
   }
   await db.manualPipelineExecution.update({

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -49,6 +49,7 @@ export {
 export {
   cancelHttpTriggerExecution,
   cancelScheduleExecution,
+  cancelTaggedHermesQueueJobs,
   errorIndicatesUserCancel,
   finalizeCancelledExecutionIfSettled,
   finalizeManualPipelineExecutionAfterCooperativeCancel,


### PR DESCRIPTION
## Summary

The first cancellation merge left a few holes where “Cancel” returned 200 but work kept moving. DataQueue only cleared **`pending`** jobs, so **`waiting`** dependency jobs were untouched. Manual runs from the dashboard mostly looked at `cancelledAt` between hops, so cancel during a long agent POST—or from another Fly machine—did not stop the request.

## Related issues

Closes #325

## Important changes

- **`cancelTaggedHermesQueueJobs`**: after `cancelAllUpcomingJobs`, sweep tagged jobs and call `cancelJob` for anything still `pending` or `waiting`.
- **Manual run loop**: `startManualExecutionCancelledPollFromDb` polls `cancelledAt` and triggers the local `AbortController` so `got` can abort mid-request when cancel lands elsewhere.
- **`markManualPipelineExecutionCancelled`**: treat both `pending` and `running` as cancellable parent states.
- **Cancel button hook**: read error bodies with `text` + safe JSON so empty error pages do not throw.

## Other changes

- Co-located dashboard tests, hook extraction for `useRouter`, `manualPipelineExecution.findUnique` stub in run-pipeline tests, scheduler lint cleanups.

## Key files to review

- `packages/hermes/scheduler/src/cancel-execution.ts` — `cancelTaggedHermesQueueJobs` and manual cancel guard.
- `apps/hermes/dashboard/lib/manual-pipeline-run-abort.ts` — DB cancel poll + abort wiring.
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — poll lifecycle in `finally` with the abort controller.

## How to test

1. `pnpm --filter @hermes/scheduler exec vitest run src/cancel-execution.test.ts`
2. `pnpm --filter @hermes/dashboard generate && pnpm --filter @hermes/dashboard exec vitest run` for the touched dashboard tests (or full `pnpm code-quality` if you have time).
3. Manually: start a multi-step manual run, click Cancel while the first agent call is in flight; the run should stop without waiting for the full HTTP timeout. Repeat for a schedule run with step dependencies and confirm queued `waiting` jobs disappear from the queue.
