### PR TITLE
Fix delivery email rendering when stream APIs are unavailable

### DIFF
--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -30,4 +30,53 @@ describe("renderNewsletterEmail", () => {
     expect(html).toMatch(/manage preferences/i);
     expect(html).toContain("https://app.example.com/settings/email");
   });
+
+  it("falls back to static render when stream render is unavailable", async () => {
+    // Setup
+    const streamError = new TypeError(
+      "undefined is not an object (evaluating 'Object.hasOwn(reactDOMServer, \"renderToReadableStream\")')",
+    );
+
+    // Act
+    const { html, text } = await renderNewsletterEmail(
+      {
+        title: "Fallback digest",
+        bodyText: "Body from fallback",
+      },
+      {
+        renderHtml: async () => {
+          throw streamError;
+        },
+        renderText: async () => {
+          throw streamError;
+        },
+      },
+    );
+
+    // Assert
+    expect(html).toContain("Fallback digest");
+    expect(text).toContain("Fallback digest");
+    expect(text).toContain("Body from fallback");
+  });
+
+  it("rethrows render errors that are unrelated to stream support", async () => {
+    // Setup
+    const failure = new Error("render exploded");
+
+    // Act & Assert
+    await expect(
+      renderNewsletterEmail(
+        {
+          title: "Will fail",
+          bodyText: "Will fail",
+        },
+        {
+          renderHtml: async () => {
+            throw failure;
+          },
+          renderText: async () => "unused",
+        },
+      ),
+    ).rejects.toThrow("render exploded");
+  });
 });

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -1,5 +1,6 @@
 import { render } from "@react-email/render";
 import type { ReactElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import DefaultNewsletterEmail from "./newsletter/default-newsletter.js";
 import type { DefaultNewsletterEmailProps } from "./newsletter/default-newsletter.js";
@@ -20,6 +21,45 @@ export type RenderNewsletterEmailInput =
       variant: "registration-confirmation";
     } & RegistrationConfirmationEmailProps)
   | ({ variant: "invalid-ticker" } & InvalidTickerEmailProps);
+
+type RenderEmailToHtml = (element: ReactElement) => Promise<string>;
+type RenderEmailToText = (element: ReactElement) => Promise<string>;
+
+export type RenderNewsletterEmailDependencies = {
+  renderHtml?: RenderEmailToHtml;
+  renderText?: RenderEmailToText;
+  fallbackRenderHtml?: (element: ReactElement) => string;
+};
+
+/**
+ * Returns true when the renderer failed due to missing ReactDOM server stream support.
+ *
+ * @param error - Unknown render error.
+ * @returns True when fallback rendering should be used.
+ */
+const shouldUseStaticFallbackRenderer = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes("renderToReadableStream");
+};
+
+/**
+ * Converts rendered HTML into a safe plain-text approximation for text-only delivery.
+ *
+ * @param html - Rendered email HTML.
+ * @returns Plain text extracted from the HTML.
+ */
+const htmlToPlainText = (html: string): string => {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/\s+/g, " ")
+    .trim();
+};
 
 /**
  * Selects the React Email root element for the given variant.
@@ -62,13 +102,28 @@ function newsletterElementForVariant(
  */
 export async function renderNewsletterEmail(
   input: RenderNewsletterEmailInput,
+  dependencies: RenderNewsletterEmailDependencies = {},
 ): Promise<{ html: string; text: string }> {
   const element = newsletterElementForVariant(input);
+  const renderHtml = dependencies.renderHtml ?? ((el) => render(el));
+  const renderText =
+    dependencies.renderText ?? ((el) => render(el, { plainText: true }));
+  const fallbackRenderHtml =
+    dependencies.fallbackRenderHtml ?? renderToStaticMarkup;
 
-  const [html, text] = await Promise.all([
-    render(element),
-    render(element, { plainText: true }),
-  ]);
+  try {
+    const [html, text] = await Promise.all([
+      renderHtml(element),
+      renderText(element),
+    ]);
+    return { html, text };
+  } catch (error) {
+    if (!shouldUseStaticFallbackRenderer(error)) {
+      throw error;
+    }
 
-  return { html, text };
+    const html = fallbackRenderHtml(element);
+    const text = htmlToPlainText(html);
+    return { html, text };
+  }
 }


### PR DESCRIPTION
## Summary

This change prevents delivery runs from crashing when the runtime does not expose ReactDOM stream rendering APIs. Instead of failing during newsletter render, the shared template renderer now falls back to static markup and still produces both HTML and text content.

## Related issues

Closes #352

## Important changes

- Add a guarded fallback in `renderNewsletterEmail` for `renderToReadableStream` compatibility failures.
- Use `renderToStaticMarkup` as a safe fallback path and derive plain text output from rendered HTML.
- Preserve existing behavior for non-compatibility errors by rethrowing unrelated render failures.

## Other changes

- Extend unit tests to cover fallback behavior and the non-fallback error path.

## Key files to review

- `packages/shared/email-templates/src/render-newsletter-email.tsx` - fallback detection and rendering path.
- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` - tests covering fallback and error rethrow behavior.

## How to test

1. Run `pnpm --filter @workspace/email-templates test -- render-newsletter-email.test.tsx`.
2. Run `pnpm --filter @mediapulse/delivery test -- deliver-newsletter.test.ts`.
3. Run `pnpm format:check`.
4. Trigger a delivery run in the same environment that previously failed and confirm it no longer throws `renderToReadableStream` errors.
