### PR TITLE
Mark content-generation skip outcomes as successful runs

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/run.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.test.ts
@@ -145,7 +145,7 @@ describe("run", () => {
   // No sources → skipped outcome
   // -------------------------------------------------------------------------
 
-  it("returns success:false with 'no sources found' message when no sources", async () => {
+  it("returns success:true with 'no sources found' message when no sources", async () => {
     // Setup
     contentGenerationNewslettersLatestGet.mockResolvedValue({
       hasNewsletter: false,
@@ -157,15 +157,13 @@ describe("run", () => {
     const result = await run(makeContext());
 
     // Assert
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.message).toContain("No data sources found");
-    }
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("No data sources found");
     expect(LlmGenerate.generateNewsletterWithLlm).not.toHaveBeenCalled();
     expect(contentGenerationCreate).not.toHaveBeenCalled();
   });
 
-  it("returns success:false when dataSources is null", async () => {
+  it("returns success:true when dataSources is null", async () => {
     // Setup
     contentGenerationNewslettersLatestGet.mockResolvedValue({
       hasNewsletter: false,
@@ -177,17 +175,15 @@ describe("run", () => {
     const result = await run(makeContext());
 
     // Assert
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.message).toContain("No data sources found");
-    }
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("No data sources found");
   });
 
   // -------------------------------------------------------------------------
   // Skip-if-fresh: newsletter exists in window → skipped
   // -------------------------------------------------------------------------
 
-  it("returns success:false with skipped message when a fresh newsletter already exists for the ticker today", async () => {
+  it("returns success:true with skipped message when a fresh newsletter already exists for the ticker today", async () => {
     // Setup
     contentGenerationNewslettersLatestGet.mockResolvedValue({
       hasNewsletter: true,
@@ -198,12 +194,10 @@ describe("run", () => {
     const result = await run(makeContext());
 
     // Assert
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.message).toContain(
-        `Newsletter already generated for ${TEST_TICKER_ID} today (skipped)`,
-      );
-    }
+    expect(result.success).toBe(true);
+    expect(result.message).toContain(
+      `Newsletter already generated for ${TEST_TICKER_ID} today (skipped)`,
+    );
     expect(contentGenerationGet).not.toHaveBeenCalled();
     expect(LlmGenerate.generateNewsletterWithLlm).not.toHaveBeenCalled();
     expect(contentGenerationCreate).not.toHaveBeenCalled();
@@ -620,7 +614,7 @@ describe("run", () => {
       const result = await run(makeContext());
 
       // Assert
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
       expect(contentGenerationRunsCreate).toHaveBeenCalledOnce();
       const callArg = contentGenerationRunsCreate.mock.calls[0]![0];
       expect(callArg.outcome).toBe("skipped");
@@ -645,7 +639,7 @@ describe("run", () => {
       const result = await run(makeContext());
 
       // Assert
-      expect(result.success).toBe(false);
+      expect(result.success).toBe(true);
       expect(contentGenerationRunsCreate).toHaveBeenCalledOnce();
       const callArg = contentGenerationRunsCreate.mock.calls[0]![0];
       expect(callArg.outcome).toBe("skipped");

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -230,7 +230,7 @@ export async function run({
       executionId,
     });
     return {
-      success: false,
+      success: true,
       message:
         outcome.message ??
         "Newsletter already generated for this ticker today (skipped)",
@@ -268,7 +268,7 @@ export async function run({
       executionId,
     });
     return {
-      success: false,
+      success: true,
       message: outcome.message ?? "No data sources found for this ticker",
     };
   }


### PR DESCRIPTION
## Summary

This update treats expected skip paths in content-generation as successful no-op runs so pipeline executions no longer look failed when no generation is needed. Skip diagnostics remain intact for operational visibility.

## Related issues

Closes #354

## Important changes

- Return `success: true` when a fresh newsletter already exists for the ticker in the current freshness window.
- Return `success: true` when no eligible data sources are found.
- Keep `contentGenerationRuns.create` behavior unchanged for skip diagnostics (`outcome=skipped` with existing error codes).

## Other changes

- Update run tests to assert success semantics for both skip paths and keep diagnostic assertions aligned.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/run.ts` - skip-path run result semantics.
- `apps/mediapulse/agents/content-generation/src/run.test.ts` - skip-path and diagnostic expectations.

## How to test

1. Run `pnpm --filter @mediapulse/content-generation test -- run.test.ts`.
2. Run `pnpm format:check`.
3. Trigger a content-generation run for a ticker that already has a newsletter for today and confirm the run result is successful with a skipped message.
4. Trigger a content-generation run for a ticker with no eligible sources and confirm the run result is successful with a no-sources message.
