### PR TITLE
Prevent schedule saves without a valid next run

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.test.ts
@@ -26,6 +26,7 @@ describe("createCreateScheduleHandler", () => {
         name: "Daily",
         repeat: "once",
         timezone: "UTC",
+        startAt: new Date("2026-04-29T00:00:00.000Z"),
         pipelineId: "00000000-0000-4000-8000-000000000001",
       },
       params: {},
@@ -58,6 +59,7 @@ describe("createCreateScheduleHandler", () => {
         name: "Daily",
         repeat: "once",
         timezone: "UTC",
+        startAt: new Date("2026-04-29T00:00:00.000Z"),
         pipelineId,
       },
       params: {},
@@ -72,9 +74,90 @@ describe("createCreateScheduleHandler", () => {
     expect(db.schedule.create).not.toHaveBeenCalled();
   });
 
+  it("returns error when one-time schedule has no startAt", async () => {
+    const pipelineId = "00000000-0000-4000-8000-000000000002";
+    const db = {
+      pipeline: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: pipelineId,
+          isActive: true,
+          steps: [],
+        }),
+      },
+      schedule: {
+        create: vi.fn(),
+      },
+    };
+    const createHandler = createCreateScheduleHandler({
+      db: db as never,
+    });
+    const result = await createHandler({
+      body: {
+        name: "Daily",
+        repeat: "once",
+        timezone: "America/New_York",
+        pipelineId,
+        startAt: null,
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "One-time schedules require a start date/time.",
+    );
+    expect(db.schedule.create).not.toHaveBeenCalled();
+  });
+
+  it("returns error when cron expression is invalid", async () => {
+    // Setup
+    const pipelineId = "00000000-0000-4000-8000-000000000002";
+    const db = {
+      pipeline: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: pipelineId,
+          isActive: true,
+          steps: [],
+        }),
+      },
+      schedule: {
+        create: vi.fn(),
+      },
+    };
+    const createHandler = createCreateScheduleHandler({
+      db: db as never,
+    });
+
+    // Act
+    const result = await createHandler({
+      body: {
+        name: "Daily",
+        repeat: "repeating",
+        cronExpression: "not-a-cron",
+        timezone: "UTC",
+        pipelineId,
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    // Assert
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Invalid cron expression for the selected timezone.",
+    );
+    expect(db.schedule.create).not.toHaveBeenCalled();
+  });
+
   it("creates schedule and returns id", async () => {
+    // Setup
     const pipelineId = "00000000-0000-4000-8000-000000000002";
     const scheduleId = "00000000-0000-4000-8000-000000000003";
+    const startAt = new Date("2026-04-29T00:00:00.000Z");
     const db = {
       pipeline: {
         findUnique: vi.fn().mockResolvedValue({
@@ -94,19 +177,23 @@ describe("createCreateScheduleHandler", () => {
     const createHandler = createCreateScheduleHandler({
       db: db as never,
     });
+
+    // Act
     const result = await createHandler({
       body: {
         name: "Daily",
         repeat: "once",
         timezone: "America/New_York",
         pipelineId,
-        startAt: null,
+        startAt,
       },
       params: {},
       headers: new Headers(),
       searchParams: {},
       user: mockDashboardUser,
     } as never);
+
+    // Assert
     expect(result.status).toBe(true);
     expect((result as { data?: { id: string } }).data?.id).toBe(scheduleId);
     expect(db.schedule.create).toHaveBeenCalledTimes(1);
@@ -117,7 +204,7 @@ describe("createCreateScheduleHandler", () => {
     expect(createData!.name).toBe("Daily");
     expect(createData.repeat).toBe("once");
     expect(createData.pipelineId).toBe(pipelineId);
-    expect(createData.nextRunAt).toBeNull();
+    expect(createData.nextRunAt).toEqual(startAt);
     expect(createData.createdById).toBe(mockDashboardUser.id);
   });
 });
@@ -145,7 +232,7 @@ describe("handler", () => {
       body: {
         name: "Test",
         repeat: "repeating",
-        cronExpression: "0 6 * * *",
+        interval: 60_000,
         timezone: "UTC",
         pipelineId: "p1",
       },

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
@@ -73,6 +73,36 @@ const bodyValidator = z
     },
   );
 
+/**
+ * Returns true when the provided cron expression yields a next run for the timezone.
+ *
+ * @param cronExpression - Candidate cron expression.
+ * @param timezone - IANA timezone string.
+ * @param startAt - Optional starting point for next-run calculation.
+ * @returns True when cron can be parsed into a next run.
+ */
+const isValidRepeatingCron = (
+  cronExpression: string | null | undefined,
+  timezone: string,
+  startAt: Date | null | undefined,
+): boolean => {
+  if (cronExpression == null || cronExpression.trim() === "") {
+    return true;
+  }
+  return (
+    computeNextRunAt(
+      {
+        repeat: "repeating",
+        cronExpression: cronExpression.trim(),
+        interval: null,
+        timezone,
+        nextRunAt: null,
+      },
+      startAt ?? new Date(),
+    ) !== null
+  );
+};
+
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
   user: requireDashboardSessionForRoute,
@@ -136,6 +166,18 @@ export const createCreateScheduleHandler = ({
     const userId = data.user.id;
     const body = data.body;
 
+    if (body.repeat === "once" && body.startAt == null) {
+      return errorResponse("One-time schedules require a start date/time.");
+    }
+    if (
+      body.repeat === "repeating" &&
+      !isValidRepeatingCron(body.cronExpression, body.timezone, body.startAt)
+    ) {
+      return errorResponse(
+        "Invalid cron expression for the selected timezone.",
+      );
+    }
+
     const pipeline = await getPipelineWithSteps(body.pipelineId, db);
     if (!pipeline) {
       return errorResponse("Pipeline not found");
@@ -154,6 +196,11 @@ export const createCreateScheduleHandler = ({
       body.interval ?? null,
       body.timezone,
     );
+    if (body.repeat === "repeating" && nextRunAt == null) {
+      return errorResponse(
+        "Unable to compute next run. Provide a valid cron or interval.",
+      );
+    }
 
     if (body.executionConfig != null) {
       ExecutionConfigSchema.parse(body.executionConfig);

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.test.ts
@@ -123,6 +123,77 @@ describe("createUpdateScheduleHandler", () => {
       }),
     });
   });
+
+  it("returns error when setting repeat=once without startAt", async () => {
+    // Setup
+    const updateMock = vi.fn().mockResolvedValue(undefined);
+    const db = {
+      schedule: {
+        findUnique: vi.fn().mockResolvedValue(existingSchedule),
+        update: updateMock,
+      },
+    };
+    const updateHandler = createUpdateScheduleHandler({
+      db: db as never,
+    });
+
+    // Act
+    const result = await updateHandler({
+      body: { scheduleId, repeat: "once", startAt: null },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    // Assert
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "One-time schedules require a start date/time.",
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("returns error when setting invalid cron on repeating schedule", async () => {
+    // Setup
+    const updateMock = vi.fn().mockResolvedValue(undefined);
+    const repeatingSchedule = {
+      ...existingSchedule,
+      repeat: "repeating" as const,
+      cronExpression: "0 6 * * *",
+      startAt: null,
+    };
+    const db = {
+      schedule: {
+        findUnique: vi.fn().mockResolvedValue(repeatingSchedule),
+        update: updateMock,
+      },
+    };
+    const updateHandler = createUpdateScheduleHandler({
+      db: db as never,
+    });
+
+    // Act
+    const result = await updateHandler({
+      body: {
+        scheduleId,
+        repeat: "repeating",
+        cronExpression: "not-a-cron",
+        timezone: "UTC",
+      },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+      user: mockDashboardUser,
+    } as never);
+
+    // Assert
+    expect(result.status).toBe(false);
+    expect((result as { message?: string }).message).toBe(
+      "Invalid cron expression for the selected timezone.",
+    );
+    expect(updateMock).not.toHaveBeenCalled();
+  });
 });
 
 describe("handler", () => {

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
@@ -71,6 +71,36 @@ const bodyValidator = z
     },
   );
 
+/**
+ * Returns true when the provided cron expression yields a next run for the timezone.
+ *
+ * @param cronExpression - Candidate cron expression.
+ * @param timezone - IANA timezone string.
+ * @param startAt - Optional starting point for next-run calculation.
+ * @returns True when cron can be parsed into a next run.
+ */
+const isValidRepeatingCron = (
+  cronExpression: string | null | undefined,
+  timezone: string,
+  startAt: Date | null | undefined,
+): boolean => {
+  if (cronExpression == null || cronExpression.trim() === "") {
+    return true;
+  }
+  return (
+    computeNextRunAt(
+      {
+        repeat: "repeating",
+        cronExpression: cronExpression.trim(),
+        interval: null,
+        timezone,
+        nextRunAt: null,
+      },
+      startAt ?? new Date(),
+    ) !== null
+  );
+};
+
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
   user: requireDashboardSessionForRoute,
@@ -136,6 +166,18 @@ export const createUpdateScheduleHandler = ({
     const interval =
       body.interval !== undefined ? body.interval : existing.interval;
 
+    if (repeat === "once" && startAt == null) {
+      return errorResponse("One-time schedules require a start date/time.");
+    }
+    if (
+      repeat === "repeating" &&
+      !isValidRepeatingCron(cronExpression, timezone, startAt)
+    ) {
+      return errorResponse(
+        "Invalid cron expression for the selected timezone.",
+      );
+    }
+
     let nextRunAt: Date | null = existing.nextRunAt;
     if (repeat === "once") {
       nextRunAt = startAt ?? null;
@@ -151,6 +193,11 @@ export const createUpdateScheduleHandler = ({
         startAt ?? new Date(),
       );
       nextRunAt = computed ?? existing.nextRunAt;
+    }
+    if (repeat === "repeating" && nextRunAt == null) {
+      return errorResponse(
+        "Unable to compute next run. Provide a valid cron or interval.",
+      );
     }
 
     const updateData: Prisma.ScheduleUpdateInput = {


### PR DESCRIPTION
## Summary

This change prevents schedules from being saved in states where no next run can be computed. The create/update handlers now reject one-time schedules without a start time and reject invalid cron expressions for the selected timezone.

## Related issues

Closes #358

## Important changes

- Add create-time validation for `repeat=once` requiring `startAt`.
- Add create/update validation that checks cron expressions by attempting next-run computation in the selected timezone.
- Return explicit error responses when repeating schedules still cannot compute a next run.

## Other changes

- Expand schedule action tests to cover one-time missing `startAt` and invalid cron failures on both create and update.
- Adjust create tests to use valid one-time/repeating payloads under stricter validation.

## Key files to review

- `apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts` - new guardrails for create flow.
- `apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts` - matching guardrails for update flow.
- `apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.test.ts` - new create-path validation tests.
- `apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.test.ts` - new update-path validation tests.

## How to test

1. Run `pnpm --filter @hermes/dashboard test -- app/dashboard/schedules/actions/create/route.post.config.test.ts app/dashboard/schedules/actions/update/route.post.config.test.ts`.
2. Run `pnpm format:check`.
3. In Hermes UI, try saving a one-time schedule without `startAt` and confirm it fails with a validation error.
4. In Hermes UI, try saving a repeating schedule with invalid cron and confirm it fails with a validation error.
