### PR TITLE
Decouple Turbo build from migrate and add deploy migration gate

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -1,17 +1,85 @@
 name: Agent Deployment
 
-# Requires GitHub secrets:
-# - FLY_API_TOKEN
-# - ORCHESTRATION_DATABASE_URL (needed during turbo build task chain)
-# - MEDIAPULSE_DATABASE_URL (needed during turbo build task chain)
 on:
   push:
     branches:
       - main
 
+env:
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
 jobs:
+  db-ready:
+    runs-on: ubuntu-latest
+    env:
+      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
+      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for orchestration DB
+        run: |
+          for i in {1..24}; do
+            pnpm --filter=@hermes/orchestration-database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
+            echo "Waiting for orchestration DB ($i/24)..."
+            sleep 5
+          done
+          echo "Orchestration DB did not become ready in time"
+          exit 1
+
+      - name: Wait for mediapulse DB
+        run: |
+          for i in {1..24}; do
+            pnpm --filter=@mediapulse/database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
+            echo "Waiting for mediapulse DB ($i/24)..."
+            sleep 5
+          done
+          echo "Mediapulse DB did not become ready in time"
+          exit 1
+
+  db-migrate:
+    name: Apply Prisma migrations (production DBs)
+    runs-on: ubuntu-latest
+    needs: db-ready
+    concurrency:
+      group: prisma-migrate-production
+      cancel-in-progress: false
+    env:
+      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
+      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Migrate deploy (orchestration)
+        run: pnpm --filter=@hermes/orchestration-database run db:migrate:deploy
+
+      - name: Migrate deploy (mediapulse)
+        run: pnpm --filter=@mediapulse/database run db:migrate:deploy
+
   data-collection:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -31,10 +99,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/data-collection --only
+        run: pnpm exec turbo build --filter=@mediapulse/data-collection
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -45,6 +112,7 @@ jobs:
 
   content-generation:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -64,10 +132,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/content-generation --only
+        run: pnpm exec turbo build --filter=@mediapulse/content-generation
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -78,6 +145,7 @@ jobs:
 
   article-analysis:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -97,10 +165,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/article-analysis --only
+        run: pnpm exec turbo build --filter=@mediapulse/article-analysis
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -111,6 +178,7 @@ jobs:
 
   query-analysis:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -130,10 +198,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/query-analysis --only
+        run: pnpm exec turbo build --filter=@mediapulse/query-analysis
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -144,6 +211,7 @@ jobs:
 
   delivery:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -163,10 +231,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/delivery --only
+        run: pnpm exec turbo build --filter=@mediapulse/delivery
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -177,6 +244,7 @@ jobs:
 
   ticker-echo:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -196,10 +264,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/ticker-echo --only
+        run: pnpm exec turbo build --filter=@mediapulse/ticker-echo
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -210,6 +277,7 @@ jobs:
 
   user-registration:
     runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -229,10 +297,9 @@ jobs:
         run: |
           ./dev-bootstrap.sh
           pnpm install
-          pnpm generate
 
       - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only
+        run: pnpm exec turbo build --filter=@mediapulse/user-registration-agent
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -1,12 +1,13 @@
 name: App Deployment
 
-# Requires GitHub secrets:
-# - ORCHESTRATION_DATABASE_URL (PostgreSQL URL for orchestration schema)
-# - MEDIAPULSE_DATABASE_URL (PostgreSQL URL for Mediapulse schema)
 on:
   push:
     branches:
       - main
+
+env:
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
 
 jobs:
   db-ready:
@@ -47,9 +48,38 @@ jobs:
           echo "Mediapulse DB did not become ready in time"
           exit 1
 
-  agent-auth-api:
+  db-migrate:
+    name: Apply Prisma migrations (production DBs)
     runs-on: ubuntu-latest
     needs: db-ready
+    concurrency:
+      group: prisma-migrate-production
+      cancel-in-progress: false
+    env:
+      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
+      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Migrate deploy (orchestration)
+        run: pnpm --filter=@hermes/orchestration-database run db:migrate:deploy
+
+      - name: Migrate deploy (mediapulse)
+        run: pnpm --filter=@mediapulse/database run db:migrate:deploy
+
+  agent-auth-api:
+    runs-on: ubuntu-latest
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -84,7 +114,7 @@ jobs:
 
   agent-data-api:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -119,7 +149,7 @@ jobs:
 
   domain-api:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -154,7 +184,7 @@ jobs:
 
   agent-registry-api:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -189,7 +219,7 @@ jobs:
 
   user-registration:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -221,7 +251,7 @@ jobs:
 
   hermes:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
