### PR TITLE
Build @workspace/utils before domain-api Docker bundle

### DIFF
--- a/apps/mediapulse/domain-api/Dockerfile
+++ b/apps/mediapulse/domain-api/Dockerfile
@@ -11,6 +11,10 @@ RUN pnpm install --frozen-lockfile
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
 RUN pnpm --filter=@mediapulse/database run db:generate
 
+# Workspace packages that export compiled `dist/` are not built when using
+# `turbo build --only` (dependency tasks are skipped). Bun must resolve real files.
+RUN pnpm --filter=@workspace/utils run build
+
 RUN pnpm exec turbo build --filter=@mediapulse/domain-api --only --env-mode=loose
 
 # Stage 2: run the built bundle only


### PR DESCRIPTION
## Summary

The domain-api image runs Turbo with **`--only`**, so dependency **`build`** scripts never fire. **`@workspace/utils`** only exposes **`dist/index.js`**, and Docker never copies **`dist`** from the host anyway, so Bun could not resolve that package during **`bun build`**. The Dockerfile now runs **`pnpm --filter=@workspace/utils run build`** before the filtered Turbo step so the bundle step sees real files.

## Related issues

Closes #374

## Important changes

- Builder stage runs **`@workspace/utils`** **`tsc`** output before **`@mediapulse/domain-api`** **`bun build`**.

## Other changes

- Short comment in the Dockerfile explaining why the extra step exists (keeps **`--only`** so we still avoid unwanted migrate tasks in the image).

## Key files to review

- `apps/mediapulse/domain-api/Dockerfile` — ordering relative to **`db:generate`** and Turbo; comment accuracy.

## How to test

1. From repo root: **`pnpm --filter=@workspace/utils run build`** then **`pnpm --filter=@mediapulse/domain-api run build`** (should bundle cleanly).
2. Optional: **`docker build -f apps/mediapulse/domain-api/Dockerfile .`** from repo root and confirm the builder stage passes past **`bun build`**.
