### PR TITLE
Migrate deploy workflows from Fly to Coolify with GHCR

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -153,10 +153,61 @@ jobs:
           - service: agent-user-registration
             webhook_secret: COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION
     steps:
-      - name: Trigger Coolify deployment
+      - name: Trigger Coolify deployment over OpenVPN
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
-        run: curl --fail --silent --show-error -X GET "$COOLIFY_WEBHOOK_URL"
+          OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
+          OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if ! command -v openvpn >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y openvpn
+          fi
+
+          WORKDIR="$(mktemp -d)"
+          cleanup() {
+            if [ -f "$WORKDIR/openvpn.pid" ]; then
+              sudo kill "$(tr -d '\n' < "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
+            fi
+            rm -rf "$WORKDIR"
+          }
+          trap cleanup EXIT
+
+          printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
+          printf "openvpn\n%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/auth.txt"
+          chmod 600 "$WORKDIR/auth.txt"
+
+          sudo openvpn \
+            --config "$WORKDIR/client.ovpn" \
+            --auth-user-pass "$WORKDIR/auth.txt" \
+            --daemon \
+            --writepid "$WORKDIR/openvpn.pid" \
+            --log "$WORKDIR/openvpn.log"
+
+          connected="false"
+          for _ in {1..30}; do
+            if ip addr show tun0 >/dev/null 2>&1; then
+              connected="true"
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$connected" != "true" ]; then
+            LOG_PATH="$WORKDIR/openvpn.log" python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          log_path = Path(os.environ["LOG_PATH"])
+          if log_path.exists():
+              print(log_path.read_text(encoding="utf-8", errors="ignore"))
+          PY
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --retry 3 --retry-delay 3 -X GET "$COOLIFY_WEBHOOK_URL"
 
   cleanup:
     name: Prune old GHCR versions (${{ matrix.image }})

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -87,22 +87,22 @@ jobs:
         include:
           - service: data-collection
             dockerfile: apps/mediapulse/agents/data-collection/Dockerfile
-            image: data-collection
+            image: agent-data-collection
           - service: content-generation
             dockerfile: apps/mediapulse/agents/content-generation/Dockerfile
-            image: content-generation
+            image: agent-content-generation
           - service: article-analysis
             dockerfile: apps/mediapulse/agents/article-analysis/Dockerfile
-            image: article-analysis
+            image: agent-article-analysis
           - service: query-analysis
             dockerfile: apps/mediapulse/agents/query-analysis/Dockerfile
-            image: query-analysis
+            image: agent-query-analysis
           - service: delivery
             dockerfile: apps/mediapulse/agents/delivery/Dockerfile
-            image: delivery
+            image: agent-delivery
           - service: ticker-echo
             dockerfile: apps/mediapulse/agents/ticker-echo/Dockerfile
-            image: ticker-echo
+            image: agent-ticker-echo
           - service: agent-user-registration
             dockerfile: apps/mediapulse/agents/user-registration/Dockerfile
             image: agent-user-registration
@@ -168,12 +168,12 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - data-collection
-          - content-generation
-          - article-analysis
-          - query-analysis
-          - delivery
-          - ticker-echo
+          - agent-data-collection
+          - agent-content-generation
+          - agent-article-analysis
+          - agent-query-analysis
+          - agent-delivery
+          - agent-ticker-echo
           - agent-user-registration
     steps:
       - uses: actions/delete-package-versions@v5

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   db-ready:
     runs-on: ubuntu-latest
@@ -73,93 +77,108 @@ jobs:
       - name: Migrate deploy (mediapulse)
         run: pnpm --filter=@mediapulse/database run db:migrate:deploy
 
-  data-collection:
+  publish:
+    name: Publish ${{ matrix.service }}
     runs-on: ubuntu-latest
     needs: db-migrate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: data-collection