@@ -253,7 +283,7 @@ jobs:
 
   hermes-worker:
     runs-on: ubuntu-latest
-    needs: db-ready
+    needs: db-migrate
     env:
       ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
       MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+
 jobs:
   changes:
     name: Determine whether heavy jobs should run
@@ -45,7 +49,6 @@ jobs:
           fi
 
           if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
-            # Fallback for initial commit-like events.
             base_sha="$(git rev-parse "${head_sha}^" 2>/dev/null || true)"
           fi
 
@@ -83,27 +86,30 @@ jobs:
     if: needs.changes.outputs.run_heavy_jobs == 'true'
 
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
         image: postgres
-        # Provide the password for postgres
         env:
           POSTGRES_USER: mediapulse
           POSTGRES_PASSWORD: mediapulse
           POSTGRES_DB: mediapulse
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Turbo local cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - uses: oven-sh/setup-bun@v2
 
@@ -116,7 +122,6 @@ jobs:
 
       - name: Set up local environment
         env:
-          # Required by dev-setup-local.sh --non-interactive (create:admin + domain seed); CI-only placeholders.
           DEV_SETUP_ADMIN_EMAIL: ci-setup@example.invalid
           DEV_SETUP_ADMIN_PASSWORD: CiLocalDevSetup2024
         run: |
@@ -137,27 +142,30 @@ jobs:
     if: needs.changes.outputs.run_heavy_jobs == 'true'
 
     services:
-      # Label used to access the service container
       postgres:
-        # Docker Hub image
         image: postgres
-        # Provide the password for postgres
         env:
           POSTGRES_USER: mediapulse
           POSTGRES_PASSWORD: mediapulse
           POSTGRES_DB: mediapulse
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
         ports:
-          # Maps tcp port 5432 on service container to the host
           - 5432:5432
 
     steps:
       - uses: actions/checkout@v6
+
+      - name: Turbo local cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
 
       - uses: oven-sh/setup-bun@v2
 
@@ -170,7 +178,6 @@ jobs:
 
       - name: Set up local environment
         env:
-          # Required by dev-setup-local.sh --non-interactive (create:admin + domain seed); CI-only placeholders.
           DEV_SETUP_ADMIN_EMAIL: ci-setup@example.invalid
           DEV_SETUP_ADMIN_PASSWORD: CiLocalDevSetup2024
         run: |

--- a/apps/hermes/agent-auth-api/Dockerfile
+++ b/apps/hermes/agent-auth-api/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
@@ -8,7 +7,6 @@ RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @hermes/agent-auth-api build
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/hermes/agent-auth-api/turbo.json
+++ b/apps/hermes/agent-auth-api/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     }

--- a/apps/hermes/agent-registry-api/Dockerfile
+++ b/apps/hermes/agent-registry-api/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
@@ -7,15 +6,11 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma client (orchestration DB)
 ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
-RUN pnpm --filter=@hermes/orchestration-database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build
 
-RUN pnpm exec turbo build --filter=@hermes/agent-registry-api --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@hermes/agent-registry-api --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/hermes/agent-registry-api/turbo.json
+++ b/apps/hermes/agent-registry-api/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     }

--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -10,7 +10,6 @@ ENV CI=true
 
 RUN npm install -g pnpm
 
-# Install build tools
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
@@ -21,21 +20,15 @@ COPY apps ./apps
 
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma client (orchestration only); dummy env is enough for generate
 ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV TEMP_ADMIN_USERNAME="dummy"
 ENV TEMP_ADMIN_PASSWORD="dummy"
 ENV HERMES_INTERNAL_API_KEY="dummy-internal-key"
-RUN pnpm --filter=@hermes/orchestration-database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build
-# next.config loads env files; provide an empty app-level .env for image builds.
 RUN rm -f apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local && \
     touch apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local
 
-RUN pnpm exec turbo build --filter=@hermes/dashboard --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@hermes/dashboard --env-mode=loose
 
-# Standalone runner: only copy traced output + static
 ARG NODE_VERSION=24.12.0
 FROM node:${NODE_VERSION}-slim AS runner
 WORKDIR /app

--- a/apps/hermes/worker/Dockerfile
+++ b/apps/hermes/worker/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
@@ -7,17 +6,13 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma client (orchestration DB)
 ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV TEMP_ADMIN_USERNAME="dummy"
 ENV TEMP_ADMIN_PASSWORD="dummy"
