### PR TITLE
Fix content-generation schema and retry classification mismatches

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/content-generation-run.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation-run.test.ts
@@ -171,6 +171,41 @@ describe("createContentGenerationRun", () => {
     );
     expect(result.outcome).toBe("success"); // fixture value
   });
+
+  it("accepts non-UUID ticker ids", async () => {
+    // Setup
+    const row = makeRow({
+      tickerId: "ticker-bca",
+    });
+    const db = makeDb();
+    db.contentGenerationRun.create.mockResolvedValue(row);
+
+    // Act
+    await createContentGenerationRun(
+      {
+        agentId: "content-generation",
+        agentVersion: "1.0.0",
+        tickerId: "ticker-bca",
+        outcome: "success",
+      },
+      {
+        db: db as unknown as Parameters<
+          typeof createContentGenerationRun
+        >[1] extends { db?: infer D }
+          ? NonNullable<D>
+          : never,
+      },
+    );
+
+    // Assert
+    expect(db.contentGenerationRun.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          tickerId: "ticker-bca",
+        }),
+      }),
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/mediapulse/agents/content-generation/src/compute-config-version.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/compute-config-version.test.ts
@@ -121,14 +121,14 @@ describe("computeConfigVersion", () => {
   it("produces the same hash regardless of property insertion order", () => {
     // Setup — two configs that are semantically identical but built in different order
     const configA = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test", model: "gpt-4o-mini", temperature: 0.5 },
+      openai: { apiKey: "sk-test", model: "gpt-4o-mini" },
       freshness: { timezone: "Asia/Jakarta" },
     });
 
     // Rebuild with keys in a different order by spreading
     const configBRaw = {
       freshness: { timezone: "Asia/Jakarta" },
-      openai: { apiKey: "sk-test", temperature: 0.5, model: "gpt-4o-mini" },
+      openai: { apiKey: "sk-test", model: "gpt-4o-mini" },
     };
     const configB = resolveContentGenerationConfig(configBRaw);
 

--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -16,7 +16,6 @@ describe("ContentGenerationConfigSchema", () => {
     expect(parsed.openai.apiKey).toBe("sk-test");
     expect(parsed.openai.baseUrl).toBeUndefined();
     expect(parsed.openai.model).toBe("gpt-4o-mini");
-    expect(parsed.openai.temperature).toBe(0.4);
     expect(parsed.openai.timeoutMs).toBe(120000);
     expect(parsed.output.topNewsCount).toBe(3);
     expect(parsed.context.maxCharsPerSource).toBe(8000);
@@ -38,7 +37,6 @@ describe("ContentGenerationConfigSchema", () => {
         apiKey: "sk-test-new",
         baseUrl: "https://example.com",
         model: "gpt-4",
-        temperature: 0.8,
         maxTokens: 1000,
         timeoutMs: 60000,
       },

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -24,8 +24,6 @@ const openaiOptionsSchema = z.object({
   baseUrl: z.string().url().optional(),
   /** Chat completions model id (e.g. `gpt-4o-mini`). */
   model: z.string().min(1).optional(),
-  /** Sampling temperature. */
-  temperature: z.number().min(0).max(2).optional(),
   /** Maximum tokens to generate. */
   maxTokens: z.number().int().positive().optional(),
   /** Per-request timeout in milliseconds passed to the AI SDK `generateObject` call. */
@@ -108,8 +106,6 @@ export const ContentGenerationConfigSchema = z
       baseUrl: z.string().url().optional(),
       /** Chat completions model id (e.g. `gpt-4o-mini`). */
       model: z.string().min(1).default("gpt-4o-mini"),
-      /** Sampling temperature. */
-      temperature: z.number().min(0).max(2).default(0.4),
       /** Maximum tokens to generate. */
       maxTokens: z.number().int().positive().optional(),
       /** Timeout in milliseconds for the OpenAI API call. */

--- a/apps/mediapulse/agents/content-generation/src/index.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.test.ts
@@ -153,6 +153,8 @@ describe("parseNewsletterJson", () => {
 
   it("accepts topNews with exactly topNewsCount items", () => {
     const raw = JSON.stringify({
+      subject: "Daily Brief",
+      executiveSummary: "Market summary.",
       topNews: [
         { title: "A", summary: "a" },
         { title: "B", summary: "b" },
@@ -167,6 +169,8 @@ describe("parseNewsletterJson", () => {
 
   it("accepts topNews with fewer than topNewsCount items", () => {
     const raw = JSON.stringify({
+      subject: "Daily Brief",
+      executiveSummary: "Market summary.",
       topNews: [{ title: "A", summary: "a" }],
     });
 
@@ -177,6 +181,8 @@ describe("parseNewsletterJson", () => {
 
   it("rejects topNews exceeding topNewsCount", () => {
     const raw = JSON.stringify({
+      subject: "Daily Brief",
+      executiveSummary: "Market summary.",
       topNews: [
         { title: "A", summary: "a" },
         { title: "B", summary: "b" },
@@ -192,6 +198,8 @@ describe("parseNewsletterJson", () => {
 
   it("defaults topNewsCount to 3 when not specified", () => {
     const raw = JSON.stringify({
+      subject: "Daily Brief",
+      executiveSummary: "Market summary.",
       topNews: [
         { title: "A", summary: "a" },
         { title: "B", summary: "b" },
@@ -238,7 +246,6 @@ describe("GET /schemas", () => {
     expect(schemaStr).toContain("apiKey");
     expect(schemaStr).toContain("baseUrl");
     expect(schemaStr).toContain("model");
-    expect(schemaStr).toContain("temperature");
     expect(schemaStr).toContain("maxTokens");
     expect(schemaStr).toContain("timeoutMs");
     expect(schemaStr).toContain("systemPrompt");

--- a/apps/mediapulse/agents/content-generation/src/index.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.ts
@@ -1,4 +1,4 @@
-import { createAgentApp } from "@workspace/agent-runtime";
+import { createAgentApp, hermesTickerIdSchema } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-content-generation";
 import { z } from "zod";
 
@@ -11,7 +11,7 @@ import { AGENT_VERSION } from "./agent-version.js";
 import { run } from "./run.js";
 
 const BodySchema = z.object({
-  tickerId: z.string().uuid(),
+  tickerId: hermesTickerIdSchema,
 });
 
 type Input = z.infer<typeof BodySchema>;

--- a/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
@@ -33,7 +33,6 @@ export async function generateContentWithOpenAI(
   deps: {
     openai: OpenAI;
     model: string;
-    temperature?: number;
     maxTokens?: number;
     topNewsCount: number;
     maxCharsPerSource: number;
@@ -79,7 +78,6 @@ export async function generateContentWithOpenAI(
       { role: "user", content: userContent },
     ],
     response_format: { type: "json_object" },
-    temperature: deps.temperature,
     max_tokens: deps.maxTokens,
   });
 

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
@@ -128,6 +128,24 @@ describe("isRetryableLlmError", () => {
     expect(isRetryableLlmError(error)).toBe(false);
   });
 
+  it("returns true for unknown Error with transient network message", () => {
+    // Setup
+    const error = new Error("socket hang up");
+
+    // Act & Assert
+    expect(isRetryableLlmError(error)).toBe(true);
+  });
+
+  it("returns true for unknown Error with 5xx statusCode", () => {
+    // Setup
+    const error = Object.assign(new Error("upstream failed"), {
+      statusCode: 503,
+    });
+
+    // Act & Assert
+    expect(isRetryableLlmError(error)).toBe(true);
+  });
+
   it("returns false for a non-Error thrown value", () => {
     // Act & Assert
     expect(isRetryableLlmError("string error")).toBe(false);
@@ -229,6 +247,28 @@ describe("classifyLlmError", () => {
 
     // Assert
     expect(code).toBe("openai_non_retryable");
+  });
+
+  it("maps unknown transient network Error to openai_retry_exhausted", () => {
+    // Setup
+    const error = new Error("network error: socket hang up");
+
+    // Act
+    const code = classifyLlmError(error);
+
+    // Assert
+    expect(code).toBe("openai_retry_exhausted");
+  });
+
+  it("maps unknown Error with 5xx statusCode to openai_retry_exhausted", () => {
+    // Setup
+    const error = Object.assign(new Error("server error"), { statusCode: 500 });
+
+    // Act
+    const code = classifyLlmError(error);
+
+    // Assert
+    expect(code).toBe("openai_retry_exhausted");
   });
 
   it("maps a non-Error thrown value to openai_non_retryable", () => {

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
@@ -38,7 +38,7 @@ export function isRetryableLlmError(error: unknown): boolean {
   if (error instanceof NoObjectGeneratedError) {
     return false;
   }
-  return false;
+  return isRetryableUnknownLlmError(error);
 }
 
 /**
@@ -65,6 +65,9 @@ export function classifyLlmError(error: unknown): OutcomeCode {
   if (isAbortOrTimeoutError(error)) {
     return "openai_retry_exhausted";
   }
+  if (isRetryableUnknownLlmError(error)) {
+    return "openai_retry_exhausted";
+  }
   return "openai_non_retryable";
 }
 
@@ -80,4 +83,56 @@ function isAbortOrTimeoutError(error: unknown): boolean {
     error instanceof Error &&
     (error.name === "AbortError" || error.name === "TimeoutError")
   );
+}
+
+/**
+ * Best-effort retry classification for non-AI-SDK errors.
+ *
+ * Some transport/runtime failures may surface as plain `Error` objects (for
+ * example from fetch/runtime boundaries) rather than `APICallError`. This
+ * helper treats obvious transient network and 5xx-like signals as retryable.
+ *
+ * @param error - Value to classify.
+ * @returns `true` when the error appears transient and worth retrying.
+ */
+function isRetryableUnknownLlmError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const maybeStatus = readNumericStatusCode(error);
+  if (
+    maybeStatus === 429 ||
+    (maybeStatus !== undefined && maybeStatus >= 500)
+  ) {
+    return true;
+  }
+  return /(timed? out|timeout|econnreset|econnrefused|eai_again|enotfound|socket hang up|network error|rate limit)/i.test(
+    error.message,
+  );
+}
+
+/**
+ * Reads a numeric status code from common error object shapes.
+ *
+ * @param error - Error instance that may include status fields.
+ * @returns Status code when present; otherwise `undefined`.
+ */
+function readNumericStatusCode(error: Error): number | undefined {
+  const asRecord = error as Record<string, unknown>;
+  const direct = asRecord.statusCode ?? asRecord.status;
+  if (typeof direct === "number") {
+    return direct;
+  }
+  if (
+    asRecord.cause &&
+    typeof asRecord.cause === "object" &&
+    asRecord.cause !== null
+  ) {
+    const causeRecord = asRecord.cause as Record<string, unknown>;
+    const nested = causeRecord.statusCode ?? causeRecord.status;
+    if (typeof nested === "number") {
+      return nested;
+    }
+  }
+  return undefined;
 }

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
@@ -118,7 +118,7 @@ function isRetryableUnknownLlmError(error: unknown): boolean {
  * @returns Status code when present; otherwise `undefined`.
  */
 function readNumericStatusCode(error: Error): number | undefined {
-  const asRecord = error as Record<string, unknown>;
+  const asRecord = error as unknown as Record<string, unknown>;
   const direct = asRecord.statusCode ?? asRecord.status;
   if (typeof direct === "number") {
     return direct;

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -62,8 +62,6 @@ export type GenerateNewsletterObjectArgs = {
   maxRetries: number;
   /** Per-request timeout in milliseconds (passed to the AI SDK). */
   timeout?: number;
-  /** Sampling temperature (0.0 to 2.0) passed to `generateObject`. */
-  temperature?: number;
   /** Maximum tokens to generate (passed to `generateObject`). */
   maxTokens?: number;
 };
@@ -225,7 +223,6 @@ export async function generateNewsletterWithLlm(
   });
 
   const timeout = config.openai?.timeoutMs;
-  const temperature = config.openai?.temperature;
   const maxTokens = config.openai?.maxTokens;
 
   const result = await retryWithBackoff(
@@ -237,7 +234,6 @@ export async function generateNewsletterWithLlm(
         prompt,
         maxRetries: 0,
         ...(timeout !== undefined ? { timeout } : {}),
-        ...(temperature !== undefined ? { temperature } : {}),
         ...(maxTokens !== undefined ? { maxTokens } : {}),
       }),
     config.llmRetry,

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
@@ -2,16 +2,14 @@ import { z } from "zod";
 
 /** Zod schema for OpenAI LLM newsletter JSON output. */
 export const newsletterStructureSchema = z.object({
-  subject: z.string().optional(),
-  executiveSummary: z.string().optional(),
-  topNews: z
-    .array(
-      z.object({
-        title: z.string(),
-        summary: z.string(),
-      }),
-    )
-    .optional(),
+  subject: z.string(),
+  executiveSummary: z.string(),
+  topNews: z.array(
+    z.object({
+      title: z.string(),
+      summary: z.string(),
+    }),
+  ),
 });
 
 /**

--- a/apps/mediapulse/agents/content-generation/src/run.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.test.ts
@@ -1078,7 +1078,6 @@ describe("provenance fields in contentGeneration.create", () => {
           openai: {
             apiKey: "sk-test",
             model: "gpt-4o",
-            temperature: 0.4,
             timeoutMs: 120000,
           },
         },

--- a/dev-docs/docs/hermes/dashboard/content-generation-runs-diagnostics.mdx
+++ b/dev-docs/docs/hermes/dashboard/content-generation-runs-diagnostics.mdx
@@ -38,7 +38,7 @@ The list page supports URL query-param filters for shareability:
 | Param       | Type   | Description                                  |
 |-------------|--------|----------------------------------------------|
 | `outcome`   | enum   | `success`, `skipped`, or `failed`            |
-| `tickerId`  | string | UUID of the ticker to filter by              |
+| `tickerId`  | string | Non-empty ticker id string to filter by      |
 | `startTime` | date   | ISO date string for start of time range      |
 | `endTime`   | date   | ISO date string for end of time range        |
 | `cursor`    | string | Cursor for pagination (from `nextCursor`)    |

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -179,7 +179,7 @@ Implemented in `apps/mediapulse/agent-data-api/src/routes/content-generation-run
 - **GET** — Lists persisted runs. **Query** (all optional, validated by `contentGenerationRunQuerySchema`):
   - `cursor` — `id` of the last item from the previous page.
   - `limit` — Page size, between 1 and 100. Default 50.
-  - `tickerId` — UUID, filter by ticker.
+  - `tickerId` — non-empty string ticker id, filter by ticker.
   - `outcome` — One of `success`, `skipped`, `failed`.
   - `startTime` — ISO 8601 datetime; when set, only rows with `createdAt >= startTime` (inclusive).
   - `endTime` — ISO 8601 datetime; when set, only rows with `createdAt <= endTime` (inclusive).

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation-config-reference.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation-config-reference.mdx
@@ -17,7 +17,6 @@ The content-generation agent loads its runtime configuration from Hermes on each
 | `openai.apiKey` | `string` | — | OpenAI API key. Required if `openaiApiKey` (deprecated) is omitted. Must be at least 1 character. |
 | `openai.baseUrl` | `string (url)` | — | OpenAI-compatible API base URL (e.g. Azure OpenAI or proxy). Must be a valid URL. |
 | `openai.model` | `string` | `gpt-4o-mini` | Chat completions model id. Must be at least 1 character. |
-| `openai.temperature` | `number` | `0.4` | Sampling temperature. Range: 0–2. |
 | `openai.maxTokens` | `number` | — | Maximum tokens to generate. Must be a positive integer. |
 | `openai.timeoutMs` | `number` | `120000` | Per-request timeout in milliseconds passed to the AI SDK `generateObject` call. Must be a positive integer. |
 

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -10,7 +10,7 @@ The content-generation agent takes **selected data sources** (scored by the anal
 
 ## Features
 
-- **Input:** `tickerId` (and optional fields). Receives bearer token from Hermes.
+- **Input:** `tickerId` as a non-empty string (UUID or opaque Hermes ticker id). Receives bearer token from Hermes.
 - **Fetches** selected high-relevance sources for the ticker from `GET /api/v1/content-generation` (rows where `article_relevance.selected = true` and scored today).
 - **Calls OpenAI** via the Vercel AI SDK (`generateObject` from `ai` with `@ai-sdk/openai` provider) to generate structured newsletter content (subject, executive summary, top news items). The API key, optional API base URL, and model id are **not** read from environment variables; they come from the **agent config** selected for the pipeline step in Hermes (Dashboard → Agent configs), so admins can manage credentials centrally (optionally using [variable expansion](/hermes/agent-hermes-contract#variables-in-config-and-params) for secrets).
 - **Retries** transient LLM failures (rate limits, 5xx errors, timeouts) using exponential backoff with optional jitter, up to `llmRetry.maxAttempts` (default 3). Non-retryable errors (auth, bad request, schema validation) short-circuit immediately.
@@ -35,7 +35,6 @@ The content-generation agent takes **selected data sources** (scored by the anal
 | `openai.apiKey` | `string` | ✅ | — | OpenAI API key. Required if `openaiApiKey` is omitted. |
 | `openai.model` | `string` | ❌ | `gpt-4o-mini` | Chat model id. |
 | `openai.baseUrl` | `string (url)` | ❌ | official | OpenAI-compatible API base URL. |
-| `openai.temperature` | `number` | ❌ | `0.4` | Sampling temperature (0.0 to 2.0). |
 | `openai.timeoutMs` | `number` | ❌ | `120000` | Per-request timeout in milliseconds. |
 | `openaiApiKey` | `string` | ❌ | — | **Deprecated**: Use `openai.apiKey`. |
 | `openaiModel` | `string` | ❌ | — | **Deprecated**: Use `openai.model`. |
@@ -73,7 +72,7 @@ The `AgentRunResult` envelope returned to Hermes is unchanged: `{ success: false
 - `@workspace/agent-data-api-client` — Typed API client for content-generation endpoints.
 - `@workspace/agent-types` — `DataSourceRecord` and related types.
 - `@workspace/utils` — `withRetryCustomDelay` used by the retry utility.
-- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config.openai`** from Hermes: required **`apiKey`**, optional **`baseUrl`**, optional **`model`** (defaults to `gpt-4o-mini`), plus **`temperature`**, **`maxTokens`**, and **`timeoutMs`** as defined in the agent config schema.
+- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config.openai`** from Hermes: required **`apiKey`**, optional **`baseUrl`**, optional **`model`** (defaults to `gpt-4o-mini`), plus **`maxTokens`** and **`timeoutMs`** as defined in the agent config schema.
 - `@workspace/logger` — Logging.
 - `ai` + `@ai-sdk/openai` — Vercel AI SDK for structured LLM calls (`generateObject`).
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -486,6 +486,32 @@ describe("createAgentDataApiClient", () => {
     expect(result.data).toEqual([]);
   });
 
+  it("accepts non-UUID tickerId for contentGenerationRuns GET", async () => {
+    // Setup
+    const getFn = vi.fn().mockResolvedValue({
+      body: JSON.stringify({ data: [] }),
+      statusCode: 200,
+    });
+    const client = createAgentDataApiClient({
+      baseUrl: "http://agent-data-api",
+      token: "Bearer sdk-token",
+      getFn,
+    });
+
+    // Act
+    await client.contentGenerationRuns.get({
+      tickerId: "ticker-bca",
+    });
+
+    // Assert
+    expect(getFn).toHaveBeenCalledWith(
+      `http://agent-data-api${agentDataApiPathname(AGENT_DATA_API_DEFAULT_VERSION, "contentGenerationRuns")}?tickerId=ticker-bca`,
+      expect.objectContaining({
+        headers: { Authorization: "Bearer sdk-token" },
+      }),
+    );
+  });
+
   it("builds contentGenerationRuns POST with typed body and returns created record", async () => {
     // Setup
     const now = "2026-04-14T00:00:00.000Z";
@@ -535,6 +561,55 @@ describe("createAgentDataApiClient", () => {
     );
     expect(result.id).toBe("33333333-3333-4333-a333-333333333333");
     expect(result.createdAt).toBe(now);
+  });
+
+  it("accepts non-UUID tickerId for contentGenerationRuns POST", async () => {
+    // Setup
+    const now = "2026-04-14T00:00:00.000Z";
+    const postFn = vi.fn().mockResolvedValue({
+      body: JSON.stringify({
+        id: "33333333-3333-4333-a333-333333333333",
+        agentId: "content-generation",
+        agentVersion: "1.0.0",
+        tickerId: "ticker-bca",
+        outcome: "success",
+        stage: null,
+        errorCode: null,
+        errorCategory: null,
+        message: null,
+        durationMs: 1200,
+        pipelineRunId: null,
+        newsletterId: null,
+        createdAt: now,
+      }),
+      statusCode: 200,
+    });
+    const client = createAgentDataApiClient({
+      baseUrl: "http://agent-data-api",
+      token: "Bearer sdk-token",
+      postFn,
+    });
+
+    // Act
+    const result = await client.contentGenerationRuns.create({
+      agentId: "content-generation",
+      agentVersion: "1.0.0",
+      tickerId: "ticker-bca",
+      outcome: "success",
+      durationMs: 1200,
+      newsletterId: null,
+    });
+
+    // Assert
+    expect(postFn).toHaveBeenCalledWith(
+      `http://agent-data-api${agentDataApiPathname(AGENT_DATA_API_DEFAULT_VERSION, "contentGenerationRuns")}`,
+      expect.objectContaining({
+        json: expect.objectContaining({
+          tickerId: "ticker-bca",
+        }),
+      }),
+    );
+    expect(result.tickerId).toBe("ticker-bca");
   });
 });
 

--- a/packages/shared/agent-data-api-contract/src/content-generation-run.ts
+++ b/packages/shared/agent-data-api-contract/src/content-generation-run.ts
@@ -13,10 +13,18 @@ export const contentGenerationRunStageSchema = z.enum([
   "persist",
 ]);
 
+/**
+ * Ticker id used by content-generation diagnostics.
+ *
+ * Aligns with Hermes agent input semantics (`hermesTickerIdSchema`): accept any
+ * non-empty trimmed string, including UUIDs and opaque ids.
+ */
+const contentGenerationRunTickerIdSchema = z.string().trim().min(1);
+
 export const postContentGenerationRunBodySchema = z.object({
   agentId: z.literal("content-generation"),
   agentVersion: z.string().min(1),
-  tickerId: z.string().uuid(),
+  tickerId: contentGenerationRunTickerIdSchema,
   outcome: contentGenerationRunOutcomeSchema,
   stage: contentGenerationRunStageSchema.nullable().optional(),
   errorCode: z.string().nullable().optional(),
@@ -32,7 +40,7 @@ export const postContentGenerationRunResponseSchema = z.object({
   id: z.string().uuid(),
   agentId: z.string(),
   agentVersion: z.string(),
-  tickerId: z.string().uuid(),
+  tickerId: contentGenerationRunTickerIdSchema,
   outcome: contentGenerationRunOutcomeSchema,
   stage: contentGenerationRunStageSchema.nullable().optional(),
   errorCode: z.string().nullable().optional(),
@@ -56,7 +64,7 @@ export const contentGenerationRunQuerySchema = z.object({
   ),
   tickerId: z.preprocess(
     (v) => (v === "" || v === undefined ? undefined : v),
-    z.string().uuid().optional(),
+    contentGenerationRunTickerIdSchema.optional(),
   ),
   outcome: z.preprocess(
     (v) => (v === "" || v === undefined ? undefined : v),
@@ -76,7 +84,7 @@ export const contentGenerationRunListItemSchema = z.object({
   id: z.string().uuid(),
   agentId: z.string(),
   agentVersion: z.string(),
-  tickerId: z.string().uuid(),
+  tickerId: contentGenerationRunTickerIdSchema,
   outcome: contentGenerationRunOutcomeSchema,
   stage: contentGenerationRunStageSchema.nullable().optional(),
   errorCode: z.string().nullable().optional(),


### PR DESCRIPTION
## Summary

Fix a cluster of content-generation failures caused by schema and config mismatches, and make LLM retry classification behave better under transient runtime/network failures.

## Related issues

Closes #350

## Important changes

- Align content-generation input with Hermes ticker semantics by accepting non-empty string `tickerId` values instead of UUID-only input.
- Relax `content-generation-runs` contract ticker fields from UUID-only to non-empty string so diagnostics writes and queries match runtime behavior.
- Fix OpenAI strict JSON schema compatibility by making newsletter structured output fields required (`subject`, `executiveSummary`, `topNews`) to avoid `invalid_json_schema` request failures.
- Improve LLM error classification so unknown transient transport/5xx-like failures are treated as retryable and map to `openai_retry_exhausted` instead of `openai_non_retryable`.
- Remove unsupported `temperature` from content-generation config and request payloads to eliminate reasoning-model warnings.

## Other changes

- Updated service/client tests for non-UUID `tickerId` handling in content-generation run diagnostics.
- Updated config/version tests to reflect removal of `temperature`.
- Synced docs for config fields and diagnostics filter semantics.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts` - strict schema fix for OpenAI response format.
- `apps/mediapulse/agents/content-generation/src/llm-classify-error.ts` - retry classification improvements for unknown transient failures.
- `apps/mediapulse/agents/content-generation/src/config-schema.ts` - removal of `openai.temperature`.
- `packages/shared/agent-data-api-contract/src/content-generation-run.ts` - tickerId contract alignment.
- `packages/shared/agent-data-api-client/src/index.test.ts` - client behavior coverage for non-UUID ticker ids.

## How to test

1. `pnpm --filter @mediapulse/content-generation test -- --run src/config-schema.test.ts src/llm-generate-newsletter.test.ts src/run.test.ts src/index.test.ts src/compute-config-version.test.ts`
2. `pnpm --filter @mediapulse/agent-data-api test -- --run src/services/content-generation-run.test.ts`
3. `pnpm --filter @workspace/agent-data-api-contract build`
4. `pnpm --filter @workspace/agent-data-api-client test -- --run src/index.test.ts`
5. `pnpm format:check`
