### PR TITLE
Move newsletter citation linking to deterministic post-processing

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/index.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.test.ts
@@ -121,20 +121,17 @@ describe("formatNewsletterContent", () => {
 
 describe("parseNewsletterJson", () => {
   it("parses valid newsletter JSON", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Markets up.",
-      topNews: [
-        {
-          title: "Headline",
-          summaryWithLinks: "Summary [S](https://example.com/s).",
-          citations: [{ url: "https://example.com/s" }],
-        },
-      ],
+      topNews: [{ title: "Headline", summary: "Markets posted gains today." }],
     });
 
+    // Act
     const result = parseNewsletterJson(raw);
 
+    // Assert
     expect(result.subject).toBe("Daily Brief");
     expect(result.executiveSummary).toBe("Markets up.");
     expect(result.topNews).toHaveLength(1);
@@ -142,128 +139,91 @@ describe("parseNewsletterJson", () => {
   });
 
   it("throws when JSON is malformed", () => {
+    // Act & Assert
     expect(() => parseNewsletterJson("not valid json")).toThrow(
       "OpenAI returned invalid JSON",
     );
   });
 
   it("throws when topNews item has invalid shape", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "x",
       executiveSummary: "y",
-      topNews: [{ title: 123, summaryWithLinks: "ok", citations: [] }],
+      topNews: [{ title: 123 }],
     });
 
+    // Act & Assert
     expect(() => parseNewsletterJson(raw)).toThrow();
   });
 
   it("accepts topNews with exactly topNewsCount items", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        {
-          title: "A",
-          summaryWithLinks: "a [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-        {
-          title: "B",
-          summaryWithLinks: "b [B](https://example.com/b)",
-          citations: [{ url: "https://example.com/b" }],
-        },
-        {
-          title: "C",
-          summaryWithLinks: "c [C](https://example.com/c)",
-          citations: [{ url: "https://example.com/c" }],
-        },
+        { title: "A", summary: "Summary A." },
+        { title: "B", summary: "Summary B." },
+        { title: "C", summary: "Summary C." },
       ],
     });
 
+    // Act
     const result = parseNewsletterJson(raw, 3);
 
+    // Assert
     expect(result.topNews).toHaveLength(3);
   });
 
   it("accepts topNews with fewer than topNewsCount items", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
-      topNews: [
-        {
-          title: "A",
-          summaryWithLinks: "a [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-      ],
+      topNews: [{ title: "A", summary: "Summary A." }],
     });
 
+    // Act
     const result = parseNewsletterJson(raw, 5);
 
+    // Assert
     expect(result.topNews).toHaveLength(1);
   });
 
   it("rejects topNews exceeding topNewsCount", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        {
-          title: "A",
-          summaryWithLinks: "a [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-        {
-          title: "B",
-          summaryWithLinks: "b [B](https://example.com/b)",
-          citations: [{ url: "https://example.com/b" }],
-        },
-        {
-          title: "C",
-          summaryWithLinks: "c [C](https://example.com/c)",
-          citations: [{ url: "https://example.com/c" }],
-        },
-        {
-          title: "D",
-          summaryWithLinks: "d [D](https://example.com/d)",
-          citations: [{ url: "https://example.com/d" }],
-        },
+        { title: "A", summary: "Summary A." },
+        { title: "B", summary: "Summary B." },
+        { title: "C", summary: "Summary C." },
+        { title: "D", summary: "Summary D." },
       ],
     });
 
