### PR TITLE
Require nested openai config for content-generation agent

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -4,18 +4,13 @@ import { describe, expect, it } from "vitest";
 import { ContentGenerationConfigSchema } from "./config-schema.js";
 
 describe("ContentGenerationConfigSchema", () => {
-  it("parses minimal config with legacy openaiApiKey and applies all defaults", () => {
-    // Act
+  it("parses minimal config with openai.apiKey and applies all defaults", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
     });
 
-    // Assert
-    expect(parsed.openaiApiKey).toBe("sk-test");
-    expect(parsed.openaiBaseUrl).toBeUndefined();
-    expect(parsed.openaiModel).toBeUndefined();
-
-    // Check defaults
+    expect(parsed.openai.apiKey).toBe("sk-test");
+    expect(parsed.openai.baseUrl).toBeUndefined();
     expect(parsed.openai.model).toBe("gpt-4o-mini");
     expect(parsed.openai.temperature).toBe(0.4);
     expect(parsed.openai.timeoutMs).toBe(120000);
@@ -34,7 +29,6 @@ describe("ContentGenerationConfigSchema", () => {
   });
 
   it("parses valid full config", () => {
-    // Act
     const parsed = ContentGenerationConfigSchema.parse({
       openai: {
         apiKey: "sk-test-new",
@@ -72,7 +66,6 @@ describe("ContentGenerationConfigSchema", () => {
       },
     });
 
-    // Assert
     expect(parsed.openai.apiKey).toBe("sk-test-new");
     expect(parsed.openai.baseUrl).toBe("https://example.com");
     expect(parsed.openai.model).toBe("gpt-4");
@@ -81,112 +74,94 @@ describe("ContentGenerationConfigSchema", () => {
     expect(parsed.freshness.timezone).toBe("America/New_York");
   });
 
-  it("accepts legacy explicit openaiModel and new openai.model", () => {
-    // Act
-    const parsed = ContentGenerationConfigSchema.parse({
-      openaiApiKey: "sk-test",
-      openaiModel: "gpt-4o",
-      openai: {
-        model: "gpt-4-turbo",
-      },
-    });
-
-    // Assert
-    expect(parsed.openaiModel).toBe("gpt-4o");
-    expect(parsed.openai.model).toBe("gpt-4-turbo");
-  });
-
-  it("rejects empty openaiApiKey if no openai.apiKey provided", () => {
-    // Act & Assert
-    const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "",
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues[0]?.path).toEqual(["openaiApiKey"]);
-    }
-  });
-
-  it("rejects missing api key", () => {
-    // Act & Assert
+  it("rejects missing openai object", () => {
     const result = ContentGenerationConfigSchema.safeParse({});
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.issues[0]?.path).toEqual(["openai", "apiKey"]);
+      expect(result.error.issues.some((i) => i.path[0] === "openai")).toBe(
+        true,
+      );
     }
   });
 
-  it("parses config with openai.apiKey only (no legacy openaiApiKey)", () => {
-    // Act
-    const parsed = ContentGenerationConfigSchema.parse({
-      openai: {
-        apiKey: "sk-new-style",
-      },
+  it("rejects missing openai.apiKey", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      openai: {},
     });
-
-    // Assert
-    expect(parsed.openai.apiKey).toBe("sk-new-style");
-    expect(parsed.openaiApiKey).toBeUndefined();
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (i) => i.path[0] === "openai" && i.path[1] === "apiKey",
+        ),
+      ).toBe(true);
+    }
   });
 
-  it("rejects if both openaiApiKey and openai.apiKey are empty or whitespace", () => {
-    // Act & Assert
+  it("rejects empty openai.apiKey", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "   ",
-      openai: {
-        apiKey: "",
-      },
+      openai: { apiKey: "" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects whitespace-only openai.apiKey", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      openai: { apiKey: "   " },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects unknown top-level legacy openaiApiKey", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects topNewsCount of 0", () => {
-    // Act & Assert
     const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
       output: { topNewsCount: 0 },
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects negative topNewsCount", () => {
-    // Act & Assert
     const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
       output: { topNewsCount: -1 },
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects invalid freshness timezone", () => {
-    // Act & Assert
     const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
       freshness: { timezone: "Not/ATimezone" },
     });
     expect(result.success).toBe(false);
   });
 
   it("rejects wrong type for topNewsCount", () => {
-    // Act & Assert
     const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "sk-test",
+      openai: { apiKey: "sk-test" },
       output: { topNewsCount: "three" },
     });
     expect(result.success).toBe(false);
   });
 
-  it("generates correct JSON schema containing all fields", () => {
-    // Act
+  it("JSON schema exposes nested openai only (no top-level openaiApiKey)", () => {
     const jsonSchema = zodToJsonSchema(ContentGenerationConfigSchema, {
       $refStrategy: "none",
     });
 
-    // Assert
-    // Using stringify checks because the object is complex.
     const schemaStr = JSON.stringify(jsonSchema);
-    expect(schemaStr).toContain("openaiApiKey");
-    expect(schemaStr).toContain("openaiModel");
+    expect(schemaStr).toContain('"openai"');
+    expect(schemaStr).toContain("apiKey");
+    expect(schemaStr).not.toContain("openaiApiKey");
+    expect(schemaStr).not.toContain("openaiModel");
     expect(schemaStr).toContain("topNewsCount");
     expect(schemaStr).toContain("systemPrompt");
     expect(schemaStr).toContain("userPromptTemplate");

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -7,43 +7,28 @@ import { z } from "zod";
 export const ContentGenerationConfigSchema = z
   .object({
     /**
-     * @deprecated Use `openai.apiKey` instead.
-     * OpenAI API key for newsletter generation.
+     * OpenAI client settings. The API key is read only from Hermes config (no
+     * `process.env.OPENAI_API_KEY` at runtime). See FR2 and MP-CGA-011 for local-dev notes.
      */
-    openaiApiKey: z.string().min(1).optional(),
-    /**
-     * @deprecated Use `openai.baseUrl` instead.
-     * Base URL for the OpenAI-compatible HTTP API.
-     */
-    openaiBaseUrl: z.string().url().optional(),
-    /**
-     * @deprecated Use `openai.model` instead.
-     * Chat completions model id.
-     */
-    openaiModel: z.string().min(1).optional(),
-
-    openai: z
-      .object({
-        /**
-         * OpenAI API key for newsletter generation. Required if legacy `openaiApiKey` is omitted.
-         * The agent reads the API key exclusively from Hermes config — do not fall back to
-         * process.env.OPENAI_API_KEY at runtime. For local development, set the key in the
-         * Hermes agent config or use the legacy `openaiApiKey` top-level field.
-         * See FR2 and MP-CGA-011 for full local-dev documentation.
-         */
-        apiKey: z.string().min(1).optional(),
-        /** Base URL for the OpenAI-compatible HTTP API (e.g. Azure OpenAI or a proxy). */
-        baseUrl: z.string().url().optional(),
-        /** Chat completions model id (e.g. `gpt-4o-mini`). */
-        model: z.string().min(1).default("gpt-4o-mini"),
-        /** Sampling temperature. */
-        temperature: z.number().min(0).max(2).default(0.4),
-        /** Maximum tokens to generate. */
-        maxTokens: z.number().int().positive().optional(),
-        /** Timeout in milliseconds for the OpenAI API call. */
-        timeoutMs: z.number().int().positive().default(120000),
-      })
-      .default({}),
+    openai: z.object({
+      /** OpenAI API key for newsletter generation (required, non-whitespace). */
+      apiKey: z
+        .string()
+        .min(1, "openai.apiKey is required")
+        .refine((k) => k.trim().length > 0, {
+          message: "openai.apiKey cannot be whitespace only",
+        }),
+      /** Base URL for the OpenAI-compatible HTTP API (e.g. Azure OpenAI or a proxy). */
+      baseUrl: z.string().url().optional(),
+      /** Chat completions model id (e.g. `gpt-4o-mini`). */
+      model: z.string().min(1).default("gpt-4o-mini"),
+      /** Sampling temperature. */
+      temperature: z.number().min(0).max(2).default(0.4),
+      /** Maximum tokens to generate. */
+      maxTokens: z.number().int().positive().optional(),
+      /** Timeout in milliseconds for the OpenAI API call. */
+      timeoutMs: z.number().int().positive().default(120000),
+    }),
 
     prompts: z
       .object({
@@ -122,19 +107,8 @@ export const ContentGenerationConfigSchema = z
       })
       .default({}),
   })
-  .superRefine((data, ctx) => {
-    if (
-      (!data.openaiApiKey || data.openaiApiKey.trim() === "") &&
-      (!data.openai?.apiKey || data.openai.apiKey.trim() === "")
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "Missing API key. Provide either openaiApiKey or openai.apiKey",
-        path: ["openai", "apiKey"],
-      });
-    }
-  });
+  /** Reject unknown keys (e.g. removed top-level `openaiApiKey`) so configs fail fast. */
+  .strict();
 
 export type ContentGenerationConfig = z.infer<
   typeof ContentGenerationConfigSchema

--- a/apps/mediapulse/agents/content-generation/src/index.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.ts
@@ -52,12 +52,12 @@ const app = createAgentApp<
       }
 
       const openai = new OpenAI({
-        apiKey: config.openai?.apiKey ?? config.openaiApiKey,
-        baseURL: config.openai?.baseUrl ?? config.openaiBaseUrl,
-        timeout: config.openai?.timeoutMs,
+        apiKey: config.openai.apiKey,
+        baseURL: config.openai.baseUrl,
+        timeout: config.openai.timeoutMs,
       });
-      const model = config.openai?.model ?? config.openaiModel ?? "gpt-4o-mini";
-      const temperature = config.openai?.temperature ?? 0.4;
+      const model = config.openai.model;
+      const temperature = config.openai.temperature;
       const today = new Date().toISOString().split("T")[0];
 
       const generated = await pRetry(

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -30,7 +30,7 @@ The content-generation agent takes **selected data sources** (scored by the anal
 - `@workspace/agent-runtime` — `createAgentApp`.
 - `@workspace/agent-data-api-client` — Typed API client for content-generation endpoints.
 - `@workspace/agent-types` — `DataSourceRecord` and related types.
-- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config`** from Hermes (`openaiApiKey`, optional `openaiBaseUrl` for non-default API hosts, optional `openaiModel` for the **model id only** — defaults to `gpt-4o-mini`).
+- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config.openai`** from Hermes: required **`apiKey`**, optional **`baseUrl`**, optional **`model`** (defaults to `gpt-4o-mini`), plus **`temperature`**, **`maxTokens`**, and **`timeoutMs`** as defined in the agent config schema.
 - `@workspace/logger` — Logging.
 
 ## Related docs


### PR DESCRIPTION
## Summary

Content-generation previously accepted OpenAI credentials in two places (top-level `openaiApiKey` and nested `openai`), which duplicated the JSON Schema and made it unclear which field Hermes should set. This PR keeps a single nested `openai` object, makes `apiKey` required there, and uses a strict root schema so stray keys fail validation instead of being ignored.

## Related issues

Closes #338

## Important changes

- **Breaking:** Pipeline agent configs must use `openai: { "apiKey": "..." }` (optional `baseUrl`, `model`, etc.). Top-level `openaiApiKey`, `openaiBaseUrl`, and `openaiModel` are removed.
- Root `ContentGenerationConfigSchema` is `.strict()` so unknown properties (including old top-level keys) return a validation error.

## Other changes

- Dev-docs content-generation page updated to describe `config.openai` only.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/config-schema.ts` — required nested `openai`, strict root.
- `apps/mediapulse/agents/content-generation/src/index.ts` — reads only `config.openai.*`.
- `apps/mediapulse/agents/content-generation/src/config-schema.test.ts` — nested-only and JSON schema expectations.

## How to test

1. `pnpm --filter @mediapulse/content-generation test`
2. In Hermes, update a content-generation step config to nested `openai` and run the pipeline; confirm requests with only legacy keys get 400 from the agent.
