### PR TITLE
Fix deployment builds for dist-based workspace dependencies

### DIFF
--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -27,7 +27,8 @@ ENV TEMP_ADMIN_USERNAME="dummy"
 ENV TEMP_ADMIN_PASSWORD="dummy"
 ENV HERMES_INTERNAL_API_KEY="dummy-internal-key"
 RUN pnpm --filter=@hermes/orchestration-database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build
 # next.config loads env files; provide an empty app-level .env for image builds.
 RUN rm -f apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local && \
     touch apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local

--- a/apps/mediapulse/agent-data-api/Dockerfile
+++ b/apps/mediapulse/agent-data-api/Dockerfile
@@ -10,7 +10,8 @@ RUN pnpm install --frozen-lockfile
 # Generate Prisma client (Mediapulse domain DB)
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
 RUN pnpm --filter=@mediapulse/database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build
 
 RUN pnpm exec turbo build --filter=@mediapulse/agent-data-api --only --env-mode=loose
 

--- a/apps/mediapulse/agents/article-analysis/Dockerfile
+++ b/apps/mediapulse/agents/article-analysis/Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build
 RUN pnpm exec turbo build --filter=@mediapulse/article-analysis --only --env-mode=loose
 
 # Stage 2: run the built bundle only

--- a/apps/mediapulse/agents/content-generation/Dockerfile
+++ b/apps/mediapulse/agents/content-generation/Dockerfile
@@ -7,7 +7,9 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build \
+  && pnpm --filter=@workspace/utils run build
 RUN pnpm exec turbo build --filter=@mediapulse/content-generation --only --env-mode=loose
 
 # Stage 2: run the built bundle only

--- a/apps/mediapulse/agents/data-collection/Dockerfile
+++ b/apps/mediapulse/agents/data-collection/Dockerfile
@@ -7,7 +7,9 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build && pnpm --filter=@workspace/utils run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build \
+  && pnpm --filter=@workspace/utils run build
 RUN pnpm exec turbo build --filter=@mediapulse/data-collection --only --env-mode=loose
 
 # Stage 2: run the built bundle only

--- a/apps/mediapulse/agents/delivery/Dockerfile
+++ b/apps/mediapulse/agents/delivery/Dockerfile
@@ -7,7 +7,9 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build && pnpm --filter=@workspace/utils run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build \
+  && pnpm --filter=@workspace/utils run build
 RUN pnpm exec turbo build --filter=@mediapulse/delivery --only --env-mode=loose
 
 # Stage 2: run the built bundle only

--- a/apps/mediapulse/agents/query-analysis/Dockerfile
+++ b/apps/mediapulse/agents/query-analysis/Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build
 RUN pnpm exec turbo build --filter=@mediapulse/query-analysis --only --env-mode=loose
 
 # Stage 2: run the built bundle only


### PR DESCRIPTION
## Summary

This patch fixes deployment build failures that started after #331 by making Docker build stages prebuild the dist-exported workspace packages they consume. It keeps the change limited to build order, so app and agent runtime behavior is unchanged.

## Related issues

Closes #344

## Important changes

- Added missing `@workspace/agent-data-api-contract` prebuild steps in Dockerfiles that run filtered `turbo build --only`.
- Kept existing `@workspace/agent-auth-client` and `@workspace/utils` prebuilds, and extended them where needed for full dependency coverage.
- Applied the same fix pattern to Hermes dashboard, `agent-data-api`, and all affected non-`ticker-echo` agents.

## Other changes

- No source-code logic or API contract changes.
- No environment variable changes.

## Key files to review

- `apps/hermes/dashboard/Dockerfile` - prebuilds contract package before dashboard build.
- `apps/mediapulse/agent-data-api/Dockerfile` - prebuilds contract package before API build.
- `apps/mediapulse/agents/content-generation/Dockerfile` - prebuilds contract and utils before agent build.
- `apps/mediapulse/agents/article-analysis/Dockerfile` - adds missing contract prebuild.
- `apps/mediapulse/agents/delivery/Dockerfile` - adds missing contract prebuild with existing utils build.
- `apps/mediapulse/agents/data-collection/Dockerfile` - adds missing contract prebuild with existing utils build.
- `apps/mediapulse/agents/query-analysis/Dockerfile` - adds missing contract prebuild.

## How to test

1. Run `pnpm install --frozen-lockfile`.
2. Run targeted builds:
   - `pnpm exec turbo build --filter=@hermes/dashboard --only --env-mode=loose`
   - `pnpm exec turbo build --filter=@mediapulse/agent-data-api --only --env-mode=loose`
   - `pnpm --filter=@hermes/agent-auth-api run build`
   - `pnpm exec turbo build --filter=@mediapulse/article-analysis --only --env-mode=loose`
   - `pnpm exec turbo build --filter=@mediapulse/delivery --only --env-mode=loose`
   - `pnpm exec turbo build --filter=@mediapulse/data-collection --only --env-mode=loose`
   - `pnpm exec turbo build --filter=@mediapulse/query-analysis --only --env-mode=loose`
3. Run `pnpm format:check` and confirm it passes.
