### PR TITLE
Add PR Docker build workflow for changed services

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,129 @@
+name: Docker Build
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  changes:
+    name: Detect changed services
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.detect.outputs.services }}
+      any: ${{ steps.detect.outputs.any }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect which services changed
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+
+          ALL_SERVICES='["user-registration","domain-api","agent-data-api","agent-auth-api","agent-registry-api","hermes","hermes-worker","data-collection","content-generation","delivery","ticker-echo","article-analysis","query-analysis"]'
+
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+
+          if [ -z "$changed_files" ]; then
+            echo "services=[]" >> "$GITHUB_OUTPUT"
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Shared changes mean all images must be rebuilt
+          shared_changed=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              packages/*|pnpm-lock.yaml|pnpm-workspace.yaml|turbo.json)
+                shared_changed=true
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if [ "$shared_changed" = "true" ]; then
+            echo "services=$ALL_SERVICES" >> "$GITHUB_OUTPUT"
+            echo "any=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Collect per-service changes
+          services_list=""
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              apps/mediapulse/user-registration/*)   services_list+=$'user-registration\n' ;;
+              apps/mediapulse/domain-api/*)           services_list+=$'domain-api\n' ;;
+              apps/mediapulse/agent-data-api/*)       services_list+=$'agent-data-api\n' ;;
+              apps/hermes/agent-auth-api/*)           services_list+=$'agent-auth-api\n' ;;
+              apps/hermes/agent-registry-api/*)       services_list+=$'agent-registry-api\n' ;;
+              apps/hermes/dashboard/*)                services_list+=$'hermes\n' ;;
+              apps/hermes/worker/*)                   services_list+=$'hermes-worker\n' ;;
+              apps/mediapulse/agents/data-collection/*)   services_list+=$'data-collection\n' ;;
+              apps/mediapulse/agents/content-generation/*) services_list+=$'content-generation\n' ;;
+              apps/mediapulse/agents/delivery/*)      services_list+=$'delivery\n' ;;
+              apps/mediapulse/agents/ticker-echo/*)   services_list+=$'ticker-echo\n' ;;
+              apps/mediapulse/agents/article-analysis/*)  services_list+=$'article-analysis\n' ;;
+              apps/mediapulse/agents/query-analysis/*)    services_list+=$'query-analysis\n' ;;
+            esac
+          done <<< "$changed_files"
+
+          services_list="$(echo "$services_list" | sort -u | grep -v '^$' || true)"
+
+          if [ -z "$services_list" ]; then
+            echo "services=[]" >> "$GITHUB_OUTPUT"
+            echo "any=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          json="$(echo "$services_list" | jq -R . | jq -sc . | tr -d '\n')"
+          echo "services=$json" >> "$GITHUB_OUTPUT"
+          echo "any=true" >> "$GITHUB_OUTPUT"
+
+  docker-build:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJson(needs.changes.outputs.services) }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve Dockerfile path
+        id: resolve
+        run: |
+          case "${{ matrix.service }}" in
+            user-registration)  echo "dockerfile=apps/mediapulse/user-registration/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            domain-api)         echo "dockerfile=apps/mediapulse/domain-api/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            agent-data-api)     echo "dockerfile=apps/mediapulse/agent-data-api/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            agent-auth-api)     echo "dockerfile=apps/hermes/agent-auth-api/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            agent-registry-api) echo "dockerfile=apps/hermes/agent-registry-api/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            hermes)             echo "dockerfile=apps/hermes/dashboard/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            hermes-worker)      echo "dockerfile=apps/hermes/worker/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            data-collection)    echo "dockerfile=apps/mediapulse/agents/data-collection/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            content-generation) echo "dockerfile=apps/mediapulse/agents/content-generation/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            delivery)           echo "dockerfile=apps/mediapulse/agents/delivery/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            ticker-echo)        echo "dockerfile=apps/mediapulse/agents/ticker-echo/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            article-analysis)   echo "dockerfile=apps/mediapulse/agents/article-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            query-analysis)     echo "dockerfile=apps/mediapulse/agents/query-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ steps.resolve.outputs.dockerfile }}
+          push: false
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -25,6 +25,7 @@ RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registrati
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local
 
 ENV MEDIAPULSE_ENV_BUILD_TARGETS=app.user-registration
+ENV NEXT_PUBLIC_REGISTRATION_EMAIL="registration@mediapulse.example"
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration --env-mode=loose
 
 ARG NODE_VERSION=24.12.0


### PR DESCRIPTION
## Summary

Add a pull-request Docker build check that catches image-level breakages before merge. The workflow detects which services changed and builds only those Dockerfiles, while still rebuilding all images when shared monorepo files changed.

This PR also fixes the current `@mediapulse/user-registration` image build failure by setting a build-time placeholder for `NEXT_PUBLIC_REGISTRATION_EMAIL`.

## Related issues

Closes #390

## Important changes

- Add `.github/workflows/docker-build.yml` for PR-time image builds on `main` PRs.
- Detect changed services from `git diff` and drive a matrix build for the matching Dockerfiles.
- Rebuild all service images when shared files change (`packages/*`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, `turbo.json`).
- Add `NEXT_PUBLIC_REGISTRATION_EMAIL="registration@mediapulse.example"` in `apps/mediapulse/user-registration/Dockerfile` before Turbo build.

## Other changes

- Enable Buildx GitHub Actions cache per service (`cache-from` / `cache-to`) to reduce repeat PR build time.

## Key files to review

- `.github/workflows/docker-build.yml` - PR workflow, change detection, service-to-Dockerfile mapping, matrix build.
- `apps/mediapulse/user-registration/Dockerfile` - build-time env var required for static prerender in image build.

## How to test

1. Open a PR that changes one service Docker context (for example `apps/mediapulse/user-registration/*`) and verify only that matrix entry runs.
2. Open a PR that changes shared files (for example `pnpm-lock.yaml` or `packages/*`) and verify all services are built.
3. Confirm `user-registration` image build passes and no longer errors on missing `NEXT_PUBLIC_REGISTRATION_EMAIL`.
