### PR TITLE
Simplify deploy workflows by removing db-ready waits

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -10,48 +10,9 @@ permissions:
   packages: write
 
 jobs:
-  db-ready:
-    runs-on: ubuntu-latest
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Wait for orchestration DB
-        run: |
-          for i in {1..24}; do
-            pnpm --filter=@hermes/orchestration-database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
-            echo "Waiting for orchestration DB ($i/24)..."
-            sleep 5
-          done
-          echo "Orchestration DB did not become ready in time"
-          exit 1
-
-      - name: Wait for mediapulse DB
-        run: |
-          for i in {1..24}; do
-            pnpm --filter=@mediapulse/database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
-            echo "Waiting for mediapulse DB ($i/24)..."
-            sleep 5
-          done
-          echo "Mediapulse DB did not become ready in time"
-          exit 1
-
   db-migrate:
     name: Apply Prisma migrations (production DBs)
     runs-on: ubuntu-latest
-    needs: db-ready
     concurrency:
       group: prisma-migrate-production
       cancel-in-progress: false

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -10,48 +10,9 @@ permissions:
   packages: write
 
 jobs:
-  db-ready:
-    runs-on: ubuntu-latest
-    env:
-      ORCHESTRATION_DATABASE_URL: ${{ secrets.ORCHESTRATION_DATABASE_URL }}
-      MEDIAPULSE_DATABASE_URL: ${{ secrets.MEDIAPULSE_DATABASE_URL }}
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Wait for orchestration DB
-        run: |
-          for i in {1..24}; do
-            pnpm --filter=@hermes/orchestration-database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
-            echo "Waiting for orchestration DB ($i/24)..."
-            sleep 5
-          done
-          echo "Orchestration DB did not become ready in time"
-          exit 1
-
-      - name: Wait for mediapulse DB
-        run: |
-          for i in {1..24}; do
-            pnpm --filter=@mediapulse/database exec prisma db execute --stdin <<< "SELECT 1;" && exit 0
-            echo "Waiting for mediapulse DB ($i/24)..."
-            sleep 5
-          done
-          echo "Mediapulse DB did not become ready in time"
-          exit 1
-
   db-migrate:
     name: Apply Prisma migrations (production DBs)
     runs-on: ubuntu-latest
-    needs: db-ready
     concurrency:
       group: prisma-migrate-production
       cancel-in-progress: false


### PR DESCRIPTION
## Summary

This simplifies deployment by removing the separate DB readiness polling jobs from both deploy workflows. Prisma migrations remain in CI and now run directly as the single DB gate before publish and deploy.

## Related issues

Closes #403

## Important changes

- Removed `db-ready` job blocks from `.github/workflows/app-deploy.yml` and `.github/workflows/agent-deploy.yml`.
- `db-migrate` jobs no longer depend on `needs: db-ready`; they start directly and continue to gate publish/deploy.

## Other changes

- No changes to GHCR publish, Coolify webhook deploy, or GHCR cleanup retention logic.

## Key files to review

- `.github/workflows/app-deploy.yml` - removed DB readiness polling job and dependency.
- `.github/workflows/agent-deploy.yml` - removed DB readiness polling job and dependency.

## How to test

1. Trigger `App Deployment` workflow on a test branch/commit path to main and confirm job order is `db-migrate -> publish -> deploy -> cleanup`.
2. Trigger `Agent Deployment` workflow and confirm the same simplified order.
3. Verify migrations still fail the workflow if the DB is unavailable, without the prior readiness loop.
