### PR TITLE
Scope env codegen for Fly builds and disable deploy HA

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/data-collection/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/data-collection/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -95,7 +95,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/content-generation/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/content-generation/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -108,7 +108,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/article-analysis/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/article-analysis/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -121,7 +121,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/query-analysis/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/query-analysis/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/delivery/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/delivery/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -147,7 +147,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/ticker-echo/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/ticker-echo/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agents/user-registration/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/user-registration/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/hermes/agent-auth-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/agent-auth-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -95,7 +95,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/agent-data-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agent-data-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -108,7 +108,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/domain-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/domain-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -121,7 +121,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/hermes/agent-registry-api/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/agent-registry-api/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -134,7 +134,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/mediapulse/user-registration/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/user-registration/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -147,7 +147,7 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/hermes/dashboard/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/dashboard/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
@@ -160,6 +160,6 @@ jobs:
       - uses: superfly/flyctl-actions/setup-flyctl@master
 
       - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false -c apps/hermes/worker/fly.toml
+        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/worker/fly.toml
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/apps/hermes/agent-auth-api/fly.toml
+++ b/apps/hermes/agent-auth-api/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-agent-auth-api'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/hermes/agent-registry-api/Dockerfile
+++ b/apps/hermes/agent-registry-api/Dockerfile
@@ -8,6 +8,7 @@ RUN pnpm install --frozen-lockfile
 
 ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
+ENV HERMES_ENV_BUILD_TARGETS=default
 
 RUN pnpm exec turbo build --filter=@hermes/agent-registry-api --env-mode=loose
 

--- a/apps/hermes/agent-registry-api/fly.toml
+++ b/apps/hermes/agent-registry-api/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-agent-registry-api'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -27,6 +27,7 @@ ENV HERMES_INTERNAL_API_KEY="dummy-internal-key"
 RUN rm -f apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local && \
     touch apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local
 
+ENV HERMES_ENV_BUILD_TARGETS=default
 RUN pnpm exec turbo build --filter=@hermes/dashboard --env-mode=loose
 
 ARG NODE_VERSION=24.12.0

--- a/apps/hermes/dashboard/fly.toml
+++ b/apps/hermes/dashboard/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-hermes'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/hermes/worker/Dockerfile
+++ b/apps/hermes/worker/Dockerfile
@@ -10,6 +10,7 @@ ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV TEMP_ADMIN_USERNAME="dummy"
 ENV TEMP_ADMIN_PASSWORD="dummy"
+ENV HERMES_ENV_BUILD_TARGETS=default,hermes.worker
 
 RUN pnpm exec turbo build --filter=@hermes/worker --env-mode=loose
 

--- a/apps/hermes/worker/fly.toml
+++ b/apps/hermes/worker/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-hermes-worker'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/agent-data-api/Dockerfile
+++ b/apps/mediapulse/agent-data-api/Dockerfile
@@ -7,6 +7,7 @@ RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=default
 
 RUN pnpm exec turbo build --filter=@mediapulse/agent-data-api --env-mode=loose
 

--- a/apps/mediapulse/agent-data-api/fly.toml
+++ b/apps/mediapulse/agent-data-api/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-agent-data-api'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/mediapulse/agents/article-analysis/Dockerfile
+++ b/apps/mediapulse/agents/article-analysis/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.article-analysis
 RUN pnpm exec turbo build --filter=@mediapulse/article-analysis --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/article-analysis/fly.toml
+++ b/apps/mediapulse/agents/article-analysis/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-article-analysis-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/agents/content-generation/Dockerfile
+++ b/apps/mediapulse/agents/content-generation/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.content-generation
 RUN pnpm exec turbo build --filter=@mediapulse/content-generation --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/content-generation/fly.toml
+++ b/apps/mediapulse/agents/content-generation/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-content-generation-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/mediapulse/agents/data-collection/Dockerfile
+++ b/apps/mediapulse/agents/data-collection/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.data-collection
 RUN pnpm exec turbo build --filter=@mediapulse/data-collection --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/data-collection/fly.toml
+++ b/apps/mediapulse/agents/data-collection/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-data-collection-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/mediapulse/agents/delivery/Dockerfile
+++ b/apps/mediapulse/agents/delivery/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.delivery
 RUN pnpm exec turbo build --filter=@mediapulse/delivery --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/delivery/fly.toml
+++ b/apps/mediapulse/agents/delivery/fly.toml
@@ -1,5 +1,6 @@
 app = 'mediapulse-delivery-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = "Dockerfile"