+    // Act & Assert
     expect(() => parseNewsletterJson(raw, 3)).toThrow(
       "Expected at most 3 topNews items, got 4",
     );
   });
 
   it("defaults topNewsCount to 3 when not specified", () => {
+    // Setup
     const raw = JSON.stringify({
       subject: "Daily Brief",
       executiveSummary: "Market summary.",
       topNews: [
-        {
-          title: "A",
-          summaryWithLinks: "a [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-        {
-          title: "B",
-          summaryWithLinks: "b [B](https://example.com/b)",
-          citations: [{ url: "https://example.com/b" }],
-        },
-        {
-          title: "C",
-          summaryWithLinks: "c [C](https://example.com/c)",
-          citations: [{ url: "https://example.com/c" }],
-        },
-        {
-          title: "D",
-          summaryWithLinks: "d [D](https://example.com/d)",
-          citations: [{ url: "https://example.com/d" }],
-        },
+        { title: "A", summary: "Summary A." },
+        { title: "B", summary: "Summary B." },
+        { title: "C", summary: "Summary C." },
+        { title: "D", summary: "Summary D." },
       ],
     });
 
+    // Act & Assert
     expect(() => parseNewsletterJson(raw)).toThrow(
       "Expected at most 3 topNews items, got 4",
     );

--- a/apps/mediapulse/agents/content-generation/src/lib/generate-content.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/generate-content.test.ts
@@ -18,13 +18,7 @@ const makeSource = (title: string, content: string): SourceForGeneration => ({
   content,
 });
 
-const makeOpenAIMock = (
-  topNews: Array<{
-    title: string;
-    summaryWithLinks: string;
-    citations: Array<{ url: string; label?: string }>;
-  }>,
-) => {
+const makeOpenAIMock = (topNews: Array<{ title: string; summary: string }>) => {
   const mockCreate = vi.fn().mockResolvedValue({
     choices: [
       {
@@ -48,36 +42,18 @@ const makeOpenAIMock = (
 
 describe("generateContentWithOpenAI", () => {
   it("topNewsCount=5 interpolates count into system and user prompts and slices topNews to 5", async () => {
+    // Setup
     const topNewsItems = [
-      {
-        title: "Story 1",
-        summaryWithLinks: "Summary 1 [A](https://example.com/source-a).",
-        citations: [{ url: "https://example.com/source-a" }],
-      },
-      {
-        title: "Story 2",
-        summaryWithLinks: "Summary 2 [A](https://example.com/source-a).",
-        citations: [{ url: "https://example.com/source-a" }],
-      },
-      {
-        title: "Story 3",
-        summaryWithLinks: "Summary 3 [A](https://example.com/source-a).",
-        citations: [{ url: "https://example.com/source-a" }],
-      },
-      {
-        title: "Story 4",
-        summaryWithLinks: "Summary 4 [A](https://example.com/source-a).",
-        citations: [{ url: "https://example.com/source-a" }],
-      },
-      {
-        title: "Story 5",
-        summaryWithLinks: "Summary 5 [A](https://example.com/source-a).",
-        citations: [{ url: "https://example.com/source-a" }],
-      },
+      { title: "Story 1", summary: "Summary 1." },
+      { title: "Story 2", summary: "Summary 2." },
+      { title: "Story 3", summary: "Summary 3." },
+      { title: "Story 4", summary: "Summary 4." },
+      { title: "Story 5", summary: "Summary 5." },
     ];
     const { openai, mockCreate } = makeOpenAIMock(topNewsItems);
     const sources = [makeSource("Source A", "Content about markets.")];
 
+    // Act
     const result = await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -86,6 +62,7 @@ describe("generateContentWithOpenAI", () => {
       maxTotalContextChars: 100000,
     });
 
+    // Assert
     const { messages } = mockCreate.mock.calls[0]![0] as {
       messages: Array<{ role: string; content: string }>;
     };
@@ -105,21 +82,14 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("slice(0, topNewsCount) clips the topNews list to the configured count", async () => {
-    // LLM returns exactly topNewsCount=2 items — slice keeps both intact.
+    // Setup — LLM returns exactly topNewsCount=2 items — slice keeps both intact.
     const { openai } = makeOpenAIMock([
-      {
-        title: "Item 1",
-        summaryWithLinks: "A [S](https://example.com/s).",
-        citations: [{ url: "https://example.com/s" }],
-      },
-      {
-        title: "Item 2",
-        summaryWithLinks: "B [S](https://example.com/s).",
-        citations: [{ url: "https://example.com/s" }],
-      },
+      { title: "Item 1", summary: "Summary A." },
+      { title: "Item 2", summary: "Summary B." },
     ]);
     const sources = [makeSource("S", "content")];
 
+    // Act
     const result = await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -128,6 +98,7 @@ describe("generateContentWithOpenAI", () => {
       maxTotalContextChars: 100000,
     });
 
+    // Assert
     expect(result.content).toContain("TOP 2 NEWS");
     expect(result.content).toContain("1. Item 1");
     expect(result.content).toContain("2. Item 2");
@@ -135,15 +106,13 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("uses default system prompt and user prompt template when none provided", async () => {
+    // Setup
     const { openai, mockCreate } = makeOpenAIMock([
-      {
-        title: "A",
-        summaryWithLinks: "a [T](https://example.com/t).",
-        citations: [{ url: "https://example.com/t" }],
-      },
+      { title: "A", summary: "A summary." },
     ]);
     const sources = [makeSource("T", "Source body text.")];
 
+    // Act
     await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -152,6 +121,7 @@ describe("generateContentWithOpenAI", () => {
       maxTotalContextChars: 100000,
     });
 
+    // Assert
     const { messages } = mockCreate.mock.calls[0]![0] as {
       messages: Array<{ role: string; content: string }>;
     };
@@ -160,22 +130,20 @@ describe("generateContentWithOpenAI", () => {
 
     // default system prompt with 3 substituted
     expect(systemMsg).toContain("exactly 3 items");
-    // default user prompt with 3 substituted and source content interpolated
-    expect(userMsg).toContain("top 3 news items");
-    expect(userMsg).toContain("inline markdown links");
+    // default user prompt references numbered articles and source content
+    expect(userMsg).toContain("3 articles");
+    expect(userMsg).toContain("Article 1:");
     expect(userMsg).toContain("Source body text.");
   });
 
   it("uses custom systemPrompt from config when provided", async () => {
+    // Setup
     const { openai, mockCreate } = makeOpenAIMock([
-      {
-        title: "A",
-        summaryWithLinks: "a [T](https://example.com/t).",
-        citations: [{ url: "https://example.com/t" }],
-      },
+      { title: "A", summary: "A summary." },
     ]);
     const sources = [makeSource("T", "content")];
 
+    // Act
     await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -185,6 +153,7 @@ describe("generateContentWithOpenAI", () => {
       systemPrompt: "Custom system: give me {{topNewsCount}} items.",
     });
 
+    // Assert
     const { messages } = mockCreate.mock.calls[0]![0] as {
       messages: Array<{ role: string; content: string }>;
     };
@@ -192,15 +161,13 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("substitutes {{tickerId}} and {{date}} in custom prompt templates", async () => {
+    // Setup
     const { openai, mockCreate } = makeOpenAIMock([
-      {
-        title: "A",
-        summaryWithLinks: "a [T](https://example.com/t).",
-        citations: [{ url: "https://example.com/t" }],
-      },
+      { title: "A", summary: "A summary." },
     ]);
     const sources = [makeSource("T", "content")];
 
+    // Act
     await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -213,6 +180,7 @@ describe("generateContentWithOpenAI", () => {
       date: "2026-04-16",
     });
 
+    // Assert
     const { messages } = mockCreate.mock.calls[0]![0] as {
       messages: Array<{ role: string; content: string }>;
     };
@@ -226,15 +194,11 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("returns subject, content, and description from the validated response", async () => {
-    const { openai } = makeOpenAIMock([
-      {
-        title: "A",
-        summaryWithLinks: "a [T](https://example.com/t).",
-        citations: [{ url: "https://example.com/t" }],
-      },
-    ]);
+    // Setup
+    const { openai } = makeOpenAIMock([{ title: "A", summary: "A summary." }]);
     const sources = [makeSource("T", "content")];
 
+    // Act
     const result = await generateContentWithOpenAI(sources, {
       openai,
       model: "gpt-4o-mini",
@@ -243,12 +207,14 @@ describe("generateContentWithOpenAI", () => {
       maxTotalContextChars: 100000,
     });
 
+    // Assert
     expect(result.subject).toBe("Daily Brief");
     expect(result.content).toContain("EXECUTIVE SUMMARY");
     expect(result.description).toBe("Markets moved on key macro data.");
   });
 
   it("throws when OpenAI returns an empty response", async () => {
+    // Setup
     const mockCreate = vi.fn().mockResolvedValue({
       choices: [{ message: { content: null } }],
     });
@@ -257,6 +223,7 @@ describe("generateContentWithOpenAI", () => {
     } as unknown as OpenAI;
     const sources = [makeSource("T", "content")];
 
+    // Act & Assert
     await expect(
       generateContentWithOpenAI(sources, {
         openai,
@@ -269,10 +236,12 @@ describe("generateContentWithOpenAI", () => {
   });
 
   it("exports DEFAULT_SYSTEM_PROMPT with {{topNewsCount}} placeholder", () => {
+    // Act & Assert
     expect(DEFAULT_SYSTEM_PROMPT).toContain("{{topNewsCount}}");
   });
 
   it("exports DEFAULT_USER_PROMPT_TEMPLATE with {{topNewsCount}} and {{sourceSummaries}} placeholders", () => {
+    // Act & Assert
     expect(DEFAULT_USER_PROMPT_TEMPLATE).toContain("{{topNewsCount}}");
     expect(DEFAULT_USER_PROMPT_TEMPLATE).toContain("{{sourceSummaries}}");
   });

--- a/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/generate-content.ts
@@ -5,19 +5,17 @@ import { parseNewsletterJson } from "../parse-newsletter-json.js";
 import type { SourceForGeneration } from "../types.js";
 import { truncateSources } from "./truncate-sources.js";
 
-export const DEFAULT_SYSTEM_PROMPT = `You are a newsletter writer for busy executives. Given multiple data sources, produce a structured newsletter.
+export const DEFAULT_SYSTEM_PROMPT = `You are a newsletter writer for busy executives. Given numbered article summaries, produce a structured newsletter.
 
 Return a JSON object with:
 - "subject": a compelling email subject line (short, under ~60 chars).
 - "executiveSummary": 2–3 sentences summarizing the main themes and why they matter. No bullet points; use clear prose.
-- "topNews": an array of exactly {{topNewsCount}} items. Each item must have:
-  - "title": short headline
-  - "summaryWithLinks": 2–4 sentences with inline markdown links like [source](https://example.com/news)
-  - "citations": at least one citation object with "url" and optional "label"
-Only cite URLs from the provided source list.`;
+- "topNews": an array of exactly {{topNewsCount}} items in the same order as the numbered articles. Each item must have:
+  - "title": short headline capturing the key point of that article
+  - "summary": 2–4 plain sentences summarizing the article. Do not include any markdown links or citation markers.`;
 
 export const DEFAULT_USER_PROMPT_TEMPLATE =
-  "Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items. Each top-news summary must include inline markdown links and only use URLs that appear in the provided sources.\n\n{{sourceSummaries}}";
+  "Create a newsletter from the {{topNewsCount}} articles below. Write exactly one top-news item per numbered article, in the same order.\n\n{{sourceSummaries}}";
 
 /**
  * Calls OpenAI to generate a newsletter with an executive summary and top news items.
@@ -56,9 +54,7 @@ export async function generateContentWithOpenAI(
   );
 
   const sourceSummaries = truncated
-    .map(
-      (source) => `Source: ${source.title} (${source.url})\n${source.content}`,
-    )
+    .map((source, i) => `Article ${i + 1}: ${source.title}\n${source.content}`)
     .join("\n\n---\n\n");
 
   const replacePlaceholders = (template: string): string =>
@@ -99,7 +95,7 @@ export async function generateContentWithOpenAI(
     validated.executiveSummary ?? "",
     topNews.map((item) => ({
       title: item.title,
-      summary: item.summaryWithLinks,
+      summary: item.summary,
     })),
     deps.topNewsCount,
   );

--- a/apps/mediapulse/agents/content-generation/src/lib/phrase-link-injector.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/phrase-link-injector.test.ts
@@ -1,0 +1,186 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findBestMatchingPhrase,
+  injectTitlePhraseLink,
+  tokenize,
+} from "./phrase-link-injector";
+
+describe("tokenize", () => {
+  it("lowercases and splits on non-word characters", () => {
+    // Act
+    const tokens = tokenize("Bank Central Asia");
+
+    // Assert
+    expect(tokens).toEqual(["bank", "central", "asia"]);
+  });
+
+  it("filters out stop words", () => {
+    // Act
+    const tokens = tokenize("the rise of inflation");
+
+    // Assert
+    expect(tokens).not.toContain("the");
+    expect(tokens).not.toContain("of");
+    expect(tokens).toContain("rise");
+    expect(tokens).toContain("inflation");
+  });
+
+  it("filters out tokens shorter than 3 characters", () => {
+    // Act
+    const tokens = tokenize("BCA Q1 earnings");
+
+    // Assert
+    expect(tokens).not.toContain("q1");
+    expect(tokens).toContain("bca");
+    expect(tokens).toContain("earnings");
+  });
+
+  it("returns empty array for text with only stop words", () => {
+    // Act
+    const tokens = tokenize("the a an");
+
+    // Assert
+    expect(tokens).toEqual([]);
+  });
+});
+
+describe("findBestMatchingPhrase", () => {
+  it("returns a phrase when summary contains words from the title", () => {
+    // Setup
+    const titleTokens = new Set(["bank", "central", "asia", "earnings"]);
+    const summary =
+      "Bank Central Asia reported strong quarterly earnings growth.";
+
+    // Act
+    const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+    // Assert
+    expect(phrase).not.toBeNull();
+    expect(typeof phrase).toBe("string");
+  });
+
+  it("returns null when there is no meaningful overlap", () => {
+    // Setup
+    const titleTokens = new Set(["unrelated", "completely", "different"]);
+    const summary =
+      "Interest rates rise following central bank policy decision.";
+
+    // Act
+    const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+    // Assert
+    expect(phrase).toBeNull();
+  });
+
+  it("returns null for an empty title token set", () => {
+    // Setup
+    const titleTokens = new Set<string>();
+    const summary = "Some summary text about a company.";
+
+    // Act
+    const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+    // Assert
+    expect(phrase).toBeNull();
+  });
+
+  it("returns null when summary is too short for a window", () => {
+    // Setup
+    const titleTokens = new Set(["earnings"]);
+    const summary = "Earnings.";
+
+    // Act
+    const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+    // Assert
+    expect(phrase).toBeNull();
+  });
+
+  it("returns the best matching window, not just the first overlap", () => {
+    // Setup — title strongly overlaps with "quarterly earnings growth" in the middle
+    const titleTokens = new Set(["quarterly", "earnings", "growth"]);
+    const summary =
+      "Despite challenges, the company posted quarterly earnings growth beating forecasts.";
+
+    // Act
+    const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+    // Assert
+    expect(phrase).not.toBeNull();
+    // The phrase should contain at least one of the meaningful title words
+    const lowerPhrase = phrase!.toLowerCase();
+    const hasTitleWord =
+      lowerPhrase.includes("quarterly") ||
+      lowerPhrase.includes("earnings") ||
+      lowerPhrase.includes("growth");
+    expect(hasTitleWord).toBe(true);
+  });
+});
+
+describe("injectTitlePhraseLink", () => {
+  it("wraps the matching phrase with a markdown link", () => {
+    // Setup
+    const summary =
+      "Bank Central Asia reported strong quarterly earnings growth this year.";
+    const title = "BCA Posts Quarterly Earnings Growth";
+    const url = "https://reuters.com/article/bca-earnings";
+
+    // Act
+    const result = injectTitlePhraseLink(summary, title, url);
+
+    // Assert
+    expect(result).toContain(`](${url})`);
+    expect(result).toContain("[");
+  });
+
+  it("returns the summary unchanged when no phrase matches", () => {
+    // Setup
+    const summary = "Global trade tensions continue to weigh on markets.";
+    const title = "XYZXYZXYZ Unrelated Zqwert Title";
+    const url = "https://reuters.com/article/unrelated";
+
+    // Act
+    const result = injectTitlePhraseLink(summary, title, url);
+
+    // Assert
+    expect(result).toBe(summary);
+    expect(result).not.toContain(url);
+  });
+
+  it("only replaces the first occurrence of the phrase", () => {
+    // Setup
+    const summary =
+      "Earnings growth was strong. The earnings growth surprised analysts.";
+    const title = "Strong Earnings Growth Reported";
+    const url = "https://bloomberg.com/article/earnings";
+
+    // Act
+    const result = injectTitlePhraseLink(summary, title, url);
+
+    // Assert
+    // Exactly one markdown link should appear
+    const linkCount = (result.match(/\]\(https?:\/\//g) ?? []).length;
+    expect(linkCount).toBe(1);
+  });
+
+  it("preserves the rest of the summary text outside the injected phrase", () => {
+    // Setup
+    const summary =
+      "The central bank raised interest rates by 25 basis points.";
+    const title = "Central Bank Raises Interest Rates";
+    const url = "https://ft.com/article/rates";
+
+    // Act
+    const result = injectTitlePhraseLink(summary, title, url);
+
+    // Assert
+    // Result should still be a valid string containing the url if a match was found,
+    // or the original summary if not. Either way, no content should be lost.
+    const textWithoutMarkdown = result.replace(/\[([^\]]+)\]\([^)]+\)/g, "$1");
+    // All original non-link words should still be present
+    expect(textWithoutMarkdown.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/lib/phrase-link-injector.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/phrase-link-injector.ts
@@ -1,0 +1,145 @@
+/**
+ * Short common words excluded from overlap scoring to focus on meaningful terms.
+ * Kept minimal so the filter is fast and language-agnostic.
+ */
+const STOP_WORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "is",
+  "are",
+  "was",
+  "were",
+  "be",
+  "been",
+  "being",
+  "to",
+  "of",
+  "and",
+  "or",
+  "in",
+  "on",
+  "at",
+  "for",
+  "with",
+  "by",
+  "as",
+  "it",
+  "its",
+  "that",
+  "this",
+  "has",
+  "had",
+  "have",
+  "not",
+  "but",
+  "from",
+  "up",
+  "all",
+]);
+
+const MIN_WINDOW_SIZE = 2;
+const MAX_WINDOW_SIZE = 7;
+
+/** Minimum Jaccard overlap score required to accept a window as a matching phrase. */
+const MIN_SCORE_THRESHOLD = 0.2;
+
+/**
+ * Tokenizes a string into lowercase, punctuation-stripped, stop-word-filtered terms.
+ *
+ * @param text - Raw text to tokenize.
+ * @returns Array of meaningful lowercase terms.
+ */
+export const tokenize = (text: string): string[] =>
+  text
+    .toLowerCase()
+    .split(/\W+/)
+    .filter((t) => t.length >= 3 && !STOP_WORDS.has(t));
+
+/**
+ * Finds the contiguous word window in `text` whose tokens best overlap with
+ * `titleTokens` using a Jaccard-like score.
+ *
+ * Windows range from `MIN_WINDOW_SIZE` to `MAX_WINDOW_SIZE` words. The function
+ * returns the raw phrase string (original casing, punctuation preserved) for the
+ * best-scoring window, or `null` when no window exceeds `MIN_SCORE_THRESHOLD`.
+ *
+ * @param text - Summary text to search within.
+ * @param titleTokens - Pre-tokenized meaningful terms from the article title.
+ * @returns Best-matching phrase string, or `null` if no good match exists.
+ */
+export const findBestMatchingPhrase = (
+  text: string,
+  titleTokens: ReadonlySet<string>,
+): string | null => {
+  if (titleTokens.size === 0) return null;
+
+  // Split on whitespace boundaries, keeping the original word strings for reconstruction.
+  const words = text.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length < MIN_WINDOW_SIZE) return null;
+
+  let bestScore = 0;
+  let bestStart = -1;
+  let bestEnd = -1;
+
+  for (
+    let windowSize = MIN_WINDOW_SIZE;
+    windowSize <= Math.min(MAX_WINDOW_SIZE, words.length);
+    windowSize++
+  ) {
+    for (let i = 0; i <= words.length - windowSize; i++) {
+      const windowWords = words.slice(i, i + windowSize);
+      const windowTokens = windowWords.flatMap((w) => tokenize(w));
+
+      const overlapCount = windowTokens.filter((t) =>
+        titleTokens.has(t),
+      ).length;
+
+      if (overlapCount === 0) continue;
+
+      // Jaccard-like: overlap / max(|title tokens|, |window tokens|)
+      const score =
+        overlapCount / Math.max(titleTokens.size, windowTokens.length);
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestStart = i;
+        bestEnd = i + windowSize;
+      }
+    }
+  }
+
+  if (bestScore < MIN_SCORE_THRESHOLD || bestStart === -1) return null;
+
+  return words.slice(bestStart, bestEnd).join(" ");
+};
+
+/**
+ * Injects a markdown link into `summary` by finding the phrase that best matches
+ * the article `title` and wrapping it as `[phrase](url)`.
+ *
+ * Uses a sliding word-window with Jaccard-like token overlap scoring. If a
+ * matching phrase is found, the first occurrence in the summary is replaced with
+ * the markdown link. If no phrase meets the minimum overlap threshold, the summary
+ * is returned unchanged.
+ *
+ * @param summary - Plain-prose summary text produced by the LLM.
+ * @param title - Article title used to find the best matching phrase.
+ * @param url - Article URL to use as the link target.
+ * @returns Summary with an injected `[phrase](url)` link, or the original summary
+ *   if no suitable phrase was found.
+ */
+export const injectTitlePhraseLink = (
+  summary: string,
+  title: string,
+  url: string,
+): string => {
+  const titleTokens = new Set(tokenize(title));
+  const phrase = findBestMatchingPhrase(summary, titleTokens);
+
+  if (!phrase) return summary;
+
+  // Escape special regex characters in the phrase for a safe replacement.
+  const escapedPhrase = phrase.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return summary.replace(new RegExp(escapedPhrase, "i"), `[${phrase}](${url})`);
+};

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.test.ts
@@ -2,7 +2,6 @@ import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { classifyLlmError, isRetryableLlmError } from "./llm-classify-error.js";
-import { CitationValidationError } from "./llm-generate-newsletter.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -97,14 +96,6 @@ describe("isRetryableLlmError", () => {
     expect(isRetryableLlmError(error)).toBe(false);
   });
 
-  it("returns true for CitationValidationError", () => {
-    // Setup
-    const error = new CitationValidationError("missing citation");
-
-    // Act & Assert
-    expect(isRetryableLlmError(error)).toBe(true);
-  });
-
   it("returns false for NoObjectGeneratedError", () => {
     // Setup
     const error = makeNoObjectGeneratedError();
@@ -171,17 +162,6 @@ describe("classifyLlmError", () => {
   it("maps TypeValidationError to validation_failed", () => {
     // Setup
     const error = makeTypeValidationError();
-
-    // Act
-    const code = classifyLlmError(error);
-
-    // Assert
-    expect(code).toBe("validation_failed");
-  });
-
-  it("maps CitationValidationError to validation_failed", () => {
-    // Setup
-    const error = new CitationValidationError("missing citation");
 
     // Act
     const code = classifyLlmError(error);

--- a/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-classify-error.ts
@@ -1,5 +1,4 @@
 import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
-import { CitationValidationError } from "./llm-generate-newsletter.js";
 
 import type { OutcomeCode } from "./types/outcome.js";
 
@@ -36,9 +35,6 @@ export function isRetryableLlmError(error: unknown): boolean {
   if (error instanceof TypeValidationError) {
     return false;
   }
-  if (error instanceof CitationValidationError) {
-    return true;
-  }
   if (error instanceof NoObjectGeneratedError) {
     return false;
   }
@@ -56,9 +52,6 @@ export function isRetryableLlmError(error: unknown): boolean {
  */
 export function classifyLlmError(error: unknown): OutcomeCode {
   if (error instanceof TypeValidationError) {
-    return "validation_failed";
-  }
-  if (error instanceof CitationValidationError) {
     return "validation_failed";
   }
   if (error instanceof NoObjectGeneratedError) {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -34,11 +34,7 @@ function makeSuccessfulGenerateFn(
   overrides: Partial<{
     subject: string;
     executiveSummary: string;
-    topNews: Array<{
-      title: string;
-      summaryWithLinks: string;
-      citations: Array<{ url: string; label?: string }>;
-    }>;
+    topNews: Array<{ title: string; summary: string }>;
   }> = {},
 ): GenerateNewsletterObjectFn {
   return vi.fn().mockResolvedValue({
@@ -49,21 +45,16 @@ function makeSuccessfulGenerateFn(
       topNews: overrides.topNews ?? [
         {
           title: "Tech gains",
-          summaryWithLinks:
-            "Big tech was up according to [Story A](https://example.com/a).",
-          citations: [{ url: "https://example.com/a", label: "Story A" }],
+          summary:
+            "Big tech stocks posted gains for the third consecutive day.",
         },
         {
           title: "Fed pause",
-          summaryWithLinks:
-            "Rates held according to [Story B](https://example.com/b).",
-          citations: [{ url: "https://example.com/b", label: "Story B" }],
+          summary: "Federal Reserve held interest rates steady at its meeting.",
         },
         {
           title: "Oil dips",
-          summaryWithLinks:
-            "Crude fell according to [Story A](https://example.com/a).",
-          citations: [{ url: "https://example.com/a", label: "Story A" }],
+          summary: "Crude oil prices fell amid demand concerns.",
         },
       ],
     },
@@ -74,6 +65,7 @@ function makeSuccessfulGenerateFn(
 const testSources = [
   { url: "https://example.com/a", title: "Story A", content: "Content A." },
   { url: "https://example.com/b", title: "Story B", content: "Content B." },
+  { url: "https://example.com/c", title: "Story C", content: "Content C." },
 ];
 
 const testContext = {
@@ -134,31 +126,11 @@ describe("generateNewsletterWithLlm — happy path", () => {
     // Setup
     const generateObjectFn = makeSuccessfulGenerateFn({
       topNews: [
-        {
-          title: "Item 1",
-          summaryWithLinks: "s1 [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-        {
-          title: "Item 2",
-          summaryWithLinks: "s2 [B](https://example.com/b)",
-          citations: [{ url: "https://example.com/b" }],
-        },
-        {
-          title: "Item 3",
-          summaryWithLinks: "s3 [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
-        {
-          title: "Item 4",
-          summaryWithLinks: "s4 [B](https://example.com/b)",
-          citations: [{ url: "https://example.com/b" }],
-        },
-        {
-          title: "Item 5",
-          summaryWithLinks: "s5 [A](https://example.com/a)",
-          citations: [{ url: "https://example.com/a" }],
-        },
+        { title: "Item 1", summary: "Summary 1." },
+        { title: "Item 2", summary: "Summary 2." },
+        { title: "Item 3", summary: "Summary 3." },
+        { title: "Item 4", summary: "Summary 4." },
+        { title: "Item 5", summary: "Summary 5." },
       ],
     });
 
@@ -177,6 +149,60 @@ describe("generateNewsletterWithLlm — happy path", () => {
     expect(result.content).toContain("1. Item 1");
     expect(result.content).toContain("3. Item 3");
     expect(result.content).not.toContain("4. Item 4");
+  });
+
+  it("injects a phrase link from the source title into each summary", async () => {
+    // Setup — source titles share key words with their corresponding summaries
+    // so the phrase-link injector finds a match and wraps it with the source URL.
+    const matchingSources = [
+      {
+        url: "https://example.com/a",
+        title: "Tech stocks gains",
+        content: "Content A.",
+      },
+      {
+        url: "https://example.com/b",
+        title: "Federal Reserve rates pause",
+        content: "Content B.",
+      },
+      {
+        url: "https://example.com/c",
+        title: "Crude oil prices fell",
+        content: "Content C.",
+      },
+    ];
+    const generateObjectFn = makeSuccessfulGenerateFn({
+      topNews: [
+        {
+          title: "Tech gains",
+          summary:
+            "Big tech stocks posted strong gains for the third consecutive day.",
+        },
+        {
+          title: "Fed pause",
+          summary:
+            "Federal Reserve held interest rates steady at its latest meeting.",
+        },
+        {
+          title: "Oil dips",
+          summary: "Crude oil prices fell amid weakening demand concerns.",
+        },
+      ],
+    });
+
+    // Act
+    const result = await generateNewsletterWithLlm(
+      matchingSources,
+      baseConfig,
+      testContext,
+      {
+        generateObjectFn,
+        sleepFn: noopSleepFn,
+      },
+    );
+
+    // Assert — at least one markdown link appears in the output
+    expect(result.content).toMatch(/\[[^\]]+\]\(https?:\/\//);
   });
 
   it("passes timeout to generateObjectFn when openai.timeoutMs is set", async () => {
@@ -310,66 +336,6 @@ describe("generateNewsletterWithLlm — non-retryable errors", () => {
 // ---------------------------------------------------------------------------
 
 describe("generateNewsletterWithLlm — retryable errors", () => {
-  it("retries when citation validation fails and eventually succeeds", async () => {
-    // Setup
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        llmRetry: {
-          maxAttempts: 3,
-          baseDelayMs: 10,
-          maxDelayMs: 100,
-          jitter: false,
-        },
-      }),
-    );
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const generateObjectFn = vi
-      .fn()
-      .mockResolvedValueOnce({
-        object: {
-          subject: "Invalid citations",
-          executiveSummary: "Summary",
-          topNews: [
-            {
-              title: "Story",
-              summaryWithLinks: "No links here.",
-              citations: [{ url: "https://example.com/a" }],
-            },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        object: {
-          subject: "Recovered",
-          executiveSummary: "Summary",
-          topNews: [
-            {
-              title: "Story",
-              summaryWithLinks: "Cited [A](https://example.com/a).",
-              citations: [{ url: "https://example.com/a" }],
-            },
-          ],
-        },
-      });
-
-    // Act
-    const result = await generateNewsletterWithLlm(
-      testSources,
-      config,
-      testContext,
-      {
-        generateObjectFn,
-        sleepFn,
-      },
-    );
-
-    // Assert
-    expect(result.subject).toBe("Recovered");
-    expect(generateObjectFn).toHaveBeenCalledTimes(2);
-    expect(sleepFn).toHaveBeenCalledTimes(1);
-  });
-
   it("retries exactly maxAttempts times on a 429 rate-limit error", async () => {
     // Setup
     const rateLimitError = new APICallError({
@@ -405,46 +371,6 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
     expect(sleepFn).toHaveBeenCalledTimes(2);
   });
 
-  it("fails after max attempts when citation URLs are not from provided sources", async () => {
-    // Setup
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        llmRetry: {
-          maxAttempts: 2,
-          baseDelayMs: 10,
-          maxDelayMs: 100,
-          jitter: false,
-        },
-      }),
-    );
-    const sleepFn = vi.fn().mockResolvedValue(undefined);
-    const generateObjectFn = vi.fn().mockResolvedValue({
-      object: {
-        subject: "Invalid source mapping",
-        executiveSummary: "Summary",
-        topNews: [
-          {
-            title: "Story",
-            summaryWithLinks: "Claim [Offsite](https://not-provided.com/x).",
-            citations: [{ url: "https://not-provided.com/x" }],
-          },
-        ],
-      },
-    });
-
-    // Act & Assert
-    await expect(
-      generateNewsletterWithLlm(testSources, config, testContext, {
-        generateObjectFn,
-        sleepFn,
-      }),
-    ).rejects.toThrow("Citation URL not in provided sources");
-
-    expect(generateObjectFn).toHaveBeenCalledTimes(2);
-    expect(sleepFn).toHaveBeenCalledTimes(1);
-  });
-
   it("succeeds after a transient 500 failure", async () => {
     // Setup
     const serverError = new APICallError({
@@ -473,13 +399,7 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
         object: {
           subject: "Recovery",
           executiveSummary: "All clear.",
-          topNews: [
-            {
-              title: "Up",
-              summaryWithLinks: "Markets up [A](https://example.com/a).",
-              citations: [{ url: "https://example.com/a" }],
-            },
-          ],
+          topNews: [{ title: "Up", summary: "Markets recovered strongly." }],
         },
       });
 
@@ -536,13 +456,7 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
       object: {
         subject: "Market Update",
         executiveSummary: "Stocks rose.",
-        topNews: [
-          {
-            title: "Gains",
-            summaryWithLinks: "Up [A](https://example.com/a).",
-            citations: [{ url: "https://example.com/a" }],
-          },
-        ],
+        topNews: [{ title: "Gains", summary: "Markets rose broadly today." }],
       },
       usage: {
         promptTokens: 120,
@@ -574,13 +488,7 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
       object: {
         subject: "No Usage",
         executiveSummary: "No usage data.",
-        topNews: [
-          {
-            title: "Story",
-            summaryWithLinks: "Summary [A](https://example.com/a).",
-            citations: [{ url: "https://example.com/a" }],
-          },
-        ],
+        topNews: [{ title: "Story", summary: "A summary without usage data." }],
       },
       // usage intentionally omitted
     });
@@ -793,5 +701,25 @@ describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
     expect(result.resolvedUserPrompt).toBe(
       `${testContext.tickerId} report: ${testContext.tickerId}.`,
     );
+  });
+
+  it("formats source summaries as numbered articles in the default template", async () => {
+    // Setup
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    // Act
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      testContext,
+      {
+        generateObjectFn,
+        sleepFn: noopSleepFn,
+      },
+    );
+
+    // Assert — articles are numbered in the prompt
+    expect(result.resolvedUserPrompt).toContain("Article 1: Story A");
+    expect(result.resolvedUserPrompt).toContain("Article 2: Story B");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -5,6 +5,7 @@ import type { z } from "zod";
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
 import { formatNewsletterContent } from "./format-newsletter-content.js";
 import { isRetryableLlmError } from "./llm-classify-error.js";
+import { injectTitlePhraseLink } from "./lib/phrase-link-injector.js";
 import { retryWithBackoff } from "./lib/retry.js";
 import { truncateSources } from "./lib/truncate-sources.js";
 import { newsletterStructureSchema } from "./parse-newsletter-json.js";
@@ -115,92 +116,26 @@ const defaultGenerateNewsletterObject: GenerateNewsletterObjectFn = async (
  * Exported so callers (e.g. `run.ts`) can compute `promptHash` from the exact
  * string passed to the model without duplicating the constant.
  */
-export const SYSTEM_PROMPT = `You are a newsletter writer for busy executives. Given multiple data sources, produce a structured newsletter.
+export const SYSTEM_PROMPT = `You are a newsletter writer for busy executives. Given numbered article summaries, produce a structured newsletter.
 
 Return a JSON object with:
 - "subject": a compelling email subject line (short, under ~60 chars).
 - "executiveSummary": 2–3 sentences summarizing the main themes and why they matter. No bullet points; use clear prose.
-- "topNews": an array of exactly {{topNewsCount}} items. Each item must have:
-  - "title": short headline
-  - "summaryWithLinks": 2–4 sentences that include inline markdown citations like [source](https://example.com/news)
-  - "citations": array with at least one citation object, each citation has "url" and optional "label"
-Use only URLs from the provided sources. Every topNews item must include at least one citation link in the summary.`;
+- "topNews": an array of exactly {{topNewsCount}} items in the same order as the numbered articles. Each item must have:
+  - "title": short headline capturing the key point of that article
+  - "summary": 2–4 plain sentences summarizing the article. Do not include any markdown links or citation markers.`;
 
 /**
  * Default user prompt template used when no template is provided in config.
  */
-export const DEFAULT_USER_PROMPT_TEMPLATE = `Create a newsletter from these data sources. Include an executive summary and the top {{topNewsCount}} news items. Each top-news summary must include inline markdown links and only use URLs from the provided sources.\n\n{{sourceSummaries}}`;
-
-const INLINE_MARKDOWN_LINK_REGEX = /\[[^\]]+\]\((https?:\/\/[^)\s]+)\)/gi;
-
-/**
- * Raised when generated top-news citations do not satisfy strict source-link rules.
- */
-export class CitationValidationError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "CitationValidationError";
-  }
-}
-
-/**
- * Validates generated citations against provided source URLs and inline link usage.
- *
- * @param topNews - Generated top news items.
- * @param sourceUrls - URL set from provided source context.
- */
-const validateTopNewsCitations = (
-  topNews: Array<{
-    title: string;
-    summaryWithLinks: string;
-    citations: Array<{ url: string; label?: string }>;
-  }>,
-  sourceUrls: ReadonlySet<string>,
-): void => {
-  for (const item of topNews) {
-    if (item.citations.length === 0) {
-      throw new CitationValidationError(
-        `Missing citations for topNews item: ${item.title}`,
-      );
-    }
-    for (const citation of item.citations) {
-      if (!sourceUrls.has(citation.url)) {
-        throw new CitationValidationError(
-          `Citation URL not in provided sources: ${citation.url}`,
-        );
-      }
-    }
-
-    const inlineUrls = [
-      ...item.summaryWithLinks.matchAll(INLINE_MARKDOWN_LINK_REGEX),
-    ]
-      .map((match) => match[1])
-      .filter((url): url is string => typeof url === "string");
-    if (inlineUrls.length === 0) {
-      throw new CitationValidationError(
-        `Missing inline markdown link in summaryWithLinks for: ${item.title}`,
-      );
-    }
-    const citationUrlSet = new Set(
-      item.citations.map((citation) => citation.url),
-    );
-    const hasMappedInlineCitation = inlineUrls.some((url) =>
-      citationUrlSet.has(url),
-    );
-    if (!hasMappedInlineCitation) {
-      throw new CitationValidationError(
-        `Inline links do not match citations for: ${item.title}`,
-      );
-    }
-  }
-};
+export const DEFAULT_USER_PROMPT_TEMPLATE = `Create a newsletter from the {{topNewsCount}} articles below. Write exactly one top-news item per numbered article, in the same order.\n\n{{sourceSummaries}}`;
 
 /**
  * Builds the LLM user prompt from the list of data sources, substituting
  * placeholders in the provided template.
  *
  * Supported placeholders:
- * - `{{sourceSummaries}}`: Concatenated list of article titles and content.
+ * - `{{sourceSummaries}}`: Numbered list of article titles and content.
  * - `{{tickerId}}`: The identifier of the ticker being processed.
  * - `{{date}}`: The current ISO date (YYYY-MM-DD).
  * - `{{topNewsCount}}`: The number of top news items to generate.
@@ -219,9 +154,7 @@ export function buildUserPrompt(
   context: { tickerId: string; date: string; topNewsCount: number },
 ): string {
   const sourceSummaries = sources
-    .map(
-      (source) => `Source: ${source.title} (${source.url})\n${source.content}`,
-    )
+    .map((source, i) => `Article ${i + 1}: ${source.title}\n${source.content}`)
     .join("\n\n---\n\n");
 
   return template
@@ -233,6 +166,12 @@ export function buildUserPrompt(
 
 /**
  * Generates newsletter content from data sources via the Vercel AI SDK with retry logic.
+ *
+ * Selects the top `topNewsCount` sources (by relevance order from the caller) and asks
+ * the LLM to write plain prose summaries — one item per article. After the LLM responds,
+ * a code-based phrase-link injection step finds the phrase in each summary that best
+ * matches the article title and wraps it as a markdown link, so citations are derived
+ * from the source content rather than generated by the model.
  *
  * Retries on transient errors (rate limits, server errors, timeouts) up to
  * `config.llmRetry.maxAttempts` times with exponential backoff and optional jitter.
@@ -274,6 +213,12 @@ export async function generateNewsletterWithLlm(
     maxTotalContextChars,
   );
 
+  // Pre-select exactly N sources (one per news item). Sources arrive sorted by
+  // relevance score from getDataSourcesForTicker; we take the top N so the LLM
+  // writes one summary per article and phrase-link injection can map each item
+  // back to its source URL deterministically.
+  const selectedSources = truncatedSources.slice(0, topNewsCount);
+
   const openai = createOpenAI({
     apiKey: config.openai.apiKey,
     ...(config.openai.baseUrl ? { baseURL: config.openai.baseUrl } : {}),
@@ -284,7 +229,7 @@ export async function generateNewsletterWithLlm(
   const systemPrompt = config.prompts?.systemPrompt || SYSTEM_PROMPT;
   const userTemplate =
     config.prompts?.userPromptTemplate || DEFAULT_USER_PROMPT_TEMPLATE;
-  const prompt = buildUserPrompt(truncatedSources, userTemplate, {
+  const prompt = buildUserPrompt(selectedSources, userTemplate, {
     tickerId: context.tickerId,
     date: context.date,
     topNewsCount,
@@ -293,10 +238,9 @@ export async function generateNewsletterWithLlm(
   const timeout = config.openai?.timeoutMs;
   const maxTokens = config.openai?.maxTokens;
 
-  const sourceUrlSet = new Set(truncatedSources.map((source) => source.url));
   const result = await retryWithBackoff(
     async () => {
-      const generated = await generateFn({
+      return generateFn({
         model,
         schema: newsletterStructureSchema,
         system: systemPrompt,
@@ -305,11 +249,6 @@ export async function generateNewsletterWithLlm(
         ...(timeout !== undefined ? { timeout } : {}),
         ...(maxTokens !== undefined ? { maxTokens } : {}),
       });
-      const topNews = Array.isArray(generated.object.topNews)
-        ? generated.object.topNews.slice(0, topNewsCount)
-        : [];
-      validateTopNewsCitations(topNews, sourceUrlSet);
-      return generated;
     },
     config.llmRetry,
     isRetryableLlmError,
@@ -320,12 +259,23 @@ export async function generateNewsletterWithLlm(
   const topNews = Array.isArray(object.topNews)
     ? object.topNews.slice(0, topNewsCount)
     : [];
+
+  // Inject phrase-based markdown links into each summary. For each item at
+  // index i, we find the phrase in the summary that best matches
+  // selectedSources[i].title and wrap it as [phrase](url). If no phrase meets
+  // the overlap threshold the summary is returned unchanged (no broken links).
+  const linkedTopNews = topNews.map((item, i) => {
+    const source = selectedSources[i];
+    const linkedSummary =
+      source !== undefined
+        ? injectTitlePhraseLink(item.summary, source.title, source.url)
+        : item.summary;
+    return { title: item.title, summary: linkedSummary };
+  });
+
   const content = formatNewsletterContent(
     object.executiveSummary ?? "",
-    topNews.map((item) => ({
-      title: item.title,
-      summary: item.summaryWithLinks,
-    })),
+    linkedTopNews,
     topNewsCount,
   );
 

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.test.ts
@@ -3,7 +3,8 @@ import { describe, expect, it } from "vitest";
 import { parseNewsletterJson } from "./parse-newsletter-json.js";
 
 describe("parseNewsletterJson", () => {
-  it("parses valid topNews items with summaryWithLinks and citations", () => {
+  it("parses valid topNews items with plain summary", () => {
+    // Act
     const parsed = parseNewsletterJson(
       JSON.stringify({
         subject: "Daily Brief",
@@ -11,110 +12,72 @@ describe("parseNewsletterJson", () => {
         topNews: [
           {
             title: "Story 1",
-            summaryWithLinks: "Update [Source](https://example.com/a).",
-            citations: [{ url: "https://example.com/a", label: "Source" }],
+            summary: "Bank reported strong quarterly earnings growth.",
           },
         ],
       }),
       3,
     );
 
-    expect(parsed.topNews[0]?.summaryWithLinks).toContain("[Source]");
-    expect(parsed.topNews[0]?.citations[0]?.url).toBe("https://example.com/a");
+    // Assert
+    expect(parsed.topNews[0]?.title).toBe("Story 1");
+    expect(parsed.topNews[0]?.summary).toBe(
+      "Bank reported strong quarterly earnings growth.",
+    );
   });
 
-  it("rejects topNews item without citations", () => {
+  it("rejects topNews items that exceed topNewsCount", () => {
+    // Act & Assert
     expect(() =>
       parseNewsletterJson(
         JSON.stringify({
           subject: "Daily Brief",
           executiveSummary: "Summary",
           topNews: [
-            {
-              title: "Story 1",
-              summaryWithLinks: "Update [Source](https://example.com/a).",
-              citations: [],
-            },
+            { title: "Story 1", summary: "s1" },
+            { title: "Story 2", summary: "s2" },
+            { title: "Story 3", summary: "s3" },
+            { title: "Story 4", summary: "s4" },
           ],
         }),
         3,
       ),
-    ).toThrow();
+    ).toThrow("Expected at most 3 topNews items");
   });
 
-  it("rejects citation with invalid URL", () => {
+  it("rejects input where topNews item is missing summary", () => {
+    // Act & Assert
     expect(() =>
       parseNewsletterJson(
         JSON.stringify({
           subject: "Daily Brief",
           executiveSummary: "Summary",
-          topNews: [
-            {
-              title: "Story 1",
-              summaryWithLinks: "Update [Source](bad-url).",
-              citations: [{ url: "bad-url" }],
-            },
-          ],
+          topNews: [{ title: "Story 1" }],
         }),
         3,
       ),
     ).toThrow();
   });
 
-  it("accepts http citation URLs", () => {
+  it("accepts an empty topNews array", () => {
+    // Act
     const parsed = parseNewsletterJson(
       JSON.stringify({
         subject: "Daily Brief",
         executiveSummary: "Summary",
-        topNews: [
-          {
-            title: "Story 1",
-            summaryWithLinks: "See [x](http://example.com/a).",
-            citations: [{ url: "http://example.com/a" }],
-          },
-        ],
+        topNews: [],
       }),
       3,
     );
-    expect(parsed.topNews[0]?.citations[0]?.url).toBe("http://example.com/a");
+
+    // Assert
+    expect(parsed.topNews).toEqual([]);
   });
 
-  it("rejects non-http(s) citation URLs (e.g. ftp)", () => {
-    expect(() =>
-      parseNewsletterJson(
-        JSON.stringify({
-          subject: "Daily Brief",
-          executiveSummary: "Summary",
-          topNews: [
-            {
-              title: "Story 1",
-              summaryWithLinks: "Update.",
-              citations: [{ url: "ftp://example.com/file" }],
-            },
-          ],
-        }),
-        3,
-      ),
-    ).toThrow();
-  });
-
-  it("parses citations that omit label (legacy JSON) by normalizing to empty label", () => {
-    const parsed = parseNewsletterJson(
-      JSON.stringify({
-        subject: "Daily Brief",
-        executiveSummary: "Summary",
-        topNews: [
-          {
-            title: "Story 1",
-            summaryWithLinks: "Update [x](https://example.com/a).",
-            citations: [{ url: "https://example.com/a" }],
-          },
-        ],
-      }),
-      3,
+  it("throws when given invalid JSON", () => {
+    // Act & Assert
+    expect(() => parseNewsletterJson("{not valid json}", 3)).toThrow(
+      "OpenAI returned invalid JSON",
     );
-    expect(parsed.topNews[0]?.citations[0]).toEqual({
-      url: "https://example.com/a",
-    });
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
+++ b/apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts
@@ -1,39 +1,5 @@
 import { z } from "zod";
 
-/**
- * Returns true when `value` is an absolute URL with an `http:` or `https:` scheme.
- *
- * Used instead of `z.string().url()` so the JSON Schema sent to OpenAI structured
- * outputs does not use `format: "uri"`, which the Responses API rejects
- * (`invalid_json_schema`).
- *
- * @param value - Candidate URL string from structured output.
- * @returns Whether the value parses as an http(s) URL.
- */
-const isHttpOrHttpsUrl = (value: string): boolean => {
-  try {
-    const parsed = new URL(value);
-    return parsed.protocol === "http:" || parsed.protocol === "https:";
-  } catch {
-    return false;
-  }
-};
-
-/**
- * Citation object for structured output. `label` is a required string (use `""` when
- * absent) because OpenAI `json_schema` with `strict: true` requires `required` to list
- * every key in `properties`; optional Zod fields omit `label` from `required` and the
- * API rejects the schema. Empty/whitespace labels are stripped on output.
- */
-const newsletterCitationSchema = z
-  .object({
-    url: z.string().min(1).refine(isHttpOrHttpsUrl, { message: "Invalid URL" }),
-    label: z.string(),
-  })
-  .transform(({ url, label }) =>
-    label.trim() === "" ? { url } : { url, label: label.trim() },
-  );
-
 /** Zod schema for OpenAI LLM newsletter JSON output. */
 export const newsletterStructureSchema = z.object({
   subject: z.string(),
@@ -41,55 +7,10 @@ export const newsletterStructureSchema = z.object({
   topNews: z.array(
     z.object({
       title: z.string(),
-      summaryWithLinks: z.string(),
-      citations: z.array(newsletterCitationSchema).min(1),
+      summary: z.string(),
     }),
   ),
 });
-
-/**
- * Fills missing `label` on each citation with `""` so legacy JSON without `label`
- * still parses after OpenAI strict-schema alignment.
- *
- * @param parsed - Unknown value from `JSON.parse` of newsletter JSON.
- * @returns Same structure with string `label` on every citation object.
- */
-const ensureCitationLabelKeys = (parsed: unknown): unknown => {
-  if (!parsed || typeof parsed !== "object") {
-    return parsed;
-  }
-  const root = parsed as Record<string, unknown>;
-  const topNews = root.topNews;
-  if (!Array.isArray(topNews)) {
-    return parsed;
-  }
-  return {
-    ...root,
-    topNews: topNews.map((item) => {
-      if (!item || typeof item !== "object") {
-        return item;
-      }
-      const row = item as Record<string, unknown>;
-      const citations = row.citations;
-      if (!Array.isArray(citations)) {
-        return item;
-      }
-      return {
-        ...row,
-        citations: citations.map((citation) => {
-          if (!citation || typeof citation !== "object") {
-            return citation;
-          }
-          const c = citation as Record<string, unknown>;
-          return {
-            ...c,
-            label: typeof c.label === "string" ? c.label : "",
-          };
-        }),
-      };
-    }),
-  };
-};
 
 /**
  * Parses and validates raw JSON string from OpenAI into newsletter structure.
@@ -113,9 +34,7 @@ export function parseNewsletterJson(
   } catch {
     throw new Error("OpenAI returned invalid JSON");
   }
-  const result = newsletterStructureSchema.parse(
-    ensureCitationLabelKeys(parsed),
-  );
+  const result = newsletterStructureSchema.parse(parsed);
   if (Array.isArray(result.topNews) && result.topNews.length > topNewsCount) {
     throw new Error(
       `Expected at most ${topNewsCount} topNews items, got ${result.topNews.length}`,

--- a/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.test.ts
@@ -57,4 +57,18 @@ describe("classifyNoisyUrl", () => {
         "https://www.reuters.com/world/asia-pacific/sample-story-2026-01-01",
     });
   });
+
+  it("blocks Reuters company/market page URLs", () => {
+    // Act
+    const decision = classifyNoisyUrl(
+      "https://www.reuters.com/markets/companies/BBCA.JK/",
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "blocked_host_path",
+      canonicalUrl: "https://www.reuters.com/markets/companies/BBCA.JK",
+    });
+  });
 });

--- a/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts
@@ -21,6 +21,7 @@ const BLOCKED_HOST_PATH_PATTERNS = [
   { host: /(^|\.)marketwatch\.com$/i, path: /^\/investing\/stock\//i },
   { host: /(^|\.)simplywall\.st$/i, path: /^\/stocks\//i },
   { host: /(^|\.)tradingview\.com$/i, path: /^\/symbols\//i },
+  { host: /(^|\.)reuters\.com$/i, path: /^\/(markets\/companies|company)\//i },
 ] as const;
 
 const BLOCKED_PATH_PATTERNS = [
@@ -107,13 +108,6 @@ export const classifyNoisyUrl = (rawUrl: string): UrlNoiseDecision => {
   const parsed = new URL(canonicalUrl);
   const hostname = parsed.hostname;
   const pathname = parsed.pathname;
-
-  const isReutersArticlePath =
-    /(^|\.)reuters\.com$/i.test(hostname) &&
-    !/^\/(markets\/companies|company)\//i.test(pathname);
-  if (isReutersArticlePath) {
-    return { blocked: false, canonicalUrl };
-  }
 
   if (BLOCKED_HOST_PATTERNS.some((pattern) => pattern.test(hostname))) {
     return { blocked: true, reason: "blocked_host", canonicalUrl };


### PR DESCRIPTION
## Summary

This change removes citation selection from the LLM response and makes link placement deterministic in app code. It also closes a URL filtering gap that allowed Reuters company pages to pass through as if they were article pages.

## Related issues

Closes #392

## Important changes

- Replace `topNews[].summaryWithLinks` + `citations` with plain `topNews[].summary` in content-generation structured output.
- Add `phrase-link-injector` to find title-similar phrases in summaries and wrap them with the assigned source URL.
- Keep source ordering deterministic by pre-selecting top N sources before generation, then mapping each summary to the same index.
- Block Reuters company/markets profile URLs via generic host+path filter rules.

## Other changes

- Update prompt templates to request plain prose only (no markdown links).
- Remove citation-validation error handling paths that are no longer needed.
- Refresh parse/format and integration tests to match the new schema and link-injection flow.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` - new plain-summary generation and post-processing link injection.
- `apps/mediapulse/agents/content-generation/src/lib/phrase-link-injector.ts` - phrase matching and markdown link insertion.
- `apps/mediapulse/agents/content-generation/src/parse-newsletter-json.ts` - simplified newsletter schema.
- `apps/mediapulse/agents/data-collection/src/utilities/url-noise-filter.ts` - generic host+path blocking update.

## How to test

1. `pnpm format:check`
2. `cd apps/mediapulse/agents/content-generation && npx vitest run --reporter=verbose`
3. `cd apps/mediapulse/agents/data-collection && npx vitest run --reporter=verbose`
4. Generate a newsletter run and confirm top-news summaries use natural linked phrases tied to selected article URLs.
