### PR TITLE
Require explicit registration email in user-registration builds

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -124,6 +124,8 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           push: true
+          build-args: |
+            NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && secrets.NEXT_PUBLIC_REGISTRATION_EMAIL || '' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -127,5 +127,7 @@ jobs:
           context: .
           file: ${{ steps.resolve.outputs.dockerfile }}
           push: false
+          build-args: |
+            NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && 'registration@example.com' || '' }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -25,7 +25,9 @@ RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registrati
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local
 
 ENV MEDIAPULSE_ENV_BUILD_TARGETS=app.user-registration
-ENV NEXT_PUBLIC_REGISTRATION_EMAIL="registration@mediapulse.example"
+ARG NEXT_PUBLIC_REGISTRATION_EMAIL
+ENV NEXT_PUBLIC_REGISTRATION_EMAIL=$NEXT_PUBLIC_REGISTRATION_EMAIL
+RUN test -n "$NEXT_PUBLIC_REGISTRATION_EMAIL"
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration --env-mode=loose
 
 ARG NODE_VERSION=24.12.0


### PR DESCRIPTION
## Summary

This change removes the baked registration email fallback from the user-registration image build and makes the value explicit at build time. That keeps production bundles from silently inheriting a placeholder contact address.

## Related issues

Closes #399

## Important changes

- `apps/mediapulse/user-registration/Dockerfile` now requires `NEXT_PUBLIC_REGISTRATION_EMAIL` as a build arg and fails fast if it is missing.
- `.github/workflows/app-deploy.yml` passes `NEXT_PUBLIC_REGISTRATION_EMAIL` from `secrets.NEXT_PUBLIC_REGISTRATION_EMAIL` only for the `user-registration` build matrix entry.
- `.github/workflows/docker-build.yml` passes a deterministic dummy value for PR build validation so the check remains runnable without production secrets.

## Other changes

- No runtime app logic changed. This is limited to build-time input handling and CI wiring.

## Key files to review

- `apps/mediapulse/user-registration/Dockerfile` - required build arg and guard.
- `.github/workflows/app-deploy.yml` - production build-arg injection from secrets.
- `.github/workflows/docker-build.yml` - PR validation build-arg injection.

## How to test

1. Run `pnpm format:check` from repo root.
2. Build `apps/mediapulse/user-registration/Dockerfile` without `NEXT_PUBLIC_REGISTRATION_EMAIL` and confirm it fails.
3. Build the same Dockerfile with `--build-arg NEXT_PUBLIC_REGISTRATION_EMAIL=registration@example.com` and confirm it succeeds.
4. Confirm GitHub Actions has `NEXT_PUBLIC_REGISTRATION_EMAIL` configured before running `app-deploy`.