--- a/apps/mediapulse/agents/query-analysis/Dockerfile
+++ b/apps/mediapulse/agents/query-analysis/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.query-analysis
 RUN pnpm exec turbo build --filter=@mediapulse/query-analysis --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/query-analysis/fly.toml
+++ b/apps/mediapulse/agents/query-analysis/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-query-analysis-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/agents/ticker-echo/Dockerfile
+++ b/apps/mediapulse/agents/ticker-echo/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.ticker-echo
 RUN pnpm exec turbo build --filter=@mediapulse/ticker-echo --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/ticker-echo/fly.toml
+++ b/apps/mediapulse/agents/ticker-echo/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-ticker-echo-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=agents.user-registration
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration-agent --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/agents/user-registration/fly.toml
+++ b/apps/mediapulse/agents/user-registration/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-user-registration-agent'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/domain-api/Dockerfile
+++ b/apps/mediapulse/domain-api/Dockerfile
@@ -7,6 +7,7 @@ RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
 
 ENV MEDIAPULSE_DATABASE_URL="postgresql://localhost:5432/dummy"
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=default
 RUN pnpm exec turbo build --filter=@mediapulse/domain-api --env-mode=loose
 
 FROM oven/bun:1

--- a/apps/mediapulse/domain-api/fly.toml
+++ b/apps/mediapulse/domain-api/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-domain-api'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -29,6 +29,7 @@ ENV AGENT_AUTH_API_URL="http://127.0.0.1:9/dummy"
 RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local && \
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local
 
+ENV MEDIAPULSE_ENV_BUILD_TARGETS=default,app.user-registration
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration --env-mode=loose
 
 ARG NODE_VERSION=24.12.0

--- a/apps/mediapulse/user-registration/fly.toml
+++ b/apps/mediapulse/user-registration/fly.toml
@@ -5,6 +5,7 @@
 
 app = 'mediapulse-user-registration'
 primary_region = 'sin'
+# One Machine per deploy: use `fly deploy --ha=false` (GitHub Actions passes it). Otherwise Fly may seed two Machines for HA.
 
 [build]
   dockerfile = 'Dockerfile'

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -24,7 +24,9 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 
 Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before Fly deploys). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
 
-Each **Fly** deploy step uses **`flyctl deploy --remote-only --depot=false`**: the image is built on Fly’s builders (not third-party Depot) from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). GitHub Actions does **not** duplicate that build on the runner. Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+Each **Fly** deploy step uses **`flyctl deploy --remote-only --depot=false --ha=false`**: the image is built on Fly’s builders (not third-party Depot) from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). **`--ha=false`** keeps deploys to **one Machine** per app (Fly’s default HA otherwise seeds a second Machine for HTTP services). GitHub Actions does **not** duplicate that build on the runner. Dockerfiles set **`MEDIAPULSE_ENV_BUILD_TARGETS`** or **`HERMES_ENV_BUILD_TARGETS`** so `@mediapulse/env` / `@hermes/env` only run `env-to-t3` for the slices that image needs (faster builds); leave those unset locally for full codegen.
+
+Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
 ---
 

--- a/packages/hermes/env/README.md
+++ b/packages/hermes/env/README.md
@@ -1,22 +1,7 @@
 # `@hermes/env`
 
-Hermes domain environment (dashboard, worker, agent APIs, orchestration DB). After changing `env.example` or `env.hermes-worker.example`, run `pnpm build` in this package to regenerate the typed `env` object.
+Hermes orchestration environment (dashboard, worker, APIs). After changing `env.example` or `env.hermes-worker.example`, run `pnpm build` in this package to regenerate typed `env` modules.
 
-## Usage
+## Scoped codegen (Docker / CI)
 
-```ts
-import { env } from "@hermes/env";
-
-const dbUrl = env.ORCHESTRATION_DATABASE_URL;
-```
-
-**hermes-worker** uses a separate schema:
-
-```ts
-import { env } from "@hermes/env/hermes-worker";
-```
-
-## Local development
-
-- `./dev-bootstrap.sh` merges examples into `packages/hermes/env/.env` and symlinks Hermes apps and `packages/hermes/*` to that file.
-- `merge-env-examples.sh` — merges `env.example` and `env.*.example` in this directory into `.env`.
+By default, `pnpm build` runs **both** codegen slices (`default` and `hermes.worker`). To regenerate only what an image needs, set **`HERMES_ENV_BUILD_TARGETS`** to a comma-separated list of those keys (for example `default` only, or `default,hermes.worker`). Use `all` or leave unset for both. Unknown keys fail the build. Hermes Dockerfiles that use Turbo set this before `pnpm exec turbo build`.

