### PR TITLE
Filter noisy non-article sources before analysis

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -160,6 +160,7 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.event).toBe(ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE);
     expect(payload.extractionFailuresVocabulary).toBe(1);
     expect(payload.extractionFailuresLlm).toBe(1);
+    expect(payload.extractionFailuresPrefilter).toBe(0);
     expect(payload.scoreFailureCount).toBe(1);
     expect(payload.chunkParseErrorsEntityRelation).toBe(1);
     expect(payload.chunkParseErrorsArticleEntity).toBe(2);
@@ -179,6 +180,7 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.failureCountsByKind).toEqual({
       llm: 1,
       vocabulary: 1,
+      prefilter: 0,
       schemaValidation: 3,
       persistenceHttp: 1,
       persistenceOther: 1,
@@ -227,6 +229,7 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.failureCountsByKind).toEqual({
       llm: 0,
       vocabulary: 0,
+      prefilter: 0,
       schemaValidation: 0,
       persistenceHttp: 0,
       persistenceOther: 0,

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -253,6 +253,9 @@ export const buildArticleAnalysisRunSummaryPayload = (
   const llmFails = input.extractionFailures.filter(
     (f) => f.stage === "llm",
   ).length;
+  const prefilterFails = input.extractionFailures.filter(
+    (f) => f.stage === "prefilter",
+  ).length;
 
   const postByKind = {
     entities_relations: 0,
@@ -295,6 +298,7 @@ export const buildArticleAnalysisRunSummaryPayload = (
     articlesProcessed: input.articlesProcessed,
     extractionSuccessCount: input.extractionSuccessCount,
     extractionFailureCount: input.extractionFailures.length,
+    extractionFailuresPrefilter: prefilterFails,
     extractionFailuresVocabulary: vocabFails,
     extractionFailuresLlm: llmFails,
     scoreFailureCount,
@@ -309,6 +313,7 @@ export const buildArticleAnalysisRunSummaryPayload = (
     failureCountsByKind: {
       llm: llmFails,
       vocabulary: vocabFails,
+      prefilter: prefilterFails,
       schemaValidation: schemaValidationFailureCount,
       persistenceHttp: postByCategory.agent_data_api_http,
       persistenceOther: postByCategory.unknown,

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
@@ -3,7 +3,10 @@
  */
 
 /** Stage at which per-source extraction stopped. */
-export type ArticleAnalysisExtractionFailureStage = "llm" | "vocabulary";
+export type ArticleAnalysisExtractionFailureStage =
+  | "llm"
+  | "vocabulary"
+  | "prefilter";
 
 /** One source that did not contribute to the merged extraction payload. */
 export type ArticleAnalysisExtractionFailureRecord = {

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   hardDeleteDataSourceById,
+  shouldHardDeleteDataSourceForNonArticleReason,
   shouldHardDeleteDataSourceForExtractionError,
 } from "./extraction-failure-pruning.js";
 
@@ -50,5 +51,31 @@ describe("hardDeleteDataSourceById", () => {
       tickerId: "ticker-1",
       dataSourceId: "ds-1",
     });
+  });
+});
+
+describe("shouldHardDeleteDataSourceForNonArticleReason", () => {
+  it("returns true for deterministic URL-based non-article reasons", () => {
+    // Act
+    const blockedHost = shouldHardDeleteDataSourceForNonArticleReason(
+      "prefilter_blocked_host",
+    );
+    const blockedPath = shouldHardDeleteDataSourceForNonArticleReason(
+      "prefilter_blocked_path",
+    );
+
+    // Assert
+    expect(blockedHost).toBe(true);
+    expect(blockedPath).toBe(true);
+  });
+
+  it("returns false for title-only heuristic reasons", () => {
+    // Act
+    const result = shouldHardDeleteDataSourceForNonArticleReason(
+      "prefilter_index_title",
+    );
+
+    // Assert
+    expect(result).toBe(false);
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
@@ -1,4 +1,5 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
+import type { NonArticleReason } from "./non-article-source-filter.js";
 
 /**
  * Minimal API client contract used to prune one data source row.
@@ -25,6 +26,17 @@ export const shouldHardDeleteDataSourceForExtractionError = (
   message: string,
 ): boolean =>
   message.includes("No object generated: could not parse the response.");
+
+/**
+ * Returns whether a non-article prefilter reason is safe for hard deletion.
+ *
+ * @param reason - Deterministic non-article classification reason.
+ * @returns True when the reason is strong enough to prune permanently.
+ */
+export const shouldHardDeleteDataSourceForNonArticleReason = (
+  reason: NonArticleReason,
+): boolean =>
+  reason === "prefilter_blocked_host" || reason === "prefilter_blocked_path";
 
 /**
  * Hard-deletes a data source row through agent-data-api.

--- a/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.test.ts
@@ -1,0 +1,44 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { classifyNonArticleSource } from "./non-article-source-filter.js";
+
+describe("classifyNonArticleSource", () => {
+  it("blocks known quote pages", () => {
+    // Act
+    const result = classifyNonArticleSource(
+      "https://finance.yahoo.com/quote/BBCA.JK/",
+      "BBCA Quote",
+      "Some long placeholder content ".repeat(20),
+    );
+
+    // Assert
+    expect(result).toBe("prefilter_blocked_path");
+  });
+
+  it("blocks index-like title markers", () => {
+    // Act
+    const result = classifyNonArticleSource(
+      "https://example.com/news/earnings-update",
+      "Company profile and key statistics",
+      "short content",
+    );
+
+    // Assert
+    expect(result).toBe("prefilter_index_title");
+  });
+
+  it("allows article-like source", () => {
+    // Act
+    const result = classifyNonArticleSource(
+      "https://example.com/news/company-expands",
+      "Company expands in Southeast Asia",
+      "The company announced expansion and reported improved earnings momentum. ".repeat(
+        15,
+      ),
+    );
+
+    // Assert
+    expect(result).toBeNull();
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.ts
+++ b/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.ts
@@ -1,0 +1,71 @@
+const BLOCKED_PATH_PATTERNS = [
+  /\/quote(\/|$)/i,
+  /\/financials(\/|$)/i,
+  /\/key-statistics(\/|$)/i,
+  /\/company(\/|$)/i,
+  /\/company-profile(\/|$)/i,
+  /\/management(\/|$)/i,
+  /\/history(\/|$)/i,
+  /\/forecast(\/|$)/i,
+  /\/consensus(\/|$)/i,
+  /\/calendar(\/|$)/i,
+  /\/investor-relations(\/|$)/i,
+] as const;
+
+const BLOCKED_HOST_PATTERNS = [
+  /(^|\.)linkedin\.com$/i,
+  /(^|\.)youtube\.com$/i,
+  /(^|\.)instagram\.com$/i,
+  /(^|\.)facebook\.com$/i,
+  /(^|\.)tiktok\.com$/i,
+  /(^|\.)reddit\.com$/i,
+] as const;
+
+const NON_ARTICLE_TITLE_MARKERS = [
+  "key statistics",
+  "historical data",
+  "financial summary",
+  "company profile",
+  "consensus estimates",
+] as const;
+
+export type NonArticleReason =
+  | "prefilter_blocked_host"
+  | "prefilter_blocked_path"
+  | "prefilter_index_title";
+
+/**
+ * Classifies whether a source is clearly non-article before running extraction.
+ *
+ * @param sourceUrl - Data source URL.
+ * @param sourceTitle - Source title.
+ * @param sourceContent - Source content.
+ * @returns Null for likely article content, otherwise a concrete non-article reason.
+ */
+export const classifyNonArticleSource = (
+  sourceUrl: string,
+  sourceTitle: string,
+  _sourceContent: string,
+): NonArticleReason | null => {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    return null;
+  }
+
+  if (BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(parsed.hostname))) {
+    return "prefilter_blocked_host";
+  }
+
+  if (BLOCKED_PATH_PATTERNS.some((pattern) => pattern.test(parsed.pathname))) {
+    return "prefilter_blocked_path";
+  }
+
+  const titleLower = sourceTitle.toLowerCase();
+  if (NON_ARTICLE_TITLE_MARKERS.some((marker) => titleLower.includes(marker))) {
+    return "prefilter_index_title";
+  }
+
+  return null;
+};

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -14,12 +14,16 @@ import { run } from "./run.js";
 
 const analysisGet = vi.fn();
 const analysisCreate = vi.fn();
+const analysisDataSourceDeleteCreate = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
     analysis: {
       get: analysisGet,
       create: analysisCreate,
+    },
+    analysisDataSourceDelete: {
+      create: analysisDataSourceDeleteCreate,
     },
   })),
 }));
