### PR TITLE
Add structured logs to delivery agent

### DIFF
--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -37,6 +37,8 @@ describe("deliverNewsletterToSubscribers", () => {
       .fn()
       .mockResolvedValue({ id: "re_1", attempts: 1 });
     const acquire = vi.fn().mockResolvedValue(0);
+    const logInfo = vi.fn();
+    const logError = vi.fn();
 
     const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
       newsletter,
@@ -47,6 +49,7 @@ describe("deliverNewsletterToSubscribers", () => {
         resend: {} as Resend,
         rateLimiter: { acquire },
         sendWithRetry,
+        logger: { info: logInfo, error: logError },
       },
     );
 
@@ -74,11 +77,23 @@ describe("deliverNewsletterToSubscribers", () => {
       }),
     ]);
     expect(resendMessageIds).toEqual(["re_1"]);
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        newsletterId: newsletter.id,
+        successCount: 1,
+        failedCount: 0,
+        skippedCount: 0,
+        totalRecipients: 1,
+      }),
+      "delivery recipient batch summary",
+    );
   });
 
   it("skips checkpointed subscribers without acquire or send", async () => {
     const sendWithRetry = vi.fn();
     const acquire = vi.fn().mockResolvedValue(0);
+    const logInfo = vi.fn();
+    const logError = vi.fn();
 
     const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
       newsletter,
@@ -89,6 +104,7 @@ describe("deliverNewsletterToSubscribers", () => {
         resend: {} as Resend,
         rateLimiter: { acquire },
         sendWithRetry,
+        logger: { info: logInfo, error: logError },
       },
     );
 
@@ -96,6 +112,15 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(acquire).not.toHaveBeenCalled();
     expect(results[0]?.status).toBe("skipped");
     expect(resendMessageIds).toEqual([]);
+    expect(logInfo).toHaveBeenCalledWith(
+      expect.objectContaining({
+        successCount: 0,
+        failedCount: 0,
+        skippedCount: 1,
+        totalRecipients: 1,
+      }),
+      "delivery recipient batch summary",
+    );
   });
 
   it("omits html from the payload when send.includeHtml is false", async () => {

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -206,5 +206,19 @@ export async function deliverNewsletterToSubscribers(
     }
   }
 
+  const successCount = results.filter((r) => r.status === "success").length;
+  const failedCount = results.filter((r) => r.status === "failed").length;
+  const skippedCount = results.filter((r) => r.status === "skipped").length;
+  logger?.info?.(
+    {
+      newsletterId: newsletter.id,
+      successCount,
+      failedCount,
+      skippedCount,
+      totalRecipients: results.length,
+    },
+    "delivery recipient batch summary",
+  );
+
   return { results, resendMessageIds };
 }

--- a/apps/mediapulse/agents/delivery/src/index.test.ts
+++ b/apps/mediapulse/agents/delivery/src/index.test.ts
@@ -1,6 +1,22 @@
 /** @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const hoistedLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+}));
+
+vi.mock("@workspace/logger", () => ({
+  logger: {
+    ...hoistedLogger,
+    warn: vi.fn(),
+    debug: vi.fn(),
+    trace: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn().mockReturnThis(),
+  },
+}));
+
 const TICKER_ID = "11111111-1111-4111-a111-111111111111";
 /** Non-UUID id (Hermes-style test id or slug). */
 const NON_UUID_TICKER_ID = "tid-non-uuid-1";