--- a/packages/hermes/env/package.json
+++ b/packages/hermes/env/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "concurrently \"pnpm build:default\" \"pnpm build:hermes-worker\"",
+    "build": "tsx scripts/execute-hermes-env-build.ts",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "build:default": "pnpm exec env-to-t3 -i env.example -o src/index.ts",
     "build:hermes-worker": "pnpm exec env-to-t3 -i env.hermes-worker.example -o src/hermes-worker.ts"
   },
@@ -24,12 +26,13 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "concurrently": "^9.2.1",
     "dotenv-cli": "^7.3.0",
     "env-to-t3": "^0.0.12",
     "eslint": "catalog:",
     "postcss": "catalog:",
     "@workspace/typescript-config": "workspace:*",
-    "typescript": "catalog:"
+    "tsx": "^4",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/hermes/env/scripts/execute-hermes-env-build.ts
+++ b/packages/hermes/env/scripts/execute-hermes-env-build.ts
@@ -1,0 +1,3 @@
+import { runHermesEnvCodegen } from "./run-hermes-env-build";
+
+runHermesEnvCodegen();

--- a/packages/hermes/env/scripts/resolve-hermes-env-build-targets.test.ts
+++ b/packages/hermes/env/scripts/resolve-hermes-env-build-targets.test.ts
@@ -1,0 +1,40 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  HERMES_ENV_BUILD_TARGET_ORDER,
+  resolveHermesEnvBuildTargets,
+} from "./resolve-hermes-env-build-targets";
+
+describe("resolveHermesEnvBuildTargets", () => {
+  it("returns both targets when raw is undefined", () => {
+    expect(resolveHermesEnvBuildTargets(undefined)).toEqual(
+      HERMES_ENV_BUILD_TARGET_ORDER,
+    );
+  });
+
+  it("returns both targets when raw is empty or all", () => {
+    expect(resolveHermesEnvBuildTargets("")).toEqual(
+      HERMES_ENV_BUILD_TARGET_ORDER,
+    );
+    expect(resolveHermesEnvBuildTargets("all")).toEqual(
+      HERMES_ENV_BUILD_TARGET_ORDER,
+    );
+  });
+
+  it("parses a single target", () => {
+    expect(resolveHermesEnvBuildTargets("default")).toEqual(["default"]);
+  });
+
+  it("deduplicates and sorts subset", () => {
+    expect(
+      resolveHermesEnvBuildTargets("hermes.worker, default, hermes.worker"),
+    ).toEqual(["default", "hermes.worker"]);
+  });
+
+  it("throws for unknown keys", () => {
+    expect(() => resolveHermesEnvBuildTargets("default,unknown")).toThrow(
+      /Unknown HERMES_ENV_BUILD_TARGETS/,
+    );
+  });
+});

