### PR TITLE
Skip redundant runner builds before Fly deploy

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/data-collection/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/data-collection/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -95,7 +95,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/content-generation/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/content-generation/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -108,7 +108,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/article-analysis/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/article-analysis/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -121,7 +121,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/query-analysis/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/query-analysis/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/delivery/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/delivery/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -147,7 +147,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/ticker-echo/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/ticker-echo/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agents/user-registration/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/user-registration/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-env:
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-
 jobs:
   db-ready:
     runs-on: ubuntu-latest
@@ -80,28 +76,8 @@ jobs:
   data-collection:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/data-collection
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -113,28 +89,8 @@ jobs:
   content-generation:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/content-generation
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -146,28 +102,8 @@ jobs:
   article-analysis:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/article-analysis
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -179,28 +115,8 @@ jobs:
   query-analysis:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/query-analysis
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -212,28 +128,8 @@ jobs:
   delivery:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/delivery
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -245,28 +141,8 @@ jobs:
   ticker-echo:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/ticker-echo
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -278,28 +154,8 @@ jobs:
   user-registration:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-
-      - name: Build
-        run: pnpm exec turbo build --filter=@mediapulse/user-registration-agent
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/hermes/agent-auth-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/hermes/agent-auth-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -95,7 +95,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/agent-data-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agent-data-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -108,7 +108,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/domain-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/domain-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -121,7 +121,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/hermes/agent-registry-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/hermes/agent-registry-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/mediapulse/user-registration/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/user-registration/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -147,7 +147,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/hermes/dashboard/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/hermes/dashboard/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only -c apps/hermes/worker/fly.toml
+        run: flyctl deploy --remote-only --depot=false -c apps/hermes/worker/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-env:
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-
 jobs:
   db-ready:
     runs-on: ubuntu-latest
@@ -80,30 +76,8 @@ jobs:
   agent-auth-api:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
-
-      - name: Build
-        run: pnpm build --filter=@hermes/agent-auth-api
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -115,30 +89,8 @@ jobs:
   agent-data-api:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
-
-      - name: Build
-        run: pnpm build --filter=@mediapulse/agent-data-api
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -150,30 +102,8 @@ jobs:
   domain-api:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
-
-      - name: Build
-        run: pnpm build --filter=@mediapulse/domain-api
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -185,30 +115,8 @@ jobs:
   agent-registry-api:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
-
-      - name: Build
-        run: pnpm build --filter=@hermes/agent-registry-api
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -220,27 +128,8 @@ jobs:
   user-registration:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -252,27 +141,8 @@ jobs:
   hermes:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
@@ -284,27 +154,8 @@ jobs:
   hermes-worker:
     runs-on: ubuntu-latest
     needs: db-migrate
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
     steps:
       - uses: actions/checkout@v6
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up build environment
-        run: |
-          ./dev-bootstrap.sh
-          pnpm install
-          pnpm --filter=@hermes/orchestration-database run db:generate && pnpm --filter=@mediapulse/database run db:generate
-          pnpm generate
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
 

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -138,7 +138,7 @@ jobs:
   code-quality:
     runs-on: ubuntu-latest
     name: Code quality check
-    needs: changes
+    needs: [changes, build]
     if: needs.changes.outputs.run_heavy_jobs == 'true'
 
     services:

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -24,6 +24,8 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 
 Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before Fly deploys). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
 
+Each **Fly** deploy step uses **`flyctl deploy --remote-only`**: the image is built on Fly’s builders from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). GitHub Actions does **not** duplicate that build on the runner. Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+
 ---
 
 ## Hermes
@@ -194,10 +196,10 @@ Public-facing newsletter signup UI. The current implementation serves ticker cho
 
 Examples: **`@mediapulse/data-collection`**, **`@mediapulse/content-generation`**, **`@mediapulse/article-analysis`**, **`@mediapulse/delivery`**, **`@mediapulse/ticker-echo`** under `apps/mediapulse/agents/*`. Merge **`packages/mediapulse/env/env.example`** with the matching **`packages/mediapulse/env/env.agents.*.example`**. Each agent may ship **`Dockerfile`** and **`fly.toml`**; merges to **`main`** trigger **`Agent Deployment`** (`.github/workflows/agent-deploy.yml`) for the configured apps.
 
-| Step                 | Command                                                                                                                       |
-| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| Install dependencies | `pnpm install --frozen-lockfile`                                                                                              |
-| Build                | `pnpm exec turbo build --filter=@mediapulse/data-collection` (swap package name per agent)                                    |
+| Step                 | Command                                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Install dependencies | `pnpm install --frozen-lockfile`                                                                                                      |
+| Build                | `pnpm exec turbo build --filter=@mediapulse/data-collection` (swap package name per agent)                                            |
 | Run (production)     | From the agent app directory: `bun run ./dist/server.js` (set `PORT` per agent; defaults e.g. `4001`, `4002`, `4003`, `4010`, `4011`) |
 
 | Variable                     | Example value                        | Explanation                                                                                                              |

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -24,7 +24,7 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 
 Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before Fly deploys). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
 
-Each **Fly** deploy step uses **`flyctl deploy --remote-only`**: the image is built on Fly’s builders from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). GitHub Actions does **not** duplicate that build on the runner. Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+Each **Fly** deploy step uses **`flyctl deploy --remote-only --depot=false`**: the image is built on Fly’s builders (not third-party Depot) from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). GitHub Actions does **not** duplicate that build on the runner. Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
 ---
 


### PR DESCRIPTION
## Summary

Deploy workflows were compiling every app twice: once on the GitHub runner, then again inside Fly’s Dockerfile. **`flyctl deploy --remote-only`** already ships the repo and builds there, so the runner **`pnpm build`** steps only added time. This trims each Fly job down to checkout + **`flyctl`**, keeps **`db-migrate`** exactly as before, and runs **`code-quality`** after **`build`** so Turbo cache can warm the second job instead of two parallel cold builds.

## Related issues

Closes #382

## Important changes

- **`app-deploy.yml`** / **`agent-deploy.yml`**: **`db-ready`** and **`db-migrate`** unchanged; all Fly deploy jobs drop install/generate/build; removed unused **`TURBO_TEAM`** / **`TURBO_TOKEN`** from those workflows.
- **`code-quality.yml`**: **`code-quality`** now **`needs: [changes, build]`** when heavy jobs run.

## Other changes

- **`dev-docs/docs/guide/production.mdx`**: short note that Fly remote builds the image and migrations still run in CI first.

## Key files to review

- `.github/workflows/app-deploy.yml` — **`db-migrate`** still gates Fly jobs; verify each service still **`needs: db-migrate`**.
- `.github/workflows/agent-deploy.yml` — same pattern for agents.
- `.github/workflows/code-quality.yml` — job graph change.

## How to test

1. Inspect workflow YAML in GitHub’s UI (or `actionlint` if you use it locally).
2. After merge, watch one **`main`** deploy: Fly logs should still show **`turbo build`** for the app; the GitHub job should not run **`pnpm build`** before **`flyctl deploy`**.
3. Confirm **`db-migrate`** steps still appear and succeed before deploy jobs in the Actions run.