-RUN pnpm --filter=@hermes/orchestration-database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build
 
-RUN pnpm exec turbo build --filter=@hermes/worker --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@hermes/worker --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agent-data-api/Dockerfile
+++ b/apps/mediapulse/agent-data-api/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
@@ -7,15 +6,10 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma client (Mediapulse domain DB)
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
-RUN pnpm --filter=@mediapulse/database run db:generate
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build
 
-RUN pnpm exec turbo build --filter=@mediapulse/agent-data-api --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/agent-data-api --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agent-data-api/turbo.json
+++ b/apps/mediapulse/agent-data-api/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "generate"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     }

--- a/apps/mediapulse/agents/article-analysis/Dockerfile
+++ b/apps/mediapulse/agents/article-analysis/Dockerfile
@@ -1,17 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build
-RUN pnpm exec turbo build --filter=@mediapulse/article-analysis --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/article-analysis --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/article-analysis/turbo.json
+++ b/apps/mediapulse/agents/article-analysis/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/content-generation/Dockerfile
+++ b/apps/mediapulse/agents/content-generation/Dockerfile
@@ -1,18 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build \
-  && pnpm --filter=@workspace/utils run build
-RUN pnpm exec turbo build --filter=@mediapulse/content-generation --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/content-generation --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/content-generation/turbo.json
+++ b/apps/mediapulse/agents/content-generation/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/data-collection/Dockerfile
+++ b/apps/mediapulse/agents/data-collection/Dockerfile
@@ -1,18 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build \
-  && pnpm --filter=@workspace/utils run build
-RUN pnpm exec turbo build --filter=@mediapulse/data-collection --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/data-collection --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/data-collection/turbo.json
+++ b/apps/mediapulse/agents/data-collection/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/delivery/Dockerfile
+++ b/apps/mediapulse/agents/delivery/Dockerfile
@@ -1,18 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build \
-  && pnpm --filter=@workspace/utils run build
-RUN pnpm exec turbo build --filter=@mediapulse/delivery --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/delivery --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/delivery/turbo.json
+++ b/apps/mediapulse/agents/delivery/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/query-analysis/Dockerfile
+++ b/apps/mediapulse/agents/query-analysis/Dockerfile
@@ -1,17 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build
-RUN pnpm exec turbo build --filter=@mediapulse/query-analysis --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/query-analysis --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/query-analysis/turbo.json
+++ b/apps/mediapulse/agents/query-analysis/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/ticker-echo/Dockerfile
+++ b/apps/mediapulse/agents/ticker-echo/Dockerfile
@@ -1,16 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build
-RUN pnpm exec turbo build --filter=@mediapulse/ticker-echo --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/ticker-echo --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/ticker-echo/turbo.json
+++ b/apps/mediapulse/agents/ticker-echo/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -1,18 +1,12 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
 