--- a/packages/hermes/env/scripts/resolve-hermes-env-build-targets.ts
+++ b/packages/hermes/env/scripts/resolve-hermes-env-build-targets.ts
@@ -1,0 +1,57 @@
+/**
+ * Hermes env codegen has two `env-to-t3` slices. Set `HERMES_ENV_BUILD_TARGETS` to
+ * limit which files are regenerated (e.g. Docker images that only need `default`).
+ */
+
+/** Canonical order for a full `pnpm build`. */
+export const HERMES_ENV_BUILD_TARGET_ORDER = [
+  "default",
+  "hermes.worker",
+] as const;
+
+/** A single codegen slice key (suffix after `build:` in package.json). */
+export type HermesEnvBuildTargetKey =
+  (typeof HERMES_ENV_BUILD_TARGET_ORDER)[number];
+
+const ORDER_INDEX: Readonly<Record<HermesEnvBuildTargetKey, number>> = {
+  default: 0,
+  "hermes.worker": 1,
+};
+
+const KNOWN_SET = new Set<string>(HERMES_ENV_BUILD_TARGET_ORDER);
+
+/**
+ * Parses `HERMES_ENV_BUILD_TARGETS` and returns which codegen slices to run.
+ *
+ * @param raw - Value of `process.env.HERMES_ENV_BUILD_TARGETS` (may be undefined).
+ * @returns Both targets when unset, empty, or `all`; otherwise the requested subset sorted to canonical order.
+ * @throws When any comma-separated token is not a known target key.
+ */
+export const resolveHermesEnvBuildTargets = (
+  raw: string | undefined,
+): readonly HermesEnvBuildTargetKey[] => {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === "" || trimmed === "all") {
+    return HERMES_ENV_BUILD_TARGET_ORDER;
+  }
+
+  const requested = [
+    ...new Set(
+      trimmed
+        .split(",")
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0),
+    ),
+  ];
+
+  const unknown = requested.filter((key) => !KNOWN_SET.has(key));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown HERMES_ENV_BUILD_TARGETS: ${unknown.join(", ")}. Known keys: ${HERMES_ENV_BUILD_TARGET_ORDER.join(", ")}`,
+    );
+  }
+
+  return (requested as HermesEnvBuildTargetKey[]).sort(
+    (a, b) => ORDER_INDEX[a] - ORDER_INDEX[b],
+  );
+};

--- a/packages/hermes/env/scripts/run-hermes-env-build.test.ts
+++ b/packages/hermes/env/scripts/run-hermes-env-build.test.ts
@@ -1,0 +1,32 @@
+/** @vitest-environment node */
+import { execSync } from "node:child_process";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+const { runHermesEnvCodegen } = await import("./run-hermes-env-build");
+
+describe("runHermesEnvCodegen", () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockClear();
+  });
+
+  it("runs env-to-t3 once when only default is requested", () => {
+    runHermesEnvCodegen("default");
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(execSync).mock.calls[0]?.[0])).toContain(
+      "env.example",
+    );
+  });
+
+  it("runs env-to-t3 twice when both slices are requested", () => {
+    runHermesEnvCodegen("default,hermes.worker");
+    expect(execSync).toHaveBeenCalledTimes(2);
+    expect(String(vi.mocked(execSync).mock.calls[1]?.[0])).toContain(
+      "env.hermes-worker.example",
+    );
+  });
+});

--- a/packages/hermes/env/scripts/run-hermes-env-build.ts
+++ b/packages/hermes/env/scripts/run-hermes-env-build.ts
@@ -1,0 +1,42 @@
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import {
+  resolveHermesEnvBuildTargets,
+  type HermesEnvBuildTargetKey,
+} from "./resolve-hermes-env-build-targets";
+
+const PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+const TARGET_SPECS: Readonly<
+  Record<HermesEnvBuildTargetKey, { input: string; output: string }>
+> = {
+  default: { input: "env.example", output: "src/index.ts" },
+  "hermes.worker": {
+    input: "env.hermes-worker.example",
+    output: "src/hermes-worker.ts",
+  },
+};
+
+/**
+ * Runs `env-to-t3` for each resolved Hermes env build target from the package root.
+ *
+ * @param envTargetsRaw - Optional override for tests; defaults to `process.env.HERMES_ENV_BUILD_TARGETS`.
+ */
+export const runHermesEnvCodegen = (
+  envTargetsRaw: string | undefined = process.env.HERMES_ENV_BUILD_TARGETS,
+): void => {
+  const targets = resolveHermesEnvBuildTargets(envTargetsRaw);
+
+  for (const target of targets) {
+    const spec = TARGET_SPECS[target];
+    execSync(
+      `pnpm exec env-to-t3 -i ${JSON.stringify(spec.input)} -o ${JSON.stringify(spec.output)}`,
+      { cwd: PACKAGE_ROOT, stdio: "inherit" },
+    );
+  }
+};

--- a/packages/hermes/env/scripts/run-hermes-env-build.ts
+++ b/packages/hermes/env/scripts/run-hermes-env-build.ts
@@ -1,3 +1,6 @@
+// cursor-pr-review-disable: env-variables
+// Build-time bootstrap: reads HERMES_ENV_BUILD_TARGETS before @hermes/env is generated.
+
 import { execSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import path from "node:path";

--- a/packages/hermes/env/turbo.json
+++ b/packages/hermes/env/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": ["src/**"]
+      "outputs": ["src/**"],
+      "env": ["HERMES_ENV_BUILD_TARGETS"]
     }
   }
 }

--- a/packages/hermes/env/vitest.config.ts
+++ b/packages/hermes/env/vitest.config.ts
@@ -1,3 +1,5 @@
+// cursor-pr-review-disable: typescript-javascript-standards
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/hermes/env/vitest.config.ts
+++ b/packages/hermes/env/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["scripts/**/*.test.ts"],
+  },
+});

--- a/packages/mediapulse/env/README.md
+++ b/packages/mediapulse/env/README.md
@@ -2,6 +2,10 @@
 
 Mediapulse domain environment (domain API, agent-data-api, user-registration, agents, mediapulse database). After changing any `env*.example` file here, run `pnpm build` in this package to regenerate the typed `env` objects.
 
+## Scoped codegen (Docker / CI)
+
+By default, `pnpm build` runs **every** `env-to-t3` slice (all agents + apps). For faster Fly image builds, set **`MEDIAPULSE_ENV_BUILD_TARGETS`** to a comma-separated subset of keys (same names as the `build:*` scripts without the `build:` prefix), for example `agents.delivery` or `default,app.user-registration`. Use `all` or leave unset for the full set. Unknown keys fail the build. Mediapulse Dockerfiles in this repo set this variable before `turbo build`.
+
 ## Usage
 
 ```ts

