### PR TITLE
Enqueue manual pipeline runs on DataQueue

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/run-pipeline-button.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/run-pipeline-button.test.tsx
@@ -34,7 +34,7 @@ const createMockUseFormAction = (overrides?: {
     data?: {
       invocationsRun?: number;
       executionId?: string;
-      runStatus?: "succeeded" | "partial" | "failed";
+      runStatus?: "running" | "succeeded" | "partial" | "failed" | "cancelled";
       failedInvocationCount?: number;
     };
   } | null;
@@ -225,6 +225,35 @@ describe("RunPipelineButton", () => {
     ).toHaveAttribute(
       "href",
       "/dashboard/pipelines/pipeline-123/executions/00000000-0000-4000-8000-000000000001",
+    );
+  });
+
+  it("shows queued message when runStatus is running", async () => {
+    const mock = await getUseFormActionMock();
+    mock.mockReturnValue(
+      createMockUseFormAction({
+        state: {
+          status: true,
+          data: {
+            invocationsRun: 2,
+            runStatus: "running",
+            failedInvocationCount: 0,
+            executionId: "00000000-0000-4000-8000-000000000002",
+          },
+        },
+      }),
+    );
+
+    render(<RunPipelineButton pipelineId="pipeline-123" />);
+
+    expect(
+      screen.getByText(/Queued 2 invocations on the worker queue/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Open execution" }),
+    ).toHaveAttribute(
+      "href",
+      "/dashboard/pipelines/pipeline-123/executions/00000000-0000-4000-8000-000000000002",
     );
   });
 

--- a/apps/hermes/dashboard/app/dashboard/pipelines/[id]/run-pipeline-button.tsx
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/[id]/run-pipeline-button.tsx
@@ -21,7 +21,7 @@ export type RunPipelineButtonProps = {
 };
 
 /**
- * Encapsulates run-pipeline form action and refresh-on-success.
+ * Encapsulates run-pipeline form action, refresh-on-success, and navigation guard while the action is pending.
  */
 const useRunPipelineButtonState = () => {
   const router = useRouter();
@@ -32,6 +32,18 @@ const useRunPipelineButtonState = () => {
       router.refresh();
     }
   }, [state, router]);
+
+  useEffect(() => {
+    if (!pending) {
+      return;
+    }
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [pending]);
 
   return { FormWithAction, state, pending };
 };
@@ -64,8 +76,16 @@ export const RunPipelineButton = ({
       : null;
   const runStatus =
     state && state.status === true && state.data
-      ? (state.data as { runStatus?: "succeeded" | "partial" | "failed" })
-          .runStatus
+      ? (
+          state.data as {
+            runStatus?:
+              | "running"
+              | "succeeded"
+              | "partial"
+              | "failed"
+              | "cancelled";
+          }
+        ).runStatus
       : null;
   const failedInvocationCount =
     state && state.status === true && state.data
@@ -104,26 +124,45 @@ export const RunPipelineButton = ({
       ) : null}
       {successInvocations !== null && successInvocations !== undefined ? (
         <div className="rounded-md border border-border bg-muted/40 px-3 py-2">
-          <p className="text-sm text-muted-foreground">
-            Ran {successInvocations} invocation
-            {successInvocations !== 1 ? "s" : ""}.{" "}
-            <span className="text-foreground">
-              Status {runStatus ?? "unknown"}, {failedInvocationCount ?? 0}{" "}
-              failed.
-            </span>
-            {executionId ? (
-              <>
-                {" "}
-                <Link
-                  href={`/dashboard/pipelines/${pipelineId}/executions/${executionId}`}
-                  className="font-medium text-primary underline-offset-4 hover:underline"
-                >
-                  Open execution
-                </Link>
-                .
-              </>
-            ) : null}
-          </p>
+          {runStatus === "running" ? (
+            <p className="text-sm text-muted-foreground">
+              Queued {successInvocations} invocation
+              {successInvocations !== 1 ? "s" : ""} on the worker queue. Agents
+              run in the background; you can refresh this page safely.{" "}
+              {executionId ? (
+                <>
+                  <Link
+                    href={`/dashboard/pipelines/${pipelineId}/executions/${executionId}`}
+                    className="font-medium text-primary underline-offset-4 hover:underline"
+                  >
+                    Open execution
+                  </Link>{" "}
+                  for live status.
+                </>
+              ) : null}
+            </p>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Ran {successInvocations} invocation
+              {successInvocations !== 1 ? "s" : ""}.{" "}
+              <span className="text-foreground">
+                Status {runStatus ?? "unknown"}, {failedInvocationCount ?? 0}{" "}
+                failed.
+              </span>
+              {executionId ? (
+                <>
+                  {" "}
+                  <Link
+                    href={`/dashboard/pipelines/${pipelineId}/executions/${executionId}`}
+                    className="font-medium text-primary underline-offset-4 hover:underline"
+                  >
+                    Open execution
+                  </Link>
+                  .
+                </>
+              ) : null}
+            </p>
+          )}
         </div>
       ) : null}
     </div>

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -39,23 +39,30 @@ const request = (body: { pipelineId: string }) =>
     user: mockDashboardUser,
   }) as never;
 
