### PR TITLE
Await Hermes registration before domain-api listens

### DIFF
--- a/apps/mediapulse/domain-api/fly.toml
+++ b/apps/mediapulse/domain-api/fly.toml
@@ -17,6 +17,14 @@ primary_region = 'sin'
   min_machines_running = 0
   processes = ['app']
 
+[[http_service.checks]]
+  grace_period = "60s"
+  interval = "30s"
+  method = "GET"
+  timeout = "10s"
+  path = "/v1/health"
+  protocol = "http"
+
 [[vm]]
   memory = '256mb'
   cpu_kind = 'shared'

--- a/apps/mediapulse/domain-api/src/http/create-hono-app.ts
+++ b/apps/mediapulse/domain-api/src/http/create-hono-app.ts
@@ -7,14 +7,14 @@ import {
   hermesDashboardTableMountPath,
 } from "../hermes-dashboard/paths";
 import { hermesDashboardRouteMounts } from "./hermes-dashboard-route-mounts";
-import { registerWithHermes } from "./register-with-hermes";
 import { healthRoutes } from "./routes/health-routes";
 import { hermesDashboardManifestRoutes } from "./routes/hermes-dashboard-manifest-routes";
 import { stepInputExpansionRoutes } from "./routes/step-input-expansion-routes";
 import { verifyInvocationJwtFromHeader } from "./verify-invocation-jwt-middleware";
 
 /**
- * Builds the Mediapulse domain API Hono application (middleware, versioned routes, Hermes registration).
+ * Builds the Mediapulse domain API Hono application (middleware, versioned routes).
+ * Hermes self-registration runs from the process entrypoint after this returns (see `src/index.ts`).
  *
  * @returns Bun-style server handle with `port` and `fetch`.
  */
@@ -63,8 +63,6 @@ export const createDomainApiServer = (): {
 
   api.route(HERMES_DASHBOARD_V1_MOUNT_PATH, hermesDashboardManifestRoutes);
   api.route("/", stepInputExpansionRoutes);
-
-  void registerWithHermes();
 
   return {
     port: env.PORT ?? 8090,

--- a/apps/mediapulse/domain-api/src/index.test.ts
+++ b/apps/mediapulse/domain-api/src/index.test.ts
@@ -1,0 +1,70 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const registerWithHermes = vi.hoisted(() =>
+  vi.fn().mockResolvedValue(undefined),
+);
+
+const fetchStub = vi.hoisted(() => vi.fn());
+
+vi.mock("./http/register-with-hermes", () => ({
+  registerWithHermes,
+}));
+
+vi.mock("./http/create-hono-app", () => ({
+  createDomainApiServer: vi.fn(() => ({
+    port: 8090,
+    fetch: fetchStub,
+  })),
+}));
+
+describe("src/index", () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("creates the server, awaits Hermes registration, then exports the handle", async () => {
+    const { createDomainApiServer } = await import("./http/create-hono-app");
+
+    const mod = await import("./index");
+
+    expect(createDomainApiServer).toHaveBeenCalledTimes(1);
+    expect(registerWithHermes).toHaveBeenCalledTimes(1);
+    expect(mod.default).toEqual({
+      port: 8090,
+      fetch: fetchStub,
+    });
+  });
+
+  it("does not export the server until registration promise settles", async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    registerWithHermes.mockImplementationOnce(() => gate);
+
+    const { createDomainApiServer } = await import("./http/create-hono-app");
+    const modPromise = import("./index");
+
+    await vi.waitFor(() => {
+      expect(createDomainApiServer).toHaveBeenCalledTimes(1);
+    });
+    await vi.waitFor(() => {
+      expect(registerWithHermes).toHaveBeenCalledTimes(1);
+    });
+
+    await expect(
+      Promise.race([
+        modPromise,
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error("still pending")), 50),
+        ),
+      ]),
+    ).rejects.toThrow("still pending");
+
+    release();
+    const mod = await modPromise;
+    expect(mod.default.port).toBe(8090);
+  });
+});

--- a/apps/mediapulse/domain-api/src/index.ts
+++ b/apps/mediapulse/domain-api/src/index.ts
@@ -1,3 +1,7 @@
 import { createDomainApiServer } from "./http/create-hono-app";
+import { registerWithHermes } from "./http/register-with-hermes";
 
-export default createDomainApiServer();
+const server = createDomainApiServer();
+await registerWithHermes();
+
+export default server;


### PR DESCRIPTION
## Summary

domain-api used to register with Hermes in the background while requests could already hit the app. Hermes still had the old **baseUrl** in the DB for a short window, which matched “first Run pipeline fails, refresh or visit the URL, second try works.” Startup now waits on `registerWithHermes()` before the Bun server handle is exported, and Fly gets an HTTP check on `/v1/health` so the machine is not marked ready until the process is actually listening (after that wait).

## Related issues

Closes #334

## Important changes

- `src/index.ts` uses top-level `await registerWithHermes()` after `createDomainApiServer()` so registration finishes or gives up before traffic is served.
- `fly.toml` adds `[[http_service.checks]]` for `GET /v1/health` with `grace_period = "60s"` (Fly caps at 1 minute).

## Other changes

- JSDoc on `createDomainApiServer` notes registration moved to the entrypoint.
- New `src/index.test.ts` asserts registration runs and blocks the default export until it settles.

## Key files to review

- `apps/mediapulse/domain-api/src/index.ts` - startup order.
- `apps/mediapulse/domain-api/src/http/create-hono-app.ts` - registration removed from the factory.
- `apps/mediapulse/domain-api/fly.toml` - health check timing vs deploy expectations.
- `apps/mediapulse/domain-api/src/index.test.ts` - bootstrap behavior.

## How to test

1. `pnpm --filter @mediapulse/domain-api run test` and `pnpm --filter @mediapulse/domain-api run type:check`.
2. Deploy or run locally with Hermes + env set: confirm logs show successful registration before you get a listening server; hit Run pipeline once after a cold start and confirm planning does not fail from a stale base URL.
3. `flyctl config validate -c apps/mediapulse/domain-api/fly.toml` (optional) to confirm TOML.