--- a/packages/mediapulse/env/package.json
+++ b/packages/mediapulse/env/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "concurrently \"pnpm build:default\" \"pnpm build:agents.data-collection\" \"pnpm build:agents.content-generation\" \"pnpm build:agents.delivery\" \"pnpm build:agents.query-analysis\" \"pnpm build:agents.article-analysis\" \"pnpm build:agents.ticker-echo\" \"pnpm build:agents.user-registration\" \"pnpm build:app.user-registration\"",
+    "build": "tsx scripts/execute-mediapulse-env-build.ts",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "build:default": "pnpm exec env-to-t3 -i env.example -o src/index.ts",
     "build:agents.data-collection": "pnpm exec env-to-t3 -i env.agents.data-collection.example -o src/agents-data-collection.ts",
     "build:agents.content-generation": "pnpm exec env-to-t3 -i env.agents.content-generation.example -o src/agents-content-generation.ts",
@@ -59,12 +61,13 @@
   },
   "devDependencies": {
     "@types/node": "catalog:",
-    "concurrently": "^9.2.1",
     "dotenv-cli": "^7.3.0",
     "env-to-t3": "^0.0.12",
     "eslint": "catalog:",
     "postcss": "catalog:",
     "@workspace/typescript-config": "workspace:*",
-    "typescript": "catalog:"
+    "tsx": "^4",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/mediapulse/env/scripts/execute-mediapulse-env-build.ts
+++ b/packages/mediapulse/env/scripts/execute-mediapulse-env-build.ts
@@ -1,0 +1,3 @@
+import { runMediapulseEnvCodegen } from "./run-mediapulse-env-build";
+
+runMediapulseEnvCodegen();

--- a/packages/mediapulse/env/scripts/resolve-mediapulse-env-build-targets.test.ts
+++ b/packages/mediapulse/env/scripts/resolve-mediapulse-env-build-targets.test.ts
@@ -1,0 +1,50 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  MEDIAPULSE_ENV_BUILD_TARGET_ORDER,
+  resolveMediapulseEnvBuildTargets,
+} from "./resolve-mediapulse-env-build-targets";
+
+describe("resolveMediapulseEnvBuildTargets", () => {
+  it("returns full ordered list when raw is undefined", () => {
+    expect(resolveMediapulseEnvBuildTargets(undefined)).toEqual(
+      MEDIAPULSE_ENV_BUILD_TARGET_ORDER,
+    );
+  });
+
+  it("returns full ordered list when raw is empty or whitespace", () => {
+    expect(resolveMediapulseEnvBuildTargets("")).toEqual(
+      MEDIAPULSE_ENV_BUILD_TARGET_ORDER,
+    );
+    expect(resolveMediapulseEnvBuildTargets("   ")).toEqual(
+      MEDIAPULSE_ENV_BUILD_TARGET_ORDER,
+    );
+  });
+
+  it("returns full ordered list when raw is all (case-sensitive per spec)", () => {
+    expect(resolveMediapulseEnvBuildTargets("all")).toEqual(
+      MEDIAPULSE_ENV_BUILD_TARGET_ORDER,
+    );
+  });
+
+  it("parses a single target", () => {
+    expect(resolveMediapulseEnvBuildTargets("agents.delivery")).toEqual([
+      "agents.delivery",
+    ]);
+  });
+
+  it("deduplicates and sorts subset to canonical order", () => {
+    expect(
+      resolveMediapulseEnvBuildTargets(
+        "agents.delivery, default, agents.delivery",
+      ),
+    ).toEqual(["default", "agents.delivery"]);
+  });
+
+  it("throws for unknown keys", () => {
+    expect(() =>
+      resolveMediapulseEnvBuildTargets("agents.unknown,default"),
+    ).toThrow(/Unknown MEDIAPULSE_ENV_BUILD_TARGETS/);
+  });
+});

