### PR TITLE
Fix agent-auth-api Docker build with turbo and Prisma generate

### DIFF
--- a/apps/hermes/agent-auth-api/Dockerfile
+++ b/apps/hermes/agent-auth-api/Dockerfile
@@ -5,7 +5,11 @@ COPY . .
 RUN corepack enable && corepack prepare pnpm@latest --activate
 RUN npm install -g bun
 RUN pnpm install --frozen-lockfile
-RUN pnpm --filter @hermes/agent-auth-api build
+
+ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
+ENV HERMES_ENV_BUILD_TARGETS=default
+
+RUN pnpm exec turbo build --filter=@hermes/agent-auth-api --env-mode=loose
 
 FROM oven/bun:1
 WORKDIR /app

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -38,11 +38,11 @@ Deploy in this order: **agent-auth-api → agent-registry-api → dashboard → 
 
 **Package:** `@hermes/agent-auth-api` · **Path:** `apps/hermes/agent-auth-api`
 
-| Step                 | Command                                                                                                                                                        |
-| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Install dependencies | `pnpm install --frozen-lockfile`                                                                                                                               |
-| Build                | `pnpm --filter @hermes/agent-auth-api build`                                                                                                                   |
-| Run (production)     | From app directory: `PORT=8080 bun run ./dist/server.js` (set env vars in the process environment or `.env`). Docker: `apps/hermes/agent-auth-api/Dockerfile`. |
+| Step                 | Command                                                                                                                                                                                                                                                                   |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Install dependencies | `pnpm install --frozen-lockfile`                                                                                                                                                                                                                                          |
+| Build                | From repo root: `pnpm exec turbo build --filter=@hermes/agent-auth-api --env-mode=loose` (runs `db:generate` on `@hermes/orchestration-database` first, same as the Dockerfile). For a local re-bundle only: `pnpm --filter @hermes/agent-auth-api build` after generate. |
+| Run (production)     | From app directory: `PORT=8080 bun run ./dist/server.js` (set env vars in the process environment or `.env`). Docker: `apps/hermes/agent-auth-api/Dockerfile`.                                                                                                            |
 
 | Variable                           | Example value                         | Explanation                                                                                                                 |
 | ---------------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

The agent-auth-api image was calling `pnpm --filter … build`, which only ran Bun. That skipped Prisma codegen for `@hermes/orchestration-database`, so the gitignored `client/` tree never appeared and the bundle died on `../client/client`. The Dockerfile now runs `turbo build` for that app (same pattern as worker/registry/dashboard) with a dummy orchestration URL and scoped Hermes env codegen. The production guide build row matches.

## Related issues

Closes #386

## Important changes

- `apps/hermes/agent-auth-api/Dockerfile` uses `pnpm exec turbo build --filter=@hermes/agent-auth-api` after setting `ORCHESTRATION_DATABASE_URL` and `HERMES_ENV_BUILD_TARGETS=default`.

## Other changes

- `dev-docs/docs/guide/production.mdx`: agent-auth-api build instructions point at the Turbo command from repo root.

## Key files to review

- `apps/hermes/agent-auth-api/Dockerfile` - env vars and turbo line sit with other Hermes Dockerfiles.
- `dev-docs/docs/guide/production.mdx` - table cell for the Build step stays accurate for copy-paste.

## How to test

1. From repo root: `ORCHESTRATION_DATABASE_URL=postgresql://localhost:5432/dummy HERMES_ENV_BUILD_TARGETS=default pnpm exec turbo build --filter=@hermes/agent-auth-api --env-mode=loose` (should pass).
2. Optional: `docker build -f apps/hermes/agent-auth-api/Dockerfile .` from repo root on a machine with Docker; expect the builder stage to finish without the previous `Could not resolve: "../client/client"` error.