@@ -141,6 +145,7 @@ describe("run", () => {
   beforeEach(() => {
     analysisGet.mockReset();
     analysisCreate.mockReset();
+    analysisDataSourceDeleteCreate.mockReset();
     mockLog.info.mockReset();
     mockLog.warn.mockReset();
     mockLog.error.mockReset();
@@ -1035,6 +1040,44 @@ describe("run", () => {
     expect(result.success).toBe(false);
     expect(result.message).toContain("run policy");
     expect(analysisCreate).not.toHaveBeenCalled();
+  });
+
+  it("skips non-article sources in prefilter stage before LLM", async () => {
+    // Setup
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: "https://finance.yahoo.com/quote/BBCA.JK/",
+            title: "BBCA quote",
+            content: "Long but non-article page body ".repeat(20),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    const extractSpy = vi.spyOn(Llm, "extractEntitiesAndRelationsForSource");
+
+    // Act
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(extractSpy).not.toHaveBeenCalled();
+    expect(analysisDataSourceDeleteCreate).toHaveBeenCalledWith({
+      tickerId: "ticker-1",
+      dataSourceId: DS_ID,
+    });
+    expect(
+      (result.details?.extractionFailures as { stage: string }[])[0]?.stage,
+    ).toBe("prefilter");
   });
 
   it("logs safe error shape when LLM extraction throws", async () => {

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -75,9 +75,11 @@ import {
 } from "./run-helpers.js";
 import {
   hardDeleteDataSourceById,
+  shouldHardDeleteDataSourceForNonArticleReason,
   shouldHardDeleteDataSourceForExtractionError,
 } from "./extraction-failure-pruning.js";
 import { normalizeEntityName } from "./normalize-entity-name.js";
+import { classifyNonArticleSource } from "./non-article-source-filter.js";
 
 type ExistingEntity = {
   canonicalName: string;
@@ -501,6 +503,54 @@ export const run = async ({
     let vocabularyFailures = 0;
 
     for (const source of batch) {
+      const nonArticleReason = classifyNonArticleSource(
+        source.url,
+        source.title,
+        source.content,
+      );
+      if (nonArticleReason) {
+        extractionFailures.push({
+          dataSourceId: source.id,
+          stage: "prefilter",
+          message: nonArticleReason,
+        });
+        log.info(
+          {
+            dataSourceId: source.id,
+            stage: "prefilter",
+            nonArticleReason,
+          },
+          "article-analysis skipped source with non-article prefilter",
+        );
+        if (shouldHardDeleteDataSourceForNonArticleReason(nonArticleReason)) {
+          try {
+            await hardDeleteDataSourceById(source.id, {
+              dataApiClient,
+              tickerId: input.tickerId,
+            });
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "prefilter",
+                nonArticleReason,
+              },
+              "article-analysis hard-deleted data source after non-article prefilter",
+            );
+          } catch (deleteErr) {
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "prefilter",
+                err: toSafeLogError(deleteErr),
+                nonArticleReason,
+              },
+              "article-analysis failed to hard-delete data source after non-article prefilter",
+            );
+          }
+        }
+        continue;
+      }
+
       const truncated =
         source.content.length > cfg.maxContentChars
           ? source.content.slice(0, cfg.maxContentChars)

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -383,4 +383,57 @@ describe("runDataCollection", () => {
       },
     });
   });
+
+  it("drops noisy quote URLs before fetch and treats run as semantic failure when none remain", async () => {
+    // Setup
+    vi.mocked(performWebSearch).mockResolvedValueOnce([
+      {
+        success: true,
+        data: {
+          ...searchSuccessPage,
+          url: "https://finance.yahoo.com/quote/BBCA.JK/",
+        },
+      },
+    ]);
+    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+
+    // Act
+    const result = await runDataCollection(createContext());
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(performWebFetch).toHaveBeenCalledWith([], expect.anything());
+  });
+
+  it("drops index-like content after fetch and does not persist source", async () => {
+    // Setup
+    vi.mocked(performWebSearch).mockResolvedValueOnce([
+      {
+        success: true,
+        data: {
+          ...searchSuccessPage,
+          title: "Stock summary",
+          url: "https://example.com/stocks",
+        },
+      },
+    ]);
+    vi.mocked(performWebFetch).mockResolvedValueOnce([
+      {
+        success: true,
+        data: {
+          ...searchSuccessPage,
+          title: "Company profile and key statistics",
+          url: "https://example.com/stocks",
+          content: `Financial summary and key statistics with market cap details. ${"data ".repeat(120)}`,
+        },
+      },
+    ]);
+
+    // Act
+    const result = await runDataCollection(createContext());
+
+    // Assert
+    expect(result.success).toBe(false);
+    expect(createMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -9,6 +9,11 @@ import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
 import { performWebFetch } from "./utilities/web-fetch";
 import { performWebSearch } from "./utilities/web-search";
+import { classifyNonArticleContent } from "./utilities/content-shape-filter";
+import {
+  classifyNoisyUrl,
+  type UrlNoiseReason,
+} from "./utilities/url-noise-filter";
 import { resolveExistingDataSourceUrls } from "./utilities/resolve-existing-data-source-urls";
 import {
   deriveRunStatus,
@@ -97,6 +102,15 @@ export async function runDataCollection(
     .filter((r) => r.success)
     .map((r) => r.data);
   const searchFailures = searchAttemptResults.filter((r) => !r.success);
+  const droppedByUrlReason: Record<UrlNoiseReason, number> = {
+    blocked_host: 0,
+    blocked_host_path: 0,
+    blocked_path: 0,
+    blocked_extension: 0,
+  };
+  let droppedByDuplicateCanonicalUrl = 0;
+  let droppedByExistingCanonicalUrl = 0;
+  let droppedByContentShape = 0;
 
   log.info(
     {
@@ -106,17 +120,41 @@ export async function runDataCollection(
     "web search stage finished",
   );
 
-  const candidateUrls = searchSuccesses.map((hit) => hit.url);
+  const canonicalUniqueHits = new Map<
+    string,
+    (typeof searchSuccesses)[number]
+  >();
+  for (const hit of searchSuccesses) {
+    const decision = classifyNoisyUrl(hit.url);
+    if (decision.blocked) {
+      droppedByUrlReason[decision.reason] += 1;
+      continue;
+    }
+
+    if (canonicalUniqueHits.has(decision.canonicalUrl)) {
+      droppedByDuplicateCanonicalUrl += 1;
+      continue;
+    }
+
+    canonicalUniqueHits.set(decision.canonicalUrl, {
+      ...hit,
+      url: decision.canonicalUrl,
+    });
+  }
+
+  const filteredSearchSuccesses = [...canonicalUniqueHits.values()];
+  const candidateUrls = filteredSearchSuccesses.map((hit) => hit.url);
   const existingUrlSet = await resolveExistingDataSourceUrls(
     input.tickerId,
     candidateUrls,
     (body) => dataApiClient.dataCollectionExistingUrls.create(body),
   );
-  const searchSuccessesForFetch = searchSuccesses.filter(
+  const searchSuccessesForFetch = filteredSearchSuccesses.filter(
     (hit) => !existingUrlSet.has(hit.url),
   );
-  const skippedExistingUrlCount =
-    searchSuccesses.length - searchSuccessesForFetch.length;
+  droppedByExistingCanonicalUrl =
+    filteredSearchSuccesses.length - searchSuccessesForFetch.length;
+  const skippedExistingUrlCount = droppedByExistingCanonicalUrl;
   if (skippedExistingUrlCount > 0) {
     log.info(
       {
@@ -135,17 +173,40 @@ export async function runDataCollection(
     .filter((r) => r.success)
     .map((r) => r.data);
   const fetchFailures = fetchAttemptResults.filter((r) => !r.success);
+  const finalFetchSuccesses: typeof fetchSuccesses = [];
+  for (const page of fetchSuccesses) {
+    const urlDecision = classifyNoisyUrl(page.url);
+    if (urlDecision.blocked) {
+      droppedByUrlReason[urlDecision.reason] += 1;
+      continue;
+    }
+
+    const contentDecision = classifyNonArticleContent(page.title, page.content);
+    if (contentDecision.blocked) {
+      droppedByContentShape += 1;
+      continue;
+    }
+
+    finalFetchSuccesses.push({
+      ...page,
+      url: urlDecision.canonicalUrl,
+    });
+  }
 
   log.info(
     {
-      fetchSuccess: fetchSuccesses.length,
+      fetchSuccess: finalFetchSuccesses.length,
       fetchFailed: fetchFailures.length,
+      droppedByUrlReason,
+      droppedByDuplicateCanonicalUrl,
+      droppedByExistingCanonicalUrl,
+      droppedByContentShape,
     },
     "web fetch stage finished",
   );
 
-  if (fetchSuccesses.length > 0) {
-    const sources: DataCollectionInput[] = fetchSuccesses.map((page) => ({
+  if (finalFetchSuccesses.length > 0) {
+    const sources: DataCollectionInput[] = finalFetchSuccesses.map((page) => ({
       url: page.url,
       title: page.title,
       content: page.content,
@@ -191,7 +252,7 @@ export async function runDataCollection(
     })),
   ];
 
-  const totalSources = fetchSuccesses.length;
+  const totalSources = finalFetchSuccesses.length;
   const status = deriveRunStatus({
     totalSources,
     failureCount: failuresPayload.length,
@@ -200,10 +261,10 @@ export async function runDataCollection(
 
   const counters: RunCounters = {
     queriesTotal: queries.length,
-    urlsTotal: searchSuccesses.length,
-    searchSuccess: searchSuccesses.length,
+    urlsTotal: filteredSearchSuccesses.length,
+    searchSuccess: filteredSearchSuccesses.length,
     searchFailed: searchFailures.length,
-    fetchSuccess: fetchSuccesses.length,
+    fetchSuccess: finalFetchSuccesses.length,
     fetchFailed: fetchFailures.length,
     retryCount: 0,
   };

--- a/apps/mediapulse/agents/data-collection/src/utilities/content-shape-filter.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/content-shape-filter.test.ts
@@ -1,0 +1,51 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { classifyNonArticleContent } from "./content-shape-filter";
+
+describe("classifyNonArticleContent", () => {
+  it("allows short content without index markers", () => {
+    // Act
+    const decision = classifyNonArticleContent("Title", "too short");
+
+    // Assert
+    expect(decision).toEqual({ blocked: false });
+  });
+
+  it("blocks index-like pages with multiple financial markers", () => {
+    // Setup
+    const content = `
+      Key statistics and financial summary are listed below.
+      This company profile page also includes market cap sections.
+      ${"word ".repeat(100)}
+    `;
+
+    // Act
+    const decision = classifyNonArticleContent("Stock overview", content);
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_index_like",
+    });
+  });
+
+  it("allows long article-like content", () => {
+    // Setup
+    const content = `
+      Bank Central Asia announced strategic expansion plans across regional markets.
+      The company reported improved margins, higher loan growth, and stronger risk controls.
+      ${"analysis ".repeat(120)}
+    `;
+
+    // Act
+    const decision = classifyNonArticleContent(
+      "BCA expands operations",
+      content,
+    );
+
+    // Assert
+    expect(decision).toEqual({ blocked: false });
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/content-shape-filter.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/content-shape-filter.ts
@@ -1,0 +1,53 @@
+const NON_ARTICLE_MARKERS = [
+  "key statistics",
+  "historical data",
+  "financial summary",
+  "company profile",
+  "market cap",
+  "consensus estimates",
+  "quote summary",
+  "earnings revisions",
+] as const;
+
+const MIN_CONTENT_LENGTH = 180;
+const MAX_LINK_DENSITY = 0.08;
+
+export type ContentShapeDecision =
+  | { blocked: true; reason: "content_link_farm" | "content_index_like" }
+  | { blocked: false };
+
+/**
+ * Detects non-article content shapes using lightweight deterministic heuristics.
+ *
+ * @param title - Page title.
+ * @param content - Fetched page body.
+ * @returns Decision indicating whether content should be excluded before persistence.
+ */
+export const classifyNonArticleContent = (
+  title: string,
+  content: string,
+): ContentShapeDecision => {
+  const normalized = content.trim();
+  const words = normalized
+    .split(/\s+/)
+    .filter((word) => word.length > 0).length;
+  const links = (normalized.match(/https?:\/\/|www\./gi) ?? []).length;
+  const linkDensity = words === 0 ? 0 : links / words;
+  if (linkDensity > MAX_LINK_DENSITY) {
+    return { blocked: true, reason: "content_link_farm" };
+  }
+
+  const haystack = `${title}\n${normalized}`.toLowerCase();
+  const markerHits = NON_ARTICLE_MARKERS.filter((marker) =>
+    haystack.includes(marker),
+  ).length;
+  if (markerHits >= 2 && normalized.length >= MIN_CONTENT_LENGTH) {
+    return { blocked: true, reason: "content_index_like" };
+  }
+
+  if (markerHits >= 1 && normalized.length < MIN_CONTENT_LENGTH) {
+    return { blocked: true, reason: "content_index_like" };
+  }
+
+  return { blocked: false };
+};

--- a/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.test.ts
@@ -1,0 +1,60 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { canonicalizeUrl, classifyNoisyUrl } from "./url-noise-filter";
+
+describe("canonicalizeUrl", () => {
+  it("strips hashes and tracking params while preserving non-tracking params", () => {
+    // Act
+    const canonical = canonicalizeUrl(
+      "https://Finance.Yahoo.com/quote/BBCA.JK/?utm_source=x&region=ID#fragment",
+    );
+
+    // Assert
+    expect(canonical).toBe("https://finance.yahoo.com/quote/BBCA.JK?region=ID");
+  });
+});
+
+describe("classifyNoisyUrl", () => {
+  it("blocks quote/profile style URLs from the CSV patterns", () => {
+    // Act
+    const decision = classifyNoisyUrl(
+      "https://finance.yahoo.com/quote/BBCA.JK/",
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "blocked_host_path",
+      canonicalUrl: "https://finance.yahoo.com/quote/BBCA.JK",
+    });
+  });
+
+  it("blocks social URLs from the CSV patterns", () => {
+    // Act
+    const decision = classifyNoisyUrl(
+      "https://www.linkedin.com/posts/example_company-update",
+    );
+
+    // Assert
+    expect(decision.blocked).toBe(true);
+    if (decision.blocked) {
+      expect(decision.reason).toBe("blocked_host");
+    }
+  });
+
+  it("allows Reuters article URLs while still allowing canonicalization", () => {
+    // Act
+    const decision = classifyNoisyUrl(
+      "https://www.reuters.com/world/asia-pacific/sample-story-2026-01-01/",
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: false,
+      canonicalUrl:
+        "https://www.reuters.com/world/asia-pacific/sample-story-2026-01-01",
+    });
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts
@@ -1,0 +1,139 @@
+const TRACKING_QUERY_PARAM_PREFIXES = [
+  "utm_",
+  "fbclid",
+  "gclid",
+  "mc_",
+] as const;
+
+const BLOCKED_HOST_PATTERNS = [
+  /(^|\.)linkedin\.com$/i,
+  /(^|\.)youtube\.com$/i,
+  /(^|\.)instagram\.com$/i,
+  /(^|\.)facebook\.com$/i,
+  /(^|\.)tiktok\.com$/i,
+  /(^|\.)reddit\.com$/i,
+] as const;
+
+const BLOCKED_HOST_PATH_PATTERNS = [
+  { host: /(^|\.)finance\.yahoo\.com$/i, path: /^\/quote\//i },
+  { host: /(^|\.)investing\.com$/i, path: /^\/equities\//i },
+  { host: /(^|\.)markets\.ft\.com$/i, path: /^\/data\/equities\/tearsheet\//i },
+  { host: /(^|\.)marketwatch\.com$/i, path: /^\/investing\/stock\//i },
+  { host: /(^|\.)simplywall\.st$/i, path: /^\/stocks\//i },
+  { host: /(^|\.)tradingview\.com$/i, path: /^\/symbols\//i },
+] as const;
+
+const BLOCKED_PATH_PATTERNS = [
+  /\/category\//i,
+  /\/tag\//i,
+  /\/topic\//i,
+  /\/topics\//i,
+  /\/search(\/|$)/i,
+  /\/newslist(\/|$)/i,
+  /\/news-key-events(\/|$)/i,
+  /\/news-publications(\/|$)/i,
+  /\/quote(\/|$)/i,
+  /\/company(\/|$)/i,
+  /\/company-profile(\/|$)/i,
+  /\/management(\/|$)/i,
+  /\/financials(\/|$)/i,
+  /\/key-statistics(\/|$)/i,
+  /\/history(\/|$)/i,
+  /\/forecast(\/|$)/i,
+  /\/ownership(\/|$)/i,
+  /\/consensus(\/|$)/i,
+  /\/calendar(\/|$)/i,
+  /\/press-release(\/|$)/i,
+  /\/investor-relations(\/|$)/i,
+  /\/investor(\/|$)/i,
+] as const;
+
+const BLOCKED_EXTENSION_PATTERNS = [/\.(pdf|xml)(\/|$)/i] as const;
+
+export type UrlNoiseReason =
+  | "blocked_host"
+  | "blocked_host_path"
+  | "blocked_path"
+  | "blocked_extension";
+
+export type UrlNoiseDecision =
+  | { blocked: true; reason: UrlNoiseReason; canonicalUrl: string }
+  | { blocked: false; canonicalUrl: string };
+
+/**
+ * Returns a normalized URL string used by dedupe and filtering.
+ *
+ * @param rawUrl - Candidate URL.
+ * @returns Canonical URL with normalized host/path and stripped tracking query params.
+ */
+export const canonicalizeUrl = (rawUrl: string): string => {
+  const parsed = new URL(rawUrl);
+  parsed.hash = "";
+  parsed.protocol = parsed.protocol.toLowerCase();
+  parsed.hostname = parsed.hostname.toLowerCase();
+
+  const keptParams = new URLSearchParams();
+  for (const [key, value] of parsed.searchParams.entries()) {
+    const isTracking = TRACKING_QUERY_PARAM_PREFIXES.some((prefix) =>
+      key.toLowerCase().startsWith(prefix),
+    );
+    if (!isTracking) {
+      keptParams.append(key, value);
+    }
+  }
+  parsed.search = keptParams.toString();
+
+  const normalizedPathname = parsed.pathname.replace(/\/{2,}/g, "/");
+  parsed.pathname =
+    normalizedPathname.length > 1
+      ? normalizedPathname.replace(/\/+$/g, "")
+      : normalizedPathname;
+
+  if (parsed.pathname === "/" && parsed.search === "") {
+    return `${parsed.protocol}//${parsed.hostname}`;
+  }
+
+  return parsed.toString();
+};
+
+/**
+ * Evaluates whether a URL should be blocked as a known non-article source.
+ *
+ * @param rawUrl - Candidate URL from search or fetch stage.
+ * @returns Decision containing canonical URL and optional block reason.
+ */
+export const classifyNoisyUrl = (rawUrl: string): UrlNoiseDecision => {
+  const canonicalUrl = canonicalizeUrl(rawUrl);
+  const parsed = new URL(canonicalUrl);
+  const hostname = parsed.hostname;
+  const pathname = parsed.pathname;
+
+  const isReutersArticlePath =
+    /(^|\.)reuters\.com$/i.test(hostname) &&
+    !/^\/(markets\/companies|company)\//i.test(pathname);
+  if (isReutersArticlePath) {
+    return { blocked: false, canonicalUrl };
+  }
+
+  if (BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(hostname))) {
+    return { blocked: true, reason: "blocked_host", canonicalUrl };
+  }
+
+  if (
+    BLOCKED_HOST_PATH_PATTERNS.some(
+      (rule) => rule.host.test(hostname) && rule.path.test(pathname),
+    )
+  ) {
+    return { blocked: true, reason: "blocked_host_path", canonicalUrl };
+  }
+
+  if (BLOCKED_EXTENSION_PATTERNS.some((pattern) => pattern.test(pathname))) {
+    return { blocked: true, reason: "blocked_extension", canonicalUrl };
+  }
+
+  if (BLOCKED_PATH_PATTERNS.some((pattern) => pattern.test(pathname))) {
+    return { blocked: true, reason: "blocked_path", canonicalUrl };
+  }
+
+  return { blocked: false, canonicalUrl };
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "turbo": "^2.5.5",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@10.30.3",
+  "packageManager": "pnpm@10.33.2",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary

This PR cuts down non-article noise before it reaches scoring. Data collection now filters and canonicalizes noisy URLs up front, and article analysis can prefilter plus hard-delete clearly non-article sources before extraction.

## Related issues

Closes #365

## Important changes

- Added deterministic URL noise filtering and canonicalization in `@mediapulse/data-collection` to block common non-article patterns (quote/profile/financial hubs, social/video domains, and document-style links).
- Added content-shape filtering to reject index-like pages before persistence.
- Added article-analysis prefiltering for non-article sources and hard-delete behavior for deterministic non-article reasons before LLM extraction.

## Other changes

- Expanded run and utility tests for both agents to cover filtering, prefiltering, and pruning paths.
- Extended article-analysis observability payload to track prefilter extraction failures explicitly.
- Updated repo package manager metadata to current pnpm version.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts` - URL canonicalization and hard block rules.
- `apps/mediapulse/agents/data-collection/src/run.ts` - filter integration, drop counters, and persistence gating.
- `apps/mediapulse/agents/article-analysis/src/non-article-source-filter.ts` - pre-analysis non-article classifier.
- `apps/mediapulse/agents/article-analysis/src/run.ts` - prefilter skip and hard-delete flow.
- `apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts` - deterministic non-article hard-delete guard.

## How to test

1. Run `pnpm --filter @mediapulse/data-collection test`.
2. Run `pnpm --filter @mediapulse/article-analysis test`.
3. Run `pnpm format:check` from repo root.
4. Spot-check logs from a run and confirm dropped URL/content counters and prefilter failure counts are present.