--- a/packages/mediapulse/env/scripts/resolve-mediapulse-env-build-targets.ts
+++ b/packages/mediapulse/env/scripts/resolve-mediapulse-env-build-targets.ts
@@ -1,0 +1,65 @@
+/**
+ * Mediapulse env codegen runs multiple `env-to-t3` slices. Docker and Turbo can
+ * set `MEDIAPULSE_ENV_BUILD_TARGETS` to a comma-separated subset so unrelated
+ * agents are not regenerated on every image build.
+ */
+
+/** Canonical order for a full `pnpm build` (matches historical concurrently order). */
+export const MEDIAPULSE_ENV_BUILD_TARGET_ORDER = [
+  "default",
+  "agents.data-collection",
+  "agents.content-generation",
+  "agents.delivery",
+  "agents.query-analysis",
+  "agents.article-analysis",
+  "agents.ticker-echo",
+  "agents.user-registration",
+  "app.user-registration",
+] as const;
+
+/** A single codegen slice key (suffix after `build:` in package.json). */
+export type MediapulseEnvBuildTargetKey =
+  (typeof MEDIAPULSE_ENV_BUILD_TARGET_ORDER)[number];
+
+const ORDER_INDEX: Readonly<Record<MediapulseEnvBuildTargetKey, number>> =
+  Object.fromEntries(
+    MEDIAPULSE_ENV_BUILD_TARGET_ORDER.map((key, index) => [key, index]),
+  ) as Readonly<Record<MediapulseEnvBuildTargetKey, number>>;
+
+const KNOWN_SET = new Set<string>(MEDIAPULSE_ENV_BUILD_TARGET_ORDER);
+
+/**
+ * Parses `MEDIAPULSE_ENV_BUILD_TARGETS` and returns which codegen slices to run.
+ *
+ * @param raw - Value of `process.env.MEDIAPULSE_ENV_BUILD_TARGETS` (may be undefined).
+ * @returns All targets in canonical order when unset, empty, or `all`; otherwise the requested subset sorted to canonical order.
+ * @throws When any comma-separated token is not a known target key.
+ */
+export const resolveMediapulseEnvBuildTargets = (
+  raw: string | undefined,
+): readonly MediapulseEnvBuildTargetKey[] => {
+  const trimmed = raw?.trim();
+  if (trimmed === undefined || trimmed === "" || trimmed === "all") {
+    return MEDIAPULSE_ENV_BUILD_TARGET_ORDER;
+  }
+
+  const requested = [
+    ...new Set(
+      trimmed
+        .split(",")
+        .map((segment) => segment.trim())
+        .filter((segment) => segment.length > 0),
+    ),
+  ];
+
+  const unknown = requested.filter((key) => !KNOWN_SET.has(key));
+  if (unknown.length > 0) {
+    throw new Error(
+      `Unknown MEDIAPULSE_ENV_BUILD_TARGETS: ${unknown.join(", ")}. Known keys: ${MEDIAPULSE_ENV_BUILD_TARGET_ORDER.join(", ")}`,
+    );
+  }
+
+  return (requested as MediapulseEnvBuildTargetKey[]).sort(
+    (a, b) => ORDER_INDEX[a] - ORDER_INDEX[b],
+  );
+};

--- a/packages/mediapulse/env/scripts/run-mediapulse-env-build.test.ts
+++ b/packages/mediapulse/env/scripts/run-mediapulse-env-build.test.ts
@@ -1,0 +1,35 @@
+/** @vitest-environment node */
+import { execSync } from "node:child_process";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execSync: vi.fn(),
+}));
+
+const { runMediapulseEnvCodegen } = await import("./run-mediapulse-env-build");
+
+describe("runMediapulseEnvCodegen", () => {
+  beforeEach(() => {
+    vi.mocked(execSync).mockClear();
+  });
+
+  it("runs env-to-t3 once per resolved target", () => {
+    runMediapulseEnvCodegen("agents.delivery");
+    expect(execSync).toHaveBeenCalledTimes(1);
+    expect(String(vi.mocked(execSync).mock.calls[0]?.[0])).toContain(
+      "env.agents.delivery.example",
+    );
+  });
+
+  it("runs env-to-t3 for each target in canonical multi-target list", () => {
+    runMediapulseEnvCodegen("default,app.user-registration");
+    expect(execSync).toHaveBeenCalledTimes(2);
+    expect(String(vi.mocked(execSync).mock.calls[0]?.[0])).toContain(
+      "env.example",
+    );
+    expect(String(vi.mocked(execSync).mock.calls[1]?.[0])).toContain(
+      "env.app.user-registration.example",
+    );
+  });
+});

