### PR TITLE
Enforce daily minimum valid article refill

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -28,6 +28,7 @@ const postMock = vi.fn();
 const existingUrlsCreateMock = vi.fn();
 const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
+const analysisGetMock = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => {
   return {
@@ -44,6 +45,9 @@ vi.mock("@workspace/agent-data-api-client", () => {
       },
       dataCollectionFailure: {
         create: failureCreateMock,
+      },
+      analysis: {
+        get: analysisGetMock,
       },
     })),
   };
@@ -91,6 +95,18 @@ describe("data-collection agent (HTTP)", () => {
     performWebSearchMock.mockResolvedValue(defaultSearchSuccess);
     performWebFetchMock.mockResolvedValue(defaultFetchSuccess);
     existingUrlsCreateMock.mockResolvedValue({ existingUrls: [] });
+    analysisGetMock.mockResolvedValue({
+      dataSources: [],
+      dataSourceTotalCount: 0,
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+      relevanceSelectionState: {
+        utcDayStartIso: "2026-01-01T00:00:00.000Z",
+        selectedCountToday: 0,
+      },
+      lastRelevanceScoredAtIso: null,
+    });
   });
 
   afterEach(() => {

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -19,6 +19,8 @@ const baseConfig = {
     authentication: { type: "bearer" as const },
     rateLimit: { requests: 1, perSeconds: 1 },
   },
+  targetDailySuccessfulSources: 1,
+  maxRefillRounds: 3,
 } satisfies ConfigSchemaType;
 
 const searchSuccessPage = {
@@ -52,6 +54,7 @@ const createMock = vi.fn();
 const existingUrlsCreateMock = vi.fn();
 const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
+const analysisGetMock = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
@@ -67,6 +70,9 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     },
     dataCollectionFailure: {
       create: failureCreateMock,
+    },
+    analysis: {
+      get: analysisGetMock,
     },
   })),
 }));
@@ -123,6 +129,18 @@ describe("runDataCollection", () => {
     });
     createMock.mockResolvedValue("{}");
     existingUrlsCreateMock.mockResolvedValue({ existingUrls: [] });