+            dockerfile: apps/mediapulse/agents/data-collection/Dockerfile
+            image: data-collection
+          - service: content-generation
+            dockerfile: apps/mediapulse/agents/content-generation/Dockerfile
+            image: content-generation
+          - service: article-analysis
+            dockerfile: apps/mediapulse/agents/article-analysis/Dockerfile
+            image: article-analysis
+          - service: query-analysis
+            dockerfile: apps/mediapulse/agents/query-analysis/Dockerfile
+            image: query-analysis
+          - service: delivery
+            dockerfile: apps/mediapulse/agents/delivery/Dockerfile
+            image: delivery
+          - service: ticker-echo
+            dockerfile: apps/mediapulse/agents/ticker-echo/Dockerfile
+            image: ticker-echo
+          - service: agent-user-registration
+            dockerfile: apps/mediapulse/agents/user-registration/Dockerfile
+            image: agent-user-registration
     steps:
       - uses: actions/checkout@v6
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/data-collection/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  content-generation:
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  deploy:
+    name: Deploy ${{ matrix.service }} via Coolify
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: data-collection
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION
+          - service: content-generation
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION
+          - service: article-analysis
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS
+          - service: query-analysis
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS
+          - service: delivery
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_DELIVERY
+          - service: ticker-echo
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_TICKER_ECHO
+          - service: agent-user-registration
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/content-generation/fly.toml
+      - name: Trigger Coolify deployment
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+        run: curl --fail --silent --show-error -X GET "$COOLIFY_WEBHOOK_URL"
 
-  article-analysis:
+  cleanup:
+    name: Prune old GHCR versions (${{ matrix.image }})
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: deploy
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - data-collection
+          - content-generation
+          - article-analysis
+          - query-analysis
+          - delivery
+          - ticker-echo
+          - agent-user-registration
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/article-analysis/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  query-analysis:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/query-analysis/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  delivery:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/delivery/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  ticker-echo:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/ticker-echo/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  user-registration:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agents/user-registration/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: container
+          min-versions-to-keep: 2
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -88,27 +88,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - service: data-collection
-            dockerfile: apps/mediapulse/agents/data-collection/Dockerfile
-            image: agent-data-collection
-          - service: content-generation
-            dockerfile: apps/mediapulse/agents/content-generation/Dockerfile
-            image: agent-content-generation
-          - service: article-analysis
-            dockerfile: apps/mediapulse/agents/article-analysis/Dockerfile
-            image: agent-article-analysis
-          - service: query-analysis
-            dockerfile: apps/mediapulse/agents/query-analysis/Dockerfile
-            image: agent-query-analysis
           - service: delivery
             dockerfile: apps/mediapulse/agents/delivery/Dockerfile
             image: agent-delivery
-          - service: ticker-echo
-            dockerfile: apps/mediapulse/agents/ticker-echo/Dockerfile
-            image: agent-ticker-echo
-          - service: agent-user-registration
-            dockerfile: apps/mediapulse/agents/user-registration/Dockerfile
-            image: agent-user-registration
     steps:
       - uses: actions/checkout@v6
 
@@ -141,20 +123,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - service: data-collection
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION
-          - service: content-generation
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION
-          - service: article-analysis
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS
-          - service: query-analysis
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS
           - service: delivery
             webhook_secret: COOLIFY_WEBHOOK_AGENT_DELIVERY
-          - service: ticker-echo
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_TICKER_ECHO
-          - service: agent-user-registration
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION
     steps:
       - name: Trigger Coolify deployment over OpenVPN
         env:
