### PR TITLE
Fix user-registration Docker prebuild for contract dependency

### DIFF
--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -7,7 +7,9 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build && pnpm --filter=@workspace/utils run build
+RUN pnpm --filter=@workspace/agent-auth-client run build \
+  && pnpm --filter=@workspace/agent-data-api-contract run build \
+  && pnpm --filter=@workspace/utils run build
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose
 
 # Stage 2: run the built bundle only


### PR DESCRIPTION
## Summary

This PR fixes the remaining deployment failure for `@mediapulse/user-registration-agent` by prebuilding the contract package required by its transitive workspace imports. The change is intentionally small and limited to Docker build order.

## Related issues

Closes #346

## Important changes

- Added `@workspace/agent-data-api-contract` to the user-registration Docker prebuild step.
- Kept existing `@workspace/agent-auth-client` and `@workspace/utils` prebuilds in place.

## Other changes

- No source logic changes.
- No environment variable or runtime behavior changes.

## Key files to review

- `apps/mediapulse/agents/user-registration/Dockerfile` - adds contract prebuild so filtered Turbo build resolves transitive workspace imports.

## How to test

1. Run `pnpm --filter=@workspace/agent-data-api-contract run build`.
2. Run `pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose`.
3. Run `pnpm format:check`.
4. Confirm the user-registration build no longer fails with `Could not resolve: "@workspace/agent-data-api-contract"`.