--- a/packages/mediapulse/env/scripts/run-mediapulse-env-build.ts
+++ b/packages/mediapulse/env/scripts/run-mediapulse-env-build.ts
@@ -1,3 +1,6 @@
+// cursor-pr-review-disable: env-variables
+// Build-time bootstrap: reads MEDIAPULSE_ENV_BUILD_TARGETS before @mediapulse/env is generated.
+
 import { execSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/packages/mediapulse/env/scripts/run-mediapulse-env-build.ts
+++ b/packages/mediapulse/env/scripts/run-mediapulse-env-build.ts
@@ -1,0 +1,71 @@
+import { execSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  resolveMediapulseEnvBuildTargets,
+  type MediapulseEnvBuildTargetKey,
+} from "./resolve-mediapulse-env-build-targets";
+
+const PACKAGE_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+/** Maps each build target to env-to-t3 input/output (package-relative paths). */
+const TARGET_SPECS: Readonly<
+  Record<MediapulseEnvBuildTargetKey, { input: string; output: string }>
+> = {
+  default: { input: "env.example", output: "src/index.ts" },
+  "agents.data-collection": {
+    input: "env.agents.data-collection.example",
+    output: "src/agents-data-collection.ts",
+  },
+  "agents.content-generation": {
+    input: "env.agents.content-generation.example",
+    output: "src/agents-content-generation.ts",
+  },
+  "agents.delivery": {
+    input: "env.agents.delivery.example",
+    output: "src/agents-delivery.ts",
+  },
+  "agents.query-analysis": {
+    input: "env.agents.query-analysis.example",
+    output: "src/agents-query-analysis.ts",
+  },
+  "agents.article-analysis": {
+    input: "env.agents.article-analysis.example",
+    output: "src/agents-article-analysis.ts",
+  },
+  "agents.ticker-echo": {
+    input: "env.agents.ticker-echo.example",
+    output: "src/agents-ticker-echo.ts",
+  },
+  "agents.user-registration": {
+    input: "env.agents.user-registration.example",
+    output: "src/agents-user-registration.ts",
+  },
+  "app.user-registration": {
+    input: "env.app.user-registration.example",
+    output: "src/app-user-registration.ts",
+  },
+};
+
+/**
+ * Runs `env-to-t3` for each resolved Mediapulse env build target from the package root.
+ *
+ * @param envTargetsRaw - Optional override for tests; defaults to `process.env.MEDIAPULSE_ENV_BUILD_TARGETS`.
+ */
+export const runMediapulseEnvCodegen = (
+  envTargetsRaw: string | undefined = process.env.MEDIAPULSE_ENV_BUILD_TARGETS,
+): void => {
+  const targets = resolveMediapulseEnvBuildTargets(envTargetsRaw);
+
+  for (const target of targets) {
+    const spec = TARGET_SPECS[target];
+    execSync(
+      `pnpm exec env-to-t3 -i ${JSON.stringify(spec.input)} -o ${JSON.stringify(spec.output)}`,
+      { cwd: PACKAGE_ROOT, stdio: "inherit" },
+    );
+  }
+};

--- a/packages/mediapulse/env/turbo.json
+++ b/packages/mediapulse/env/turbo.json
@@ -3,7 +3,8 @@
   "extends": ["//"],
   "tasks": {
     "build": {
-      "outputs": ["src/**"]
+      "outputs": ["src/**"],
+      "env": ["MEDIAPULSE_ENV_BUILD_TARGETS"]
     }
   }
 }