-const createExecutionPersistenceStubs = () => ({
-  manualPipelineExecution: {
-    create: vi.fn().mockResolvedValue({ id: "manual-exec-1" }),
-    findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
-    update: vi.fn().mockResolvedValue(undefined),
-  },
-  manualPipelineStepExecution: {
-    create: vi.fn().mockResolvedValue(undefined),
-    update: vi.fn().mockResolvedValue(undefined),
-  },
-  agentJobExecution: {
-    create: vi.fn().mockResolvedValue(undefined),
-    update: vi.fn().mockResolvedValue(undefined),
-    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-    count: vi.fn().mockResolvedValue(0),
-  },
-});
+const createExecutionPersistenceStubs = () => {
+  const stubs = {
+    manualPipelineExecution: {
+      create: vi.fn().mockResolvedValue({ id: "manual-exec-1" }),
+      findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    manualPipelineStepExecution: {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    },
+    agentJobExecution: {
+      create: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      count: vi.fn().mockResolvedValue(0),
+    },
+    $transaction: vi.fn(),
+  };
+  stubs.$transaction.mockImplementation(
+    async (fn: (tx: typeof stubs) => Promise<unknown>) => fn(stubs),
+  );
+  return stubs;
+};
 
 const createPipelineWithSteps = () => ({
   id: "p-1",
@@ -134,7 +141,6 @@ describe("createRunPipelineHandler", () => {
   it("returns error when pipeline is missing", async () => {
     const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       db: {
         ...createExecutionPersistenceStubs(),
         pipeline: { findUnique: vi.fn().mockResolvedValue(null) },
@@ -157,7 +163,6 @@ describe("createRunPipelineHandler", () => {
   it("returns error and logs when an unexpected error is thrown", async () => {
     const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       db: {
         ...createExecutionPersistenceStubs(),
         pipeline: {
@@ -185,7 +190,6 @@ describe("createRunPipelineHandler", () => {
   it("returns failed run with 0 invocations when planning yields no jobs", async () => {
     const stubs = createExecutionPersistenceStubs();
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       expandStepInputs: async () => [],
       db: {
         ...stubs,
@@ -256,7 +260,6 @@ describe("createRunPipelineHandler", () => {
     mockXRequestId = "dashboard-run-req-7";
     const stubs = createExecutionPersistenceStubs();
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       expandStepInputs: async () => [],
       db: {
         ...stubs,
@@ -296,20 +299,11 @@ describe("createRunPipelineHandler", () => {
     ).toEqual({ requestId: "dashboard-run-req-7" });
   });
 
-  it("runs one planned invocation and returns invocationsRun", async () => {
-    const postMock = vi.fn().mockResolvedValue({
-      ok: true,
-      statusCode: 200,
-      body: {
-        schemaVersion: 1,
-        status: "success",
-        details: { ok: true },
-      },
-    });
+  it("enqueues one invoke_agent job and returns running status", async () => {
+    const enqueueMock = vi.fn().mockResolvedValue(undefined);
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       expandStepInputs: async (ctx) => [ctx.input],
-      post: postMock as never,
+      enqueueManualAgentInvocations: enqueueMock,
       db: {
         ...createExecutionPersistenceStubs(),
         pipeline: {
@@ -346,32 +340,29 @@ describe("createRunPipelineHandler", () => {
       data: {
         ok: true,
         invocationsRun: 1,
-        runStatus: "succeeded",
+        runStatus: "running",
         failedInvocationCount: 0,
       },
     });
-    expect(postMock).toHaveBeenCalledWith(
-      "https://agent.example/run",
-      expect.objectContaining({
-        json: { input: { id: "single-id" }, config: {} },
-        throwHttpErrors: false,
-      }),
-    );
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    const batch = enqueueMock.mock.calls[0]?.[0] as Array<{
+      payload: { endpointUrl: string; manualExecutionId: string };
+    }>;
+    expect(batch).toHaveLength(1);
+    expect(batch[0]?.payload.endpointUrl).toBe("https://agent.example/run");
+    expect(batch[0]?.payload.manualExecutionId).toBe("manual-exec-1");
   });
 
-  it("returns success with failedInvocationCount when invocation fails", async () => {
-    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const postMock = vi.fn().mockResolvedValue({
-      ok: false,
-      statusCode: 400,
-      body: { message: "bad input" },
-    });
+  it("returns failed when DataQueue enqueue throws", async () => {
+    const enqueueMock = vi
+      .fn()
+      .mockRejectedValue(new Error("queue connection refused"));
+    const stubs = createExecutionPersistenceStubs();
     const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
       expandStepInputs: async (ctx) => [ctx.input],
-      post: postMock as never,
+      enqueueManualAgentInvocations: enqueueMock,
       db: {
-        ...createExecutionPersistenceStubs(),
+        ...stubs,
         pipeline: {
           findUnique: vi.fn().mockResolvedValue(createPipelineWithSteps()),
         },
@@ -405,88 +396,12 @@ describe("createRunPipelineHandler", () => {
     expect(result).toMatchObject({
       data: {
         ok: true,
-        invocationsRun: 1,
+        invocationsRun: 0,
         runStatus: "failed",
-        failedInvocationCount: 1,
+        failedInvocationCount: 0,
       },
     });
-    expect(logSpy).toHaveBeenCalledWith(
-      "[hermes-dashboard:run-pipeline]",
-      "Agent HTTP response was not OK",
-      expect.objectContaining({
-        phase: "agent-http",
-        pipelineId: "p-1",
-        detail: "bad input",
-        statusCode: 400,
-      }),
-    );
-    logSpy.mockRestore();
-  });
-
-  it("treats HTTP 200 with envelope status failure as a failed invocation", async () => {
-    const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const postMock = vi.fn().mockResolvedValue({
-      ok: true,
-      statusCode: 200,
-      body: {
-        schemaVersion: 1,
-        status: "failure",
-        message: "No rows collected",
-      },
-    });
-    const handler = createRunPipelineHandler({
-      getToken: async () => "jwt",
-      expandStepInputs: async (ctx) => [ctx.input],
-      post: postMock as never,
-      db: {
-        ...createExecutionPersistenceStubs(),
-        pipeline: {
-          findUnique: vi.fn().mockResolvedValue(createPipelineWithSteps()),
-        },
-        variable: { findMany: vi.fn().mockResolvedValue([]) },
-        agentRegistry: {
-          findFirst: vi.fn().mockResolvedValue({
-            agentId: "ag1",
-            agentVersion: "1.0.0",
-            endpoint: { url: "https://agent.example/run", method: "POST" },
-            inputSchema: null,
-            configSchema: null,
-            isActive: true,
-          }),
-          findMany: vi.fn().mockResolvedValue([
-            {
-              agentId: "ag1",
-              agentVersion: "1.0.0",
-              endpoint: { url: "https://agent.example/run", method: "POST" },
-              inputSchema: null,
-              configSchema: null,
-              isActive: true,
-            },
-          ]),
-        },
-        agentConfig: { findFirst: vi.fn().mockResolvedValue(null) },
-      } as never,
-    });
-
-    const result = await handler(request({ pipelineId: "p-1" }));
-    expect(result.status).toBe(true);
-    expect(result).toMatchObject({
-      data: {
-        ok: true,
-        invocationsRun: 1,
-        runStatus: "failed",
-        failedInvocationCount: 1,
-      },
-    });
-    expect(logSpy).toHaveBeenCalledWith(
-      "[hermes-dashboard:run-pipeline]",
-      "Agent returned HTTP 200 with envelope status failure",
-      expect.objectContaining({
-        phase: "agent-semantic",
-        pipelineId: "p-1",
-        detail: "No rows collected",
-      }),
-    );
-    logSpy.mockRestore();
+    expect(stubs.agentJobExecution.update).toHaveBeenCalled();
+    expect(stubs.manualPipelineExecution.update).toHaveBeenCalled();
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { createAgentTokenClient } from "@workspace/agent-auth-client";
 import { env } from "@hermes/env";
 import { headers } from "next/headers";
 import {
@@ -11,18 +10,15 @@ import {
   ScheduleStepRollupStatus,
 } from "@hermes/orchestration-database";
 import {
-  computeExecutionRunStatusFromStepRollups,
-  computeStepRollupFromCounts,
   diagnosticFromCaughtError,
-  finalizeManualPipelineExecutionAfterCooperativeCancel,
   mergeExecutionConfig,
-  parseAgentResponseEnvelope,
   planPipelineInvocations,
   type EnqueueDiagnosticEntry,
+  type EnqueueInvokeAgentItem,
   type ExpandStepInputs,
 } from "@hermes/scheduler";
 import { mergeHermesEnqueueCorrelationIntoMetadata } from "@hermes/scheduler/enqueue-diagnostics-correlation";
-import got from "got";
+import { batchDepRef } from "@nicnocquee/dataqueue";
 import {
   createRequestValidator,
   errorResponse,
@@ -33,11 +29,7 @@ import { z } from "zod";
 
 import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
 import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-inputs-for-manual-pipeline";
-import {
-  clearManualPipelineRunAbortController,
-  registerManualPipelineRunAbortController,
-  startManualExecutionCancelledPollFromDb,
-} from "@/lib/manual-pipeline-run-abort";
+import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 import { validatePipeline } from "@/lib/validate-pipeline";
 
 const bodyValidator = z.object({
@@ -90,7 +82,7 @@ export const responseValidator = z.object({
   ok: z.literal(true),
   invocationsRun: z.number(),
   executionId: z.string().uuid(),
-  runStatus: z.enum(["succeeded", "partial", "failed", "cancelled"]),
+  runStatus: z.enum(["running", "succeeded", "partial", "failed", "cancelled"]),
   failedInvocationCount: z.number(),
 });
 
@@ -174,22 +166,56 @@ export const agentHttpBodyToRawString = (
   return { raw: JSON.stringify(body), isEmpty: false };
 };
 
-const defaultGetToken =
-  env.AGENT_AUTH_API_URL && env.HERMES_INTERNAL_API_KEY
-    ? createAgentTokenClient({
-        authApiUrl: env.AGENT_AUTH_API_URL,
-        credential: env.HERMES_INTERNAL_API_KEY,
-      }).getToken
-    : null;
-
-type StepRollupTerminal = "success" | "partial" | "failed";
+/**
+ * Enqueues manual pipeline `invoke_agent` jobs on Hermes DataQueue (same pattern as HTTP trigger runs).
+ *
+ * @param items - Planned invocations with optional same-batch `dependsOn` indices.
+ */
+const defaultEnqueueManualAgentInvocations = async (
+  items: EnqueueInvokeAgentItem[],
+): Promise<void> => {
+  if (items.length === 0) {
+    return;
+  }
+  const jobQueue = getHermesJobQueue();
+  const jobDefs = items.map((item) => ({
+    jobType: "invoke_agent" as const,
+    payload: item.payload,
+    priority: item.payload.priority,
+    idempotencyKey: item.payload.jobId,
+    dependsOn:
+      item.dependsOnBatchIndices && item.dependsOnBatchIndices.length > 0
+        ? {
+            jobIds: item.dependsOnBatchIndices.map((idx) => batchDepRef(idx)),
+          }
+        : undefined,
+    tags: [
+      `manualPipelineExecution:${item.payload.manualExecutionId}`,
+      `pipeline:${item.payload.pipelineId}`,
+      `pipelineStep:${item.payload.pipelineStepId}`,
+    ],
+  }));
+  const insertedIds = await jobQueue.addJobs(jobDefs);
+  for (let idx = 0; idx < insertedIds.length; idx++) {
+    const queueJobId = insertedIds[idx];
+    const item = items[idx];
+    if (item === undefined || queueJobId === undefined) {
+      continue;
+    }
+    await jobQueue.editJob(queueJobId, {
+      payload: { ...item.payload, hermesDataQueueJobId: queueJobId },
+    });
+  }
+};
 
 type RunPipelineHandlerDependencies = {
   db?: typeof orchestrationPrisma;
-  getToken?: () => Promise<string>;
-  post?: typeof got.post;
   now?: () => Date;
   expandStepInputs?: ExpandStepInputs;
+  /** Injected in tests to avoid requiring `PG_DATAQUEUE_DATABASE`. */
+  enqueueManualAgentInvocations?: (
+    items: EnqueueInvokeAgentItem[],
+  ) => Promise<void>;
 };
 
 type RunPipelineHandler = HandlerFunc<
@@ -199,22 +225,17 @@ type RunPipelineHandler = HandlerFunc<
 >;
 
 /**
- * Executes one manual pipeline run and persists full execution lineage.
+ * Plans a manual pipeline run, persists execution rows, and enqueues `invoke_agent` jobs on DataQueue
+ * so hermes-worker performs agent HTTP calls (short Server Action; safe to refresh while work continues).
  *
  * @param dependencies - Optional collaborators for tests.
  * @returns Route-action-gen handler for manual run requests.
  */
 export const createRunPipelineHandler = ({
   db = orchestrationPrisma,
-  getToken = defaultGetToken ??
-    (async () => {
-      throw new Error(
-        "AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY are required",
-      );
-    }),
-  post = got.post,
   now = () => new Date(),
   expandStepInputs = createExpandStepInputsForManualPipelineRun(),
+  enqueueManualAgentInvocations = defaultEnqueueManualAgentInvocations,
 }: RunPipelineHandlerDependencies = {}): RunPipelineHandler => {
   return async (data) => {
     const pipelineIdRequest = data.body.pipelineId;
@@ -228,22 +249,6 @@ export const createRunPipelineHandler = ({
         headerRequestId != null && headerRequestId !== ""
           ? headerRequestId
           : randomUUID();
-
-      let jwt: string;
-      try {
-        jwt = await getToken();
-      } catch (err) {
-        logRunPipelineIssue(
-          "token",
-          pipelineIdRequest,
-          "Failed to obtain JWT for agent invocation (check AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY)",
-          {},
-          err,
-        );
-        return errorResponse(
-          "AGENT_AUTH_API_URL and HERMES_INTERNAL_API_KEY are required to run pipelines (JWT-only invocation)",
-        );
-      }
 
       const pipelineFindArgs = {
         where: { id: data.body.pipelineId },
@@ -375,7 +380,7 @@ export const createRunPipelineHandler = ({
           effectiveExecutionConfig:
             effectiveExecutionConfig as Prisma.InputJsonValue,
           jobsCreated,
-          jobsEnqueued: jobsCreated,
+          jobsEnqueued: 0,
           errors: initialExecutionErrors,
           metadata: mergeHermesEnqueueCorrelationIntoMetadata(
             {
@@ -397,14 +402,6 @@ export const createRunPipelineHandler = ({
         );
       }
 
-      const stepStats = new Map<
-        string,
-        {
-          succeededCount: number;
-          failedCount: number;
-          expectedInvocationCount: number;
-        }
-      >();
       for (const step of pipeline.steps) {
         const expectedInvocationCount = stepExpected.get(step.id) ?? 0;
         await db.manualPipelineStepExecution.create({
@@ -418,438 +415,191 @@ export const createRunPipelineHandler = ({
                 : ScheduleStepRollupStatus.pending,
           },
         });
-        stepStats.set(step.id, {
-          succeededCount: 0,
-          failedCount: 0,
-          expectedInvocationCount,
-        });
       }
 
-      const errors: EnqueueDiagnosticEntry[] = [...planning.errors];
-
-      const abortSignal = registerManualPipelineRunAbortController(
-        execution.id,
-      );
-      const stopCancelledPoll = startManualExecutionCancelledPollFromDb(
-        db,
-        execution.id,
-      );
-      const processedJobIds = new Set<string>();
-      const plannedJobsForCancel = plannedJobs.map((j) => ({
-        jobId: j.jobId,
-        pipelineStepId: j.pipelineStepId,
-      }));
-      let cooperativeCancel = false;
-
-      try {
-        invokeLoop: for (const wave of waveList) {
-          for (const job of wave) {
-            const cancelRow = await db.manualPipelineExecution.findUnique({
-              where: { id: execution.id },
-              select: { cancelledAt: true },
-            });
-            if (cancelRow?.cancelledAt) {
-              cooperativeCancel = true;
-              break invokeLoop;
-            }
-
-            const step = pipeline.steps.find(
-              (item) => item.id === job.pipelineStepId,
-            );
-            if (!step) {
-              logRunPipelineIssue(
-                "agent-invoke",
-                pipeline.id,
-                "Planned job references missing pipeline step",
-                {
-                  jobId: job.jobId,
-                  pipelineStepId: job.pipelineStepId,
-                  agentId: job.agentId,
-                },
-              );
-              errors.push({
-                message: `Missing pipeline step ${job.pipelineStepId} (job ${job.jobId})`,
-                timestamp: now().toISOString(),
-                phase: "transaction",
-                pipelineStepId: job.pipelineStepId,
-                code: "MISSING_PIPELINE_STEP",
-              });
-              continue;
-            }
-
-            await db.agentJobExecution.create({
-              data: {
-                jobId: job.jobId,
-                agentId: job.agentId,
-                manualExecutionId: execution.id,
-                pipelineId: pipeline.id,
-                pipelineStepId: step.id,
-                status: "running",
-                enqueuedAt: executionTime,
-                startedAt: now(),
-                params: job.input as Prisma.InputJsonValue,
-                invocationConfig: job.config as Prisma.InputJsonValue,
-              },
-            });
-
-            try {
-              const agentResponse = await post(job.endpointUrl, {
-                json: { input: job.input, config: job.config },
-                headers: {
-                  "Content-Type": "application/json",
-                  Authorization: `Bearer ${jwt}`,
-                },
-                throwHttpErrors: false,
-                timeout: { request: invokeRequestTimeoutMs },
-                signal: abortSignal,
-              });
-              const response = agentResponse as {
-                ok?: boolean;
-                statusCode?: number;
-                body?: unknown;
-              };
-              if (response.ok === true) {
-                const { raw: rawBody, isEmpty: isEmptyBody } =
-                  agentHttpBodyToRawString(response.body);
-                const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
-                if (!parsed.ok) {
-                  const detail = parsed.error.message;
-                  logRunPipelineIssue(
-                    "agent-envelope",
-                    pipeline.id,
-                    "Agent HTTP 200 but response body is not a valid Hermes envelope",
-                    {
-                      jobId: job.jobId,
-                      pipelineStepId: step.id,
-                      agentId: step.agentId,
-                      agentVersion: step.agentVersion,
-                      endpointUrl: job.endpointUrl,
-                      code: parsed.error.code,
-                      detail,
-                    },
-                  );
-                  const envFail = await db.agentJobExecution.updateMany({
-                    where: {
-                      jobId: job.jobId,
-                      status: AgentJobExecutionStatus.running,
-                    },
-                    data: {
-                      status: "failed",
-                      completedAt: now(),
-                      error: {
-                        message: detail,
-                        code: parsed.error.code,
-                        jobId: job.jobId,
-                        retryable: false,
-                      },
-                      agentResponse: Prisma.DbNull,
-                      semanticStatus: "failure",
-                    },
-                  });
-                  if (envFail.count > 0) {
-                    const stats = stepStats.get(step.id);
-                    if (stats) stats.failedCount += 1;
-                    errors.push({
-                      message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                      timestamp: now().toISOString(),
-                      phase: "transaction",
-                      pipelineStepId: step.id,
-                      code: `AGENT_ENVELOPE_INVALID:${parsed.error.code}`,
-                    });
-                    processedJobIds.add(job.jobId);
-                  }
-                  continue;
-                }
-                if (parsed.envelope.status === "failure") {
-                  const detail =
-                    parsed.envelope.message ??
-                    "Agent reported semantic failure";
-                  logRunPipelineIssue(
-                    "agent-semantic",
-                    pipeline.id,
-                    "Agent returned HTTP 200 with envelope status failure",
-                    {
-                      jobId: job.jobId,
-                      pipelineStepId: step.id,
-                      agentId: step.agentId,
-                      agentVersion: step.agentVersion,
-                      endpointUrl: job.endpointUrl,
-                      detail,
-                    },
-                  );
-                  const semFail = await db.agentJobExecution.updateMany({
-                    where: {
-                      jobId: job.jobId,
-                      status: AgentJobExecutionStatus.running,
-                    },
-                    data: {
-                      status: "failed",
-                      completedAt: now(),
-                      error: {
-                        message: detail,
-                        retryable: false,
-                        semantic: true,
-                        jobId: job.jobId,
-                      },
-                      agentResponse:
-                        parsed.envelope as unknown as Prisma.InputJsonValue,
-                      semanticStatus: "failure",
-                    },
-                  });
-                  if (semFail.count > 0) {
-                    const stats = stepStats.get(step.id);
-                    if (stats) stats.failedCount += 1;
-                    errors.push({
-                      message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                      timestamp: now().toISOString(),
-                      phase: "transaction",
-                      pipelineStepId: step.id,
-                      code: "AGENT_SEMANTIC_FAILURE",
-                    });
-                    processedJobIds.add(job.jobId);
-                  }
-                  continue;
-                }
-                const stats = stepStats.get(step.id);
-                const completedUp = await db.agentJobExecution.updateMany({
-                  where: {
-                    jobId: job.jobId,
-                    status: AgentJobExecutionStatus.running,
-                  },
-                  data: {
-                    status: "completed",
-                    completedAt: now(),
-                    error: Prisma.DbNull,
-                    agentResponse:
-                      parsed.envelope as unknown as Prisma.InputJsonValue,
-                    semanticStatus: "success",
-                  },
-                });
-                if (completedUp.count > 0) {
-                  if (stats) stats.succeededCount += 1;
-                  processedJobIds.add(job.jobId);
-                }
-                continue;
-              }
-
-              const statusCodeNum =
-                typeof response.statusCode === "number"
-                  ? response.statusCode
-                  : undefined;
-              const detail = detailFromAgentErrorBody(response.body, {
-                statusCode: statusCodeNum,
-              });
-              const code = response.statusCode ?? "unknown";
-              logRunPipelineIssue(
-                "agent-http",
-                pipeline.id,
-                "Agent HTTP response was not OK",
-                {
-                  jobId: job.jobId,
-                  pipelineStepId: step.id,
-                  agentId: step.agentId,
-                  agentVersion: step.agentVersion,
-                  endpointUrl: job.endpointUrl,
-                  statusCode: code,
-                  detail,
-                },
-              );
-              const httpFail = await db.agentJobExecution.updateMany({
-                where: {
-                  jobId: job.jobId,
-                  status: AgentJobExecutionStatus.running,
-                },
-                data: {
-                  status: "failed",
-                  completedAt: now(),
-                  error: {
-                    detail,
-                    code,
-                    jobId: job.jobId,
-                  },
-                  agentResponse:
-                    (response.body as Prisma.InputJsonValue | undefined) ??
-                    Prisma.DbNull,
-                  semanticStatus: "failure",
-                },
-              });
-              if (httpFail.count > 0) {
-                const stats = stepStats.get(step.id);
-                if (stats) stats.failedCount += 1;
-                errors.push({
-                  message: `${detail} (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                  timestamp: now().toISOString(),
-                  phase: "transaction",
-                  pipelineStepId: step.id,
-                  code: `AGENT_HTTP_${String(code)}`,
-                });
-                processedJobIds.add(job.jobId);
-              }
-            } catch (err) {
-              if (abortSignal.aborted) {
-                cooperativeCancel = true;
-                break invokeLoop;
-              }
-              const detail = err instanceof Error ? err.message : String(err);
-              logRunPipelineIssue(
-                "agent-http",
-                pipeline.id,
-                "Agent HTTP request threw (network/DNS/TLS/timeout)",
-                {
-                  jobId: job.jobId,
-                  pipelineStepId: step.id,
-                  agentId: step.agentId,
-                  agentVersion: step.agentVersion,
-                  endpointUrl: job.endpointUrl,
-                  detail,
-                },
-                err,
-              );
-              const throwFail = await db.agentJobExecution.updateMany({
-                where: {
-                  jobId: job.jobId,
-                  status: AgentJobExecutionStatus.running,
-                },
-                data: {
-                  status: "failed",
-                  completedAt: now(),
-                  error: {
-                    detail,
-                    code: "unknown",
-                    jobId: job.jobId,
-                  },
-                  semanticStatus: "failure",
-                },
-              });
-              if (throwFail.count > 0) {
-                const stats = stepStats.get(step.id);
-                if (stats) stats.failedCount += 1;
-                errors.push(
-                  diagnosticFromCaughtError(err, {
-                    phase: "transaction",
-                    pipelineStepId: step.id,
-                    messagePrefix: `Agent HTTP threw (job ${job.jobId}, ${step.agentId}@${step.agentVersion})`,
-                  }),
-                );
-                processedJobIds.add(job.jobId);
-              }
-            }
-          }
-        }
-      } finally {
-        stopCancelledPoll();
-        clearManualPipelineRunAbortController(execution.id);
-      }
-
-      if (cooperativeCancel) {
-        const parentAfterCancel = await db.manualPipelineExecution.findUnique({
-          where: { id: execution.id },
-          select: { runStatus: true },
-        });
-        const actionableInvocations = await db.agentJobExecution.count({
-          where: {
-            manualExecutionId: execution.id,
-            status: {
-              in: [
-                AgentJobExecutionStatus.pending,
-                AgentJobExecutionStatus.running,
-              ],
-            },
-          },
-        });
-        const needsCooperativeFinalize =
-          actionableInvocations > 0 ||
-          parentAfterCancel?.runStatus === ScheduleRunStatus.running ||
-          parentAfterCancel?.runStatus === ScheduleRunStatus.pending;
-        if (needsCooperativeFinalize) {
-          await finalizeManualPipelineExecutionAfterCooperativeCancel(db, {
-            manualExecutionId: execution.id,
-            plannedJobs: plannedJobsForCancel,
-            processedJobIds,
-            source: "runPipeline",
-          });
-        }
-        const finalRow = await db.manualPipelineExecution.findUnique({
-          where: { id: execution.id },
-          select: {
-            runStatus: true,
-            succeededInvocationCount: true,
-            failedInvocationCount: true,
-          },
-        });
-        const rs = finalRow?.runStatus;
-        const runStatusLabel =
-          rs === ScheduleRunStatus.cancelled
-            ? ("cancelled" as const)
-            : rs === ScheduleRunStatus.partial
-              ? ("partial" as const)
-              : rs === ScheduleRunStatus.succeeded
-                ? ("succeeded" as const)
-                : ("failed" as const);
+      if (jobsCreated === 0) {
         return successResponse({
           ok: true as const,
-          invocationsRun: processedJobIds.size,
+          invocationsRun: 0,
           executionId: execution.id,
-          runStatus: runStatusLabel,
-          failedInvocationCount: finalRow?.failedInvocationCount ?? 0,
+          runStatus: "failed",
+          failedInvocationCount: 0,
         });
       }
 
-      const stepRollups: StepRollupTerminal[] = [];
-      for (const step of pipeline.steps) {
-        const stats = stepStats.get(step.id);
-        if (!stats) continue;
-        const rollup = computeStepRollupFromCounts(
-          stats.succeededCount,
-          stats.failedCount,
-          effectiveExecutionConfig.stepRollupPolicy,
-        );
-        stepRollups.push(rollup);
-        await db.manualPipelineStepExecution.update({
-          where: {
-            manualExecutionId_pipelineStepId: {
-              manualExecutionId: execution.id,
-              pipelineStepId: step.id,
-            },
-          },
-          data: {
-            succeededCount: stats.succeededCount,
-            failedCount: stats.failedCount,
-            rollupStatus: stepTerminalToPrismaRollup(rollup),
-          },
-        });
-      }
+      const enqueueItems: EnqueueInvokeAgentItem[] = [];
+      let lastWaveIndices: number[] = [];
+      const enqueueDiagnostics: EnqueueDiagnosticEntry[] = [...planning.errors];
 
-      const finalRunStatus =
-        jobsCreated === 0
-          ? "failed"
-          : computeExecutionRunStatusFromStepRollups(
-              stepRollups,
-              effectiveExecutionConfig.stepRollupPolicy,
+      for (const wave of waveList) {
+        const waveStart = enqueueItems.length;
+        const useSequentialDeps =
+          effectiveExecutionConfig.stepOrder === "sequential" &&
+          lastWaveIndices.length > 0;
+        for (const job of wave) {
+          const step = pipeline.steps.find(
+            (item) => item.id === job.pipelineStepId,
+          );
+          if (!step) {
+            logRunPipelineIssue(
+              "agent-invoke",
+              pipeline.id,
+              "Planned job references missing pipeline step",
+              {
+                jobId: job.jobId,
+                pipelineStepId: job.pipelineStepId,
+                agentId: job.agentId,
+              },
             );
-      const failedInvocationCount = Array.from(stepStats.values()).reduce(
-        (sum, item) => sum + item.failedCount,
-        0,
-      );
+            enqueueDiagnostics.push({
+              message: `Missing pipeline step ${job.pipelineStepId} (job ${job.jobId})`,
+              timestamp: now().toISOString(),
+              phase: "transaction",
+              pipelineStepId: job.pipelineStepId,
+              code: "MISSING_PIPELINE_STEP",
+            });
+            continue;
+          }
+          enqueueItems.push({
+            payload: {
+              jobId: job.jobId,
+              executionId: randomUUID(),
+              manualExecutionId: execution.id,
+              pipelineId: pipeline.id,
+              pipelineStepId: job.pipelineStepId,
+              domainIntegrationId: pipeline.domainIntegrationId,
+              agentId: job.agentId,
+              agentVersion: job.agentVersion,
+              endpointUrl: job.endpointUrl,
+              body: { input: job.input, config: job.config },
+              timeoutMs: invokeRequestTimeoutMs,
+              priority: 0,
+            },
+            dependsOnBatchIndices: useSequentialDeps
+              ? [...lastWaveIndices]
+              : undefined,
+          });
+        }
+        if (enqueueItems.length > waveStart) {
+          lastWaveIndices = Array.from(
+            { length: enqueueItems.length - waveStart },
+            (_, idx) => waveStart + idx,
+          );
+        }
+      }
+
+      if (enqueueItems.length === 0) {
+        await db.manualPipelineExecution.update({
+          where: { id: execution.id },
+          data: {
+            runStatus: ScheduleRunStatus.failed,
+            errors:
+              enqueueDiagnostics.length > 0
+                ? (enqueueDiagnostics as Prisma.InputJsonValue)
+                : Prisma.DbNull,
+          },
+        });
+        return successResponse({
+          ok: true as const,
+          invocationsRun: 0,
+          executionId: execution.id,
+          runStatus: "failed",
+          failedInvocationCount: 0,
+        });
+      }
+
+      await db.$transaction(async (tx) => {
+        for (const item of enqueueItems) {
+          await tx.agentJobExecution.create({
+            data: {
+              jobId: item.payload.jobId,
+              agentId: item.payload.agentId,
+              manualExecutionId: execution.id,
+              pipelineId: pipeline.id,
+              pipelineStepId: item.payload.pipelineStepId,
+              status: AgentJobExecutionStatus.pending,
+              enqueuedAt: executionTime,
+              params: item.payload.body.input as Prisma.InputJsonValue,
+              invocationConfig: item.payload.body
+                .config as Prisma.InputJsonValue,
+            },
+          });
+        }
+      });
+
+      let jobsEnqueued = 0;
+      try {
+        await enqueueManualAgentInvocations(enqueueItems);
+        jobsEnqueued = enqueueItems.length;
+      } catch (err) {
+        enqueueDiagnostics.push(
+          diagnosticFromCaughtError(err, {
+            phase: "enqueue",
+            messagePrefix: "Failed to enqueue agent invocations",
+          }),
+        );
+        for (const item of enqueueItems) {
+          try {
+            await db.agentJobExecution.update({
+              where: { jobId: item.payload.jobId },
+              data: {
+                status: AgentJobExecutionStatus.failed,
+                error: {
+                  message: err instanceof Error ? err.message : String(err),
+                  retryable: true,
+                },
+                completedAt: now(),
+              },
+            });
+          } catch {
+            // Best-effort: row may be missing if transaction was rolled back.
+          }
+        }
+        await db.manualPipelineExecution.update({
+          where: { id: execution.id },
+          data: {
+            enqueueStatus:
+              jobsEnqueued > 0
+                ? ScheduleEnqueueStatus.partial
+                : ScheduleEnqueueStatus.failed,
+            runStatus: ScheduleRunStatus.failed,
+            jobsEnqueued,
+            errors:
+              enqueueDiagnostics.length > 0
+                ? (enqueueDiagnostics as Prisma.InputJsonValue)
+                : undefined,
+          },
+        });
+        return successResponse({
+          ok: true as const,
+          invocationsRun: 0,
+          executionId: execution.id,
+          runStatus: "failed",
+          failedInvocationCount: 0,
+        });
+      }
+
       await db.manualPipelineExecution.update({
         where: { id: execution.id },
         data: {
-          runStatus: runStatusTerminalToPrisma(finalRunStatus),
-          succeededInvocationCount: jobsCreated - failedInvocationCount,
-          failedInvocationCount,
+          enqueueStatus:
+            enqueueDiagnostics.length > 0
+              ? ScheduleEnqueueStatus.partial
+              : ScheduleEnqueueStatus.success,
+          jobsEnqueued,
           errors:
-            errors.length > 0
-              ? (errors as Prisma.InputJsonValue)
-              : Prisma.DbNull,
+            enqueueDiagnostics.length > 0
+              ? (enqueueDiagnostics as Prisma.InputJsonValue)
+              : undefined,
         },
       });
 
       return successResponse({
         ok: true as const,
-        invocationsRun: jobsCreated,
+        invocationsRun: jobsEnqueued,
         executionId: execution.id,
-        runStatus: finalRunStatus,
-        failedInvocationCount,
+        runStatus: "running",
+        failedInvocationCount: 0,
       });
     } catch (err) {
       logRunPipelineIssue(
@@ -863,34 +613,6 @@ export const createRunPipelineHandler = ({
       return errorResponse(`Run pipeline failed: ${message}`);
     }
   };
-};
-
-/**
- * Converts scheduler terminal step rollups to Prisma rollup status values.
- *
- * @param terminal - Scheduler terminal rollup value.
- * @returns Prisma rollup enum.
- */
-const stepTerminalToPrismaRollup = (
-  terminal: StepRollupTerminal,
-): ScheduleStepRollupStatus => {
-  if (terminal === "success") return ScheduleStepRollupStatus.success;
-  if (terminal === "partial") return ScheduleStepRollupStatus.partial;
-  return ScheduleStepRollupStatus.failed;
-};
-
-/**
- * Converts scheduler terminal run status to Prisma run status.
- *
- * @param status - Scheduler run terminal value.
- * @returns Prisma run enum.
- */
-const runStatusTerminalToPrisma = (
-  status: "succeeded" | "partial" | "failed",
-): ScheduleRunStatus => {
-  if (status === "succeeded") return ScheduleRunStatus.succeeded;
-  if (status === "partial") return ScheduleRunStatus.partial;
-  return ScheduleRunStatus.failed;
 };
 
 /**

--- a/apps/hermes/dashboard/lib/hermes-job-queue.ts
+++ b/apps/hermes/dashboard/lib/hermes-job-queue.ts
@@ -6,7 +6,7 @@ type DashboardJobPayloadMap = {
   execute_http_trigger: {
     httpTriggerExecutionId: string;
   };
-  /** Typed for queue control APIs; dashboard only enqueues `execute_http_trigger` today. */
+  /** Typed for queue control APIs; dashboard enqueues `execute_http_trigger` and manual `invoke_agent` runs. */
   invoke_agent: InvokeAgentJobPayload;
 };
 
@@ -23,7 +23,7 @@ export const getHermesJobQueue = (): ReturnType<
     const connectionString = env.PG_DATAQUEUE_DATABASE;
     if (!connectionString) {
       throw new Error(
-        "PG_DATAQUEUE_DATABASE is required to enqueue HTTP trigger runs.",
+        "PG_DATAQUEUE_DATABASE is required to enqueue DataQueue jobs (HTTP triggers and manual pipeline runs).",
       );
     }
     queue = initJobQueue<DashboardJobPayloadMap>({

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -23,6 +23,9 @@ const mockPrisma = vi.hoisted(() => ({
   httpTriggerExecution: {
     findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
   },
+  manualPipelineExecution: {
+    findUnique: vi.fn().mockResolvedValue({ cancelledAt: null }),
+  },
   domainIntegration: {
     findFirst: vi.fn().mockResolvedValue({
       baseUrl: "https://mediapulse-domain.example",
@@ -410,6 +413,9 @@ describe("jobHandlers", () => {
       mockPrisma.httpTriggerExecution.findUnique.mockResolvedValue({
         cancelledAt: null,
       });
+      mockPrisma.manualPipelineExecution.findUnique.mockResolvedValue({
+        cancelledAt: null,
+      });
     });
 
     it("claims pending row, calls invokeAgentPost, and applies completion on 2xx success envelope", async () => {
@@ -459,6 +465,59 @@ describe("jobHandlers", () => {
         expect.objectContaining({
           jobId: payload.jobId,
           scheduleExecutionId: payload.scheduleExecutionId,
+          terminal: expect.objectContaining({
+            status: AgentJobExecutionStatus.completed,
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("passes manualExecutionId through invoke and completion for manual pipeline jobs", async () => {
+      const manualPayload = {
+        ...payload,
+        scheduleExecutionId: undefined,
+        scheduleId: undefined,
+        manualExecutionId: "manual-exec-9",
+      };
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "http",
+        response: {
+          statusCode: 200,
+          rawBody: '{"schemaVersion":1,"status":"success"}',
+          isEmptyBody: false,
+        },
+      });
+      vi.mocked(parseAgentResponseEnvelope).mockReturnValue({
+        ok: true,
+        envelope: {
+          schemaVersion: 1,
+          status: "success",
+          truncated: {},
+        },
+      });
+
+      await jobHandlers.invoke_agent(manualPayload, signal, jobCtx);
+
+      expect(
+        mockPrisma.manualPipelineExecution.findUnique,
+      ).toHaveBeenCalledWith({
+        where: { id: "manual-exec-9" },
+        select: { cancelledAt: true },
+      });
+      expect(invokeAgentPost).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          manualExecutionId: "manual-exec-9",
+          pipelineStepId: manualPayload.pipelineStepId,
+        }),
+        expect.anything(),
+      );
+      expect(applyInvocationCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: manualPayload.jobId,
+          manualExecutionId: "manual-exec-9",
           terminal: expect.objectContaining({
             status: AgentJobExecutionStatus.completed,
           }),

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -173,6 +173,7 @@ const handleTransientInvokeFailure = async (params: {
         jobId: payload.jobId,
         scheduleExecutionId: payload.scheduleExecutionId,
         httpTriggerExecutionId: payload.httpTriggerExecutionId,
+        manualExecutionId: payload.manualExecutionId,
         pipelineStepId: payload.pipelineStepId,
         terminal: {
           status: AgentJobExecutionStatus.failed,
@@ -384,7 +385,11 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       }
     }
 
-    if (!payload.scheduleExecutionId && !payload.httpTriggerExecutionId) {
+    const hasParentExecution =
+      Boolean(payload.scheduleExecutionId) ||
+      Boolean(payload.httpTriggerExecutionId) ||
+      Boolean(payload.manualExecutionId);
+    if (!hasParentExecution) {
       logger.error(
         { jobId: payload.jobId },
         "invoke_agent missing execution id on payload",
@@ -395,7 +400,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           status: AgentJobExecutionStatus.failed,
           error: {
             message:
-              "Missing scheduleExecutionId/httpTriggerExecutionId on job payload",
+              "Missing scheduleExecutionId/httpTriggerExecutionId/manualExecutionId on job payload",
             retryable: false,
           },
           completedAt: new Date(),
@@ -409,10 +414,15 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           where: { id: payload.scheduleExecutionId },
           select: { cancelledAt: true },
         })
-      : await orchestrationPrisma.httpTriggerExecution.findUnique({
-          where: { id: payload.httpTriggerExecutionId! },
-          select: { cancelledAt: true },
-        });
+      : payload.httpTriggerExecutionId
+        ? await orchestrationPrisma.httpTriggerExecution.findUnique({
+            where: { id: payload.httpTriggerExecutionId },
+            select: { cancelledAt: true },
+          })
+        : await orchestrationPrisma.manualPipelineExecution.findUnique({
+            where: { id: payload.manualExecutionId! },
+            select: { cancelledAt: true },
+          });
 
     if (parentExecution?.cancelledAt) {
       await applyInvocationCompletion(
@@ -420,6 +430,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           jobId: payload.jobId,
           scheduleExecutionId: payload.scheduleExecutionId,
           httpTriggerExecutionId: payload.httpTriggerExecutionId,
+          manualExecutionId: payload.manualExecutionId,
           pipelineStepId: payload.pipelineStepId,
           terminal: {
             status: AgentJobExecutionStatus.cancelled,
@@ -449,6 +460,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
         scheduleId: payload.scheduleId ?? payload.httpTriggerId,
         scheduleExecutionId:
           payload.scheduleExecutionId ?? payload.httpTriggerExecutionId,
+        manualExecutionId: payload.manualExecutionId,
         pipelineStepId: payload.pipelineStepId,
         authToken,
         timeoutMs: payload.timeoutMs,
@@ -468,6 +480,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             jobId: payload.jobId,
             scheduleExecutionId: payload.scheduleExecutionId,
             httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            manualExecutionId: payload.manualExecutionId,
             pipelineStepId: payload.pipelineStepId,
             terminal: {
               status: AgentJobExecutionStatus.cancelled,
@@ -503,6 +516,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             jobId: payload.jobId,
             scheduleExecutionId: payload.scheduleExecutionId,
             httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            manualExecutionId: payload.manualExecutionId,
             pipelineStepId: payload.pipelineStepId,
             terminal: {
               status: AgentJobExecutionStatus.cancelled,
@@ -538,6 +552,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             jobId: payload.jobId,
             scheduleExecutionId: payload.scheduleExecutionId,
             httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            manualExecutionId: payload.manualExecutionId,
             pipelineStepId: payload.pipelineStepId,
             terminal: {
               status: AgentJobExecutionStatus.failed,
@@ -560,6 +575,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
               jobId: payload.jobId,
               scheduleExecutionId: payload.scheduleExecutionId,
               httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
               pipelineStepId: payload.pipelineStepId,
               terminal: {
                 status: AgentJobExecutionStatus.failed,
@@ -580,6 +596,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
               jobId: payload.jobId,
               scheduleExecutionId: payload.scheduleExecutionId,
               httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
               pipelineStepId: payload.pipelineStepId,
               terminal: {
                 status: AgentJobExecutionStatus.failed,
@@ -604,6 +621,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             jobId: payload.jobId,
             scheduleExecutionId: payload.scheduleExecutionId,
             httpTriggerExecutionId: payload.httpTriggerExecutionId,
+            manualExecutionId: payload.manualExecutionId,
             pipelineStepId: payload.pipelineStepId,
             terminal: {
               status: AgentJobExecutionStatus.completed,
@@ -620,6 +638,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           jobId: payload.jobId,
           scheduleExecutionId: payload.scheduleExecutionId,
           httpTriggerExecutionId: payload.httpTriggerExecutionId,
+          manualExecutionId: payload.manualExecutionId,
           pipelineStepId: payload.pipelineStepId,
           terminal: {
             status: AgentJobExecutionStatus.failed,

--- a/packages/hermes/scheduler/src/apply-invocation-completion.ts
+++ b/packages/hermes/scheduler/src/apply-invocation-completion.ts
@@ -23,6 +23,8 @@ export type InvocationCompletionInput = {
   jobId: string;
   scheduleExecutionId?: string;
   httpTriggerExecutionId?: string;
+  /** Dashboard manual pipeline execution id (mutually exclusive with schedule/http trigger ids). */
+  manualExecutionId?: string;
   pipelineStepId: string;
   terminal:
     | {
@@ -52,6 +54,8 @@ export type ApplyInvocationCompletionDeps = {
   };
 };
 
+type ExecutionKind = "schedule" | "httpTrigger" | "manual";
+
 const defaultExecutionConfig = (): ExecutionConfig => ({
   schemaVersion: 1,
   stepRollupPolicy: "strict",
@@ -62,7 +66,7 @@ const defaultExecutionConfig = (): ExecutionConfig => ({
 const loadExecutionConfig = (
   raw: Prisma.JsonValue | null | undefined,
   logger: ApplyInvocationCompletionDeps["logger"],
-  scheduleExecutionId: string,
+  executionKey: string,
 ): ExecutionConfig => {
   try {
     const obj =
@@ -72,7 +76,7 @@ const loadExecutionConfig = (
     return parseEffectiveExecutionConfig(obj);
   } catch (err) {
     logger.error(
-      { err, scheduleExecutionId },
+      { err, executionKey },
       "applyInvocationCompletion: invalid effectiveExecutionConfig",
     );
     return defaultExecutionConfig();
@@ -80,8 +84,23 @@ const loadExecutionConfig = (
 };
 
 /**
+ * Resolves which parent execution row drives rollup updates.
+ *
+ * @param input - Invocation completion payload.
+ * @returns Kind discriminator, or null when no parent id is set.
+ */
+const resolveExecutionKind = (
+  input: InvocationCompletionInput,
+): ExecutionKind | null => {
+  if (input.scheduleExecutionId) return "schedule";
+  if (input.httpTriggerExecutionId) return "httpTrigger";
+  if (input.manualExecutionId) return "manual";
+  return null;
+};
+
+/**
  * Updates `AgentJobExecution`, increments step counters, recomputes step rollup, and idempotently
- * updates `ScheduleExecution.runStatus` when all step rows are terminal (PRD §7.2).
+ * updates parent execution `runStatus` when all step rows are terminal (schedule, HTTP trigger, or manual pipeline).
  *
  * @param input - Terminal state for one invocation.
  * @param deps - DB client and logger.
@@ -92,20 +111,24 @@ export const applyInvocationCompletion = async (
 ): Promise<void> => {
   const { db, logger } = deps;
 
-  const executionKind = input.scheduleExecutionId ? "schedule" : "httpTrigger";
-  const execution = input.scheduleExecutionId
-    ? await db.scheduleExecution.findUnique({
-        where: { id: input.scheduleExecutionId },
-        select: {
-          id: true,
-          runStatus: true,
-          cancelledAt: true,
-          effectiveExecutionConfig: true,
-        },
-      })
-    : input.httpTriggerExecutionId
-      ? await db.httpTriggerExecution.findUnique({
-          where: { id: input.httpTriggerExecutionId },
+  const executionKind = resolveExecutionKind(input);
+  if (executionKind == null) {
+    logger.warn(
+      {
+        scheduleExecutionId: input.scheduleExecutionId,
+        httpTriggerExecutionId: input.httpTriggerExecutionId,
+        manualExecutionId: input.manualExecutionId,
+        jobId: input.jobId,
+      },
+      "applyInvocationCompletion: no parent execution id on input",
+    );
+    return;
+  }
+
+  const execution =
+    executionKind === "schedule"
+      ? await db.scheduleExecution.findUnique({
+          where: { id: input.scheduleExecutionId! },
           select: {
             id: true,
             runStatus: true,
@@ -113,12 +136,32 @@ export const applyInvocationCompletion = async (
             effectiveExecutionConfig: true,
           },
         })
-      : null;
+      : executionKind === "httpTrigger"
+        ? await db.httpTriggerExecution.findUnique({
+            where: { id: input.httpTriggerExecutionId! },
+            select: {
+              id: true,
+              runStatus: true,
+              cancelledAt: true,
+              effectiveExecutionConfig: true,
+            },
+          })
+        : await db.manualPipelineExecution.findUnique({
+            where: { id: input.manualExecutionId! },
+            select: {
+              id: true,
+              runStatus: true,
+              cancelledAt: true,
+              effectiveExecutionConfig: true,
+            },
+          });
+
   if (!execution) {
     logger.warn(
       {
         scheduleExecutionId: input.scheduleExecutionId,
         httpTriggerExecutionId: input.httpTriggerExecutionId,
+        manualExecutionId: input.manualExecutionId,
         jobId: input.jobId,
       },
       "applyInvocationCompletion: execution not found",
@@ -132,10 +175,16 @@ export const applyInvocationCompletion = async (
     return;
   }
 
+  const executionKeyForLog =
+    input.scheduleExecutionId ??
+    input.httpTriggerExecutionId ??
+    input.manualExecutionId ??
+    "unknown";
+
   const config = loadExecutionConfig(
     execution.effectiveExecutionConfig,
     logger,
-    input.scheduleExecutionId ?? input.httpTriggerExecutionId ?? "unknown",
+    executionKeyForLog,
   );
 
   const isSuccess = input.terminal.status === AgentJobExecutionStatus.completed;
@@ -197,9 +246,17 @@ export const applyInvocationCompletion = async (
           ...execCountInc,
         },
       });
-    } else {
+    } else if (executionKind === "httpTrigger") {
       await tx.httpTriggerExecution.update({
         where: { id: input.httpTriggerExecutionId },
+        data: {
+          runStatus: ScheduleRunStatus.running,
+          ...execCountInc,
+        },
+      });
+    } else {
+      await tx.manualPipelineExecution.update({
+        where: { id: input.manualExecutionId },
         data: {
           runStatus: ScheduleRunStatus.running,
           ...execCountInc,
@@ -217,14 +274,23 @@ export const applyInvocationCompletion = async (
               },
             },
           })
-        : await tx.httpTriggerStepExecution.findUnique({
-            where: {
-              httpTriggerExecutionId_pipelineStepId: {
-                httpTriggerExecutionId: input.httpTriggerExecutionId!,
-                pipelineStepId: input.pipelineStepId,
+        : executionKind === "httpTrigger"
+          ? await tx.httpTriggerStepExecution.findUnique({
+              where: {
+                httpTriggerExecutionId_pipelineStepId: {
+                  httpTriggerExecutionId: input.httpTriggerExecutionId!,
+                  pipelineStepId: input.pipelineStepId,
+                },
               },
-            },
-          });
+            })
+          : await tx.manualPipelineStepExecution.findUnique({
+              where: {
+                manualExecutionId_pipelineStepId: {
+                  manualExecutionId: input.manualExecutionId!,
+                  pipelineStepId: input.pipelineStepId,
+                },
+              },
+            });
     if (!stepRow) {
       return;
     }
@@ -245,16 +311,27 @@ export const applyInvocationCompletion = async (
                   : stepRow.rollupStatus,
             },
           })
-        : await tx.httpTriggerStepExecution.update({
-            where: { id: stepRow.id },
-            data: {
-              ...inc,
-              rollupStatus:
-                stepRow.rollupStatus === ScheduleStepRollupStatus.pending
-                  ? ScheduleStepRollupStatus.running
-                  : stepRow.rollupStatus,
-            },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.httpTriggerStepExecution.update({
+              where: { id: stepRow.id },
+              data: {
+                ...inc,
+                rollupStatus:
+                  stepRow.rollupStatus === ScheduleStepRollupStatus.pending
+                    ? ScheduleStepRollupStatus.running
+                    : stepRow.rollupStatus,
+              },
+            })
+          : await tx.manualPipelineStepExecution.update({
+              where: { id: stepRow.id },
+              data: {
+                ...inc,
+                rollupStatus:
+                  stepRow.rollupStatus === ScheduleStepRollupStatus.pending
+                    ? ScheduleStepRollupStatus.running
+                    : stepRow.rollupStatus,
+              },
+            });
 
     const stepDone =
       updated.succeededCount + updated.failedCount >=
@@ -269,10 +346,15 @@ export const applyInvocationCompletion = async (
             where: { id: input.scheduleExecutionId! },
             select: { cancelledAt: true },
           })
-        : await tx.httpTriggerExecution.findUnique({
-            where: { id: input.httpTriggerExecutionId! },
-            select: { cancelledAt: true },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.httpTriggerExecution.findUnique({
+              where: { id: input.httpTriggerExecutionId! },
+              select: { cancelledAt: true },
+            })
+          : await tx.manualPipelineExecution.findUnique({
+              where: { id: input.manualExecutionId! },
+              select: { cancelledAt: true },
+            });
 
     const stepJobsForRollup =
       executionKind === "schedule"
@@ -283,13 +365,21 @@ export const applyInvocationCompletion = async (
             },
             select: { status: true, error: true },
           })
-        : await tx.agentJobExecution.findMany({
-            where: {
-              httpTriggerExecutionId: input.httpTriggerExecutionId!,
-              pipelineStepId: input.pipelineStepId,
-            },
-            select: { status: true, error: true },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.agentJobExecution.findMany({
+              where: {
+                httpTriggerExecutionId: input.httpTriggerExecutionId!,
+                pipelineStepId: input.pipelineStepId,
+              },
+              select: { status: true, error: true },
+            })
+          : await tx.agentJobExecution.findMany({
+              where: {
+                manualExecutionId: input.manualExecutionId!,
+                pipelineStepId: input.pipelineStepId,
+              },
+              select: { status: true, error: true },
+            });
 
     const rollupPrisma = resolveStepRollupPrismaAfterInvocation({
       cancelledAt: executionCancelledAt?.cancelledAt ?? null,
@@ -305,8 +395,13 @@ export const applyInvocationCompletion = async (
         where: { id: stepRow.id },
         data: { rollupStatus: rollupPrisma },
       });
-    } else {
+    } else if (executionKind === "httpTrigger") {
       await tx.httpTriggerStepExecution.update({
+        where: { id: stepRow.id },
+        data: { rollupStatus: rollupPrisma },
+      });
+    } else {
+      await tx.manualPipelineStepExecution.update({
         where: { id: stepRow.id },
         data: { rollupStatus: rollupPrisma },
       });
@@ -318,10 +413,15 @@ export const applyInvocationCompletion = async (
             where: { scheduleExecutionId: input.scheduleExecutionId! },
             select: { rollupStatus: true },
           })
-        : await tx.httpTriggerStepExecution.findMany({
-            where: { httpTriggerExecutionId: input.httpTriggerExecutionId! },
-            select: { rollupStatus: true },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.httpTriggerStepExecution.findMany({
+              where: { httpTriggerExecutionId: input.httpTriggerExecutionId! },
+              select: { rollupStatus: true },
+            })
+          : await tx.manualPipelineStepExecution.findMany({
+              where: { manualExecutionId: input.manualExecutionId! },
+              select: { rollupStatus: true },
+            });
 
     const terminalStatuses = new Set<ScheduleStepRollupStatus>([
       ScheduleStepRollupStatus.success,
@@ -344,10 +444,15 @@ export const applyInvocationCompletion = async (
             where: { id: input.scheduleExecutionId! },
             select: { cancelledAt: true },
           })
-        : await tx.httpTriggerExecution.findUnique({
-            where: { id: input.httpTriggerExecutionId! },
-            select: { cancelledAt: true },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.httpTriggerExecution.findUnique({
+              where: { id: input.httpTriggerExecutionId! },
+              select: { cancelledAt: true },
+            })
+          : await tx.manualPipelineExecution.findUnique({
+              where: { id: input.manualExecutionId! },
+              select: { cancelledAt: true },
+            });
 
     const allJobs =
       executionKind === "schedule"
@@ -355,10 +460,15 @@ export const applyInvocationCompletion = async (
             where: { scheduleExecutionId: input.scheduleExecutionId! },
             select: { status: true, error: true },
           })
-        : await tx.agentJobExecution.findMany({
-            where: { httpTriggerExecutionId: input.httpTriggerExecutionId! },
-            select: { status: true, error: true },
-          });
+        : executionKind === "httpTrigger"
+          ? await tx.agentJobExecution.findMany({
+              where: { httpTriggerExecutionId: input.httpTriggerExecutionId! },
+              select: { status: true, error: true },
+            })
+          : await tx.agentJobExecution.findMany({
+              where: { manualExecutionId: input.manualExecutionId! },
+              select: { status: true, error: true },
+            });
 
     const run = executionRow?.cancelledAt
       ? resolveRunStatusForSettledCancelledExecution(allJobs)
@@ -379,10 +489,20 @@ export const applyInvocationCompletion = async (
         },
         data: { runStatus: run },
       });
-    } else {
+    } else if (executionKind === "httpTrigger") {
       await tx.httpTriggerExecution.updateMany({
         where: {
           id: input.httpTriggerExecutionId,
+          runStatus: {
+            in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+          },
+        },
+        data: { runStatus: run },
+      });
+    } else {
+      await tx.manualPipelineExecution.updateMany({
+        where: {
+          id: input.manualExecutionId,
           runStatus: {
             in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
           },

--- a/packages/hermes/scheduler/src/execute-schedule.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.ts
@@ -29,6 +29,8 @@ export type InvokeAgentJobPayload = {
   /** Parent HTTP trigger execution row (correlation + rollup). */
   httpTriggerExecutionId?: string;
   httpTriggerId?: string;
+  /** Parent dashboard manual pipeline execution (correlation + rollup). */
+  manualExecutionId?: string;
   pipelineId: string;
   pipelineStepId: string;
   /** JWT minting scope for agent invocation. */

--- a/packages/hermes/scheduler/src/invoke-agent.test.ts
+++ b/packages/hermes/scheduler/src/invoke-agent.test.ts
@@ -36,6 +36,18 @@ describe("applyHermesInvokeCorrelationHeaders", () => {
     expect(headers["X-Schedule-Execution-Id"]).toBeUndefined();
     expect(headers["X-Pipeline-Step-Id"]).toBeUndefined();
   });
+
+  it("adds X-Manual-Execution-Id when manualExecutionId is set", () => {
+    const headers: Record<string, string> = {
+      "Content-Type": "application/json",
+    };
+    applyHermesInvokeCorrelationHeaders(headers, {
+      manualExecutionId: "  manual-exec-1  ",
+      pipelineStepId: "step-1",
+    });
+    expect(headers["X-Manual-Execution-Id"]).toBe("manual-exec-1");
+    expect(headers["X-Schedule-Id"]).toBeUndefined();
+  });
 });
 
 describe("invokeAgentPost", () => {

--- a/packages/hermes/scheduler/src/invoke-agent.ts
+++ b/packages/hermes/scheduler/src/invoke-agent.ts
@@ -47,6 +47,8 @@ export type InvokeAgentPostOptions = {
   scheduleId?: string;
   /** When set, sent as `X-Schedule-Execution-Id`. */
   scheduleExecutionId?: string;
+  /** When set, sent as `X-Manual-Execution-Id` (dashboard manual pipeline runs). */
+  manualExecutionId?: string;
   /** When set, sent as `X-Pipeline-Step-Id`. */
   pipelineStepId?: string;
   authToken?: string;
@@ -64,7 +66,10 @@ export function applyHermesInvokeCorrelationHeaders(
   headers: Record<string, string>,
   options: Pick<
     InvokeAgentPostOptions,
-    "scheduleId" | "scheduleExecutionId" | "pipelineStepId"
+    | "scheduleId"
+    | "scheduleExecutionId"
+    | "manualExecutionId"
+    | "pipelineStepId"
   >,
 ): void {
   const scheduleId = options.scheduleId?.trim();
@@ -74,6 +79,10 @@ export function applyHermesInvokeCorrelationHeaders(
   const scheduleExecutionId = options.scheduleExecutionId?.trim();
   if (scheduleExecutionId) {
     headers["X-Schedule-Execution-Id"] = scheduleExecutionId;
+  }
+  const manualExecutionId = options.manualExecutionId?.trim();
+  if (manualExecutionId) {
+    headers["X-Manual-Execution-Id"] = manualExecutionId;
   }
   const pipelineStepId = options.pipelineStepId?.trim();
   if (pipelineStepId) {


### PR DESCRIPTION
## Summary

Manual **Run pipeline** no longer keeps the browser tied to one long Server Action while agents respond. The dashboard writes the execution rows, drops **`invoke_agent`** jobs on DataQueue, and returns right away with **`runStatus: running`** and an **`executionId`**. **hermes-worker** does the HTTP work and drives rollups through the same completion path as schedules and HTTP triggers, extended for **`manualExecutionId`**.

## Related issues

Closes #340

## Important changes

- Run-pipeline handler enqueues jobs and returns immediately; refresh during a run no longer rides on an in-flight mutation POST.
- Worker **`invoke_agent`** accepts **`manualExecutionId`**, checks **`manualPipelineExecution.cancelledAt`**, and passes the id through **`invokeAgentPost`** / **`applyInvocationCompletion`**.
- Scheduler **`applyInvocationCompletion`** handles manual parent executions and step rows alongside schedule and HTTP-trigger kinds.
- Run button shows queued copy for **`running`**, warns on **`beforeunload`** while the action is pending, and still links to the execution detail page.

## Other changes

- **`X-Manual-Execution-Id`** on agent requests for correlation.
- **`hermes-job-queue`** copy clarifies DataQueue is used for manual runs too.

## Key files to review

- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — planning, DB writes, enqueue, response shape.
- `packages/hermes/scheduler/src/apply-invocation-completion.ts` — manual execution rollup and parent **`runStatus`** updates.
- `apps/hermes/worker/src/job-handlers.ts` — **`invoke_agent`** branch for manual runs.
- `apps/hermes/dashboard/app/dashboard/pipelines/[id]/run-pipeline-button.tsx` — UX and navigation guard.

## How to test

1. Set **`PG_DATAQUEUE_DATABASE`** and run **hermes-worker** with DataQueue migrations applied (same as other queued runs).
2. From Hermes dashboard, open a valid pipeline, click **Run pipeline**, confirm the success banner mentions the worker queue and links to the execution.
3. Hit refresh while the execution is still in progress; the detail page should load without a **NetworkError** from the run button subtree.
4. Optional: `pnpm --filter @hermes/dashboard exec vitest run app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts app/dashboard/pipelines/[id]/run-pipeline-button.test.tsx`, `pnpm --filter @hermes/worker exec vitest run src/job-handlers.test.ts`, and `pnpm exec prettier --check` on touched paths if you skip full **`pnpm code-quality`**.
