### PR TITLE
Raise domain-api Fly VM memory to 512 MB

### DIFF
--- a/apps/mediapulse/domain-api/fly.toml
+++ b/apps/mediapulse/domain-api/fly.toml
@@ -26,7 +26,7 @@ primary_region = 'sin'
   protocol = "http"
 
 [[vm]]
-  memory = '256mb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
-  memory_mb = 256
+  memory_mb = 512


### PR DESCRIPTION
## Summary

The Agent Data API Fly app was still on a 256 MB VM. That is a small heap for Bun/Node plus Prisma under concurrent agent-data calls, and we have seen pressure line up with odd 502s from the edge. This PR bumps the Fly `[[vm]]` block to 512 MB so production has more headroom without touching runtime code.

## Related issues

Closes #342

## Important changes

- `apps/mediapulse/domain-api/fly.toml`: set `memory` / `memory_mb` to 512.

## Other changes

- None.

## Key files to review

- `apps/mediapulse/domain-api/fly.toml` — sole change; worth a quick sanity check that it matches your Fly billing/plan expectations.

## How to test

1. After merge, deploy `mediapulse-domain-api` (your usual `fly deploy` path for domain-api).
2. Confirm machines show 512 MB in the Fly UI or `fly scale show` for that app.