+    analysisGetMock.mockResolvedValue({
+      dataSources: [],
+      dataSourceTotalCount: 0,
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+      relevanceSelectionState: {
+        utcDayStartIso: "2026-01-01T00:00:00.000Z",
+        selectedCountToday: 0,
+      },
+      lastRelevanceScoredAtIso: null,
+    });
   });
 
   afterEach(() => {
@@ -134,7 +152,7 @@ describe("runDataCollection", () => {
     const result = await runDataCollection(createContext());
 
     // Assert
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: true,
       details: {
         summary: {
@@ -142,6 +160,13 @@ describe("runDataCollection", () => {
           status: "success",
           searchSuccess: 1,
           fetchSuccess: 1,
+          refill: {
+            roundsExecuted: 1,
+            targetDailySuccessfulSources: 1,
+            existingTodaySourceCount: 0,
+            effectiveTodayCount: 1,
+            stopReason: "daily_target_met",
+          },
         },
       },
     });
@@ -311,7 +336,7 @@ describe("runDataCollection", () => {
     const result = await runDataCollection(createContext());
 
     // Assert — Hermes maps `success: false` to HTTP 200 + failure envelope (not 500), so pipeline UIs get the message
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: false,
       message:
         "Data collection run failed: no sources were successfully collected, but the run policy requires at least 1 successful source.",
@@ -321,6 +346,9 @@ describe("runDataCollection", () => {
           status: "failed",
           searchSuccess: 0,
           fetchSuccess: 0,
+          refill: {
+            roundsExecuted: 1,
+          },
         },
         failureReason: "insufficient_successful_sources",
         requiredSuccessfulSources: 1,
@@ -366,7 +394,7 @@ describe("runDataCollection", () => {
     );
 
     // Assert
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       success: false,
       message:
         "Data collection run failed: only 1 successful source collected, but the run policy requires at least 2.",
@@ -376,6 +404,9 @@ describe("runDataCollection", () => {
           status: "failed",
           searchSuccess: 1,
           fetchSuccess: 1,
+          refill: {
+            roundsExecuted: 1,
+          },
         },
         failureReason: "insufficient_successful_sources",
         requiredSuccessfulSources: 2,
@@ -435,5 +466,158 @@ describe("runDataCollection", () => {
     // Assert
     expect(result.success).toBe(false);
     expect(createMock).not.toHaveBeenCalled();
+  });
+
+  it("skips refill rounds when daily target is already satisfied by existing data", async () => {
+    // Setup
+    analysisGetMock.mockResolvedValueOnce({
+      dataSources: [],
+      dataSourceTotalCount: 5,
+      entityTypes: [],
+      relationTypes: [],
+      existingEntities: [],
+      relevanceSelectionState: {
+        utcDayStartIso: "2026-01-01T00:00:00.000Z",
+        selectedCountToday: 0,
+      },
+      lastRelevanceScoredAtIso: null,
+    });
+
+    // Act
+    const result = await runDataCollection(
+      createContext({
+        config: {
+          ...baseConfig,
+          runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+        },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(performWebSearch).not.toHaveBeenCalled();
+    expect(
+      (result.details?.summary as { refill?: { roundsExecuted: number } })
+        .refill?.roundsExecuted,
+    ).toBe(0);
+  });
+
+  it("runs refill rounds until target is met", async () => {
+    // Setup
+    vi.mocked(performWebSearch)
+      .mockResolvedValueOnce([
+        {
+          success: true,
+          data: searchSuccessPage,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          success: true,
+          data: searchSuccessPage,
+        },
+      ]);
+    vi.mocked(performWebFetch)
+      .mockResolvedValueOnce([
+        {
+          success: true,
+          data: {
+            ...searchSuccessPage,
+            content: "Main content",
+          },
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          success: true,
+          data: {
+            ...searchSuccessPage,
+            content: "Main content",
+          },
+        },
+      ]);
+
+    // Act
+    const result = await runDataCollection(
+      createContext({
+        config: {
+          ...baseConfig,
+          targetDailySuccessfulSources: 2,
+          maxRefillRounds: 3,
+        },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(performWebSearch).toHaveBeenCalledTimes(2);
+    expect(createMock).toHaveBeenCalledTimes(2);
+    expect(
+      (result.details?.summary as { refill?: { stopReason: string } }).refill
+        ?.stopReason,
+    ).toBe("daily_target_met");
+  });
+
+  it("stops refill when no progress is made in a round", async () => {
+    // Setup
+    vi.mocked(performWebSearch).mockResolvedValue([]);
+    vi.mocked(performWebFetch).mockResolvedValue([]);
+
+    // Act
+    const result = await runDataCollection(
+      createContext({
+        config: {
+          ...baseConfig,
+          targetDailySuccessfulSources: 5,
+          runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+        },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(performWebSearch).toHaveBeenCalledTimes(1);
+    expect(
+      (result.details?.summary as { refill?: { stopReason: string } }).refill
+        ?.stopReason,
+    ).toBe("no_progress");
+  });
+
+  it("stops refill after max rounds when target remains unmet", async () => {
+    // Setup
+    vi.mocked(performWebSearch).mockResolvedValue([
+      {
+        success: true,
+        data: searchSuccessPage,
+      },
+    ]);
+    vi.mocked(performWebFetch).mockResolvedValue([
+      {
+        success: true,
+        data: {
+          ...searchSuccessPage,
+          content: "Main content",
+        },
+      },
+    ]);
+
+    // Act
+    const result = await runDataCollection(
+      createContext({
+        config: {
+          ...baseConfig,
+          runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+          targetDailySuccessfulSources: 10,
+          maxRefillRounds: 3,
+        },
+      }),
+    );
+
+    // Assert
+    expect(performWebSearch).toHaveBeenCalledTimes(4);
+    expect(
+      (result.details?.summary as { refill?: { stopReason: string } }).refill
+        ?.stopReason,
+    ).toBe("max_rounds_reached");
   });
 });

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -63,6 +63,9 @@ export async function runDataCollection(
     minSuccessfulSources: 1,
     failOnZeroSuccess: true,
   };
+  const targetDailySuccessfulSources = config.targetDailySuccessfulSources ?? 5;
+  const maxRefillRounds = config.maxRefillRounds ?? 3;
+  const maxTotalRounds = 1 + maxRefillRounds;
 
   const dataApiClient = createAgentDataApiClient({
     baseUrl: env.AGENT_DATA_API_URL,
@@ -94,14 +97,45 @@ export async function runDataCollection(
     );
   }
 
-  const searchAttemptResults = await performWebSearch(queries, {
-    config: webSearchConfig,
-    logger: log,
+  const now = new Date();
+  const utcDayStart = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()),
+  );
+  const utcDayEnd = new Date(utcDayStart.getTime() + 24 * 60 * 60 * 1000 - 1);
+  const baselineToday = await dataApiClient.analysis.get({
+    tickerId: input.tickerId,
+    unanalyzed: false,
+    start: utcDayStart.toISOString(),
+    end: utcDayEnd.toISOString(),
+    limit: 1,
   });
-  const searchSuccesses = searchAttemptResults
-    .filter((r) => r.success)
-    .map((r) => r.data);
-  const searchFailures = searchAttemptResults.filter((r) => !r.success);
+  const existingTodaySourceCount = baselineToday.dataSourceTotalCount;
+
+  let roundsExecuted = 0;
+  let refillStopReason:
+    | "daily_target_met_before_start"
+    | "daily_target_met"
+    | "max_rounds_reached"
+    | "no_progress"
+    | "no_queries"
+    | null = null;
+  let persistedThisRunCount = 0;
+  let searchSuccessCount = 0;
+  let searchFailedCount = 0;
+  let fetchSuccessCount = 0;
+  let fetchFailedCount = 0;
+  const searchFailures: Array<
+    Extract<
+      Awaited<ReturnType<typeof performWebSearch>>[number],
+      { success: false }
+    >
+  > = [];
+  const fetchFailures: Array<
+    Extract<
+      Awaited<ReturnType<typeof performWebFetch>>[number],
+      { success: false }
+    >
+  > = [];
   const droppedByUrlReason: Record<UrlNoiseReason, number> = {
     blocked_host: 0,
     blocked_host_path: 0,
@@ -112,114 +146,167 @@ export async function runDataCollection(
   let droppedByExistingCanonicalUrl = 0;
   let droppedByContentShape = 0;
 
-  log.info(
-    {
-      searchHitCount: searchSuccesses.length,
-      searchFailed: searchFailures.length,
-    },
-    "web search stage finished",
-  );
-
-  const canonicalUniqueHits = new Map<
-    string,
-    (typeof searchSuccesses)[number]
-  >();
-  for (const hit of searchSuccesses) {
-    const decision = classifyNoisyUrl(hit.url);
-    if (decision.blocked) {
-      droppedByUrlReason[decision.reason] += 1;
-      continue;
-    }
-
-    if (canonicalUniqueHits.has(decision.canonicalUrl)) {
-      droppedByDuplicateCanonicalUrl += 1;
-      continue;
-    }
-
-    canonicalUniqueHits.set(decision.canonicalUrl, {
-      ...hit,
-      url: decision.canonicalUrl,
-    });
-  }
-
-  const filteredSearchSuccesses = [...canonicalUniqueHits.values()];
-  const candidateUrls = filteredSearchSuccesses.map((hit) => hit.url);
-  const existingUrlSet = await resolveExistingDataSourceUrls(
-    input.tickerId,
-    candidateUrls,
-    (body) => dataApiClient.dataCollectionExistingUrls.create(body),
-  );
-  const searchSuccessesForFetch = filteredSearchSuccesses.filter(
-    (hit) => !existingUrlSet.has(hit.url),
-  );
-  droppedByExistingCanonicalUrl =
-    filteredSearchSuccesses.length - searchSuccessesForFetch.length;
-  const skippedExistingUrlCount = droppedByExistingCanonicalUrl;
-  if (skippedExistingUrlCount > 0) {
-    log.info(
-      {
-        skippedExistingUrlCount,
-        searchHitCount: searchSuccesses.length,
-      },
-      "skipped web fetch for URLs already stored as data sources",
-    );
-  }
-
-  const fetchAttemptResults = await performWebFetch(searchSuccessesForFetch, {
-    config: webFetchConfig,
-    logger: log,
-  });
-  const fetchSuccesses = fetchAttemptResults
-    .filter((r) => r.success)
-    .map((r) => r.data);
-  const fetchFailures = fetchAttemptResults.filter((r) => !r.success);
-  const finalFetchSuccesses: typeof fetchSuccesses = [];
-  for (const page of fetchSuccesses) {
-    const urlDecision = classifyNoisyUrl(page.url);
-    if (urlDecision.blocked) {
-      droppedByUrlReason[urlDecision.reason] += 1;
-      continue;
-    }
-
-    const contentDecision = classifyNonArticleContent(page.title, page.content);
-    if (contentDecision.blocked) {
-      droppedByContentShape += 1;
-      continue;
-    }
-
-    finalFetchSuccesses.push({
-      ...page,
-      url: urlDecision.canonicalUrl,
-    });
-  }
-
-  log.info(
-    {
-      fetchSuccess: finalFetchSuccesses.length,
-      fetchFailed: fetchFailures.length,
-      droppedByUrlReason,
-      droppedByDuplicateCanonicalUrl,
-      droppedByExistingCanonicalUrl,
-      droppedByContentShape,
-    },
-    "web fetch stage finished",
-  );
-
-  if (finalFetchSuccesses.length > 0) {
-    const sources: DataCollectionInput[] = finalFetchSuccesses.map((page) => ({
-      url: page.url,
-      title: page.title,
-      content: page.content,
-      tickerId: input.tickerId,
-      searchQueryId: page.searchQueryId,
-    }));
-    log.info(
-      { sourcesToPersist: sources.length },
-      "persisting collected sources to Agent Data API",
-    );
-    await dataApiClient.dataCollection.create(sources);
+  if (queries.length === 0) {
+    refillStopReason = "no_queries";
+  } else if (existingTodaySourceCount >= targetDailySuccessfulSources) {
+    refillStopReason = "daily_target_met_before_start";
   } else {
-    log.info({}, "no sources to persist after fetch stage");
+    for (let round = 1; round <= maxTotalRounds; round += 1) {
+      roundsExecuted += 1;
+      const searchAttemptResults = await performWebSearch(queries, {
+        config: webSearchConfig,
+        logger: log,
+      });
+      const roundSearchSuccesses = searchAttemptResults
+        .filter((r) => r.success)
+        .map((r) => r.data);
+      const roundSearchFailures = searchAttemptResults.filter(
+        (r) => !r.success,
+      );
+      searchSuccessCount += roundSearchSuccesses.length;
+      searchFailedCount += roundSearchFailures.length;
+      searchFailures.push(...roundSearchFailures);
+
+      log.info(
+        {
+          round,
+          searchHitCount: roundSearchSuccesses.length,
+          searchFailed: roundSearchFailures.length,
+        },
+        "web search stage finished",
+      );
+
+      const canonicalUniqueHits = new Map<
+        string,
+        (typeof roundSearchSuccesses)[number]
+      >();
+      for (const hit of roundSearchSuccesses) {
+        const decision = classifyNoisyUrl(hit.url);
+        if (decision.blocked) {
+          droppedByUrlReason[decision.reason] += 1;
+          continue;
+        }
+
+        if (canonicalUniqueHits.has(decision.canonicalUrl)) {
+          droppedByDuplicateCanonicalUrl += 1;
+          continue;
+        }
+
+        canonicalUniqueHits.set(decision.canonicalUrl, {
+          ...hit,
+          url: decision.canonicalUrl,
+        });
+      }
+
+      const filteredSearchSuccesses = [...canonicalUniqueHits.values()];
+      const candidateUrls = filteredSearchSuccesses.map((hit) => hit.url);
+      const existingUrlSet = await resolveExistingDataSourceUrls(
+        input.tickerId,
+        candidateUrls,
+        (body) => dataApiClient.dataCollectionExistingUrls.create(body),
+      );
+      const searchSuccessesForFetch = filteredSearchSuccesses.filter(
+        (hit) => !existingUrlSet.has(hit.url),
+      );
+      const skippedExistingUrlCount =
+        filteredSearchSuccesses.length - searchSuccessesForFetch.length;
+      droppedByExistingCanonicalUrl += skippedExistingUrlCount;
+      if (skippedExistingUrlCount > 0) {
+        log.info(
+          {
+            round,
+            skippedExistingUrlCount,
+            searchHitCount: roundSearchSuccesses.length,
+          },
+          "skipped web fetch for URLs already stored as data sources",
+        );
+      }
+
+      const fetchAttemptResults = await performWebFetch(
+        searchSuccessesForFetch,
+        {
+          config: webFetchConfig,
+          logger: log,
+        },
+      );
+      const roundFetchSuccesses = fetchAttemptResults
+        .filter((r) => r.success)
+        .map((r) => r.data);
+      const roundFetchFailures = fetchAttemptResults.filter((r) => !r.success);
+      fetchFailedCount += roundFetchFailures.length;
+      fetchFailures.push(...roundFetchFailures);
+
+      const finalFetchSuccesses: typeof roundFetchSuccesses = [];
+      for (const page of roundFetchSuccesses) {
+        const urlDecision = classifyNoisyUrl(page.url);
+        if (urlDecision.blocked) {
+          droppedByUrlReason[urlDecision.reason] += 1;
+          continue;
+        }
+
+        const contentDecision = classifyNonArticleContent(
+          page.title,
+          page.content,
+        );
+        if (contentDecision.blocked) {
+          droppedByContentShape += 1;
+          continue;
+        }
+
+        finalFetchSuccesses.push({
+          ...page,
+          url: urlDecision.canonicalUrl,
+        });
+      }
+      fetchSuccessCount += finalFetchSuccesses.length;
+
+      log.info(
+        {
+          round,
+          fetchSuccess: finalFetchSuccesses.length,
+          fetchFailed: roundFetchFailures.length,
+          droppedByUrlReason,
+          droppedByDuplicateCanonicalUrl,
+          droppedByExistingCanonicalUrl,
+          droppedByContentShape,
+        },
+        "web fetch stage finished",
+      );
+
+      if (finalFetchSuccesses.length > 0) {
+        const sources: DataCollectionInput[] = finalFetchSuccesses.map(
+          (page) => ({
+            url: page.url,
+            title: page.title,
+            content: page.content,
+            tickerId: input.tickerId,
+            searchQueryId: page.searchQueryId,
+          }),
+        );
+        log.info(
+          { round, sourcesToPersist: sources.length },
+          "persisting collected sources to Agent Data API",
+        );
+        await dataApiClient.dataCollection.create(sources);
+        persistedThisRunCount += sources.length;
+      } else {
+        log.info({ round }, "no sources to persist after fetch stage");
+      }
+
+      const effectiveTodayCount =
+        existingTodaySourceCount + persistedThisRunCount;
+      if (effectiveTodayCount >= targetDailySuccessfulSources) {
+        refillStopReason = "daily_target_met";
+        break;
+      }
+      if (finalFetchSuccesses.length === 0) {
+        refillStopReason = "no_progress";
+        break;
+      }
+      if (round === maxTotalRounds) {
+        refillStopReason = "max_rounds_reached";
+      }
+    }
   }
 
   const failuresPayload = [
@@ -252,7 +339,7 @@ export async function runDataCollection(
     })),
   ];
 
-  const totalSources = finalFetchSuccesses.length;
+  const totalSources = persistedThisRunCount;
   const status = deriveRunStatus({
     totalSources,
     failureCount: failuresPayload.length,
@@ -261,11 +348,11 @@ export async function runDataCollection(
 
   const counters: RunCounters = {
     queriesTotal: queries.length,
-    urlsTotal: filteredSearchSuccesses.length,
-    searchSuccess: filteredSearchSuccesses.length,
-    searchFailed: searchFailures.length,
-    fetchSuccess: finalFetchSuccesses.length,
-    fetchFailed: fetchFailures.length,
+    urlsTotal: searchSuccessCount,
+    searchSuccess: searchSuccessCount,
+    searchFailed: searchFailedCount,
+    fetchSuccess: fetchSuccessCount,
+    fetchFailed: fetchFailedCount,
     retryCount: 0,
   };
 
@@ -295,8 +382,16 @@ export async function runDataCollection(
   const summary = {
     totalSources,
     status,
-    searchSuccess: searchSuccesses.length,
-    fetchSuccess: fetchSuccesses.length,
+    searchSuccess: searchSuccessCount,
+    fetchSuccess: fetchSuccessCount,
+    refill: {
+      roundsExecuted,
+      maxTotalRounds,
+      targetDailySuccessfulSources,
+      existingTodaySourceCount,
+      effectiveTodayCount: existingTodaySourceCount + persistedThisRunCount,
+      stopReason: refillStopReason,
+    },
   };
 
   const durationMs = Date.now() - startedAt.getTime();

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -47,6 +47,8 @@ describe("dataCollectionAgentConfigSchema", () => {
           perSeconds: 60,
         },
       },
+      targetDailySuccessfulSources: 5,
+      maxRefillRounds: 3,
     };
 
     // Act
@@ -55,6 +57,8 @@ describe("dataCollectionAgentConfigSchema", () => {
     // Assert
     expect(parsed.webSearch.baseUrl).toBe("https://google.serper.dev");
     expect(parsed.webFetch.baseUrl).toBe("https://r.jina.ai");
+    expect(parsed.targetDailySuccessfulSources).toBe(5);
+    expect(parsed.maxRefillRounds).toBe(3);
   });
 
   it("rejects non-positive webSearch rate limits", () => {
@@ -88,6 +92,50 @@ describe("dataCollectionAgentConfigSchema", () => {
           ...base.webSearch,
           rateLimit: { requests: 10, perSeconds: 0 },
         },
+      }),
+    ).toThrow();
+  });
+
+  it("rejects invalid refill configuration values", () => {
+    // Setup
+    const base = {
+      webSearch: {
+        baseUrl: "https://google.serper.dev",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "key",
+          headerName: "X-API-KEY",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+      webFetch: {
+        baseUrl: "https://r.jina.ai",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "key",
+          headerName: "Authorization",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+    };
+
+    // Act + Assert
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        ...base,
+        targetDailySuccessfulSources: 0,
+      }),
+    ).toThrow();
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        ...base,
+        maxRefillRounds: -1,
       }),
     ).toThrow();
   });

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -47,6 +47,8 @@ const webFetchSchema = z.object({
 export const ConfigSchema = z.object({
   webSearch: webSearchSchema,
   webFetch: webFetchSchema,
+  targetDailySuccessfulSources: z.number().int().positive().optional(),
+  maxRefillRounds: z.number().int().nonnegative().optional(),
   runPolicy: z
     .object({
       minSuccessfulSources: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary

This change makes data collection keep trying within a run until there are enough valid sources for today. Instead of stopping after a single pass, the agent can refill in additional rounds and stop only when the target is met or a safe stop condition is reached.

## Related issues

Closes #367

## Important changes

- Added refill controls in data-collection config: `targetDailySuccessfulSources` and `maxRefillRounds`.
- Refactored `runDataCollection` into a round-based loop that uses `existingToday + newlyPersistedThisRun` as the progress metric.
- Added explicit refill stop conditions: target met, max rounds reached, no progress, no queries, or already satisfied before start.

## Other changes

- Extended summary payload with refill observability (`roundsExecuted`, `stopReason`, effective day count, and target metadata).
- Updated HTTP-level and unit tests to cover baseline-satisfied, refill-success, max-round, and no-progress behavior.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/run.ts` - refill loop, baseline count lookup, and stop-reason logic.
- `apps/mediapulse/agents/data-collection/src/run.test.ts` - round-loop behavior and stop-condition tests.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` - new config knobs.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts` - schema validation coverage.
- `apps/mediapulse/agents/data-collection/src/index.test.ts` - API-level mock wiring for daily baseline lookup.

## How to test

1. Run `pnpm --filter @mediapulse/data-collection test`.
2. Run `pnpm format:check` from the repository root.
3. Trigger a data-collection run with a high daily target and verify refill rounds are logged with the expected stop reason.
