### PR TITLE
Fix newsletter structured output schema for OpenAI strict mode

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/lib/sanitize-source-content-markdown-urls.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/sanitize-source-content-markdown-urls.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { sanitizeSourceContentMarkdownUrls } from "./sanitize-source-content-markdown-urls.js";
+
+describe("sanitizeSourceContentMarkdownUrls", () => {
+  it("preserves absolute https links on public hosts", () => {
+    const input = "Read [Reuters](https://www.reuters.com/world/).";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe(input);
+  });
+
+  it("replaces blob markdown image targets with alt text only", () => {
+    const input =
+      "Bad ![Image 2](blob:http://localhost/a2f9abce2c7bd7e72f7c1065e8e25533) end";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe("Bad Image 2 end");
+  });
+
+  it("replaces localhost https markdown links with link text only", () => {
+    const input = "See [local](http://localhost:3000/path).";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe("See local.");
+  });
+
+  it("replaces relative markdown links with link text only", () => {
+    const input = "Nav [World](/world/).";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe("Nav World.");
+  });
+
+  it("strips raw blob URLs outside markdown", () => {
+    const input = "x blob:http://localhost/abc y";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe("x  y");
+  });
+
+  it("strips raw data and javascript URLs", () => {
+    const input = "a data:image/png;base64,AAA b javascript:alert(1) c";
+    expect(sanitizeSourceContentMarkdownUrls(input)).toBe("a  b  c");
+  });
+
+  it("handles empty content", () => {
+    expect(sanitizeSourceContentMarkdownUrls("")).toBe("");
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/lib/sanitize-source-content-markdown-urls.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/sanitize-source-content-markdown-urls.ts
@@ -1,0 +1,71 @@
+/**
+ * Markdown link/image pattern: optional `!`, bracket label, then parenthesized target.
+ * Does not handle nested `]` inside labels (rare in scraped snippets).
+ */
+const MARKDOWN_LINK_OR_IMAGE = /(!?)\[([^\]]*)\]\(([^)]+)\)/g;
+
+/**
+ * Raw disallowed schemes often left in HTML-to-markdown conversion (blob pages,
+ * data URIs, script handlers).
+ */
+/** Match through the next whitespace so `javascript:alert(1)` is removed in full. */
+const RAW_DISALLOWED_SCHEME =
+  /\b(?:blob|data|javascript|mailto|tel|file):[^\s]+/gi;
+
+/**
+ * Returns true when `raw` is an absolute `http`/`https` URL whose host is suitable
+ * for article-style citations (excludes localhost, loopback, and `.local` hosts).
+ *
+ * @param raw - URL string from a markdown link target (trimmed by caller).
+ * @returns Whether the URL is kept in sanitized source content.
+ */
+const isPermittedArticleMarkdownTargetUrl = (raw: string): boolean => {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+    return false;
+  }
+  try {
+    const u = new URL(trimmed);
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return false;
+    }
+    const host = u.hostname.toLowerCase();
+    if (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "::1" ||
+      host.endsWith(".local")
+    ) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Removes non-article markdown link targets (blob, data, localhost, relative URLs,
+ * etc.) from scraped source content so the LLM prompt only shows citable `http(s)`
+ * links aligned with real article origins.
+ *
+ * - `![alt](blob:...)` becomes `alt` (or empty when alt is empty).
+ * - `[text](bad)` becomes `text`.
+ * - Permitted absolute `http(s)` links (non-loopback) are left unchanged.
+ * - Standalone `blob:...`, `data:...`, `javascript:...`, etc. are stripped from the text.
+ *
+ * @param content - Raw markdown or HTML-ish snippet from a data source.
+ * @returns Sanitized content safe to embed in the LLM context.
+ */
+export const sanitizeSourceContentMarkdownUrls = (content: string): string => {
+  const withoutBadMarkdown = content.replace(
+    MARKDOWN_LINK_OR_IMAGE,
+    (full, bang: string, label: string, url: string) => {
+      if (isPermittedArticleMarkdownTargetUrl(url)) {
+        return full;
+      }
+      return label;
+    },
+  );
+  return withoutBadMarkdown.replace(RAW_DISALLOWED_SCHEME, "");
+};

--- a/apps/mediapulse/agents/content-generation/src/lib/truncate-sources.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/truncate-sources.test.ts
@@ -22,6 +22,26 @@ describe("truncateSources", () => {
     expect(result).toEqual(sources);
   });
 
+  it("sanitizes blob and localhost markdown targets before truncation", () => {
+    const sources: SourceForGeneration[] = [
+      {
+        url: "https://www.reuters.com/markets/companies/BBCA.JK/",
+        title: "Reuters",
+        content:
+          "Intro ![x](blob:http://localhost/abc) more [nav](http://127.0.0.1/x) keep [ok](https://www.reuters.com/markets/companies/BBCA.JK/)",
+      },
+    ];
+
+    const result = truncateSources(sources, 8000, 100000);
+
+    expect(result[0]!.content).not.toContain("blob:");
+    expect(result[0]!.content).not.toContain("127.0.0.1");
+    expect(result[0]!.content).toContain(
+      "https://www.reuters.com/markets/companies/BBCA.JK/",
+    );
+    expect(result[0]!.url).toBe(sources[0]!.url);
+  });
+
   it("truncates a single source exceeding maxCharsPerSource from the tail", () => {
     const sources = [makeSource("A", "a".repeat(10000))];
 

--- a/apps/mediapulse/agents/content-generation/src/lib/truncate-sources.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/truncate-sources.ts
@@ -1,12 +1,16 @@
+import { sanitizeSourceContentMarkdownUrls } from "./sanitize-source-content-markdown-urls.js";
 import type { SourceForGeneration } from "../types.js";
 
 /**
  * Truncates data sources to fit within configured character limits.
  *
  * Processing order:
- * 1. Per-source truncation: each source's content is truncated from the **tail**
+ * 1. **URL hygiene:** each source's `content` is passed through
+ *    {@link sanitizeSourceContentMarkdownUrls} to strip blob/data/localhost and other
+ *    non-article markdown targets before truncation.
+ * 2. Per-source truncation: each source's content is truncated from the **tail**
  *    to `maxCharsPerSource` characters. Sources within the limit are unchanged.
- * 2. Total context cap: if the combined content still exceeds `maxTotalContextChars`,
+ * 3. Total context cap: if the combined content still exceeds `maxTotalContextChars`,
  *    sources are dropped from the **end** of the list (preserving the relevance order
  *    from `getDataSourcesForTicker`, which returns most-relevant first) until the total
  *    fits. At least one source is always kept; if a single source exceeds the total
@@ -26,14 +30,18 @@ export function truncateSources(
     return sources;
   }
 
-  const truncated: SourceForGeneration[] = sources.map((source) => ({
-    url: source.url,
-    title: source.title,
-    content:
-      source.content.length > maxCharsPerSource
-        ? source.content.slice(0, maxCharsPerSource)
-        : source.content,
-  }));
+  const truncated: SourceForGeneration[] = sources.map((source) => {
+    const cleaned = sanitizeSourceContentMarkdownUrls(source.content);
+    const content =
+      cleaned.length > maxCharsPerSource
+        ? cleaned.slice(0, maxCharsPerSource)
+        : cleaned;
+    return {
+      url: source.url,
+      title: source.title,
+      content,
+    };
+  });
 
   const totalChars = () =>
     truncated.reduce((sum, s) => sum + s.content.length, 0);

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
@@ -60,4 +60,61 @@ describe("parseNewsletterJson", () => {
       ),
     ).toThrow();
   });
+
+  it("accepts http citation URLs", () => {
+    const parsed = parseNewsletterJson(
+      JSON.stringify({
+        subject: "Daily Brief",
+        executiveSummary: "Summary",
+        topNews: [
+          {
+            title: "Story 1",
+            summaryWithLinks: "See [x](http://example.com/a).",
+            citations: [{ url: "http://example.com/a" }],
+          },
+        ],
+      }),
+      3,
+    );
+    expect(parsed.topNews[0]?.citations[0]?.url).toBe("http://example.com/a");
+  });
+
+  it("rejects non-http(s) citation URLs (e.g. ftp)", () => {
+    expect(() =>
+      parseNewsletterJson(
+        JSON.stringify({
+          subject: "Daily Brief",
+          executiveSummary: "Summary",
+          topNews: [
+            {
+              title: "Story 1",
+              summaryWithLinks: "Update.",
+              citations: [{ url: "ftp://example.com/file" }],
+            },
+          ],
+        }),
+        3,
+      ),
+    ).toThrow();
+  });
+
+  it("parses citations that omit label (legacy JSON) by normalizing to empty label", () => {
+    const parsed = parseNewsletterJson(
+      JSON.stringify({
+        subject: "Daily Brief",
+        executiveSummary: "Summary",
+        topNews: [
+          {
+            title: "Story 1",
+            summaryWithLinks: "Update [x](https://example.com/a).",
+            citations: [{ url: "https://example.com/a" }],
+          },
+        ],
+      }),
+      3,
+    );
+    expect(parsed.topNews[0]?.citations[0]).toEqual({
+      url: "https://example.com/a",
+    });
+  });
 });

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
@@ -1,5 +1,39 @@
 import { z } from "zod";
 
+/**
+ * Returns true when `value` is an absolute URL with an `http:` or `https:` scheme.
+ *
+ * Used instead of `z.string().url()` so the JSON Schema sent to OpenAI structured
+ * outputs does not use `format: "uri"`, which the Responses API rejects
+ * (`invalid_json_schema`).
+ *
+ * @param value - Candidate URL string from structured output.
+ * @returns Whether the value parses as an http(s) URL.
+ */
+const isHttpOrHttpsUrl = (value: string): boolean => {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Citation object for structured output. `label` is a required string (use `""` when
+ * absent) because OpenAI `json_schema` with `strict: true` requires `required` to list
+ * every key in `properties`; optional Zod fields omit `label` from `required` and the
+ * API rejects the schema. Empty/whitespace labels are stripped on output.
+ */
+const newsletterCitationSchema = z
+  .object({
+    url: z.string().min(1).refine(isHttpOrHttpsUrl, { message: "Invalid URL" }),
+    label: z.string(),
+  })
+  .transform(({ url, label }) =>
+    label.trim() === "" ? { url } : { url, label: label.trim() },
+  );
+
 /** Zod schema for OpenAI LLM newsletter JSON output. */
 export const newsletterStructureSchema = z.object({
   subject: z.string(),
@@ -8,17 +42,54 @@ export const newsletterStructureSchema = z.object({
     z.object({
       title: z.string(),
       summaryWithLinks: z.string(),
-      citations: z
-        .array(
-          z.object({
-            url: z.string().url(),
-            label: z.string().optional(),
-          }),
-        )
-        .min(1),
+      citations: z.array(newsletterCitationSchema).min(1),
     }),
   ),
 });
+
+/**
+ * Fills missing `label` on each citation with `""` so legacy JSON without `label`
+ * still parses after OpenAI strict-schema alignment.
+ *
+ * @param parsed - Unknown value from `JSON.parse` of newsletter JSON.
+ * @returns Same structure with string `label` on every citation object.
+ */
+const ensureCitationLabelKeys = (parsed: unknown): unknown => {
+  if (!parsed || typeof parsed !== "object") {
+    return parsed;
+  }
+  const root = parsed as Record<string, unknown>;
+  const topNews = root.topNews;
+  if (!Array.isArray(topNews)) {
+    return parsed;
+  }
+  return {
+    ...root,
+    topNews: topNews.map((item) => {
+      if (!item || typeof item !== "object") {
+        return item;
+      }
+      const row = item as Record<string, unknown>;
+      const citations = row.citations;
+      if (!Array.isArray(citations)) {
+        return item;
+      }
+      return {
+        ...row,
+        citations: citations.map((citation) => {
+          if (!citation || typeof citation !== "object") {
+            return citation;
+          }
+          const c = citation as Record<string, unknown>;
+          return {
+            ...c,
+            label: typeof c.label === "string" ? c.label : "",
+          };
+        }),
+      };
+    }),
+  };
+};
 
 /**
  * Parses and validates raw JSON string from OpenAI into newsletter structure.
@@ -42,7 +113,9 @@ export function parseNewsletterJson(
   } catch {
     throw new Error("OpenAI returned invalid JSON");
   }
-  const result = newsletterStructureSchema.parse(parsed);
+  const result = newsletterStructureSchema.parse(
+    ensureCitationLabelKeys(parsed),
+  );
   if (Array.isArray(result.topNews) && result.topNews.length > topNewsCount) {
     throw new Error(
       `Expected at most ${topNewsCount} topNews items, got ${result.topNews.length}`,


### PR DESCRIPTION
## Summary

OpenAI was rejecting our structured-output schema before generation ran: citation `url` used a **URI format** the Responses API does not allow, and **strict JSON Schema** expects every property—including **`label`**—to sit in `required`. This aligns the Zod-derived schema with those rules and scrubs **blob**, **data**, **localhost**, and **relative** markdown targets out of scraped source bodies so the model mostly sees real article URLs.

## Related issues

Closes #378

## Important changes

- Citation `label` is a required string in the API payload (use `""` when empty) with a transform so downstream code still treats an empty label as absent; `parseNewsletterJson` back-fills missing `label` keys for older JSON.
- Citation `url` stays on strict http(s) checks without emitting `format: "uri"`.
- `truncateSources` runs `sanitizeSourceContentMarkdownUrls` on each source `content` before per-source and total caps.

## Other changes

- Tests for sanitization rules, truncation wiring, and parsing citations that omit `label`.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts` — strict-mode-safe citation schema and legacy normalization.
- `apps/mediapulse/agents/content-generation/src/lib/sanitize-source-content-markdown-urls.ts` — what we strip or downgrade to plain text.
- `apps/mediapulse/agents/content-generation/src/lib/truncate-sources.ts` — hook point before the LLM.

## How to test

1. `cd apps/mediapulse/agents/content-generation && pnpm test`
2. From repo root: `pnpm format:check`
3. Run content-generation against OpenAI with the same model; confirm the call is not rejected with `invalid_json_schema` on `text.format.schema` for citations or `label`.