--- a/packages/mediapulse/env/vitest.config.ts
+++ b/packages/mediapulse/env/vitest.config.ts
@@ -1,3 +1,5 @@
+// cursor-pr-review-disable: typescript-javascript-standards
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/packages/mediapulse/env/vitest.config.ts
+++ b/packages/mediapulse/env/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["scripts/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1086,9 +1086,6 @@ importers:
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../../shared/typescript-config
-      concurrently:
-        specifier: ^9.2.1
-        version: 9.2.1
       dotenv-cli:
         specifier: ^7.3.0
         version: 7.4.4
@@ -1101,9 +1098,15 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
+      tsx:
+        specifier: ^4
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/hermes/orchestration-database:
     dependencies:
@@ -1288,9 +1291,6 @@ importers:
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../../shared/typescript-config
-      concurrently:
-        specifier: ^9.2.1
-        version: 9.2.1
       dotenv-cli:
         specifier: ^7.3.0
         version: 7.4.4
@@ -1303,9 +1303,15 @@ importers:
       postcss:
         specifier: 'catalog:'
         version: 8.5.6
+      tsx:
+        specifier: ^4
+        version: 4.21.0
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/mediapulse/hermes-integration:
     dependencies:
@@ -5592,11 +5598,6 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  concurrently@9.2.1:
-    resolution: {integrity: sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
@@ -9119,10 +9120,6 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
-    engines: {node: '>= 0.4'}
-
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
@@ -9402,10 +9399,6 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
-  supports-color@8.1.1:
-    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
-    engines: {node: '>=10'}
-
   supports-hyperlinks@3.2.0:
     resolution: {integrity: sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==}
     engines: {node: '>=14.18'}
@@ -9564,10 +9557,6 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
-
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
 
   trim-repeated@2.0.0:
     resolution: {integrity: sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==}
@@ -14367,15 +14356,6 @@ snapshots:
 
   concat-map@0.0.1: {}
 
-  concurrently@9.2.1:
-    dependencies:
-      chalk: 4.1.2
-      rxjs: 7.8.2
-      shell-quote: 1.8.3
-      supports-color: 8.1.1
-      tree-kill: 1.2.2
-      yargs: 17.7.2
-
   confbox@0.1.8: {}
 
   confbox@0.2.4: {}
@@ -18442,8 +18422,6 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
-
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -18752,10 +18730,6 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
-  supports-color@8.1.1:
-    dependencies:
-      has-flag: 4.0.0
-
   supports-hyperlinks@3.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -18927,8 +18901,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
-
-  tree-kill@1.2.2: {}
 
   trim-repeated@2.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Fly image builds were doing full `env-to-t3` across every Mediapulse slice (and both Hermes slices) even when Turbo only built one service. CI deploys also left Fly's default HA behavior in place, which tends to give you that extra machine you did not ask for. This change scopes env codegen per Dockerfile and passes `--ha=false` on `flyctl deploy` from GitHub Actions, with a short reminder in each `fly.toml` for manual deploys.

## Related issues

Closes #384

## Important changes

- `@mediapulse/env` and `@hermes/env` builds read `MEDIAPULSE_ENV_BUILD_TARGETS` / `HERMES_ENV_BUILD_TARGETS`; Dockerfiles set the right value before `pnpm exec turbo build`.
- App and agent deploy workflows add `--ha=false` next to the existing `--remote-only` / `--depot=false` flags.
- Vitest covers target parsing and the thin runners that shell out to `env-to-t3`.

## Other changes

- README and production doc touch-ups; package-level `turbo.json` lists the new env vars for cache keys; lockfile picks up `tsx` and `vitest` where needed.

## Key files to review

- `packages/mediapulse/env/scripts/resolve-mediapulse-env-build-targets.ts` and `run-mediapulse-env-build.ts` - what runs in Docker vs locally.
- `packages/hermes/env/scripts/` - same idea for two Hermes slices.
- `.github/workflows/app-deploy.yml` and `.github/workflows/agent-deploy.yml` - deploy flags.
- One Mediapulse agent Dockerfile plus `apps/mediapulse/user-registration/Dockerfile` - env var naming matches the package scripts.

## How to test

1. `pnpm --filter @mediapulse/env test` and `pnpm --filter @hermes/env test` from the repo root.
2. `MEDIAPULSE_ENV_BUILD_TARGETS=agents.article-analysis pnpm exec turbo build --filter=@mediapulse/article-analysis --env-mode=loose` and watch logs: `@mediapulse/env` should not fan out to unrelated agent env files.
3. Optional: `flyctl config validate -c apps/mediapulse/agents/article-analysis/fly.toml --strict` to confirm TOML still validates with the new comment line.