@@ -172,7 +142,7 @@ jobs:
           WORKDIR="$(mktemp -d)"
           cleanup() {
             if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(tr -d '\n' < "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
+              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
             fi
             rm -rf "$WORKDIR"
           }
@@ -199,14 +169,7 @@ jobs:
           done
 
           if [ "$connected" != "true" ]; then
-            LOG_PATH="$WORKDIR/openvpn.log" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          log_path = Path(os.environ["LOG_PATH"])
-          if log_path.exists():
-              print(log_path.read_text(encoding="utf-8", errors="ignore"))
-          PY
+            sudo cat "$WORKDIR/openvpn.log" || true
             exit 1
           fi
 
@@ -222,13 +185,7 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - agent-data-collection
-          - agent-content-generation
-          - agent-article-analysis
-          - agent-query-analysis
           - agent-delivery
-          - agent-ticker-echo
-          - agent-user-registration
     steps:
       - uses: actions/delete-package-versions@v5
         with:

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -88,9 +85,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - service: data-collection
+            dockerfile: apps/mediapulse/agents/data-collection/Dockerfile
+            image: agent-data-collection
+          - service: content-generation
+            dockerfile: apps/mediapulse/agents/content-generation/Dockerfile
+            image: agent-content-generation
+          - service: article-analysis
+            dockerfile: apps/mediapulse/agents/article-analysis/Dockerfile
+            image: agent-article-analysis
+          - service: query-analysis
+            dockerfile: apps/mediapulse/agents/query-analysis/Dockerfile
+            image: agent-query-analysis
           - service: delivery
             dockerfile: apps/mediapulse/agents/delivery/Dockerfile
             image: agent-delivery
+          - service: ticker-echo
+            dockerfile: apps/mediapulse/agents/ticker-echo/Dockerfile
+            image: agent-ticker-echo
+          - service: agent-user-registration
+            dockerfile: apps/mediapulse/agents/user-registration/Dockerfile
+            image: agent-user-registration
     steps:
       - uses: actions/checkout@v6
 
@@ -123,12 +138,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - service: data-collection
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION
+          - service: content-generation
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION
+          - service: article-analysis
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS
+          - service: query-analysis
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS
           - service: delivery
             webhook_secret: COOLIFY_WEBHOOK_AGENT_DELIVERY
+          - service: ticker-echo
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_TICKER_ECHO
+          - service: agent-user-registration
+            webhook_secret: COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION
     steps:
       - name: Trigger Coolify deployment over OpenVPN
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+          COOLIFY_WEBHOOK_SECRET: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
           OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
           OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
         run: |
@@ -176,7 +204,9 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent --show-error --retry 3 --retry-delay 3 -X GET "$COOLIFY_WEBHOOK_URL"
+          curl --fail --silent --show-error --retry 3 --retry-delay 3 --verbose \
+            -X GET "$COOLIFY_WEBHOOK_URL" \
+            --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
 
   cleanup:
     name: Prune old GHCR versions (${{ matrix.image }})
@@ -188,7 +218,13 @@ jobs:
       fail-fast: false
       matrix:
         image:
+          - agent-data-collection
+          - agent-content-generation
+          - agent-article-analysis
+          - agent-query-analysis
           - agent-delivery
+          - agent-ticker-echo
+          - agent-user-registration
     steps:
       - uses: actions/delete-package-versions@v5
         with:

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -149,12 +149,12 @@ jobs:
           trap cleanup EXIT
 
           printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
-          printf "openvpn\n%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/auth.txt"
-          chmod 600 "$WORKDIR/auth.txt"
+          printf "%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/passphrase.txt"
+          chmod 600 "$WORKDIR/passphrase.txt"
 
           sudo openvpn \
             --config "$WORKDIR/client.ovpn" \
-            --auth-user-pass "$WORKDIR/auth.txt" \
+            --askpass "$WORKDIR/passphrase.txt" \
             --daemon \
             --writepid "$WORKDIR/openvpn.pid" \
             --log "$WORKDIR/openvpn.log"

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -161,8 +161,11 @@ jobs:
 
           connected="false"
           for _ in {1..30}; do
-            if ip addr show tun0 >/dev/null 2>&1; then
+            if sudo grep -q "Initialization Sequence Completed" "$WORKDIR/openvpn.log"; then
               connected="true"
+              break
+            fi
+            if [ -f "$WORKDIR/openvpn.pid" ] && ! sudo kill -0 "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1; then
               break
             fi
             sleep 2

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -176,12 +176,12 @@ jobs:
           trap cleanup EXIT
 
           printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
-          printf "openvpn\n%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/auth.txt"
-          chmod 600 "$WORKDIR/auth.txt"
+          printf "%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/passphrase.txt"
+          chmod 600 "$WORKDIR/passphrase.txt"
 
           sudo openvpn \
             --config "$WORKDIR/client.ovpn" \
-            --auth-user-pass "$WORKDIR/auth.txt" \
+            --askpass "$WORKDIR/passphrase.txt" \
             --daemon \
             --writepid "$WORKDIR/openvpn.pid" \
             --log "$WORKDIR/openvpn.log"

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -153,10 +153,61 @@ jobs:
           - service: hermes-worker
             webhook_secret: COOLIFY_WEBHOOK_APP_HERMES_WORKER
     steps:
-      - name: Trigger Coolify deployment
+      - name: Trigger Coolify deployment over OpenVPN
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
-        run: curl --fail --silent --show-error -X GET "$COOLIFY_WEBHOOK_URL"
+          OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
+          OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
+        run: |
+          set -euo pipefail
+
+          if ! command -v openvpn >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y openvpn
+          fi
+
+          WORKDIR="$(mktemp -d)"
+          cleanup() {
+            if [ -f "$WORKDIR/openvpn.pid" ]; then
+              sudo kill "$(tr -d '\n' < "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
+            fi
+            rm -rf "$WORKDIR"
+          }
+          trap cleanup EXIT
+
+          printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
+          printf "openvpn\n%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/auth.txt"
+          chmod 600 "$WORKDIR/auth.txt"
+
+          sudo openvpn \
+            --config "$WORKDIR/client.ovpn" \
+            --auth-user-pass "$WORKDIR/auth.txt" \
+            --daemon \
+            --writepid "$WORKDIR/openvpn.pid" \
+            --log "$WORKDIR/openvpn.log"
+
+          connected="false"
+          for _ in {1..30}; do
+            if ip addr show tun0 >/dev/null 2>&1; then
+              connected="true"
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$connected" != "true" ]; then
+            LOG_PATH="$WORKDIR/openvpn.log" python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          log_path = Path(os.environ["LOG_PATH"])
+          if log_path.exists():
+              print(log_path.read_text(encoding="utf-8", errors="ignore"))
+          PY
+            exit 1
+          fi
+
+          curl --fail --silent --show-error --retry 3 --retry-delay 3 -X GET "$COOLIFY_WEBHOOK_URL"
 
   cleanup:
     name: Prune old GHCR versions (${{ matrix.image }})

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -169,7 +169,7 @@ jobs:
           WORKDIR="$(mktemp -d)"
           cleanup() {
             if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(tr -d '\n' < "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
+              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
             fi
             rm -rf "$WORKDIR"
           }
@@ -196,14 +196,7 @@ jobs:
           done
 
           if [ "$connected" != "true" ]; then
-            LOG_PATH="$WORKDIR/openvpn.log" python3 - <<'PY'
-          import os
-          from pathlib import Path
-
-          log_path = Path(os.environ["LOG_PATH"])
-          if log_path.exists():
-              print(log_path.read_text(encoding="utf-8", errors="ignore"))
-          PY
+            sudo cat "$WORKDIR/openvpn.log" || true
             exit 1
           fi
 

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -188,8 +188,11 @@ jobs:
 
           connected="false"
           for _ in {1..30}; do
-            if ip addr show tun0 >/dev/null 2>&1; then
+            if sudo grep -q "Initialization Sequence Completed" "$WORKDIR/openvpn.log"; then
               connected="true"
+              break
+            fi
+            if [ -f "$WORKDIR/openvpn.pid" ] && ! sudo kill -0 "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1; then
               break
             fi
             sleep 2

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   db-ready:
     runs-on: ubuntu-latest
@@ -73,93 +77,108 @@ jobs:
       - name: Migrate deploy (mediapulse)
         run: pnpm --filter=@mediapulse/database run db:migrate:deploy
 
-  agent-auth-api:
+  publish:
+    name: Publish ${{ matrix.service }}
     runs-on: ubuntu-latest
     needs: db-migrate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: agent-auth-api
+            dockerfile: apps/hermes/agent-auth-api/Dockerfile
+            image: agent-auth-api
+          - service: agent-data-api
+            dockerfile: apps/mediapulse/agent-data-api/Dockerfile
+            image: agent-data-api
+          - service: domain-api
+            dockerfile: apps/mediapulse/domain-api/Dockerfile
+            image: domain-api
+          - service: agent-registry-api
+            dockerfile: apps/hermes/agent-registry-api/Dockerfile
+            image: agent-registry-api
+          - service: user-registration
+            dockerfile: apps/mediapulse/user-registration/Dockerfile
+            image: user-registration
+          - service: hermes
+            dockerfile: apps/hermes/dashboard/Dockerfile
+            image: hermes
+          - service: hermes-worker
+            dockerfile: apps/hermes/worker/Dockerfile
+            image: hermes-worker
     steps:
       - uses: actions/checkout@v6
 
-      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - uses: docker/setup-buildx-action@v3
 
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/agent-auth-api/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-  agent-data-api:
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+
+  deploy:
+    name: Deploy ${{ matrix.service }} via Coolify
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: publish
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: agent-auth-api
+            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_AUTH_API
+          - service: agent-data-api
+            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_DATA_API
+          - service: domain-api
+            webhook_secret: COOLIFY_WEBHOOK_APP_DOMAIN_API
+          - service: agent-registry-api
+            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_REGISTRY_API
+          - service: user-registration
+            webhook_secret: COOLIFY_WEBHOOK_APP_USER_REGISTRATION
+          - service: hermes
+            webhook_secret: COOLIFY_WEBHOOK_APP_HERMES
+          - service: hermes-worker
+            webhook_secret: COOLIFY_WEBHOOK_APP_HERMES_WORKER
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/agent-data-api/fly.toml
+      - name: Trigger Coolify deployment
         env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+          COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+        run: curl --fail --silent --show-error -X GET "$COOLIFY_WEBHOOK_URL"
 
-  domain-api:
+  cleanup:
+    name: Prune old GHCR versions (${{ matrix.image }})
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: deploy
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - agent-auth-api
+          - agent-data-api
+          - domain-api
+          - agent-registry-api
+          - user-registration
+          - hermes
+          - hermes-worker
     steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/domain-api/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  agent-registry-api:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/agent-registry-api/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  user-registration:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/mediapulse/user-registration/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  hermes:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/dashboard/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
-
-  hermes-worker:
-    runs-on: ubuntu-latest
-    needs: db-migrate
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: superfly/flyctl-actions/setup-flyctl@master
-
-      - name: Deploy to fly.io
-        run: flyctl deploy --remote-only --depot=false --ha=false -c apps/hermes/worker/fly.toml
-        env:
-          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+      - uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: container
+          min-versions-to-keep: 2
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -156,6 +156,7 @@ jobs:
       - name: Trigger Coolify deployment over OpenVPN
         env:
           COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
+          COOLIFY_WEBHOOK_SECRET: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
           OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
           OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
         run: |
@@ -203,7 +204,9 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent --show-error --retry 3 --retry-delay 3 -X GET "$COOLIFY_WEBHOOK_URL"
+          curl --fail --silent --show-error --retry 3 --retry-delay 3 --verbose \
+            -X GET "$COOLIFY_WEBHOOK_URL" \
+            --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
 
   cleanup:
     name: Prune old GHCR versions (${{ matrix.image }})

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -87,25 +87,25 @@ jobs:
         include:
           - service: agent-auth-api
             dockerfile: apps/hermes/agent-auth-api/Dockerfile
-            image: agent-auth-api
+            image: app-agent-auth-api
           - service: agent-data-api
             dockerfile: apps/mediapulse/agent-data-api/Dockerfile
-            image: agent-data-api
+            image: app-agent-data-api
           - service: domain-api
             dockerfile: apps/mediapulse/domain-api/Dockerfile
-            image: domain-api
+            image: app-domain-api
           - service: agent-registry-api
             dockerfile: apps/hermes/agent-registry-api/Dockerfile
-            image: agent-registry-api
+            image: app-agent-registry-api
           - service: user-registration
             dockerfile: apps/mediapulse/user-registration/Dockerfile
-            image: user-registration
+            image: app-user-registration
           - service: hermes
             dockerfile: apps/hermes/dashboard/Dockerfile
-            image: hermes
+            image: app-hermes
           - service: hermes-worker
             dockerfile: apps/hermes/worker/Dockerfile
-            image: hermes-worker
+            image: app-hermes-worker
     steps:
       - uses: actions/checkout@v6
 
@@ -168,13 +168,13 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - agent-auth-api
-          - agent-data-api
-          - domain-api
-          - agent-registry-api
-          - user-registration
-          - hermes
-          - hermes-worker
+          - app-agent-auth-api
+          - app-agent-data-api
+          - app-domain-api
+          - app-agent-registry-api
+          - app-user-registration
+          - app-hermes
+          - app-hermes-worker
     steps:
       - uses: actions/delete-package-versions@v5
         with:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -eu
 
-          ALL_SERVICES='["user-registration","domain-api","agent-data-api","agent-auth-api","agent-registry-api","hermes","hermes-worker","data-collection","content-generation","delivery","ticker-echo","article-analysis","query-analysis"]'
+          ALL_SERVICES='["user-registration","domain-api","agent-data-api","agent-auth-api","agent-registry-api","hermes","hermes-worker","data-collection","content-generation","delivery","ticker-echo","article-analysis","query-analysis","agent-user-registration"]'
 
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
 
@@ -71,6 +71,7 @@ jobs:
               apps/mediapulse/agents/ticker-echo/*)   services_list+=$'ticker-echo\n' ;;
               apps/mediapulse/agents/article-analysis/*)  services_list+=$'article-analysis\n' ;;
               apps/mediapulse/agents/query-analysis/*)    services_list+=$'query-analysis\n' ;;
+              apps/mediapulse/agents/user-registration/*)  services_list+=$'agent-user-registration\n' ;;
             esac
           done <<< "$changed_files"
 
@@ -114,7 +115,8 @@ jobs:
             delivery)           echo "dockerfile=apps/mediapulse/agents/delivery/Dockerfile" >> "$GITHUB_OUTPUT" ;;
             ticker-echo)        echo "dockerfile=apps/mediapulse/agents/ticker-echo/Dockerfile" >> "$GITHUB_OUTPUT" ;;
             article-analysis)   echo "dockerfile=apps/mediapulse/agents/article-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
-            query-analysis)     echo "dockerfile=apps/mediapulse/agents/query-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            query-analysis)          echo "dockerfile=apps/mediapulse/agents/query-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            agent-user-registration) echo "dockerfile=apps/mediapulse/agents/user-registration/Dockerfile" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - uses: docker/setup-buildx-action@v3

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -22,11 +22,13 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 | **Mediapulse (domain)**    | Tickers, newsletters, KG, subscribers, user registration data, etc. | `MEDIAPULSE_DATABASE_URL`                                                                  | `pnpm --filter @mediapulse/database db:migrate:deploy`                       |
 | **DataQueue**              | hermes-worker job queue (scheduler)                                 | `PG_DATAQUEUE_DATABASE` (same host is fine; use `?schema=dataqueue&search_path=dataqueue`) | `pnpm --filter @hermes/worker run migrate-dataqueue` (with queue URL in env) |
 
-Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before Fly deploys). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
+Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before image publish). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
 
-Each **Fly** deploy step uses **`flyctl deploy --remote-only --depot=false --ha=false`**: the image is built on Fly’s builders (not third-party Depot) from the repo **`Dockerfile`** (`pnpm install` and **`turbo build`** for that app). **`--ha=false`** keeps deploys to **one Machine** per app (Fly’s default HA otherwise seeds a second Machine for HTTP services). GitHub Actions does **not** duplicate that build on the runner. Dockerfiles set **`MEDIAPULSE_ENV_BUILD_TARGETS`** or **`HERMES_ENV_BUILD_TARGETS`** so `@mediapulse/env` / `@hermes/env` only run `env-to-t3` for the slices that image needs (faster builds); leave those unset locally for full codegen.
+After migrations succeed, each workflow builds and pushes per-service images to **GitHub Container Registry (GHCR)** as `ghcr.io/<owner>/<image>:sha-<commit>` and `ghcr.io/<owner>/<image>:latest`. Images are built from the repository root using each app's **`Dockerfile`**. Dockerfiles set **`MEDIAPULSE_ENV_BUILD_TARGETS`** or **`HERMES_ENV_BUILD_TARGETS`** so `@mediapulse/env` / `@hermes/env` only run `env-to-t3` for the slices that image needs (faster builds); leave those unset locally for full codegen.
 
-Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict “tests then deploy” order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+Once an image is published, CI triggers a **Coolify deploy webhook** for each service. Coolify pulls the new image from GHCR and rolls it out. A **cleanup job** runs after all deploys succeed and deletes older GHCR package versions, retaining the **two newest versions** per service for rollback.
+
+Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
 ---
 
@@ -196,7 +198,7 @@ Public-facing newsletter signup UI. The current implementation serves ticker cho
 
 ### 4. Mediapulse agents
 
-Examples: **`@mediapulse/data-collection`**, **`@mediapulse/content-generation`**, **`@mediapulse/article-analysis`**, **`@mediapulse/delivery`**, **`@mediapulse/ticker-echo`** under `apps/mediapulse/agents/*`. Merge **`packages/mediapulse/env/env.example`** with the matching **`packages/mediapulse/env/env.agents.*.example`**. Each agent may ship **`Dockerfile`** and **`fly.toml`**; merges to **`main`** trigger **`Agent Deployment`** (`.github/workflows/agent-deploy.yml`) for the configured apps.
+Examples: **`@mediapulse/data-collection`**, **`@mediapulse/content-generation`**, **`@mediapulse/article-analysis`**, **`@mediapulse/delivery`**, **`@mediapulse/ticker-echo`** under `apps/mediapulse/agents/*`. Merge **`packages/mediapulse/env/env.example`** with the matching **`packages/mediapulse/env/env.agents.*.example`**. Each agent ships a **`Dockerfile`**; merges to **`main`** trigger **`Agent Deployment`** (`.github/workflows/agent-deploy.yml`), which builds and pushes images to GHCR and then deploys via Coolify webhook.
 
 | Step                 | Command                                                                                                                               |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
@@ -245,5 +247,7 @@ Annotated templates: **`packages/hermes/env/env.example`**, **`env.hermes-worker
 ## Summary
 
 - **Order:** Prerequisites (three DB roles + migrations) → **Hermes** (auth API → registry API → dashboard → worker, with **`HERMES_INTERNAL_API_KEY`** aligned) → **Mediapulse** (agent-data-api → domain-api → optional **user-registration** → agents).
-- **Secrets:** Never commit real values; use your platform’s secret storage. **`HERMES_INTERNAL_API_KEY`** is a deploy-time preset. **`DOMAIN_INTEGRATION_API_KEY`** on Mediapulse/agents is the API key generated in **Domain integrations** (Hermes dashboard).
+- **CI deploy flow:** Every merge to `main` runs `db-ready` → `db-migrate` → build and push per-service images to GHCR → trigger Coolify deploy webhooks → prune old GHCR versions (keep newest 2 per service for rollback).
+- **Rollback:** Promote the previous image tag (`sha-<commit>`) in Coolify to roll back a service without a new merge.
+- **Secrets:** Never commit real values; use your platform’s secret storage. **`HERMES_INTERNAL_API_KEY`** is a deploy-time preset. **`DOMAIN_INTEGRATION_API_KEY`** on Mediapulse/agents is the API key generated in **Domain integrations** (Hermes dashboard). Apps require **`COOLIFY_WEBHOOK_APP_<SERVICE>`** secrets and agents require **`COOLIFY_WEBHOOK_AGENT_<SERVICE>`** secrets in GitHub Actions; GHCR access uses the built-in **`GITHUB_TOKEN`** with `packages: write`.
 - **JWTs:** agent-auth-api issues tokens for the internal preset and for **domain_integration** API keys (hash in DB); Hermes decrypts per-integration ciphertext for outbound domain/agent calls where configured. Verification uses **`AGENT_AUTH_API_URL`** / **`AGENT_AUTH_JWT_SECRET`** on the auth API.


### PR DESCRIPTION
## Summary

This migrates production deployment from Fly.io to Coolify with GHCR-backed images while keeping the current main-merge cadence. Prisma migrations remain the gate before publish/deploy so schema changes land before services roll out.

## Related issues

Closes #395

## Important changes

- Replace `flyctl deploy` jobs in both deployment workflows with a two-stage release path: publish Docker images to GHCR, then trigger per-service Coolify deploy webhooks.
- Keep `db-ready` and `db-migrate` at the top of both workflows, including the shared `prisma-migrate-production` concurrency guard.
- Add GHCR package cleanup jobs to retain only the two newest versions per service, preserving one rollback slot while controlling registry growth.
- Apply the requested secret naming convention: app services use `COOLIFY_WEBHOOK_APP_*` and agent services use `COOLIFY_WEBHOOK_AGENT_*`.

## Other changes

- Extend the PR Docker validation workflow to include the `agent-user-registration` image path and change detection rules.
- Update production docs with the GHCR publish -> Coolify webhook flow, rollback note, and webhook secret naming guidance.

## Key files to review

- `.github/workflows/app-deploy.yml` - app-service publish/deploy/cleanup migration from Fly to GHCR + Coolify.
- `.github/workflows/agent-deploy.yml` - agent-service publish/deploy/cleanup migration and agent webhook secret mapping.
- `.github/workflows/docker-build.yml` - PR build matrix updates for `agent-user-registration`.
- `dev-docs/docs/guide/production.mdx` - production deployment and secret documentation updates.

## How to test

1. Run `pnpm format:check` from repo root and confirm it exits clean.
2. In a test branch, inspect GitHub Actions plans for `app-deploy` and `agent-deploy` to confirm job order: `db-ready` -> `db-migrate` -> `publish` -> `deploy` -> `cleanup`.
3. Confirm each matrix entry resolves expected GHCR tags (`sha-<commit>` and `latest`) and expected Coolify webhook secret names.
4. Validate docs now describe GHCR + Coolify flow and the app/agent webhook prefix split.