-# pnpm for workspace install; bun for the app build
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter=@workspace/agent-auth-client run build \
-  && pnpm --filter=@workspace/agent-data-api-contract run build \
-  && pnpm --filter=@workspace/utils run build
-RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --only --env-mode=loose
+RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --env-mode=loose
 
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/user-registration/turbo.json
+++ b/apps/mediapulse/agents/user-registration/turbo.json
@@ -3,7 +3,6 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": ["dist/**"]
     }

--- a/apps/mediapulse/domain-api/Dockerfile
+++ b/apps/mediapulse/domain-api/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1: install and build (monorepo context from repo root)
 FROM node:24-bookworm-slim AS builder
 WORKDIR /app
 COPY . .
@@ -7,17 +6,9 @@ RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
-# Generate Prisma client (Mediapulse domain DB)
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
-RUN pnpm --filter=@mediapulse/database run db:generate
+RUN pnpm exec turbo build --filter=@mediapulse/domain-api --env-mode=loose
 
-# Workspace packages that export compiled `dist/` are not built when using
-# `turbo build --only` (dependency tasks are skipped). Bun must resolve real files.
-RUN pnpm --filter=@workspace/utils run build
-
-RUN pnpm exec turbo build --filter=@mediapulse/domain-api --only --env-mode=loose
-
-# Stage 2: run the built bundle only
 FROM oven/bun:1
 WORKDIR /app
 ENV NODE_ENV=production

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -11,32 +11,26 @@ ENV CI=true
 
 RUN npm install -g pnpm
 
-# Install build tools
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential node-gyp pkg-config python-is-python3
 
-COPY pnpm-lock.yaml package.json pnpm-workspace.yaml ./
+COPY pnpm-lock.yaml package.json pnpm-workspace.yaml turbo.json ./
 
 COPY packages ./packages
 COPY apps ./apps
 
 RUN pnpm install --frozen-lockfile
 
-# next build imports @mediapulse/database → default @mediapulse/env (t3) validates at module load.
-# Prisma client output is gitignored; match domain-api / agent-data-api image builds.
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV DOMAIN_INTEGRATION_API_KEY="docker-build-dummy"
 ENV DOMAIN_INTEGRATION_ID="docker-build-dummy"
 ENV AGENT_AUTH_API_URL="http://127.0.0.1:9/dummy"
-RUN pnpm --filter=@mediapulse/database run db:generate
 
-# next.config loads env files; provide an empty app-level .env for image builds.
 RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local && \
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local
 
-RUN pnpm --filter=@mediapulse/user-registration run build
+RUN pnpm exec turbo build --filter=@mediapulse/user-registration --env-mode=loose
 
-# Standalone runner: only copy traced output + static
 ARG NODE_VERSION=24.12.0
 FROM node:${NODE_VERSION}-slim AS runner
 WORKDIR /app

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -22,6 +22,8 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 | **Mediapulse (domain)**    | Tickers, newsletters, KG, subscribers, user registration data, etc. | `MEDIAPULSE_DATABASE_URL`                                                                  | `pnpm --filter @mediapulse/database db:migrate:deploy`                       |
 | **DataQueue**              | hermes-worker job queue (scheduler)                                 | `PG_DATAQUEUE_DATABASE` (same host is fine; use `?schema=dataqueue&search_path=dataqueue`) | `pnpm --filter @hermes/worker run migrate-dataqueue` (with queue URL in env) |
 
+Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before Fly deploys). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
+
 ---
 
 ## Hermes

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "cache": false
     },
     "build": {
-      "dependsOn": ["^db:migrate:deploy", "^build", "generate"],
+      "dependsOn": ["^db:generate", "^build", "generate"],
       "env": [
         "ORCHESTRATION_DATABASE_URL",
         "MEDIAPULSE_DATABASE_URL"


### PR DESCRIPTION
## Summary

Turbo **`build`** no longer pulls in **`prisma migrate deploy`**, so local CI and Docker builds only compile and generate Prisma clients. **`main`** deploy workflows now run a single **`db-migrate`** job (after **`db-ready`**) for orchestration and mediapulse, with a shared concurrency group so two workflows do not migrate at once. Dockerfiles lean on one **`turbo build`** line where we can, and we dropped stray comments in those files and the three touched workflows.

## Related issues

Closes #376

Refs #356

## Important changes

- Root **`turbo.json`**: **`build.dependsOn`** uses **`^db:generate`** instead of **`^db:migrate:deploy`**.
- **`app-deploy.yml` / `agent-deploy.yml`**: **`db-migrate`** before Fly; optional **`TURBO_TEAM` / `TURBO_TOKEN`** for remote cache; agent workflow gets the same DB wait + migrate gate as apps.
- **`code-quality.yml`**: optional Turbo remote env; **`.turbo`** cache on the two heavy jobs.

## Other changes

- Workspace **`turbo.json`** overrides: dropped redundant **`build.dependsOn`** where it blocked the root graph.
- Dockerfiles: fewer manual **`pnpm --filter`** steps; Next images still keep the **`# syntax`** line.
- **`production.mdx`**: short note on where migrate runs in CI.

## Key files to review

- **`turbo.json`** — new **`build`** dependency order.
- **`.github/workflows/app-deploy.yml`** — **`db-migrate`** + **`needs`** wiring + concurrency group name.
- **`.github/workflows/agent-deploy.yml`** — same pattern vs parallel agent jobs.
- **`apps/mediapulse/domain-api/Dockerfile`** — representative slim Docker build.

## How to test

1. With dummy URLs: **`ORCHESTRATION_DATABASE_URL=postgresql://localhost:5432/dummy MEDIAPULSE_DATABASE_URL=postgresql://localhost:5432/dummy pnpm exec turbo build --filter=@mediapulse/domain-api --env-mode=loose`**.
2. **`pnpm format:check`** from repo root.
3. After merge: confirm **`main`** **`app-deploy` / `agent-deploy`** show **`db-migrate`** green before Fly steps (and that **`TURBO_*`** secrets are set if you want remote cache).
