### PR TITLE
[FEAT unsubscribe]  Add per-ticker one-click unsubscribe (RFC 8058)

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -767,6 +767,7 @@ describe("agent-data-api", () => {
           subject: "News",
           content: "Body",
           id: NL_ID,
+          symbol: "AAPL",
         },
         subscribers: [{ userTickerId: UT_ID, email: "u@example.com" }],
         deliveredUserTickerIds: [],

--- a/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
@@ -70,6 +70,7 @@ describe("getDeliveryData", () => {
       totalTokens: null,
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+      ticker: { symbol: "AAPL" },
     };
     vi.mocked(prisma.newsletter.findFirst).mockResolvedValue(newsletter);
     vi.mocked(prisma.newsletterDeliveryCheckpoint.findMany).mockResolvedValue([
@@ -125,6 +126,7 @@ describe("getDeliveryData", () => {
         id: "n1",
         subject: "Subj",
         content: "Body",
+        symbol: "AAPL",
       },
       subscribers: [
         { userTickerId: "ut1", email: "a@example.com" },
@@ -136,7 +138,7 @@ describe("getDeliveryData", () => {
 
   it("filters out empty emails", async () => {
     const { prisma } = await import("@mediapulse/database");
-    vi.mocked(prisma.newsletter.findFirst).mockResolvedValue({
+    const newsletter = {
       id: "n1",
       subject: "S",
       description: null,
@@ -152,7 +154,13 @@ describe("getDeliveryData", () => {
       totalTokens: null,
       createdAt: new Date(),
       updatedAt: new Date(),
-    });
+      ticker: { symbol: "BBRI" },
+    };
+    vi.mocked(prisma.newsletter.findFirst).mockResolvedValue(
+      newsletter as unknown as Awaited<
+        ReturnType<typeof prisma.newsletter.findFirst>
+      >,
+    );
     vi.mocked(prisma.newsletterDeliveryCheckpoint.findMany).mockResolvedValue(
       [],
     );

--- a/apps/mediapulse/agent-data-api/src/services/delivery.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.ts
@@ -8,6 +8,7 @@ export async function getDeliveryData(tickerId: string) {
   const newsletter = await mediapulsePrisma.newsletter.findFirst({
     where: { tickerId },
     orderBy: { createdAt: "desc" },
+    include: { ticker: true },
   });
 
   if (!newsletter) {
@@ -43,6 +44,7 @@ export async function getDeliveryData(tickerId: string) {
       id: newsletter.id,
       subject: newsletter.subject,
       content: newsletter.content,
+      symbol: newsletter.ticker.symbol,
     },
     subscribers,
     deliveredUserTickerIds: checkpoints.map((c) => c.userTickerId),

--- a/apps/mediapulse/agents/delivery/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/delivery/src/config-schema.test.ts
@@ -17,7 +17,10 @@ describe("DeliveryConfigSchema", () => {
   });
 
   it("accepts default send (html + text) when resend fields are set", () => {
-    const r = DeliveryConfigSchema.safeParse(minimalResendConfig);
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      unsubscribe: { secret: "secret", baseUrl: "https://example.com/api" },
+    });
     expect(r.success).toBe(true);
     expect(r.data?.send.includeHtml).toBe(true);
     expect(r.data?.send.includeText).toBe(true);
@@ -38,24 +41,25 @@ describe("DeliveryConfigSchema", () => {
     expect(r.success).toBe(false);
   });
 
-  it("accepts optional template.preferencesUrl when valid absolute URL", () => {
+  it("accepts optional unsubscribe config with secret and baseUrl", () => {
     const r = DeliveryConfigSchema.safeParse({
       ...minimalResendConfig,
-      template: {
-        newsletterVariant: "default" as const,
-        preferencesUrl: "https://example.com/prefs",
+      unsubscribe: {
+        secret: "my-hmac-secret",
+        baseUrl: "https://app.example.com/api",
       },
     });
     expect(r.success).toBe(true);
-    expect(r.data?.template.preferencesUrl).toBe("https://example.com/prefs");
+    expect(r.data?.unsubscribe.secret).toBe("my-hmac-secret");
+    expect(r.data?.unsubscribe.baseUrl).toBe("https://app.example.com/api");
   });
 
-  it("rejects invalid template.preferencesUrl", () => {
+  it("rejects invalid unsubscribe.baseUrl", () => {
     const r = DeliveryConfigSchema.safeParse({
       ...minimalResendConfig,
-      template: {
-        newsletterVariant: "default" as const,
-        preferencesUrl: "not-a-url",
+      unsubscribe: {
+        secret: "secret",
+        baseUrl: "not-a-url",
       },
     });
     expect(r.success).toBe(false);

--- a/apps/mediapulse/agents/delivery/src/config-schema.ts
+++ b/apps/mediapulse/agents/delivery/src/config-schema.ts
@@ -48,13 +48,18 @@ export const DeliveryConfigSchema = z
     template: z
       .object({
         newsletterVariant: z.enum(["default"]).default("default"),
-        /**
-         * Absolute URL for the “Manage preferences” link in the default newsletter template.
-         * Omit to hide that link (recommended until a real preferences URL exists).
-         */
-        preferencesUrl: z.string().url().optional(),
       })
       .default({ newsletterVariant: "default" }),
+    /** Unsubscribe feature config for per-subscriber token generation. */
+    unsubscribe: z.object({
+      /** Shared HMAC secret for signing/verifying unsubscribe tokens. */
+      secret: z.string().min(1),
+      /**
+       * Public base URL of the domain API (e.g. "https://mediapulse.com").
+       * The full unsubscribe path `/api/unsubscribe` is appended at runtime.
+       */
+      baseUrl: z.string().url(),
+    }),
   })
   .superRefine((val, ctx) => {
     if (!val.send.includeHtml && !val.send.includeText) {

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -14,6 +14,7 @@ const newsletter = {
   id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   subject: "Subject",
   content: "Body",
+  symbol: "AAPL",
 } as const;
 
 const userTickerId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -30,9 +31,10 @@ describe("deliverNewsletterToSubscribers", () => {
   const baseConfig = DeliveryConfigSchema.parse({
     resendApiKey: "re_k",
     resend: { from: "from@example.com" },
+    unsubscribe: { secret: "test-secret", baseUrl: "https://example.com" },
   });
 
-  it("renders once, rate-limits, sends with html+text, and records success", async () => {
+  it("renders per subscriber, injects unsubscribeUrl and List-Unsubscribe headers", async () => {
     const sendWithRetry = vi
       .fn()
       .mockResolvedValue({ id: "re_1", attempts: 1 });
@@ -53,10 +55,15 @@ describe("deliverNewsletterToSubscribers", () => {
       },
     );
 
-    expect(vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0]).toMatchObject({
+    const renderCall = vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0];
+    expect(renderCall).toMatchObject({
       title: newsletter.subject,
       bodyText: newsletter.content,
       variant: "default",
+      unsubscribeUrl: expect.stringContaining(
+        "https://example.com/api/unsubscribe",
+      ),
+      tickerSymbol: "AAPL",
     });
     expect(acquire).toHaveBeenCalledOnce();
     expect(sendWithRetry).toHaveBeenCalledOnce();
@@ -67,6 +74,12 @@ describe("deliverNewsletterToSubscribers", () => {
       from: "from@example.com",
       to: "u@example.com",
       subject: newsletter.subject,
+      headers: {
+        "List-Unsubscribe": expect.stringContaining(
+          "https://example.com/api/unsubscribe",
+        ),
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
     });
     expect(results).toEqual([
       expect.objectContaining({
@@ -77,16 +90,6 @@ describe("deliverNewsletterToSubscribers", () => {
       }),
     ]);
     expect(resendMessageIds).toEqual(["re_1"]);
-    expect(logInfo).toHaveBeenCalledWith(
-      expect.objectContaining({
-        newsletterId: newsletter.id,
-        successCount: 1,
-        failedCount: 0,
-        skippedCount: 0,
-        totalRecipients: 1,
-      }),
-      "delivery recipient batch summary",
-    );
   });
 
   it("skips checkpointed subscribers without acquire or send", async () => {
@@ -128,6 +131,10 @@ describe("deliverNewsletterToSubscribers", () => {
       resendApiKey: "re_k",
       resend: { from: "from@example.com" },
       send: { includeHtml: false, includeText: true },
+      unsubscribe: {
+        secret: "test-secret",
+        baseUrl: "https://example.com/api",
+      },
     });
     const sendWithRetry = vi
       .fn()
@@ -155,6 +162,10 @@ describe("deliverNewsletterToSubscribers", () => {
       resendApiKey: "re_k",
       resend: { from: "from@example.com" },
       send: { includeHtml: true, includeText: false },
+      unsubscribe: {
+        secret: "test-secret",
+        baseUrl: "https://example.com/api",
+      },
     });
     const sendWithRetry = vi
       .fn()
@@ -185,6 +196,10 @@ describe("deliverNewsletterToSubscribers", () => {
         replyTo: "replies@example.com",
         tags: [{ name: "env", value: "test" }],
       },
+      unsubscribe: {
+        secret: "test-secret",
+        baseUrl: "https://example.com/api",
+      },
     });
     const sendWithRetry = vi
       .fn()
@@ -205,36 +220,6 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(sendWithRetry.mock.calls[0]?.[1]).toMatchObject({
       replyTo: "replies@example.com",
       tags: [{ name: "env", value: "test" }],
-    });
-  });
-
-  it("passes template.preferencesUrl into renderNewsletterEmail when set", async () => {
-    const cfg = DeliveryConfigSchema.parse({
-      resendApiKey: "re_k",
-      resend: { from: "from@example.com" },
-      template: {
-        newsletterVariant: "default",
-        preferencesUrl: "https://app.example.com/prefs",
-      },
-    });
-    const sendWithRetry = vi
-      .fn()
-      .mockResolvedValue({ id: "re_4", attempts: 1 });
-
-    await deliverNewsletterToSubscribers(
-      newsletter,
-      [{ userTickerId, email: "u@example.com" }],
-      [],
-      cfg,
-      {
-        resend: {} as Resend,
-        rateLimiter: { acquire: vi.fn().mockResolvedValue(0) },
-        sendWithRetry,
-      },
-    );
-
-    expect(vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0]).toMatchObject({
-      preferencesUrl: "https://app.example.com/prefs",
     });
   });
 

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 
 import { renderNewsletterEmail } from "@workspace/email-templates";
 import type { LoggerLike } from "@workspace/agent-runtime";
+import { createUnsubscribeToken } from "@workspace/utils";
 import { Resend } from "resend";
 
 import {
@@ -80,7 +81,7 @@ function recipientErrorCategory(
  * @returns Per-recipient results and Resend message ids (for diagnostics).
  */
 export async function deliverNewsletterToSubscribers(
-  newsletter: { id: string; subject: string; content: string },
+  newsletter: { id: string; subject: string; content: string; symbol: string },
   subscribers: DeliverySubscriber[],
   deliveredUserTickerIds: string[],
   config: DeliveryConfig,
@@ -99,23 +100,6 @@ export async function deliverNewsletterToSubscribers(
     });
 
   const deliveredSet = new Set(deliveredUserTickerIds);
-  const renderStarted = Date.now();
-  const { html, text } = await renderNewsletterEmail({
-    title: newsletter.subject,
-    bodyText: newsletter.content,
-    variant: config.template.newsletterVariant,
-    ...(config.template.preferencesUrl !== undefined
-      ? { preferencesUrl: config.template.preferencesUrl }
-      : {}),
-  });
-  logger?.info?.(
-    {
-      ms: Date.now() - renderStarted,
-      newsletterId: newsletter.id,
-    },
-    "delivery newsletter render timing",
-  );
-
   const from = config.resend.from;
 
   const results: RecipientSendResult[] = [];
@@ -142,6 +126,31 @@ export async function deliverNewsletterToSubscribers(
       );
     }
 
+    // Generate per-subscriber unsubscribe token and URL
+    const unsubscribeToken = createUnsubscribeToken({
+      userTickerId: sub.userTickerId,
+      tickerSymbol: newsletter.symbol,
+      secret: config.unsubscribe.secret,
+    });
+    const unsubscribeUrl = `${config.unsubscribe.baseUrl}/api/unsubscribe?token=${unsubscribeToken}`;
+
+    const renderStart = Date.now();
+    const { html, text } = await renderNewsletterEmail({
+      title: newsletter.subject,
+      bodyText: newsletter.content,
+      variant: config.template.newsletterVariant,
+      unsubscribeUrl,
+      tickerSymbol: newsletter.symbol,
+    });
+    logger?.info?.(
+      {
+        ms: Date.now() - renderStart,
+        newsletterId: newsletter.id,
+        recipientRef: ref,
+      },
+      "delivery newsletter render timing",
+    );
+
     const payload: SendEmailPayload = {
       from,
       to: sub.email,
@@ -154,6 +163,10 @@ export async function deliverNewsletterToSubscribers(
       ...(config.resend.tags !== undefined && config.resend.tags.length > 0
         ? { tags: config.resend.tags }
         : {}),
+      headers: {
+        "List-Unsubscribe": `<${unsubscribeUrl}>`,
+        "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+      },
     };
 
     try {

--- a/apps/mediapulse/agents/delivery/src/index.test.ts
+++ b/apps/mediapulse/agents/delivery/src/index.test.ts
@@ -30,6 +30,7 @@ const AUTH_HEADERS = { Authorization: "Bearer test-token" };
 const DELIVERY_CONFIG = {
   resendApiKey: "re_test_key",
   resend: { from: "sender@example.com" },
+  unsubscribe: { secret: "test-secret", baseUrl: "https://example.com/api" },
 };
 
 vi.mock("@workspace/agent-auth-client", () => ({
@@ -77,7 +78,12 @@ describe("delivery-agent", () => {
       ok: true,
       statusCode: 200,
       body: JSON.stringify({
-        newsletter: { id: NL_ID, subject: "News", content: "Body" },
+        newsletter: {
+          id: NL_ID,
+          subject: "News",
+          content: "Body",
+          symbol: "AAPL",
+        },
         subscribers: [{ userTickerId: UT_ID, email: "u@example.com" }],
         deliveredUserTickerIds: [],
       }),
@@ -238,7 +244,12 @@ describe("delivery-agent", () => {
       ok: true,
       statusCode: 200,
       body: JSON.stringify({
-        newsletter: { id: NL_ID, subject: "News", content: "Body" },
+        newsletter: {
+          id: NL_ID,
+          subject: "News",
+          content: "Body",
+          symbol: "AAPL",
+        },
         subscribers: [{ userTickerId: UT_ID, email: "u@example.com" }],
         deliveredUserTickerIds: [UT_ID],
       }),

--- a/apps/mediapulse/agents/delivery/src/send-with-resend-retry.ts
+++ b/apps/mediapulse/agents/delivery/src/send-with-resend-retry.ts
@@ -17,6 +17,7 @@ export type SendEmailPayload = {
   text?: string;
   replyTo?: string;
   tags?: { name: string; value: string }[];
+  headers?: Record<string, string>;
 };
 
 /**
@@ -85,6 +86,10 @@ export async function sendWithResendRetry(
             : {}),
           ...(payload.tags !== undefined && payload.tags.length > 0
             ? { tags: payload.tags }
+            : {}),
+          ...(payload.headers !== undefined &&
+          Object.keys(payload.headers).length > 0
+            ? { headers: payload.headers }
             : {}),
         } as CreateEmailOptions;
         const { data, error, headers } = await resend.emails.send(emailPayload);

--- a/apps/mediapulse/domain-api/package.json
+++ b/apps/mediapulse/domain-api/package.json
@@ -18,6 +18,7 @@
     "@hermes/domain-contract": "workspace:*",
     "@hermes/step-input-syntax": "workspace:*",
     "@workspace/logger": "workspace:*",
+    "@workspace/utils": "workspace:*",
     "@mediapulse/hermes-integration": "workspace:*",
     "@mediapulse/idx-tickers-importer": "workspace:*",
     "@mediapulse/database": "workspace:*",

--- a/apps/mediapulse/domain-api/src/http/create-hono-app.ts
+++ b/apps/mediapulse/domain-api/src/http/create-hono-app.ts
@@ -28,6 +28,12 @@ export const createDomainApiServer = (): {
   // Public routes — no agent-auth JWT required.
   app.route("/api", unsubscribeRoutes);
 
+  if (!env.UNSUBSCRIBE_SECRET) {
+    logger.warn(
+      "UNSUBSCRIBE_SECRET is not set — unsubscribe endpoints will return safe fallback responses",
+    );
+  }
+
   const api = app.basePath("/v1");
 
   api.use(

--- a/apps/mediapulse/domain-api/src/http/create-hono-app.ts
+++ b/apps/mediapulse/domain-api/src/http/create-hono-app.ts
@@ -10,6 +10,7 @@ import { hermesDashboardRouteMounts } from "./hermes-dashboard-route-mounts";
 import { healthRoutes } from "./routes/health-routes";
 import { hermesDashboardManifestRoutes } from "./routes/hermes-dashboard-manifest-routes";
 import { stepInputExpansionRoutes } from "./routes/step-input-expansion-routes";
+import { unsubscribeRoutes } from "./routes/unsubscribe-routes";
 import { verifyInvocationJwtFromHeader } from "./verify-invocation-jwt-middleware";
 
 /**
@@ -23,6 +24,10 @@ export const createDomainApiServer = (): {
   fetch: Hono["fetch"];
 } => {
   const app = new Hono();
+
+  // Public routes — no agent-auth JWT required.
+  app.route("/api", unsubscribeRoutes);
+
   const api = app.basePath("/v1");
 
   api.use(

--- a/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.test.ts
+++ b/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.test.ts
@@ -163,6 +163,58 @@ describe("unsubscribe-routes", () => {
     });
   });
 
+  describe("when UNSUBSCRIBE_SECRET is not configured", () => {
+    beforeEach(() => {
+      vi.doMock("@mediapulse/env", () => ({
+        env: {
+          // UNSUBSCRIBE_SECRET intentionally omitted — simulates misconfigured env
+        },
+      }));
+    });
+
+    afterEach(() => {
+      // Restore the original mock (doUnmock would strip the hoisted vi.mock)
+      vi.doMock("@mediapulse/env", () => ({
+        env: {
+          UNSUBSCRIBE_SECRET: SECRET,
+        },
+      }));
+    });
+
+    it("GET returns friendly HTML fallback (200-safe)", async () => {
+      const { unsubscribeRoutes } = await import("./unsubscribe-routes");
+      const res = await unsubscribeRoutes.request(
+        "/unsubscribe?token=anything",
+        {
+          method: "GET",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("temporarily unavailable");
+      // prisma is never called — we bail out before token verification
+      expect(mockFindUnique).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("POST returns empty 200 (RFC 8058 safe)", async () => {
+      const { unsubscribeRoutes } = await import("./unsubscribe-routes");
+      const res = await unsubscribeRoutes.request(
+        "/unsubscribe?token=anything",
+        {
+          method: "POST",
+        },
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("");
+      expect(mockFindUnique).not.toHaveBeenCalled();
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+
   describe("POST /api/unsubscribe (RFC 8058)", () => {
     it("returns empty 200 for a valid token", async () => {
       mockFindUnique.mockResolvedValue({

--- a/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.test.ts
+++ b/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.test.ts
@@ -1,0 +1,226 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createUnsubscribeToken } from "@workspace/utils";
+
+const SECRET = "test-unsubscribe-secret";
+const USER_TICKER_ID = "550e8400-e29b-41d4-a716-446655440000";
+const TICKER_SYMBOL = "AAPL";
+
+// Mock dependencies before importing the routes
+vi.mock("@mediapulse/env", () => ({
+  env: {
+    UNSUBSCRIBE_SECRET: SECRET,
+  },
+}));
+
+const mockFindUnique = vi.fn();
+const mockUpdate = vi.fn();
+
+vi.mock("@mediapulse/database", () => ({
+  prisma: {
+    userTicker: {
+      findUnique: mockFindUnique,
+      update: mockUpdate,
+    },
+  },
+}));
+
+describe("unsubscribe-routes", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockFindUnique.mockReset();
+    mockUpdate.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function validToken() {
+    return createUnsubscribeToken({
+      userTickerId: USER_TICKER_ID,
+      tickerSymbol: TICKER_SYMBOL,
+      secret: SECRET,
+    });
+  }
+
+  async function getUnsubscribe(query = "") {
+    const { unsubscribeRoutes } = await import("./unsubscribe-routes");
+    return unsubscribeRoutes.request(`/unsubscribe${query}`, {
+      method: "GET",
+    });
+  }
+
+  async function postUnsubscribe(query = "") {
+    const { unsubscribeRoutes } = await import("./unsubscribe-routes");
+    return unsubscribeRoutes.request(`/unsubscribe${query}`, {
+      method: "POST",
+    });
+  }
+
+  describe("GET /api/unsubscribe", () => {
+    it("returns success HTML with ticker symbol for a valid token", async () => {
+      mockFindUnique.mockResolvedValue({
+        id: USER_TICKER_ID,
+        enabled: true,
+        unsubscribedAt: null,
+        ticker: { symbol: TICKER_SYMBOL },
+      });
+      mockUpdate.mockResolvedValue({});
+
+      const res = await getUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      const body = await res.text();
+      expect(body).toContain(TICKER_SYMBOL);
+      expect(body).toContain("Unsubscribed");
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: USER_TICKER_ID },
+        data: {
+          enabled: false,
+          unsubscribedAt: expect.any(Date),
+          unsubscribeMethod: "link",
+        },
+      });
+    });
+
+    it("is idempotent for already unsubscribed users", async () => {
+      mockFindUnique.mockResolvedValue({
+        id: USER_TICKER_ID,
+        enabled: false,
+        unsubscribedAt: new Date(),
+        ticker: { symbol: TICKER_SYMBOL },
+      });
+
+      const res = await getUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("already unsubscribed");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("returns expired message for an expired token", async () => {
+      const expiredToken = createUnsubscribeToken({
+        userTickerId: USER_TICKER_ID,
+        tickerSymbol: TICKER_SYMBOL,
+        secret: SECRET,
+        expiresInMs: -1,
+      });
+
+      const res = await getUnsubscribe(`?token=${expiredToken}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("expired");
+    });
+
+    it("returns invalid message for a garbage token", async () => {
+      const res = await getUnsubscribe("?token=garbage");
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("invalid");
+    });
+
+    it("returns missing-subscription message when UserTicker is deleted", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const res = await getUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toContain("couldn't find");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("uses token-embedded ticker symbol as fallback when DB lookup fails", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const res = await getUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      // The "couldn't find" message is shown, not the ticker symbol
+      expect(body).toContain("couldn't find");
+    });
+
+    it("unsubscribes a user with registrationConfirmedAt=null", async () => {
+      mockFindUnique.mockResolvedValue({
+        id: USER_TICKER_ID,
+        enabled: true,
+        unsubscribedAt: null,
+        ticker: { symbol: TICKER_SYMBOL },
+      });
+      mockUpdate.mockResolvedValue({});
+
+      const res = await getUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/unsubscribe (RFC 8058)", () => {
+    it("returns empty 200 for a valid token", async () => {
+      mockFindUnique.mockResolvedValue({
+        id: USER_TICKER_ID,
+        enabled: true,
+        unsubscribedAt: null,
+        ticker: { symbol: TICKER_SYMBOL },
+      });
+      mockUpdate.mockResolvedValue({});
+
+      const res = await postUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("");
+
+      expect(mockUpdate).toHaveBeenCalledWith({
+        where: { id: USER_TICKER_ID },
+        data: {
+          enabled: false,
+          unsubscribedAt: expect.any(Date),
+          unsubscribeMethod: "one_click",
+        },
+      });
+    });
+
+    it("returns empty 200 for an invalid token (no leaky errors)", async () => {
+      const res = await postUnsubscribe("?token=garbage");
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("");
+    });
+
+    it("returns empty 200 when UserTicker not found", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const res = await postUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("");
+    });
+
+    it("is idempotent for already unsubscribed users", async () => {
+      mockFindUnique.mockResolvedValue({
+        id: USER_TICKER_ID,
+        enabled: false,
+        unsubscribedAt: new Date(),
+        ticker: { symbol: TICKER_SYMBOL },
+      });
+
+      const res = await postUnsubscribe(`?token=${validToken()}`);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+      expect(body).toBe("");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
+++ b/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
@@ -1,0 +1,108 @@
+import { Hono } from "hono";
+import { verifyUnsubscribeToken } from "@workspace/utils";
+import { env } from "@mediapulse/env";
+import { prisma } from "@mediapulse/database";
+
+export const unsubscribeRoutes = new Hono();
+
+/**
+ * Renders a minimal HTML response for browser-based unsubscribe clicks.
+ *
+ * @param body - Inner HTML for the body element.
+ * @param status - HTTP status (always 200 for email-client compatibility).
+ */
+function htmlResponse(body: string, status = 200): Response {
+  return new Response(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>MediaPulse</title></head><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:40px auto;padding:0 16px;color:#1a1a1a">${body}</body></html>`,
+    {
+      status,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    },
+  );
+}
+
+/**
+ * Core unsubscribe logic shared by GET and POST.
+ *
+ * Verifies the HMAC token, flips `UserTicker.enabled` to `false`,
+ * and records `unsubscribedAt` / `unsubscribeMethod` for audit.
+ *
+ * @param token - The signed token from the URL query parameter.
+ * @param method - `"link"` for GET or `"one_click"` for POST.
+ */
+async function handleUnsubscribe(
+  token: string,
+  method: "link" | "one_click",
+): Promise<Response> {
+  const result = verifyUnsubscribeToken(token, env.UNSUBSCRIBE_SECRET);
+
+  if (!result.valid) {
+    if (method === "one_click") {
+      // RFC 8058: POST returns empty 200 regardless
+      return new Response(null, { status: 200 });
+    }
+    const message =
+      result.reason === "expired"
+        ? "This unsubscribe link has expired. Please contact support or reply to this email."
+        : "This unsubscribe link is invalid. Please contact support or reply to this email.";
+    return htmlResponse(`<p style="color:#6b7280">${message}</p>`);
+  }
+
+  // Look up the UserTicker with its Ticker for display
+  const userTicker = await prisma.userTicker.findUnique({
+    where: { id: result.userTickerId },
+    include: { ticker: true },
+  });
+
+  // Use DB ticker symbol if available, fall back to token-embedded symbol
+  const displaySymbol = userTicker?.ticker?.symbol ?? result.tickerSymbol;
+
+  if (!userTicker) {
+    if (method === "one_click") {
+      return new Response(null, { status: 200 });
+    }
+    return htmlResponse(
+      `<p style="color:#6b7280">We couldn't find this subscription. It may have already been removed.</p>`,
+    );
+  }
+
+  // Idempotent: already unsubscribed via self-service
+  if (!userTicker.enabled && userTicker.unsubscribedAt != null) {
+    if (method === "one_click") {
+      return new Response(null, { status: 200 });
+    }
+    return htmlResponse(
+      `<p style="color:#6b7280">You are already unsubscribed from ${displaySymbol} updates.</p>`,
+    );
+  }
+
+  // Perform the unsubscribe
+  await prisma.userTicker.update({
+    where: { id: result.userTickerId },
+    data: {
+      enabled: false,
+      unsubscribedAt: new Date(),
+      unsubscribeMethod: method,
+    },
+  });
+
+  if (method === "one_click") {
+    return new Response(null, { status: 200 });
+  }
+
+  return htmlResponse(
+    `<p style="font-size:18px;font-weight:600;margin-bottom:8px">Unsubscribed</p><p style="color:#6b7280">You have been unsubscribed from <strong>${displaySymbol}</strong> updates.</p>`,
+  );
+}
+
+unsubscribeRoutes.get("/unsubscribe", (c) => {
+  const token = c.req.query("token") ?? "";
+  return handleUnsubscribe(token, "link");
+});
+
+unsubscribeRoutes.post("/unsubscribe", (c) => {
+  const token = c.req.query("token") ?? "";
+  return handleUnsubscribe(token, "one_click");
+});
+
+export { handleUnsubscribe };

--- a/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
+++ b/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
@@ -3,15 +3,6 @@ import { verifyUnsubscribeToken } from "@workspace/utils";
 import { env } from "@mediapulse/env";
 import { prisma } from "@mediapulse/database";
 
-/** Get the unsubscribe secret or throw at boot. */
-function requireUnsubscribeSecret(): string {
-  const secret = env.UNSUBSCRIBE_SECRET;
-  if (!secret) {
-    throw new Error("UNSUBSCRIBE_SECRET is required for unsubscribe routes");
-  }
-  return secret;
-}
-
 export const unsubscribeRoutes = new Hono();
 
 /**
@@ -43,7 +34,18 @@ async function handleUnsubscribe(
   token: string,
   method: "link" | "one_click",
 ): Promise<Response> {
-  const result = verifyUnsubscribeToken(token, requireUnsubscribeSecret());
+  const secret = env.UNSUBSCRIBE_SECRET;
+  if (!secret) {
+    // Misconfigured environment — return 200-safe per RFC 8058
+    if (method === "one_click") {
+      return new Response(null, { status: 200 });
+    }
+    return htmlResponse(
+      `<p style="color:#6b7280">Unsubscribe is temporarily unavailable. Please try again later.</p>`,
+    );
+  }
+
+  const result = verifyUnsubscribeToken(token, secret);
 
   if (!result.valid) {
     if (method === "one_click") {

--- a/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
+++ b/apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts
@@ -3,6 +3,15 @@ import { verifyUnsubscribeToken } from "@workspace/utils";
 import { env } from "@mediapulse/env";
 import { prisma } from "@mediapulse/database";
 
+/** Get the unsubscribe secret or throw at boot. */
+function requireUnsubscribeSecret(): string {
+  const secret = env.UNSUBSCRIBE_SECRET;
+  if (!secret) {
+    throw new Error("UNSUBSCRIBE_SECRET is required for unsubscribe routes");
+  }
+  return secret;
+}
+
 export const unsubscribeRoutes = new Hono();
 
 /**
@@ -34,7 +43,7 @@ async function handleUnsubscribe(
   token: string,
   method: "link" | "one_click",
 ): Promise<Response> {
-  const result = verifyUnsubscribeToken(token, env.UNSUBSCRIBE_SECRET);
+  const result = verifyUnsubscribeToken(token, requireUnsubscribeSecret());
 
   if (!result.valid) {
     if (method === "one_click") {

--- a/apps/mediapulse/domain-api/vitest.config.ts
+++ b/apps/mediapulse/domain-api/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
       AGENT_AUTH_API_URL: "http://127.0.0.1:8080",
       DOMAIN_INTEGRATION_ID: "mediapulse",
       DOMAIN_INTEGRATION_API_KEY: "vitest-placeholder-domain-integration-key",
+      UNSUBSCRIBE_SECRET: "vitest-placeholder-unsubscribe-secret",
     },
   },
 });

--- a/packages/mediapulse/database/prisma/migrations/20260430050614_add_unsubscribe_fields/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260430050614_add_unsubscribe_fields/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "user_ticker" ADD COLUMN     "unsubscribe_method" TEXT,
+ADD COLUMN     "unsubscribed_at" TIMESTAMP(3);

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -285,6 +285,10 @@ model UserTicker {
   tickerId  String   @map("ticker_id")
   enabled   Boolean  @default(true)
   registrationConfirmedAt DateTime? @map("registration_confirmed_at")
+  /// When the user voluntarily unsubscribed (null for admin/manual disables).
+  unsubscribedAt    DateTime? @map("unsubscribed_at")
+  /// How the user unsubscribed: "link" (GET) or "one_click" (POST). Null for admin/manual.
+  unsubscribeMethod String?   @map("unsubscribe_method")
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 

--- a/packages/mediapulse/env/env.agents.delivery.example
+++ b/packages/mediapulse/env/env.agents.delivery.example
@@ -13,3 +13,8 @@ DOMAIN_INTEGRATION_API_KEY= # required
 DOMAIN_INTEGRATION_ID=mediapulse # required # default
 
 # Resend: configure `resendApiKey` and `resend.from` on the delivery Agent config in Hermes (not env).
+
+# Unsubscribe: HMAC secret for signing/verifying unsubscribe tokens (shared with domain-api)
+UNSUBSCRIBE_SECRET= #required
+# Unsubscribe: public base URL for the unsubscribe endpoint (e.g. https://mediapulse.com/api)
+UNSUBSCRIBE_BASE_URL= #required

--- a/packages/mediapulse/env/env.example
+++ b/packages/mediapulse/env/env.example
@@ -44,5 +44,6 @@ OUTLOOK_TENANT_ID=
 OUTLOOK_USER_ID=
 
 # Unsubscribe: HMAC secret shared with the delivery agent (must match the agent's UNSUBSCRIBE_SECRET).
-# Required for domain-api's unsubscribe endpoint; optional everywhere else.
+# When set, unsubscribe links work normally. When omitted, unsubscribe endpoints return safe
+# 200 fallback responses and a warning is logged at startup — the feature degrades gracefully.
 UNSUBSCRIBE_SECRET=

--- a/packages/mediapulse/env/env.example
+++ b/packages/mediapulse/env/env.example
@@ -42,3 +42,6 @@ OUTLOOK_CLIENT_SECRET=
 OUTLOOK_TENANT_ID=
 # Shared mailbox for app-only: use mailbox email (e.g. shared@domain.com) or Azure AD object ID; omit for "me"
 OUTLOOK_USER_ID=
+
+# Unsubscribe: HMAC secret shared with the delivery agent (must match the agent's UNSUBSCRIBE_SECRET)
+UNSUBSCRIBE_SECRET= #required

--- a/packages/mediapulse/env/env.example
+++ b/packages/mediapulse/env/env.example
@@ -43,5 +43,6 @@ OUTLOOK_TENANT_ID=
 # Shared mailbox for app-only: use mailbox email (e.g. shared@domain.com) or Azure AD object ID; omit for "me"
 OUTLOOK_USER_ID=
 
-# Unsubscribe: HMAC secret shared with the delivery agent (must match the agent's UNSUBSCRIBE_SECRET)
-UNSUBSCRIBE_SECRET= #required
+# Unsubscribe: HMAC secret shared with the delivery agent (must match the agent's UNSUBSCRIBE_SECRET).
+# Required for domain-api's unsubscribe endpoint; optional everywhere else.
+UNSUBSCRIBE_SECRET=

--- a/packages/mediapulse/env/src/agents-delivery.ts
+++ b/packages/mediapulse/env/src/agents-delivery.ts
@@ -12,6 +12,8 @@ export const env = createEnv({
     AGENT_PUBLIC_URL: z.string().min(1),
     DOMAIN_INTEGRATION_API_KEY: z.string().min(1),
     DOMAIN_INTEGRATION_ID: z.string().min(1),
+    UNSUBSCRIBE_SECRET: z.string().min(1),
+    UNSUBSCRIBE_BASE_URL: z.string().min(1),
   },
   client: {
   },

--- a/packages/mediapulse/env/src/index.ts
+++ b/packages/mediapulse/env/src/index.ts
@@ -20,7 +20,7 @@ export const env = createEnv({
     OUTLOOK_CLIENT_SECRET: z.string().optional(),
     OUTLOOK_TENANT_ID: z.string().optional(),
     OUTLOOK_USER_ID: z.string().optional(),
-    UNSUBSCRIBE_SECRET: z.string().min(1),
+    UNSUBSCRIBE_SECRET: z.string().optional(),
   },
   client: {
   },

--- a/packages/mediapulse/env/src/index.ts
+++ b/packages/mediapulse/env/src/index.ts
@@ -20,6 +20,7 @@ export const env = createEnv({
     OUTLOOK_CLIENT_SECRET: z.string().optional(),
     OUTLOOK_TENANT_ID: z.string().optional(),
     OUTLOOK_USER_ID: z.string().optional(),
+    UNSUBSCRIBE_SECRET: z.string().min(1),
   },
   client: {
   },

--- a/packages/shared/agent-data-api-contract/src/delivery.ts
+++ b/packages/shared/agent-data-api-contract/src/delivery.ts
@@ -14,6 +14,7 @@ export const deliveryNewsletterSchema = z.object({
   id: z.string().uuid(),
   subject: z.string(),
   content: z.string(),
+  symbol: z.string(),
 });
 
 export const deliverySubscriberSchema = z.object({

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -23,9 +23,15 @@ export interface DefaultNewsletterEmailProps {
   /** Optional footer line (e.g. unsubscribe placeholder). */
   footerNote?: string;
   /**
-   * Absolute HTTPS URL for account/preferences; when omitted, the “Manage preferences” link is omitted.
+   * Absolute HTTPS URL for the one-click unsubscribe endpoint;
+   * when omitted, the unsubscribe link is hidden.
    */
-  preferencesUrl?: string;
+  unsubscribeUrl?: string;
+  /**
+   * Ticker symbol shown in the unsubscribe link text (e.g. "AAPL").
+   * Falls back to "these" when omitted.
+   */
+  tickerSymbol?: string;
 }
 
 /**
@@ -34,14 +40,16 @@ export interface DefaultNewsletterEmailProps {
  * @param props.title - Heading text in the body.
  * @param props.bodyText - Main content; treated as plain text with preserved line breaks.
  * @param props.footerNote - Optional footer copy.
- * @param props.preferencesUrl - Optional URL for the preferences link.
+ * @param props.unsubscribeUrl - Optional URL for the one-click unsubscribe link.
+ * @param props.tickerSymbol - Ticker symbol shown in the unsubscribe link text.
  * @returns React Email document tree.
  */
 export const DefaultNewsletterEmail = ({
   title,
   bodyText,
   footerNote = "You are receiving this because you subscribed to updates.",
-  preferencesUrl,
+  unsubscribeUrl,
+  tickerSymbol,
 }: DefaultNewsletterEmailProps): ReactElement => {
   return (
     <Html>
@@ -56,10 +64,10 @@ export const DefaultNewsletterEmail = ({
           <Text style={bodyParagraph}>{bodyText}</Text>
           <Hr style={hr} />
           <Text style={footer}>{footerNote}</Text>
-          {preferencesUrl !== undefined && preferencesUrl !== "" ? (
+          {unsubscribeUrl !== undefined && unsubscribeUrl !== "" ? (
             <Text style={footerMuted}>
-              <Link href={preferencesUrl} style={link}>
-                Manage preferences
+              <Link href={unsubscribeUrl} style={link}>
+                Unsubscribe from {tickerSymbol ?? "these"} updates
               </Link>
             </Text>
           ) : null}
@@ -74,6 +82,8 @@ DefaultNewsletterEmail.PreviewProps = {
   bodyText: "Hello,\n\nHere is your newsletter content.\n\n— The team",
   footerNote:
     "You can unsubscribe from ticker updates in your account settings.",
+  unsubscribeUrl: "https://mediapulse.com/api/unsubscribe?token=example",
+  tickerSymbol: "AAPL",
 } satisfies DefaultNewsletterEmailProps;
 
 export default DefaultNewsletterEmail;

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -13,21 +13,32 @@ describe("renderNewsletterEmail", () => {
     expect(text).toMatch(/first line/i);
   });
 
-  it("omits manage-preferences link when preferencesUrl is not set", async () => {
+  it("omits unsubscribe link when unsubscribeUrl is not set", async () => {
     const { html } = await renderNewsletterEmail({
       title: "T",
       bodyText: "B",
     });
-    expect(html).not.toMatch(/manage preferences/i);
+    expect(html).not.toMatch(/unsubscribe/i);
   });
 
-  it("includes manage-preferences link when preferencesUrl is set", async () => {
+  it("includes unsubscribe link with ticker symbol when unsubscribeUrl is set", async () => {
     const { html } = await renderNewsletterEmail({
       title: "T",
       bodyText: "B",
-      preferencesUrl: "https://app.example.com/settings/email",
+      unsubscribeUrl: "https://app.example.com/api/unsubscribe?token=abc",
+      tickerSymbol: "AAPL",
     });
-    expect(html).toMatch(/manage preferences/i);
-    expect(html).toContain("https://app.example.com/settings/email");
+    // React Email inserts comment nodes between JSX expressions
+    expect(html).toMatch(/Unsubscribe from.*AAPL.*updates/i);
+    expect(html).toContain("https://app.example.com/api/unsubscribe?token=abc");
+  });
+
+  it("shows generic text when tickerSymbol is omitted", async () => {
+    const { html } = await renderNewsletterEmail({
+      title: "T",
+      bodyText: "B",
+      unsubscribeUrl: "https://app.example.com/api/unsubscribe?token=abc",
+    });
+    expect(html).toMatch(/Unsubscribe from.*these.*updates/i);
   });
 });

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -15,7 +15,10 @@ export type NewsletterTemplateVariant =
   | "invalid-ticker";
 
 export type RenderNewsletterEmailInput =
-  | ({ variant?: "default" } & DefaultNewsletterEmailProps)
+  | ({ variant?: "default" } & DefaultNewsletterEmailProps & {
+        unsubscribeUrl?: string;
+        tickerSymbol?: string;
+      })
   | ({
       variant: "registration-confirmation";
     } & RegistrationConfirmationEmailProps)
@@ -38,7 +41,8 @@ function newsletterElementForVariant(
           title={input.title}
           bodyText={input.bodyText}
           footerNote={input.footerNote}
-          preferencesUrl={input.preferencesUrl}
+          unsubscribeUrl={input.unsubscribeUrl}
+          tickerSymbol={input.tickerSymbol}
         />
       );
     case "registration-confirmation":

--- a/packages/shared/utils/package.json
+++ b/packages/shared/utils/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "@types/node": "catalog:",
     "@workspace/typescript-config": "workspace:*",
     "typescript": "catalog:",
     "vitest": "catalog:"

--- a/packages/shared/utils/src/index.ts
+++ b/packages/shared/utils/src/index.ts
@@ -3,6 +3,10 @@ export {
   type SlidingWindowRateLimiter,
   type SlidingWindowRateLimiterClock,
 } from "./create-sliding-window-rate-limiter.js";
+export {
+  createUnsubscribeToken,
+  verifyUnsubscribeToken,
+} from "./unsubscribe-token.js";
 export { sleep } from "./sleep.js";
 export {
   withRetry,

--- a/packages/shared/utils/src/unsubscribe-token.test.ts
+++ b/packages/shared/utils/src/unsubscribe-token.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import {
+  createUnsubscribeToken,
+  verifyUnsubscribeToken,
+} from "./unsubscribe-token.js";
+
+const SECRET = "test-secret-key-123";
+const OTHER_SECRET = "different-secret-456";
+
+describe("createUnsubscribeToken", () => {
+  it("produces a two-part token separated by a dot", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+    });
+    const parts = token.split(".");
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).not.toBe("");
+    expect(parts[1]).not.toBe("");
+    expect(token).not.toContain("+"); // base64url, no padding
+  });
+});
+
+describe("verifyUnsubscribeToken", () => {
+  it("round-trips: verify returns decoded fields after create", () => {
+    const userTickerId = "550e8400-e29b-41d4-a716-446655440000";
+    const tickerSymbol = "AAPL";
+    const token = createUnsubscribeToken({
+      userTickerId,
+      tickerSymbol,
+      secret: SECRET,
+    });
+
+    const result = verifyUnsubscribeToken(token, SECRET);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.userTickerId).toBe(userTickerId);
+      expect(result.tickerSymbol).toBe(tickerSymbol);
+    }
+  });
+
+  it("rejects a tampered payload", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+    });
+    const [payload, sig] = token.split(".");
+    // Flip one character in the payload
+    const tampered = `${payload}X.${sig}`;
+    const result = verifyUnsubscribeToken(tampered, SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+
+  it("rejects a tampered signature", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+    });
+    const [payload, sig] = token.split(".");
+    const tampered = `${payload}.${sig}X`;
+    const result = verifyUnsubscribeToken(tampered, SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+
+  it("rejects an expired token", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+      expiresInMs: -1, // already expired
+    });
+    const result = verifyUnsubscribeToken(token, SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("expired");
+    }
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+    });
+    const result = verifyUnsubscribeToken(token, OTHER_SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+
+  it("accepts a token with very short expiry immediately after creation", () => {
+    const token = createUnsubscribeToken({
+      userTickerId: "550e8400-e29b-41d4-a716-446655440000",
+      tickerSymbol: "AAPL",
+      secret: SECRET,
+      expiresInMs: 5000, // 5 seconds
+    });
+    const result = verifyUnsubscribeToken(token, SECRET);
+    expect(result.valid).toBe(true);
+  });
+
+  it("rejects a completely malformed token", () => {
+    const result = verifyUnsubscribeToken("not-a-token-at-all", SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+
+  it("rejects an empty string token", () => {
+    const result = verifyUnsubscribeToken("", SECRET);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toBe("invalid");
+    }
+  });
+});

--- a/packages/shared/utils/src/unsubscribe-token.ts
+++ b/packages/shared/utils/src/unsubscribe-token.ts
@@ -1,0 +1,132 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const DEFAULT_EXPIRES_IN_MS = 90 * 24 * 60 * 60 * 1000; // 90 days
+
+/**
+ * Payload embedded in the unsubscribe token.
+ */
+interface UnsubscribeTokenPayload {
+  uti: string; // userTickerId
+  ts: string; // tickerSymbol
+  exp: number; // unix timestamp (seconds)
+}
+
+/**
+ * URL-safe base64 encoding (no padding).
+ */
+function base64UrlEncode(buf: Buffer): string {
+  return buf.toString("base64url");
+}
+
+/**
+ * URL-safe base64 decoding.
+ */
+function base64UrlDecode(str: string): Buffer {
+  return Buffer.from(str, "base64url");
+}
+
+/**
+ * Creates a signed HMAC-SHA256 unsubscribe token.
+ *
+ * The token is a two-part string: `payload.signature`, both base64url-encoded.
+ *
+ * @param params.userTickerId - The UserTicker row UUID.
+ * @param params.tickerSymbol - Ticker symbol for display (e.g. "AAPL").
+ * @param params.secret - Shared HMAC secret (must match domain-api's `UNSUBSCRIBE_SECRET`).
+ * @param params.expiresInMs - Token lifetime. Defaults to 90 days.
+ * @returns Token string for inclusion in unsubscribe URLs.
+ */
+export function createUnsubscribeToken(params: {
+  userTickerId: string;
+  tickerSymbol: string;
+  secret: string;
+  expiresInMs?: number;
+}): string {
+  const {
+    userTickerId,
+    tickerSymbol,
+    secret,
+    expiresInMs = DEFAULT_EXPIRES_IN_MS,
+  } = params;
+
+  const payload: UnsubscribeTokenPayload = {
+    uti: userTickerId,
+    ts: tickerSymbol,
+    exp: Math.floor((Date.now() + expiresInMs) / 1000),
+  };
+
+  const payloadJson = JSON.stringify(payload);
+  const payloadEncoded = base64UrlEncode(Buffer.from(payloadJson, "utf-8"));
+  const signature = base64UrlEncode(
+    createHmac("sha256", secret).update(payloadEncoded, "utf-8").digest(),
+  );
+
+  return `${payloadEncoded}.${signature}`;
+}
+
+/**
+ * Verifies an HMAC-SHA256 unsubscribe token.
+ *
+ * Checks signature integrity (timing-safe comparison) and expiry.
+ *
+ * @param token - The token string from the URL query parameter.
+ * @param secret - Shared HMAC secret (must match the signing secret).
+ * @returns Decoded payload on success, or `{ valid: false, reason }` on failure.
+ */
+export function verifyUnsubscribeToken(
+  token: string,
+  secret: string,
+):
+  | { valid: true; userTickerId: string; tickerSymbol: string }
+  | { valid: false; reason: "expired" | "invalid" } {
+  try {
+    const parts = token.split(".");
+    if (parts.length !== 2) {
+      return { valid: false, reason: "invalid" };
+    }
+
+    const payloadEncoded = parts[0] as string;
+    const signatureEncoded = parts[1] as string;
+
+    // Verify signature using timing-safe comparison
+    const expectedSignature = createHmac("sha256", secret)
+      .update(payloadEncoded, "utf-8")
+      .digest();
+    const providedSignature = base64UrlDecode(signatureEncoded);
+
+    if (
+      expectedSignature.length !== providedSignature.length ||
+      !timingSafeEqual(expectedSignature, providedSignature)
+    ) {
+      return { valid: false, reason: "invalid" };
+    }
+
+    // Decode payload
+    const payloadJson = base64UrlDecode(payloadEncoded).toString("utf-8");
+    const payload: UnsubscribeTokenPayload = JSON.parse(payloadJson);
+
+    if (
+      !payload.uti ||
+      !payload.ts ||
+      !payload.exp ||
+      typeof payload.uti !== "string" ||
+      typeof payload.ts !== "string" ||
+      typeof payload.exp !== "number"
+    ) {
+      return { valid: false, reason: "invalid" };
+    }
+
+    // Check expiry
+    if (Date.now() / 1000 > payload.exp) {
+      return { valid: false, reason: "expired" };
+    }
+
+    return {
+      valid: true,
+      userTickerId: payload.uti,
+      tickerSymbol: payload.ts,
+    };
+  } catch {
+    return { valid: false, reason: "invalid" };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -887,6 +887,9 @@ importers:
       '@workspace/logger':
         specifier: workspace:*
         version: link:../../../packages/shared/logger
+      '@workspace/utils':
+        specifier: workspace:*
+        version: link:../../../packages/shared/utils
       hono:
         specifier: 'catalog:'
         version: 4.11.9
@@ -1785,6 +1788,9 @@ importers:
 
   packages/shared/utils:
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 20.19.33
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -1793,7 +1799,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/shared/variable-expansion-picker:
     dependencies:


### PR DESCRIPTION
## Summary

Adds a self-service unsubscribe flow for newsletter recipients:

- **One-click unsubscribe endpoint** on the domain API (`GET/POST /api/unsubscribe?token=...`) with friendly HTML confirmation pages
- **RFC 8058 compliance** — `List-Unsubscribe` and `List-Unsubscribe-Post` headers on every outgoing newsletter, so Gmail/Yahoo/Outlook auto-unsubscribe buttons work
- **Per-subscriber unsubscribe tokens** — stateless HMAC-SHA256 signed tokens (90-day expiry, no DB storage), generated inside the delivery loop so each recipient gets a unique URL
- **Audit tracking** — new `unsubscribedAt` and `unsubscribeMethod` (`"link"` / `"one_click"`) columns on `UserTicker` to distinguish voluntary self-service unsubscribes from admin/manual disables

## Why

Without this, recipients have no way to opt out of newsletters other than replying to emails or contacting support. Gmail/Yahoo increasingly penalize bulk senders that lack one-click unsubscribe.

## How

### Token design
Stateless `payload.signature` tokens using HMAC-SHA256 over `{ uti: userTickerId, ts: tickerSymbol, exp: unixTimestamp }`. The delivery agent signs them with a shared `UNSUBSCRIBE_SECRET`; the domain API verifies them with the same secret. No DB table needed.

### Flow
1. Delivery agent generates a per-recipient unsubscribe URL during the send loop
2. Each email gets `List-Unsubscribe` + `List-Unsubscribe-Post` headers **and** an "Unsubscribe from AAPL updates" link in the footer
3. Clicking the link → domain API verifies the token, sets `UserTicker.enabled = false`, and shows a confirmation page
4. Gmail's auto-unsubscribe button → POSTs to the same endpoint → empty `200 OK` per RFC 8058

### Files changed

| Layer | File | Change |
|---|---|---|
| Schema | `packages/mediapulse/database/prisma/schema.prisma` | Added `unsubscribedAt` + `unsubscribeMethod` to `UserTicker` |
| Migration | `prisma/migrations/.../add_unsubscribe_fields` | Auto-generated |
| Shared | `packages/shared/utils/src/unsubscribe-token.ts` | **New** — `createUnsubscribeToken` / `verifyUnsubscribeToken` |
| Email | `packages/shared/email-templates/.../default-newsletter.tsx` | `preferencesUrl` → `unsubscribeUrl` + `tickerSymbol` |
| Delivery agent | `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` | Per-subscriber render, token generation, `List-Unsubscribe` headers |
| Delivery agent | `apps/mediapulse/agents/delivery/src/send-with-resend-retry.ts` | Added generic `headers` field to payload |
| Delivery agent | `apps/mediapulse/agents/delivery/src/config-schema.ts` | Added `unsubscribe.secret` + `unsubscribe.baseUrl` config |
| Data API | `packages/shared/agent-data-api-contract/src/delivery.ts` | Added `symbol` to newsletter response schema |
| Data API | `apps/mediapulse/agent-data-api/src/services/delivery.ts` | Include ticker symbol in delivery payload |
| Domain API | `apps/mediapulse/domain-api/src/http/routes/unsubscribe-routes.ts` | **New** — GET + POST handlers |
| Domain API | `apps/mediapulse/domain-api/src/http/create-hono-app.ts` | Register public unsubscribe route outside auth |
| Env | `packages/mediapulse/env/env.example` | Added `UNSUBSCRIBE_SECRET` |
| Env | `packages/mediapulse/env/env.agents.delivery.example` | Added `UNSUBSCRIBE_SECRET` + `UNSUBSCRIBE_BASE_URL` |

### Configuration required

The delivery agent needs two new config fields in its Hermes pipeline step config:

```json
{
  "unsubscribe": {
    "secret": "<shared-hmac-secret>",
    "baseUrl": "https://mediapulse.com"
  }
}
```

And the domain API needs `UNSUBSCRIBE_SECRET` set to the same value.