@@ -107,6 +123,28 @@ describe("delivery-agent", () => {
     expect(body.details?.outcome).toBe("success");
     expect(got.get).toHaveBeenCalled();
     expect(deliver).toHaveBeenCalled();
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: TICKER_ID,
+        hasNewsletter: true,
+        newsletterId: NL_ID,
+        subscriberCount: 1,
+        checkpointCount: 0,
+        pendingRecipientCount: 1,
+      }),
+      "delivery data-api fetch summary",
+    );
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: TICKER_ID,
+        newsletterId: NL_ID,
+        runOutcome: "success",
+        successCount: 1,
+        failureCount: 0,
+        skippedCount: 0,
+      }),
+      "delivery run outcome",
+    );
   }, 20_000);
 
   it("returns 200 skip when no newsletter with non-UUID tickerId", async () => {
@@ -141,6 +179,23 @@ describe("delivery-agent", () => {
     const body = (await res.json()) as { status: string; message?: string };
     expect(body.status).toBe("success");
     expect(body.message).toContain("Skipped");
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: NON_UUID_TICKER_ID,
+        hasNewsletter: false,
+        subscriberCount: 0,
+        checkpointCount: 0,
+        pendingRecipientCount: 0,
+      }),
+      "delivery data-api fetch summary",
+    );
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: NON_UUID_TICKER_ID,
+        runSkipReason: "skipped_no_newsletter",
+      }),
+      "delivery run skipped",
+    );
   }, 20_000);
 
   it("returns 200 skip when no newsletter with db: expansion tickerId", async () => {
@@ -226,6 +281,26 @@ describe("delivery-agent", () => {
     expect(body.status).toBe("success");
     expect(body.details?.outcome).toBe("skipped_all_already_delivered");
     expect(body.message).toContain("already delivered");
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: TICKER_ID,
+        hasNewsletter: true,
+        newsletterId: NL_ID,
+        subscriberCount: 1,
+        checkpointCount: 1,
+        pendingRecipientCount: 0,
+      }),
+      "delivery data-api fetch summary",
+    );
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runOutcome: "skipped_all_already_delivered",
+        successCount: 0,
+        failureCount: 0,
+        skippedCount: 1,
+      }),
+      "delivery run outcome",
+    );
   });
 
   it("returns 400 when tickerId is only whitespace", async () => {

--- a/apps/mediapulse/agents/delivery/src/index.ts
+++ b/apps/mediapulse/agents/delivery/src/index.ts
@@ -75,6 +75,24 @@ function aggregateOutcome(results: RecipientSendResult[]): DeliveryRunOutcome {
   return "success";
 }
 
+/**
+ * Counts subscribers not yet covered by a delivery checkpoint for this newsletter.
+ *
+ * @param subscribers - Rows from the delivery data API (enabled subscribers with email).
+ * @param deliveredUserTickerIds - User-ticker ids already checkpointed for this newsletter.
+ * @returns How many subscribers are still candidates for a Resend attempt this run.
+ */
+function pendingRecipientCount(
+  subscribers: ReadonlyArray<{ userTickerId: string }>,
+  deliveredUserTickerIds: readonly string[],
+): number {
+  const delivered = new Set(deliveredUserTickerIds);
+  return subscribers.reduce(
+    (n, s) => n + (delivered.has(s.userTickerId) ? 0 : 1),
+    0,
+  );
+}
+
 const app = createAgentApp<
   Input,
   typeof BodySchema,
@@ -111,13 +129,38 @@ const app = createAgentApp<
         const deliveryData = await dataApiClient.delivery.get({
           tickerId: input.tickerId,
         });
+        const fetchMs = Date.now() - fetchStarted;
+        const subscriberCount = deliveryData.subscribers.length;
+        const checkpointCount = deliveryData.deliveredUserTickerIds.length;
+        const pendingRecipients = pendingRecipientCount(
+          deliveryData.subscribers,
+          deliveryData.deliveredUserTickerIds,
+        );
         logger.info(
-          { ms: Date.now() - fetchStarted, tickerId: input.tickerId },
-          "delivery data-api fetch timing",
+          {
+            tickerId: input.tickerId,
+            fetchMs,
+            hasNewsletter: deliveryData.newsletter != null,
+            ...(deliveryData.newsletter != null
+              ? { newsletterId: deliveryData.newsletter.id }
+              : {}),
+            subscriberCount,
+            checkpointCount,
+            pendingRecipientCount: pendingRecipients,
+          },
+          "delivery data-api fetch summary",
         );
 
         if (!deliveryData.newsletter) {
           runOutcome = "skipped";
+          logger.info(
+            {
+              tickerId: input.tickerId,
+              runId,
+              runSkipReason: "skipped_no_newsletter",
+            },
+            "delivery run skipped",
+          );
           await dataApiClient.deliveryRun.create({
             id: runId,
             agentId: "delivery",
@@ -147,6 +190,15 @@ const app = createAgentApp<
 
         if (deliveryData.subscribers.length === 0) {
           runOutcome = "skipped";
+          logger.info(
+            {
+              tickerId: input.tickerId,
+              runId,
+              newsletterId,
+              runSkipReason: "skipped_no_subscribers",
+            },
+            "delivery run skipped",
+          );
           await dataApiClient.deliveryRun.create({
             id: runId,
             agentId: "delivery",
@@ -238,6 +290,19 @@ const app = createAgentApp<
             resendEmailId: r.resendEmailId ?? null,
           })),
         });
+
+        logger.info(
+          {
+            tickerId: input.tickerId,
+            runId,
+            newsletterId,
+            runOutcome,
+            successCount,
+            failureCount,
+            skippedCount,
+          },
+          "delivery run outcome",
+        );
 
         if (runOutcome === "failed") {
           return {


### PR DESCRIPTION
## Summary

The delivery agent returns HTTP 200 for intentional skips as well as real sends, and Fly only logs generic request completion. That made it look like email should have gone out when the run never reached Resend.

This change adds structured INFO logs after the data-api fetch (counts and `pendingRecipientCount`), on skip paths (`runSkipReason` plus `runId`), after persisting a completed run (outcome and per-status counts), and a short batch summary at the end of the recipient loop.

## Related issues

Closes #336

## Important changes

- `delivery data-api fetch summary` replaces the timing-only line so one log line explains whether a send was even possible.
- `delivery run skipped` fires before persisting when there is no newsletter or no subscribers with email.
- `delivery run outcome` fires after a successful persist when the send path ran.
- `delivery recipient batch summary` aggregates success, failed, and skipped counts per newsletter after the loop.

## Other changes

- Vitest mocks `@workspace/logger` in the delivery agent HTTP tests and extends `deliver-newsletter` tests to assert the batch summary log.

## Key files to review

- `apps/mediapulse/agents/delivery/src/index.ts` - fetch summary, skip logs, outcome log, `pendingRecipientCount` helper.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` - batch summary after recipients.
- `apps/mediapulse/agents/delivery/src/index.test.ts` and `deliver-newsletter.test.ts` - log contract assertions.

## How to test

1. From repo root: `pnpm --filter @mediapulse/delivery test` (expect all green).
2. Optional: invoke the agent against a ticker with no newsletter and confirm logs include `delivery run skipped` with `skipped_no_newsletter`.
