### PR TITLE
Add strict inline citation validation to content generation

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/index.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.test.ts
@@ -124,7 +124,13 @@ describe("parseNewsletterJson", () => {
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Markets up.",
-      topNews: [{ title: "Headline", summary: "Summary text." }],
+      topNews: [
+        {
+          title: "Headline",
+          summaryWithLinks: "Summary [S](https://example.com/s).",
+          citations: [{ url: "https://example.com/s" }],
+        },
+      ],
     });
 
     const result = parseNewsletterJson(raw);
@@ -145,7 +151,7 @@ describe("parseNewsletterJson", () => {
     const raw = JSON.stringify({
       subject: "x",
       executiveSummary: "y",
-      topNews: [{ title: 123, summary: "ok" }],
+      topNews: [{ title: 123, summaryWithLinks: "ok", citations: [] }],
     });
 
     expect(() => parseNewsletterJson(raw)).toThrow();
@@ -156,9 +162,21 @@ describe("parseNewsletterJson", () => {
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        { title: "A", summary: "a" },
-        { title: "B", summary: "b" },
-        { title: "C", summary: "c" },
+        {
+          title: "A",
+          summaryWithLinks: "a [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+        {
+          title: "B",
+          summaryWithLinks: "b [B](https://example.com/b)",
+          citations: [{ url: "https://example.com/b" }],
+        },
+        {
+          title: "C",
+          summaryWithLinks: "c [C](https://example.com/c)",
+          citations: [{ url: "https://example.com/c" }],
+        },
       ],
     });
 
@@ -171,7 +189,13 @@ describe("parseNewsletterJson", () => {
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
-      topNews: [{ title: "A", summary: "a" }],
+      topNews: [
+        {
+          title: "A",
+          summaryWithLinks: "a [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+      ],
     });
 
     const result = parseNewsletterJson(raw, 5);
@@ -184,10 +208,26 @@ describe("parseNewsletterJson", () => {
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        { title: "A", summary: "a" },
-        { title: "B", summary: "b" },
-        { title: "C", summary: "c" },
-        { title: "D", summary: "d" },
+        {
+          title: "A",
+          summaryWithLinks: "a [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+        {
+          title: "B",
+          summaryWithLinks: "b [B](https://example.com/b)",
+          citations: [{ url: "https://example.com/b" }],
+        },
+        {
+          title: "C",
+          summaryWithLinks: "c [C](https://example.com/c)",
+          citations: [{ url: "https://example.com/c" }],
+        },
+        {
+          title: "D",
+          summaryWithLinks: "d [D](https://example.com/d)",
+          citations: [{ url: "https://example.com/d" }],
+        },
       ],
     });
 
@@ -201,10 +241,26 @@ describe("parseNewsletterJson", () => {
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        { title: "A", summary: "a" },
-        { title: "B", summary: "b" },
-        { title: "C", summary: "c" },
-        { title: "D", summary: "d" },
+        {
+          title: "A",
+          summaryWithLinks: "a [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+        {
+          title: "B",
+          summaryWithLinks: "b [B](https://example.com/b)",
+          citations: [{ url: "https://example.com/b" }],
+        },
+        {
+          title: "C",
+          summaryWithLinks: "c [C](https://example.com/c)",
+          citations: [{ url: "https://example.com/c" }],
+        },
+        {
+          title: "D",
+          summaryWithLinks: "d [D](https://example.com/d)",
+          citations: [{ url: "https://example.com/d" }],
+        },
       ],
     });
 

--- a/apps/mediapulse/agents/content-generation/src/lib/generate-content.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/generate-content.test.ts
@@ -18,7 +18,13 @@ const makeSource = (title: string, content: string): SourceForGeneration => ({
   content,
 });
 
-const makeOpenAIMock = (topNews: Array<{ title: string; summary: string }>) => {
+const makeOpenAIMock = (
+  topNews: Array<{
+    title: string;
+    summaryWithLinks: string;
+    citations: Array<{ url: string; label?: string }>;
+  }>,
+) => {
   const mockCreate = vi.fn().mockResolvedValue({
     choices: [
       {
@@ -43,11 +49,31 @@ const makeOpenAIMock = (topNews: Array<{ title: string; summary: string }>) => {
 describe("generateContentWithOpenAI", () => {
   it("topNewsCount=5 interpolates count into system and user prompts and slices topNews to 5", async () => {
     const topNewsItems = [
-      { title: "Story 1", summary: "Summary 1." },
-      { title: "Story 2", summary: "Summary 2." },
-      { title: "Story 3", summary: "Summary 3." },
-      { title: "Story 4", summary: "Summary 4." },
-      { title: "Story 5", summary: "Summary 5." },
+      {
+        title: "Story 1",
+        summaryWithLinks: "Summary 1 [A](https://example.com/source-a).",
+        citations: [{ url: "https://example.com/source-a" }],
+      },
+      {
+        title: "Story 2",
+        summaryWithLinks: "Summary 2 [A](https://example.com/source-a).",
+        citations: [{ url: "https://example.com/source-a" }],
+      },
+      {
+        title: "Story 3",
+        summaryWithLinks: "Summary 3 [A](https://example.com/source-a).",
+        citations: [{ url: "https://example.com/source-a" }],
+      },
+      {
+        title: "Story 4",
+        summaryWithLinks: "Summary 4 [A](https://example.com/source-a).",
+        citations: [{ url: "https://example.com/source-a" }],
+      },
+      {
+        title: "Story 5",
+        summaryWithLinks: "Summary 5 [A](https://example.com/source-a).",
+        citations: [{ url: "https://example.com/source-a" }],
+      },
     ];
     const { openai, mockCreate } = makeOpenAIMock(topNewsItems);
     const sources = [makeSource("Source A", "Content about markets.")];
@@ -71,7 +97,7 @@ describe("generateContentWithOpenAI", () => {
     expect(userMsg).toContain("5");
     // hardcoded "3" must not appear as the count in the default prompts
     expect(systemMsg).not.toMatch(/exactly 3 items/);
-    expect(userMsg).not.toMatch(/top 3 news items/);
+    expect(userMsg).not.toMatch(/top 3 news items/i);
 
     // slice(0, 5) preserved all 5 items; formatted output reflects topNewsCount=5
     expect(result.content).toContain("TOP 5 NEWS");
@@ -81,8 +107,16 @@ describe("generateContentWithOpenAI", () => {
   it("slice(0, topNewsCount) clips the topNews list to the configured count", async () => {
     // LLM returns exactly topNewsCount=2 items — slice keeps both intact.
     const { openai } = makeOpenAIMock([
-      { title: "Item 1", summary: "A." },
-      { title: "Item 2", summary: "B." },
+      {
+        title: "Item 1",
+        summaryWithLinks: "A [S](https://example.com/s).",
+        citations: [{ url: "https://example.com/s" }],
+      },
+      {
+        title: "Item 2",
+        summaryWithLinks: "B [S](https://example.com/s).",
+        citations: [{ url: "https://example.com/s" }],
+      },
     ]);
     const sources = [makeSource("S", "content")];
 
@@ -102,7 +136,11 @@ describe("generateContentWithOpenAI", () => {
 
   it("uses default system prompt and user prompt template when none provided", async () => {
     const { openai, mockCreate } = makeOpenAIMock([
-      { title: "A", summary: "a." },
+      {
+        title: "A",
+        summaryWithLinks: "a [T](https://example.com/t).",
+        citations: [{ url: "https://example.com/t" }],
+      },
     ]);
     const sources = [makeSource("T", "Source body text.")];
 
@@ -124,12 +162,17 @@ describe("generateContentWithOpenAI", () => {
     expect(systemMsg).toContain("exactly 3 items");
     // default user prompt with 3 substituted and source content interpolated
     expect(userMsg).toContain("top 3 news items");
+    expect(userMsg).toContain("inline markdown links");
     expect(userMsg).toContain("Source body text.");
   });
 
   it("uses custom systemPrompt from config when provided", async () => {
     const { openai, mockCreate } = makeOpenAIMock([
-      { title: "A", summary: "a." },
+      {
+        title: "A",
+        summaryWithLinks: "a [T](https://example.com/t).",
+        citations: [{ url: "https://example.com/t" }],
+      },
     ]);
     const sources = [makeSource("T", "content")];
 
@@ -150,7 +193,11 @@ describe("generateContentWithOpenAI", () => {
 
   it("substitutes {{tickerId}} and {{date}} in custom prompt templates", async () => {
     const { openai, mockCreate } = makeOpenAIMock([
-      { title: "A", summary: "a." },
+      {
+        title: "A",
+        summaryWithLinks: "a [T](https://example.com/t).",
+        citations: [{ url: "https://example.com/t" }],
+      },
     ]);
     const sources = [makeSource("T", "content")];
 
@@ -179,7 +226,13 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("returns subject, content, and description from the validated response", async () => {
-    const { openai } = makeOpenAIMock([{ title: "A", summary: "a." }]);
+    const { openai } = makeOpenAIMock([
+      {
+        title: "A",
+        summaryWithLinks: "a [T](https://example.com/t).",
+        citations: [{ url: "https://example.com/t" }],
+      },
+    ]);
     const sources = [makeSource("T", "content")];
 
     const result = await generateContentWithOpenAI(sources, {

--- a/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
@@ -10,10 +10,14 @@ export const DEFAULT_SYSTEM_PROMPT = `You are a newsletter writer for busy execu
 Return a JSON object with:
 - "subject": a compelling email subject line (short, under ~60 chars).
 - "executiveSummary": 2–3 sentences summarizing the main themes and why they matter. No bullet points; use clear prose.
-- "topNews": an array of exactly {{topNewsCount}} items. Each item has "title" (short headline) and "summary" (2–4 sentences). Pick the {{topNewsCount}} most important or impactful stories. Keep summaries concise and actionable.`;
+- "topNews": an array of exactly {{topNewsCount}} items. Each item must have:
+  - "title": short headline
+  - "summaryWithLinks": 2–4 sentences with inline markdown links like [source](https://example.com/news)
+  - "citations": at least one citation object with "url" and optional "label"
+Only cite URLs from the provided source list.`;
 
 export const DEFAULT_USER_PROMPT_TEMPLATE =
-  "Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items with brief summaries.\n\n{{sourceSummaries}}";
+  "Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items. Each top-news summary must include inline markdown links and only use URLs that appear in the provided sources.\n\n{{sourceSummaries}}";
 
 /**
  * Calls OpenAI to generate a newsletter with an executive summary and top news items.
@@ -93,7 +97,10 @@ export async function generateContentWithOpenAI(
     : [];
   const content = formatNewsletterContent(
     validated.executiveSummary ?? "",
-    topNews,
+    topNews.map((item) => ({
+      title: item.title,
+      summary: item.summaryWithLinks,
+    })),
     deps.topNewsCount,
   );
 

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
@@ -2,6 +2,7 @@ import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { classifyLlmError, isRetryableLlmError } from "./llm-classify-error.js";
+import { CitationValidationError } from "./llm-generate-newsletter.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -96,6 +97,14 @@ describe("isRetryableLlmError", () => {
     expect(isRetryableLlmError(error)).toBe(false);
   });
 
+  it("returns true for CitationValidationError", () => {
+    // Setup
+    const error = new CitationValidationError("missing citation");
+
+    // Act & Assert
+    expect(isRetryableLlmError(error)).toBe(true);
+  });
+
   it("returns false for NoObjectGeneratedError", () => {
     // Setup
     const error = makeNoObjectGeneratedError();
@@ -162,6 +171,17 @@ describe("classifyLlmError", () => {
   it("maps TypeValidationError to validation_failed", () => {
     // Setup
     const error = makeTypeValidationError();
+
+    // Act
+    const code = classifyLlmError(error);
+
+    // Assert
+    expect(code).toBe("validation_failed");
+  });
+
+  it("maps CitationValidationError to validation_failed", () => {
+    // Setup
+    const error = new CitationValidationError("missing citation");
 
     // Act
     const code = classifyLlmError(error);

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
@@ -1,4 +1,5 @@
 import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
+import { CitationValidationError } from "./llm-generate-newsletter.js";
 
 import type { OutcomeCode } from "./types/outcome.js";
 
@@ -35,6 +36,9 @@ export function isRetryableLlmError(error: unknown): boolean {
   if (error instanceof TypeValidationError) {
     return false;
   }
+  if (error instanceof CitationValidationError) {
+    return true;
+  }
   if (error instanceof NoObjectGeneratedError) {
     return false;
   }
@@ -52,6 +56,9 @@ export function isRetryableLlmError(error: unknown): boolean {
  */
 export function classifyLlmError(error: unknown): OutcomeCode {
   if (error instanceof TypeValidationError) {
+    return "validation_failed";
+  }
+  if (error instanceof CitationValidationError) {
     return "validation_failed";
   }
   if (error instanceof NoObjectGeneratedError) {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -34,7 +34,11 @@ function makeSuccessfulGenerateFn(
   overrides: Partial<{
     subject: string;
     executiveSummary: string;
-    topNews: Array<{ title: string; summary: string }>;
+    topNews: Array<{
+      title: string;
+      summaryWithLinks: string;
+      citations: Array<{ url: string; label?: string }>;
+    }>;
   }> = {},
 ): GenerateNewsletterObjectFn {
   return vi.fn().mockResolvedValue({
@@ -43,9 +47,24 @@ function makeSuccessfulGenerateFn(
       executiveSummary:
         overrides.executiveSummary ?? "Stocks rose for the third day.",
       topNews: overrides.topNews ?? [
-        { title: "Tech gains", summary: "Big tech was up." },
-        { title: "Fed pause", summary: "Rates held." },
-        { title: "Oil dips", summary: "Crude fell." },
+        {
+          title: "Tech gains",
+          summaryWithLinks:
+            "Big tech was up according to [Story A](https://example.com/a).",
+          citations: [{ url: "https://example.com/a", label: "Story A" }],
+        },
+        {
+          title: "Fed pause",
+          summaryWithLinks:
+            "Rates held according to [Story B](https://example.com/b).",
+          citations: [{ url: "https://example.com/b", label: "Story B" }],
+        },
+        {
+          title: "Oil dips",
+          summaryWithLinks:
+            "Crude fell according to [Story A](https://example.com/a).",
+          citations: [{ url: "https://example.com/a", label: "Story A" }],
+        },
       ],
     },
   });
@@ -115,11 +134,31 @@ describe("generateNewsletterWithLlm — happy path", () => {
     // Setup
     const generateObjectFn = makeSuccessfulGenerateFn({
       topNews: [
-        { title: "Item 1", summary: "s1" },
-        { title: "Item 2", summary: "s2" },
-        { title: "Item 3", summary: "s3" },
-        { title: "Item 4", summary: "s4" },
-        { title: "Item 5", summary: "s5" },
+        {
+          title: "Item 1",
+          summaryWithLinks: "s1 [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+        {
+          title: "Item 2",
+          summaryWithLinks: "s2 [B](https://example.com/b)",
+          citations: [{ url: "https://example.com/b" }],
+        },
+        {
+          title: "Item 3",
+          summaryWithLinks: "s3 [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
+        {
+          title: "Item 4",
+          summaryWithLinks: "s4 [B](https://example.com/b)",
+          citations: [{ url: "https://example.com/b" }],
+        },
+        {
+          title: "Item 5",
+          summaryWithLinks: "s5 [A](https://example.com/a)",
+          citations: [{ url: "https://example.com/a" }],
+        },
       ],
     });
 
@@ -271,6 +310,66 @@ describe("generateNewsletterWithLlm — non-retryable errors", () => {
 // ---------------------------------------------------------------------------
 
 describe("generateNewsletterWithLlm — retryable errors", () => {
+  it("retries when citation validation fails and eventually succeeds", async () => {
+    // Setup
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        openai: { apiKey: "sk-test" },
+        llmRetry: {
+          maxAttempts: 3,
+          baseDelayMs: 10,
+          maxDelayMs: 100,
+          jitter: false,
+        },
+      }),
+    );
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const generateObjectFn = vi
+      .fn()
+      .mockResolvedValueOnce({
+        object: {
+          subject: "Invalid citations",
+          executiveSummary: "Summary",
+          topNews: [
+            {
+              title: "Story",
+              summaryWithLinks: "No links here.",
+              citations: [{ url: "https://example.com/a" }],
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        object: {
+          subject: "Recovered",
+          executiveSummary: "Summary",
+          topNews: [
+            {
+              title: "Story",
+              summaryWithLinks: "Cited [A](https://example.com/a).",
+              citations: [{ url: "https://example.com/a" }],
+            },
+          ],
+        },
+      });
+
+    // Act
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      config,
+      testContext,
+      {
+        generateObjectFn,
+        sleepFn,
+      },
+    );
+
+    // Assert
+    expect(result.subject).toBe("Recovered");
+    expect(generateObjectFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
   it("retries exactly maxAttempts times on a 429 rate-limit error", async () => {
     // Setup
     const rateLimitError = new APICallError({
@@ -306,6 +405,46 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
     expect(sleepFn).toHaveBeenCalledTimes(2);
   });
 
+  it("fails after max attempts when citation URLs are not from provided sources", async () => {
+    // Setup
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        openai: { apiKey: "sk-test" },
+        llmRetry: {
+          maxAttempts: 2,
+          baseDelayMs: 10,
+          maxDelayMs: 100,
+          jitter: false,
+        },
+      }),
+    );
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const generateObjectFn = vi.fn().mockResolvedValue({
+      object: {
+        subject: "Invalid source mapping",
+        executiveSummary: "Summary",
+        topNews: [
+          {
+            title: "Story",
+            summaryWithLinks: "Claim [Offsite](https://not-provided.com/x).",
+            citations: [{ url: "https://not-provided.com/x" }],
+          },
+        ],
+      },
+    });
+
+    // Act & Assert
+    await expect(
+      generateNewsletterWithLlm(testSources, config, testContext, {
+        generateObjectFn,
+        sleepFn,
+      }),
+    ).rejects.toThrow("Citation URL not in provided sources");
+
+    expect(generateObjectFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).toHaveBeenCalledTimes(1);
+  });
+
   it("succeeds after a transient 500 failure", async () => {
     // Setup
     const serverError = new APICallError({
@@ -334,7 +473,13 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
         object: {
           subject: "Recovery",
           executiveSummary: "All clear.",
-          topNews: [{ title: "Up", summary: "Markets up." }],
+          topNews: [
+            {
+              title: "Up",
+              summaryWithLinks: "Markets up [A](https://example.com/a).",
+              citations: [{ url: "https://example.com/a" }],
+            },
+          ],
         },
       });
 
@@ -391,7 +536,13 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
       object: {
         subject: "Market Update",
         executiveSummary: "Stocks rose.",
-        topNews: [{ title: "Gains", summary: "Up." }],
+        topNews: [
+          {
+            title: "Gains",
+            summaryWithLinks: "Up [A](https://example.com/a).",
+            citations: [{ url: "https://example.com/a" }],
+          },
+        ],
       },
       usage: {
         promptTokens: 120,
@@ -423,7 +574,13 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
       object: {
         subject: "No Usage",
         executiveSummary: "No usage data.",
-        topNews: [{ title: "Story", summary: "Summary." }],
+        topNews: [
+          {
+            title: "Story",
+            summaryWithLinks: "Summary [A](https://example.com/a).",
+            citations: [{ url: "https://example.com/a" }],
+          },
+        ],
       },
       // usage intentionally omitted
     });
@@ -519,7 +676,8 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
     // Setup
     const generateObjectFn = makeSuccessfulGenerateFn();
     const otherSources = [
-      { url: "https://example.com/z", title: "Story Z", content: "Content Z." },
+      { url: "https://example.com/a", title: "Story Z", content: "Content Z." },
+      { url: "https://example.com/b", title: "Story Y", content: "Content Y." },
     ];
 
     // Act

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -171,9 +171,9 @@ const validateTopNewsCitations = (
       }
     }
 
-    const inlineUrls = [
-      ...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX),
-    ].map((match) => match[1]);
+    const inlineUrls = [...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX)]
+      .map((match) => match[1])
+      .filter((url): url is string => typeof url === "string");
     if (inlineUrls.length === 0) {
       throw new CitationValidationError(
         `Missing inline markdown link in summaryWithLinks for: ${item.title}`,

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -171,7 +171,9 @@ const validateTopNewsCitations = (
       }
     }
 
-    const inlineUrls = [...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX)]
+    const inlineUrls = [
+      ...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX),
+    ]
       .map((match) => match[1])
       .filter((url): url is string => typeof url === "string");
     if (inlineUrls.length === 0) {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -120,12 +120,78 @@ export const SYSTEM_PROMPT = `You are a newsletter writer for busy executives. G
 Return a JSON object with:
 - "subject": a compelling email subject line (short, under ~60 chars).
 - "executiveSummary": 2–3 sentences summarizing the main themes and why they matter. No bullet points; use clear prose.
-- "topNews": an array of exactly {{topNewsCount}} items. Each item has "title" (short headline) and "summary" (2–4 sentences). Pick the {{topNewsCount}} most important or impactful stories. Keep summaries concise and actionable.`;
+- "topNews": an array of exactly {{topNewsCount}} items. Each item must have:
+  - "title": short headline
+  - "summaryWithLinks": 2–4 sentences that include inline markdown citations like [source](https://example.com/news)
+  - "citations": array with at least one citation object, each citation has "url" and optional "label"
+Use only URLs from the provided sources. Every topNews item must include at least one citation link in the summary.`;
 
 /**
  * Default user prompt template used when no template is provided in config.
  */
-export const DEFAULT_USER_PROMPT_TEMPLATE = `Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items with brief summaries.\n\n{{sourceSummaries}}`;
+export const DEFAULT_USER_PROMPT_TEMPLATE = `Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items. Each top-news summary must include inline markdown links and only use URLs from the provided sources.\n\n{{sourceSummaries}}`;
+
+const INLINE_MARKDOWN_LINK_REGEX = /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/gi;
+
+/**
+ * Raised when generated top-news citations do not satisfy strict source-link rules.
+ */
+export class CitationValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CitationValidationError";
+  }
+}
+
+/**
+ * Validates generated citations against provided source URLs and inline link usage.
+ *
+ * @param topNews - Generated top news items.
+ * @param sourceUrls - URL set from provided source context.
+ */
+const validateTopNewsCitations = (
+  topNews: Array<{
+    title: string;
+    summaryWithLinks: string;
+    citations: Array<{ url: string; label?: string }>;
+  }>,
+  sourceUrls: ReadonlySet<string>,
+): void => {
+  for (const item of topNews) {
+    if (item.citations.length === 0) {
+      throw new CitationValidationError(
+        `Missing citations for topNews item: ${item.title}`,
+      );
+    }
+    for (const citation of item.citations) {
+      if (!sourceUrls.has(citation.url)) {
+        throw new CitationValidationError(
+          `Citation URL not in provided sources: ${citation.url}`,
+        );
+      }
+    }
+
+    const inlineUrls = [
+      ...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX),
+    ].map((match) => match[1]);
+    if (inlineUrls.length === 0) {
+      throw new CitationValidationError(
+        `Missing inline markdown link in summaryWithLinks for: ${item.title}`,
+      );
+    }
+    const citationUrlSet = new Set(
+      item.citations.map((citation) => citation.url),
+    );
+    const hasMappedInlineCitation = inlineUrls.some((url) =>
+      citationUrlSet.has(url),
+    );
+    if (!hasMappedInlineCitation) {
+      throw new CitationValidationError(
+        `Inline links do not match citations for: ${item.title}`,
+      );
+    }
+  }
+};
 
 /**
  * Builds the LLM user prompt from the list of data sources, substituting
@@ -225,9 +291,10 @@ export async function generateNewsletterWithLlm(
   const timeout = config.openai?.timeoutMs;
   const maxTokens = config.openai?.maxTokens;
 
+  const sourceUrlSet = new Set(truncatedSources.map((source) => source.url));
   const result = await retryWithBackoff(
-    () =>
-      generateFn({
+    async () => {
+      const generated = await generateFn({
         model,
         schema: newsletterStructureSchema,
         system: systemPrompt,
@@ -235,7 +302,13 @@ export async function generateNewsletterWithLlm(
         maxRetries: 0,
         ...(timeout !== undefined ? { timeout } : {}),
         ...(maxTokens !== undefined ? { maxTokens } : {}),
-      }),
+      });
+      const topNews = Array.isArray(generated.object.topNews)
+        ? generated.object.topNews.slice(0, topNewsCount)
+        : [];
+      validateTopNewsCitations(topNews, sourceUrlSet);
+      return generated;
+    },
     config.llmRetry,
     isRetryableLlmError,
     { sleepFn: deps.sleepFn },
@@ -247,7 +320,10 @@ export async function generateNewsletterWithLlm(
     : [];
   const content = formatNewsletterContent(
     object.executiveSummary ?? "",
-    topNews,
+    topNews.map((item) => ({
+      title: item.title,
+      summary: item.summaryWithLinks,
+    })),
     topNewsCount,
   );
 

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { parseNewsletterJson } from "./parse-newsletter-json.js";
+
+describe("parseNewsletterJson", () => {
+  it("parses valid topNews items with summaryWithLinks and citations", () => {
+    const parsed = parseNewsletterJson(
+      JSON.stringify({
+        subject: "Daily Brief",
+        executiveSummary: "Summary",
+        topNews: [
+          {
+            title: "Story 1",
+            summaryWithLinks: "Update [Source](https://example.com/a).",
+            citations: [{ url: "https://example.com/a", label: "Source" }],
+          },
+        ],
+      }),
+      3,
+    );
+
+    expect(parsed.topNews[0]?.summaryWithLinks).toContain("[Source]");
+    expect(parsed.topNews[0]?.citations[0]?.url).toBe("https://example.com/a");
+  });
+
+  it("rejects topNews item without citations", () => {
+    expect(() =>
+      parseNewsletterJson(
+        JSON.stringify({
+          subject: "Daily Brief",
+          executiveSummary: "Summary",
+          topNews: [
+            {
+              title: "Story 1",
+              summaryWithLinks: "Update [Source](https://example.com/a).",
+              citations: [],
+            },
+          ],
+        }),
+        3,
+      ),
+    ).toThrow();
+  });
+
+  it("rejects citation with invalid URL", () => {
+    expect(() =>
+      parseNewsletterJson(
+        JSON.stringify({
+          subject: "Daily Brief",
+          executiveSummary: "Summary",
+          topNews: [
+            {
+              title: "Story 1",
+              summaryWithLinks: "Update [Source](bad-url).",
+              citations: [{ url: "bad-url" }],
+            },
+          ],
+        }),
+        3,
+      ),
+    ).toThrow();
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
@@ -7,7 +7,15 @@ export const newsletterStructureSchema = z.object({
   topNews: z.array(
     z.object({
       title: z.string(),
-      summary: z.string(),
+      summaryWithLinks: z.string(),
+      citations: z
+        .array(
+          z.object({
+            url: z.string().url(),
+            label: z.string().optional(),
+          }),
+        )
+        .min(1),
     }),
   ),
 });


### PR DESCRIPTION
## Summary
Add strict inline source citations to content-generation output so every top-news summary carries verifiable links and invalid citation output is rejected.

## Related issues
Closes #369

## Important changes
- Extend newsletter structured output so each `topNews` item must include `summaryWithLinks` and a non-empty `citations` array.
- Add strict citation validation in LLM generation: fail when inline markdown links are missing, citations are empty, inline links do not map to cited URLs, or citation URLs are not in the provided source set.
- Run citation validation inside retry handling and classify failures as `validation_failed`, so existing retry/backoff behavior applies.

## Other changes
- Update default system and user prompts to explicitly require inline markdown links and source-only citation URLs.
- Update formatting flow to render `summaryWithLinks` into final newsletter content.
- Add and update tests for schema parsing, retry/failure behavior, prompt expectations, and rendering compatibility.

## Key files to review
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` - citation validation rules and retry integration.
- `apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts` - stricter newsletter schema for citation fields.
- `apps/mediapulse/agents/content-generation/src/llm-classify-error.ts` - citation validation classification as retryable validation failures.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts` - coverage for citation retries and invalid-source failures.
- `apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts` - new parse/schema validation tests.

## How to test
1. Run `pnpm test` in `apps/mediapulse/agents/content-generation`.
2. Run `pnpm format:check` at the repository root.
3. Verify generated top-news summaries include inline markdown links to provided source URLs, and generation fails/retries when links are missing or mismatched.
