### PR TITLE
Fix article-analysis persistence and auto-prune unrecoverable sources

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -11,6 +11,7 @@ import { bearerAuth } from "hono/bearer-auth";
 import { pinoLogger } from "hono-pino";
 
 import { getAnalysis, postAnalysis } from "./routes/analysis.js";
+import { postAnalysisDataSourceDelete } from "./routes/analysis-data-source-delete.js";
 import {
   getContentGeneration,
   getContentGenerationNewslettersLatest,
@@ -71,6 +72,9 @@ const routeHandlers = {
   analysis: {
     get: getAnalysis,
     post: postAnalysis,
+  },
+  analysisDataSourceDelete: {
+    post: postAnalysisDataSourceDelete,
   },
   contentGeneration: {
     get: getContentGeneration,

--- a/apps/mediapulse/agent-data-api/src/routes/analysis-data-source-delete.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/analysis-data-source-delete.ts
@@ -1,0 +1,23 @@
+import { Context } from "hono";
+
+import {
+  postAnalysisDataSourceDeleteBodySchema,
+  postAnalysisDataSourceDeleteResponseSchema,
+} from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+
+import { deleteAnalysisDataSource } from "../services/analysis.js";
+
+export async function postAnalysisDataSourceDelete(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const data = await postAnalysisDataSourceDeleteBodySchema.parseAsync(body);
+    const result = await deleteAnalysisDataSource(data);
+    const response = postAnalysisDataSourceDeleteResponseSchema.parse(result);
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -11,6 +11,7 @@ vi.mock("@mediapulse/database", () => ({
 
 let AnalysisPostValidationError: typeof import("./analysis.js").AnalysisPostValidationError;
 let applyAnalysisPost: typeof import("./analysis.js").applyAnalysisPost;
+let deleteAnalysisDataSource: typeof import("./analysis.js").deleteAnalysisDataSource;
 let loadAnalysisContext: typeof import("./analysis.js").loadAnalysisContext;
 let normalizeAnalysisName: typeof import("./analysis.js").normalizeAnalysisName;
 
@@ -18,6 +19,7 @@ beforeAll(async () => {
   const mod = await import("./analysis.js");
   AnalysisPostValidationError = mod.AnalysisPostValidationError;
   applyAnalysisPost = mod.applyAnalysisPost;
+  deleteAnalysisDataSource = mod.deleteAnalysisDataSource;
   loadAnalysisContext = mod.loadAnalysisContext;
   normalizeAnalysisName = mod.normalizeAnalysisName;
 });
@@ -562,5 +564,55 @@ describe("applyAnalysisPost", () => {
         },
       }),
     );
+  });
+});
+
+describe("deleteAnalysisDataSource", () => {
+  it("deletes source scoped by ticker id", async () => {
+    // Setup
+    const db = {
+      dataSource: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+    };
+
+    // Act
+    const result = await deleteAnalysisDataSource(
+      {
+        tickerId: "ticker-1",
+        dataSourceId: "11111111-1111-4111-a111-111111111111",
+      },
+      { db: db as never },
+    );
+
+    // Assert
+    expect(db.dataSource.deleteMany).toHaveBeenCalledWith({
+      where: {
+        id: "11111111-1111-4111-a111-111111111111",
+        tickerId: "ticker-1",
+      },
+    });
+    expect(result).toEqual({ deleted: true });
+  });
+
+  it("returns deleted false when no row matches", async () => {
+    // Setup
+    const db = {
+      dataSource: {
+        deleteMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+    };
+
+    // Act
+    const result = await deleteAnalysisDataSource(
+      {
+        tickerId: "ticker-1",
+        dataSourceId: "11111111-1111-4111-a111-111111111111",
+      },
+      { db: db as never },
+    );
+
+    // Assert
+    expect(result).toEqual({ deleted: false });
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -1,6 +1,7 @@
 import type {
   GetAnalysisQuery,
   GetAnalysisResponse,
+  PostAnalysisDataSourceDeleteBody,
   PostAnalysisBody,
   PostAnalysisResponse,
 } from "@workspace/agent-data-api-contract";
@@ -23,7 +24,7 @@ export class AnalysisPostValidationError extends Error {
 type AnalysisDb = {
   dataSource: Pick<
     typeof prisma.dataSource,
-    "findMany" | "findUnique" | "findFirst" | "count"
+    "findMany" | "findUnique" | "findFirst" | "count" | "deleteMany"
   >;
   entityType: Pick<typeof prisma.entityType, "findMany">;
   relationType: Pick<typeof prisma.relationType, "findMany">;
@@ -432,6 +433,29 @@ export const applyAnalysisPost = async (
       articlesSelected,
     };
   });
+};
+
+/**
+ * Hard-deletes one data source row scoped by ticker id.
+ *
+ * @param body - Validated delete request with ticker and source ids.
+ * @param deps - Injectable database delegates for tests.
+ * @returns Whether a row was deleted.
+ */
+export const deleteAnalysisDataSource = async (
+  body: PostAnalysisDataSourceDeleteBody,
+  deps: { db?: Pick<AnalysisDb, "dataSource"> } = {},
+): Promise<{ deleted: boolean }> => {
+  const db = deps.db ?? defaultDb;
+  const result = await db.dataSource.deleteMany({
+    where: {
+      id: body.dataSourceId,
+      tickerId: body.tickerId,
+    },
+  });
+  return {
+    deleted: result.count > 0,
+  };
 };
 
 /**

--- a/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.test.ts
@@ -7,6 +7,7 @@ import {
   buildArticleEntityPostChunks,
   buildNormalizedEntityCatalogForArticle,
   buildNormalizedEntityCatalogFromProposals,
+  canonicalizeArticleEntityRowsToRunEntities,
   dedupeArticleEntityMentions,
   filterArticleEntityRowsToRunCatalog,
   filterMentionsToArticleEntityCatalog,
@@ -132,6 +133,49 @@ describe("filterArticleEntityRowsToRunCatalog", () => {
     expect(droppedCount).toBe(1);
     expect(rows).toHaveLength(1);
     expect(rows[0]?.entityName).toBe("Foo");
+  });
+});
+
+describe("canonicalizeArticleEntityRowsToRunEntities", () => {
+  it("rewrites aliases to canonical names and drops unmapped rows", () => {
+    // Setup
+    const rows = [
+      {
+        dataSourceId: DS,
+        entityName: "VOI",
+        mentionCount: 1,
+        confidence: 0.5,
+      },
+      {
+        dataSourceId: DS,
+        entityName: "PT Bank Central Asia Tbk.",
+        mentionCount: 1,
+        confidence: 0.7,
+      },
+      {
+        dataSourceId: DS,
+        entityName: "Unknown Name",
+        mentionCount: 1,
+        confidence: 0.4,
+      },
+    ];
+    const entities = [
+      {
+        canonicalName: "PT Bank Central Asia Tbk.",
+        typeId: TYPE_ID,
+        aliases: ["VOI"],
+      },
+    ];
+
+    // Act
+    const result = canonicalizeArticleEntityRowsToRunEntities(rows, entities);
+
+    // Assert
+    expect(result.droppedCount).toBe(1);
+    expect(result.canonicalizedCount).toBe(1);
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]?.entityName).toBe("PT Bank Central Asia Tbk.");
+    expect(result.rows[1]?.entityName).toBe("PT Bank Central Asia Tbk.");
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
@@ -120,6 +120,62 @@ export const filterArticleEntityRowsToRunCatalog = (
 };
 
 /**
+ * Canonicalizes mention row `entityName` values using run-level entity proposals.
+ *
+ * The analysis POST endpoint resolves `articleEntities.entityName` against ticker
+ * entities persisted in prior chunks/rows. Sending canonical names avoids failures
+ * when an alias (for example "VOI") was extracted but is not yet persisted as an
+ * alias on a reused entity.
+ *
+ * @param rows - Mention rows after run-level filtering/caps.
+ * @param entities - Final run-level entity proposals.
+ * @returns Canonicalized rows, drop count for unmapped names, and rename count.
+ */
+export const canonicalizeArticleEntityRowsToRunEntities = (
+  rows: readonly ArticleEntityRow[],
+  entities: readonly EntityProposal[],
+): {
+  rows: ArticleEntityRow[];
+  droppedCount: number;
+  canonicalizedCount: number;
+} => {
+  const aliasToCanonical = new Map<string, string>();
+  for (const entity of entities) {
+    aliasToCanonical.set(
+      normalizeEntityName(entity.canonicalName),
+      entity.canonicalName.trim(),
+    );
+    for (const alias of entity.aliases) {
+      aliasToCanonical.set(
+        normalizeEntityName(alias),
+        entity.canonicalName.trim(),
+      );
+    }
+  }
+
+  const out: ArticleEntityRow[] = [];
+  let droppedCount = 0;
+  let canonicalizedCount = 0;
+  for (const row of rows) {
+    const canonicalName = aliasToCanonical.get(
+      normalizeEntityName(row.entityName),
+    );
+    if (!canonicalName) {
+      droppedCount += 1;
+      continue;
+    }
+    if (canonicalName !== row.entityName.trim()) {
+      canonicalizedCount += 1;
+    }
+    out.push({
+      ...row,
+      entityName: canonicalName,
+    });
+  }
+  return { rows: out, droppedCount, canonicalizedCount };
+};
+
+/**
  * Dedupes by (`dataSourceId`, normalized `entityName`). Sums `mentionCount`, takes max `confidence`,
  * keeps first non-undefined `sentiment` if any.
  *

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.test.ts
@@ -18,6 +18,14 @@ describe("parseAgentDataApiHttpStatus", () => {
     ).toBe(503);
   });
 
+  it("returns status when error includes response-body details", () => {
+    expect(
+      parseAgentDataApiHttpStatus(
+        new Error('Agent data API error: 400 - {"error":"bad payload"}'),
+      ),
+    ).toBe(400);
+  });
+
   it("returns undefined for unrelated errors", () => {
     expect(parseAgentDataApiHttpStatus(new Error("boom"))).toBeUndefined();
     expect(parseAgentDataApiHttpStatus(null)).toBeUndefined();

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-agent-data-api-post.ts
@@ -3,7 +3,7 @@ import type {
   ArticleAnalysisPostFailureRecord,
 } from "./article-analysis-run-policy.js";
 
-const agentDataApiErrorPattern = /^Agent data API error: (\d+)$/;
+const agentDataApiErrorPattern = /^Agent data API error: (\d+)(?:\b|$)/;
 
 /**
  * Parses HTTP status from {@link createAgentDataApiClient} POST errors, when present.

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
@@ -1,0 +1,54 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  hardDeleteDataSourceById,
+  shouldHardDeleteDataSourceForExtractionError,
+} from "./extraction-failure-pruning.js";
+
+describe("shouldHardDeleteDataSourceForExtractionError", () => {
+  it("returns true for parse-response extraction failures", () => {
+    // Act
+    const result = shouldHardDeleteDataSourceForExtractionError(
+      "No object generated: could not parse the response.",
+    );
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for other extraction failures", () => {
+    // Act
+    const result = shouldHardDeleteDataSourceForExtractionError(
+      "No object generated: the model did not return a response.",
+    );
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});
+
+describe("hardDeleteDataSourceById", () => {
+  it("calls agent-data-api prune endpoint with ticker and source id", async () => {
+    // Setup
+    const dataApiClient = {
+      analysisDataSourceDelete: {
+        create: vi.fn().mockResolvedValue({ deleted: true }),
+      },
+    };
+
+    // Act
+    await hardDeleteDataSourceById("ds-1", {
+      dataApiClient: dataApiClient as Parameters<
+        typeof hardDeleteDataSourceById
+      >[1]["dataApiClient"],
+      tickerId: "ticker-1",
+    });
+
+    // Assert
+    expect(dataApiClient.analysisDataSourceDelete.create).toHaveBeenCalledWith({
+      tickerId: "ticker-1",
+      dataSourceId: "ds-1",
+    });
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
@@ -1,0 +1,44 @@
+import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
+
+/**
+ * Minimal API client contract used to prune one data source row.
+ */
+type DataSourcePruneClient = Pick<
+  ReturnType<typeof createAgentDataApiClient>,
+  "analysisDataSourceDelete"
+>;
+
+type PruneDeps = {
+  /** Typed agent-data-api client used to call `analysisDataSourceDelete.create`. */
+  dataApiClient: DataSourcePruneClient;
+  /** Ticker id used to scope the delete request. */
+  tickerId: string;
+};
+
+/**
+ * Returns whether an extraction error should trigger hard deletion of the source.
+ *
+ * @param message - Error message captured from extraction failure.
+ * @returns True when the message matches known unrecoverable parse failures.
+ */
+export const shouldHardDeleteDataSourceForExtractionError = (
+  message: string,
+): boolean =>
+  message.includes("No object generated: could not parse the response.");
+
+/**
+ * Hard-deletes a data source row through agent-data-api.
+ *
+ * @param dataSourceId - Data source id to delete.
+ * @param deps - API dependencies.
+ * @returns Promise that resolves when deletion is complete.
+ */
+export const hardDeleteDataSourceById = async (
+  dataSourceId: string,
+  deps: PruneDeps,
+): Promise<void> => {
+  await deps.dataApiClient.analysisDataSourceDelete.create({
+    tickerId: deps.tickerId,
+    dataSourceId,
+  });
+};

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -16,6 +16,7 @@ import {
   buildArticleEntityPostChunks,
   buildNormalizedEntityCatalogForArticle,
   buildNormalizedEntityCatalogFromProposals,
+  canonicalizeArticleEntityRowsToRunEntities,
   dedupeArticleEntityMentions,
   filterArticleEntityRowsToRunCatalog,
   filterMentionsToArticleEntityCatalog,
@@ -72,6 +73,10 @@ import {
   applyMaxBatchSizeCap,
   sortAnalysisDataSourcesByCreatedAt,
 } from "./run-helpers.js";
+import {
+  hardDeleteDataSourceById,
+  shouldHardDeleteDataSourceForExtractionError,
+} from "./extraction-failure-pruning.js";
 import { normalizeEntityName } from "./normalize-entity-name.js";
 
 type ExistingEntity = {
@@ -606,6 +611,30 @@ export const run = async ({
           },
           "article-analysis LLM extraction failed for source; skipping",
         );
+        if (shouldHardDeleteDataSourceForExtractionError(message)) {
+          try {
+            await hardDeleteDataSourceById(source.id, {
+              dataApiClient,
+              tickerId: input.tickerId,
+            });
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "llm",
+              },
+              "article-analysis hard-deleted data source after unrecoverable extraction parse failure",
+            );
+          } catch (deleteErr) {
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "llm",
+                err: toSafeLogError(deleteErr),
+              },
+              "article-analysis failed to hard-delete data source after extraction parse failure",
+            );
+          }
+        }
       }
     }
 
@@ -738,7 +767,31 @@ export const run = async ({
       );
     }
 
-    let articleEntitiesForPost = dedupeArticleEntityMentions(articleRowsForRun);
+    const {
+      rows: canonicalArticleRowsForRun,
+      droppedCount: droppedArticleMentionsUnmappableToCanonicalEntity,
+      canonicalizedCount: canonicalizedArticleMentionsToCanonicalEntityName,
+    } = canonicalizeArticleEntityRowsToRunEntities(articleRowsForRun, entities);
+    if (droppedArticleMentionsUnmappableToCanonicalEntity > 0) {
+      log.warn(
+        {
+          droppedArticleMentionsUnmappableToCanonicalEntity,
+        },
+        "article-analysis dropped article entity mentions not mappable to run canonical entity names",
+      );
+    }
+    if (canonicalizedArticleMentionsToCanonicalEntityName > 0) {
+      log.info(
+        {
+          canonicalizedArticleMentionsToCanonicalEntityName,
+        },
+        "article-analysis canonicalized article entity mention names before POST",
+      );
+    }
+
+    let articleEntitiesForPost = dedupeArticleEntityMentions(
+      canonicalArticleRowsForRun,
+    );
     articleEntitiesForPost = applyPerRunArticleEntityCap(
       articleEntitiesForPost,
       cfg.maxArticleEntitiesPerRun,

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -34,6 +34,7 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | POST   | `/api/v1/data-collection`            | Store data-collection payload                                         |
 | GET    | `/api/v1/analysis`                   | Get analysis context (sources + KG vocabulary) for a ticker           |
 | POST   | `/api/v1/analysis`                   | Persist analysis results (entities, relations, mentions, relevance)   |
+| POST   | `/api/v1/analysis-data-source-delete` | Hard-delete one data source row for a ticker                          |
 | GET    | `/api/v1/delivery`                   | Get delivery payload (nullable newsletter, subscribers + checkpoints) |
 | POST   | `/api/v1/delivery`                   | Upsert delivery checkpoint after successful send                      |
 | GET    | `/api/v1/delivery-run`               | List delivery diagnostic runs (filters optional)                      |
@@ -114,6 +115,15 @@ Implemented in `apps/mediapulse/agent-data-api/src/routes/analysis.ts`. Schemas 
 - **POST** — Body validated by `postAnalysisBodySchema`: `tickerId`, optional arrays `entities`, `relations`, `articleEntities`, `articleRelevances`. Response includes aggregate counts (`entitiesCreated`, `entitiesReused`, `relationsCreated`, `articlesScored`, `articlesSelected`).
 
 From agents, use the SDK namespace **`analysis`**: `get` for the query object (including optional `limit` and `timeWindow` as `start` / `end`), **`create`** for POST.
+
+### Analysis data-source delete (`POST /api/v1/analysis-data-source-delete`)
+
+Used by the article-analysis agent to remove unrecoverable sources (for example repeated extraction parse failures) without direct DB access from the agent process.
+
+- **POST** — Body (`postAnalysisDataSourceDeleteBodySchema`): `tickerId` (required) and `dataSourceId` (UUID, required).
+- **POST response** — `{ deleted: boolean }` where `deleted=true` only when a row matching both `tickerId` and `dataSourceId` existed and was removed.
+
+From agents, use SDK namespace **`analysisDataSourceDelete`** with `create`.
 
 ### Delivery run (`/api/v1/delivery-run`)
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -210,6 +210,29 @@ describe("createAgentDataApiClient", () => {
     await expect(act).rejects.toThrow("Agent data API error: 404");
   });
 
+  it("includes compact response body in non-2xx error message", async () => {
+    // Setup
+    const getFn = vi.fn().mockResolvedValue({
+      body: JSON.stringify({
+        error: "Unknown entityName for article entity: BCA",
+      }),
+      statusCode: 400,
+    });
+    const client = createAgentDataApiClient({
+      baseUrl: "http://agent-data-api",
+      getFn,
+    });
+
+    // Act
+    const act = () =>
+      client.delivery.get({ tickerId: "11111111-1111-4111-a111-111111111111" });
+
+    // Assert
+    await expect(act).rejects.toThrow(
+      'Agent data API error: 400 - {"error":"Unknown entityName for article entity: BCA"}',
+    );
+  });
+
   it("builds analysis GET with typed query and auth header", async () => {
     const getFn = vi.fn().mockResolvedValue({
       body: JSON.stringify({

--- a/packages/shared/agent-data-api-client/src/index.ts
+++ b/packages/shared/agent-data-api-client/src/index.ts
@@ -26,6 +26,11 @@ export type DataApiPostFn = (
   },
 ) => Promise<PostResponse>;
 
+type AgentDataApiErrorWithContext = Error & {
+  statusCode?: number;
+  responseBody?: string;
+};
+
 type AgentDataApiClientOptions = {
   baseUrl: string;
   version?: AgentDataApiVersion;
@@ -103,7 +108,7 @@ export const createAgentDataApiClient = <
       throwHttpErrors: false,
     });
     if (res.statusCode < 200 || res.statusCode >= 300) {
-      throw new Error(`Agent data API error: ${res.statusCode}`);
+      throw createAgentDataApiError(res.statusCode, res.body);
     }
     return schema.parse(JSON.parse(res.body));
   };
@@ -125,7 +130,7 @@ export const createAgentDataApiClient = <
       throwHttpErrors: false,
     });
     if (res.statusCode < 200 || res.statusCode >= 300) {
-      throw new Error(`Agent data API error: ${res.statusCode}`);
+      throw createAgentDataApiError(res.statusCode, res.body);
     }
     return schema.parse(JSON.parse(res.body));
   };
@@ -232,4 +237,43 @@ const defaultPost = async (
     throwHttpErrors: opts?.throwHttpErrors ?? false,
   });
   return { body: res.body, statusCode: res.statusCode ?? 200 };
+};
+
+/**
+ * Builds an Error that preserves status and sanitized response body for debugging.
+ *
+ * The prefix `Agent data API error: <status>` remains stable so existing retry and
+ * classification logic based on status parsing continues to work.
+ *
+ * @param statusCode - HTTP status returned by agent-data-api.
+ * @param body - Raw response body text, if any.
+ * @returns Error with message and structured context fields.
+ */
+const createAgentDataApiError = (
+  statusCode: number,
+  body: string | undefined,
+): AgentDataApiErrorWithContext => {
+  const compactBody = toCompactBody(body);
+  const message =
+    compactBody.length > 0
+      ? `Agent data API error: ${statusCode} - ${compactBody}`
+      : `Agent data API error: ${statusCode}`;
+  const error = new Error(message) as AgentDataApiErrorWithContext;
+  error.statusCode = statusCode;
+  error.responseBody = compactBody.length > 0 ? compactBody : undefined;
+  return error;
+};
+
+/**
+ * Compacts and bounds response text to keep logs readable and safe.
+ *
+ * @param body - Raw HTTP response body.
+ * @returns Single-line string truncated to a safe max length.
+ */
+const toCompactBody = (body: string | undefined): string => {
+  if (!body) {
+    return "";
+  }
+  const compact = body.replace(/\s+/g, " ").trim();
+  return compact.slice(0, 500);
 };

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -6,6 +6,10 @@ import {
   postAnalysisResponseSchema,
 } from "./analysis.js";
 import {
+  postAnalysisDataSourceDeleteBodySchema,
+  postAnalysisDataSourceDeleteResponseSchema,
+} from "./analysis-data-source-delete.js";
+import {
   getContentGenerationQuerySchema,
   getContentGenerationResponseSchema,
   getContentGenerationNewslettersLatestQuerySchema,
@@ -128,6 +132,20 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postAnalysisBodySchema,
         response: postAnalysisResponseSchema,
+      },
+    },
+  },
+  analysisDataSourceDelete: {
+    v1: {
+      post: {
+        body: postAnalysisDataSourceDeleteBodySchema,
+        response: postAnalysisDataSourceDeleteResponseSchema,
+      },
+    },
+    v2: {
+      post: {
+        body: postAnalysisDataSourceDeleteBodySchema,
+        response: postAnalysisDataSourceDeleteResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/analysis-data-source-delete.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis-data-source-delete.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const postAnalysisDataSourceDeleteBodySchema = z.object({
+  tickerId: z.string().trim().min(1),
+  dataSourceId: z.string().uuid(),
+});
+
+export const postAnalysisDataSourceDeleteResponseSchema = z.object({
+  deleted: z.boolean(),
+});
+
+export type PostAnalysisDataSourceDeleteBody = z.infer<
+  typeof postAnalysisDataSourceDeleteBodySchema
+>;
+export type PostAnalysisDataSourceDeleteResponse = z.infer<
+  typeof postAnalysisDataSourceDeleteResponseSchema
+>;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -27,6 +27,12 @@ export {
   type PostAnalysisResponse,
 } from "./analysis.js";
 export {
+  postAnalysisDataSourceDeleteBodySchema,
+  postAnalysisDataSourceDeleteResponseSchema,
+  type PostAnalysisDataSourceDeleteBody,
+  type PostAnalysisDataSourceDeleteResponse,
+} from "./analysis-data-source-delete.js";
+export {
   contentGenerationDataSourceSchema,
   getContentGenerationQuerySchema,
   getContentGenerationResponseSchema,


### PR DESCRIPTION
## Summary

Fix article-analysis runs that stalled before relevance scoring by making mention persistence more resilient and adding a typed cleanup path for unrecoverable extraction parse failures.

## Related issues

Closes #348

## Important changes

- Added a new typed agent-data-api endpoint, `analysisDataSourceDelete`, that hard-deletes one data source when scoped by `tickerId` + `dataSourceId`.
- Updated article-analysis to canonicalize mention `entityName` values to run canonical entities before posting `article_entities`, and to drop unmappable names with explicit counters.
- Added automatic pruning in article-analysis for extraction failures with message `No object generated: could not parse the response.` via `analysisDataSourceDelete.create(...)`.
- Improved SDK error detail by preserving compact non-2xx response bodies in `Agent data API error: <status> - <body>` messages.

## Other changes

- Relaxed article-analysis HTTP status parser to handle extended SDK error messages while keeping retry classification behavior.
- Added tests for canonicalization, pruning behavior, SDK error-body propagation, and analysis delete service behavior.
- Updated agent-data-api docs with the new `/api/v1/analysis-data-source-delete` route and SDK usage.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` - canonicalization + auto-prune flow in extraction failure path.
- `apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts` - extraction failure matcher and prune call helper.
- `apps/mediapulse/agent-data-api/src/routes/analysis-data-source-delete.ts` - new delete route.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` - ticker-scoped delete service.
- `packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts` - new manifest resource.
- `packages/shared/agent-data-api-client/src/index.ts` - non-2xx error context improvements.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test -- --run src/services/analysis.test.ts`
2. `pnpm --filter @mediapulse/article-analysis test -- --run src/extraction-failure-pruning.test.ts src/run.test.ts`
3. `pnpm format:check`
4. Deploy `agent-data-api`, then deploy `article-analysis`, then run analysis for a ticker that previously emitted alias mention failures (for example `VOI`) and verify relevance rows are written.
