### PR TITLE
Migrate unsubscribe endpoint to user-registration app

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -126,6 +126,7 @@ jobs:
           push: true
           build-args: |
             NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && secrets.NEXT_PUBLIC_REGISTRATION_EMAIL || '' }}
+            AGENT_DATA_API_URL=${{ matrix.service == 'user-registration' && secrets.AGENT_DATA_API_URL || '' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -129,5 +129,6 @@ jobs:
           push: false
           build-args: |
             NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && 'registration@example.com' || '' }}
+            AGENT_DATA_API_URL=${{ matrix.service == 'user-registration' && 'http://agent-data-api.local' || '' }}
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}

--- a/apps/mediapulse/agent-data-api/package.json
+++ b/apps/mediapulse/agent-data-api/package.json
@@ -11,13 +11,14 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@mediapulse/database": "workspace:*",
+    "@mediapulse/env": "workspace:*",
     "@workspace/agent-auth-client": "workspace:*",
     "@workspace/agent-data-api-contract": "workspace:*",
     "@workspace/agent-types": "workspace:*",
     "@workspace/api-utils": "workspace:*",
-    "@mediapulse/env": "workspace:*",
-    "@mediapulse/database": "workspace:*",
     "@workspace/logger": "workspace:*",
+    "@workspace/utils": "workspace:*",
     "hono": "catalog:",
     "hono-pino": "catalog:",
     "zod": "catalog:"

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -35,6 +35,8 @@ import { getDelivery, postDeliveryHandler } from "./routes/delivery.js";
 import {
   postUserRegistrationRegisterHandler,
   postUserRegistrationConfirmHandler,
+  getUserRegistrationUnsubscribeHandler,
+  postUserRegistrationUnsubscribeHandler,
 } from "./routes/user-registration.js";
 import {
   getQueryAnalysis,
@@ -116,6 +118,10 @@ const routeHandlers = {
   userRegistrationConfirm: {
     post: postUserRegistrationConfirmHandler,
   },
+  userRegistrationUnsubscribe: {
+    get: getUserRegistrationUnsubscribeHandler,
+    post: postUserRegistrationUnsubscribeHandler,
+  },
   contentGenerationRuns: {
     get: getContentGenerationRuns,
     post: postContentGenerationRun,
@@ -124,13 +130,17 @@ const routeHandlers = {
 
 for (const version of AGENT_DATA_API_LIVE_VERSIONS) {
   const versionApi = new Hono();
-  versionApi.use(
-    "*",
-    bearerAuth({
+  const unsubscribePath = `${AGENT_DATA_API_PREFIX}/${version}/user-registration-unsubscribe`;
+  versionApi.use("*", async (context, next) => {
+    const pathname = new URL(context.req.url).pathname;
+    if (pathname === unsubscribePath) {
+      return next();
+    }
+    return bearerAuth({
       verifyToken: (token) =>
         verifyTokenViaAuthApi(token, env.AGENT_AUTH_API_URL!),
-    }),
-  );
+    })(context, next);
+  });
   registerAgentDataApiRoutes(
     versionApi,
     agentDataApiManifestForVersion(version),

--- a/apps/mediapulse/agent-data-api/src/routes/user-registration.test.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/user-registration.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+
+vi.mock("@mediapulse/env", () => ({
+  env: {
+    UNSUBSCRIBE_SECRET: "test-unsubscribe-secret",
+  },
+}));
+
+vi.mock("../services/user-registration.js", () => ({
+  processRegistration: vi.fn(),
+  confirmRegistration: vi.fn(),
+  processUnsubscribe: vi.fn(),
+}));
+
+import { processUnsubscribe } from "../services/user-registration.js";
+import {
+  getUserRegistrationUnsubscribeHandler,
+  postUserRegistrationUnsubscribeHandler,
+} from "./user-registration.js";
+
+describe("user-registration unsubscribe route handlers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns JSON for GET unsubscribe lookups", async () => {
+    vi.mocked(processUnsubscribe).mockResolvedValue({
+      status: "already_unsubscribed",
+      displaySymbol: "BBCA",
+    });
+    const app = new Hono();
+    app.get("/unsubscribe", getUserRegistrationUnsubscribeHandler);
+
+    const response = await app.request(
+      "http://localhost/unsubscribe?token=test-token",
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "already_unsubscribed",
+      displaySymbol: "BBCA",
+    });
+    expect(processUnsubscribe).toHaveBeenCalledWith({
+      token: "test-token",
+      secret: "test-unsubscribe-secret",
+      method: "link",
+    });
+  });
+
+  it("returns JSON for POST one-click unsubscribe", async () => {
+    vi.mocked(processUnsubscribe).mockResolvedValue({
+      status: "unsubscribed",
+      displaySymbol: "BBCA",
+    });
+    const app = new Hono();
+    app.post("/unsubscribe", postUserRegistrationUnsubscribeHandler);
+
+    const response = await app.request("http://localhost/unsubscribe", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "test-token" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "unsubscribed",
+      displaySymbol: "BBCA",
+    });
+    expect(processUnsubscribe).toHaveBeenCalledWith({
+      token: "test-token",
+      secret: "test-unsubscribe-secret",
+      method: "one_click",
+    });
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/routes/user-registration.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/user-registration.ts
@@ -1,14 +1,19 @@
 import { Context } from "hono";
 import { internalError } from "@workspace/api-utils";
+import { env } from "@mediapulse/env";
 import {
   postUserRegistrationRegisterBodySchema,
   postUserRegistrationRegisterResponseSchema,
   postUserRegistrationConfirmBodySchema,
   postUserRegistrationConfirmResponseSchema,
+  postUserRegistrationUnsubscribeBodySchema,
+  userRegistrationUnsubscribeQuerySchema,
+  userRegistrationUnsubscribeResponseSchema,
 } from "@workspace/agent-data-api-contract";
 import {
   processRegistration,
   confirmRegistration,
+  processUnsubscribe,
 } from "../services/user-registration.js";
 
 export async function postUserRegistrationRegisterHandler(
@@ -33,6 +38,44 @@ export async function postUserRegistrationConfirmHandler(
     const data = await postUserRegistrationConfirmBodySchema.parseAsync(body);
     const result = await confirmRegistration(data);
     const response = postUserRegistrationConfirmResponseSchema.parse(result);
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}
+
+export async function getUserRegistrationUnsubscribeHandler(
+  context: Context,
+): Promise<Response> {
+  try {
+    const query = userRegistrationUnsubscribeQuerySchema.parse(
+      context.req.query(),
+    );
+    const result = await processUnsubscribe({
+      token: query.token,
+      secret: env.UNSUBSCRIBE_SECRET,
+      method: "link",
+    });
+    const response = userRegistrationUnsubscribeResponseSchema.parse(result);
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}
+
+export async function postUserRegistrationUnsubscribeHandler(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const data =
+      await postUserRegistrationUnsubscribeBodySchema.parseAsync(body);
+    const result = await processUnsubscribe({
+      token: data.token,
+      secret: env.UNSUBSCRIBE_SECRET,
+      method: "one_click",
+    });
+    const response = userRegistrationUnsubscribeResponseSchema.parse(result);
     return context.json(response, 200);
   } catch (error) {
     return internalError(context, error);

--- a/apps/mediapulse/agent-data-api/src/services/user-registration.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/user-registration.test.ts
@@ -331,3 +331,116 @@ describe("processRegistration with immediate confirmation", () => {
     });
   });
 });
+
+describe("processUnsubscribe", () => {
+  const SECRET = "test-unsubscribe-secret";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns invalid when token is malformed", async () => {
+    const { processUnsubscribe } = await import("./user-registration.js");
+    const result = await processUnsubscribe({
+      token: "bad-token",
+      secret: SECRET,
+      method: "link",
+    });
+    expect(result).toEqual({ status: "invalid" });
+    const { prisma } = await import("@mediapulse/database");
+    expect(prisma.userTicker.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("returns not_found when token is valid but subscription is missing", async () => {
+    const { createUnsubscribeToken } = await import("@workspace/utils");
+    const token = createUnsubscribeToken({
+      userTickerId: "11111111-1111-4111-a111-111111111111",
+      tickerSymbol: "BBCA",
+      secret: SECRET,
+    });
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.userTicker.findUnique).mockResolvedValue(null);
+
+    const { processUnsubscribe } = await import("./user-registration.js");
+    const result = await processUnsubscribe({
+      token,
+      secret: SECRET,
+      method: "link",
+    });
+
+    expect(result).toEqual({ status: "not_found", displaySymbol: "BBCA" });
+  });
+
+  it("returns already_unsubscribed for idempotent retries", async () => {
+    const { createUnsubscribeToken } = await import("@workspace/utils");
+    const token = createUnsubscribeToken({
+      userTickerId: "11111111-1111-4111-a111-111111111111",
+      tickerSymbol: "BBCA",
+      secret: SECRET,
+    });
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.userTicker.findUnique).mockResolvedValue({
+      ...makeUserTicker({
+        enabled: false,
+      }),
+      unsubscribedAt: new Date(),
+      ticker: { symbol: "BBCA" },
+    } as unknown as Awaited<ReturnType<typeof prisma.userTicker.findUnique>>);
+
+    const { processUnsubscribe } = await import("./user-registration.js");
+    const result = await processUnsubscribe({
+      token,
+      secret: SECRET,
+      method: "link",
+    });
+
+    expect(result).toEqual({
+      status: "already_unsubscribed",
+      displaySymbol: "BBCA",
+    });
+    expect(prisma.userTicker.update).not.toHaveBeenCalled();
+  });
+
+  it("disables the subscription and records method", async () => {
+    const { createUnsubscribeToken } = await import("@workspace/utils");
+    const token = createUnsubscribeToken({
+      userTickerId: "11111111-1111-4111-a111-111111111111",
+      tickerSymbol: "BBCA",
+      secret: SECRET,
+    });
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.userTicker.findUnique).mockResolvedValue({
+      ...makeUserTicker({
+        enabled: true,
+      }),
+      unsubscribedAt: null,
+      ticker: { symbol: "BBCA" },
+    } as unknown as Awaited<ReturnType<typeof prisma.userTicker.findUnique>>);
+    vi.mocked(prisma.userTicker.update).mockResolvedValue(
+      makeUserTicker({ enabled: false }) as unknown as Awaited<
+        ReturnType<typeof prisma.userTicker.update>
+      >,
+    );
+
+    const { processUnsubscribe } = await import("./user-registration.js");
+    const result = await processUnsubscribe({
+      token,
+      secret: SECRET,
+      method: "one_click",
+    });
+
+    expect(result).toEqual({ status: "unsubscribed", displaySymbol: "BBCA" });
+    expect(prisma.userTicker.update).toHaveBeenCalledWith({
+      where: { id: "11111111-1111-4111-a111-111111111111" },
+      data: {
+        enabled: false,
+        unsubscribedAt: expect.any(Date),
+        unsubscribeMethod: "one_click",
+      },
+    });
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/user-registration.ts
+++ b/apps/mediapulse/agent-data-api/src/services/user-registration.ts
@@ -1,4 +1,9 @@
 import { prisma as mediapulsePrisma } from "@mediapulse/database";
+import { verifyUnsubscribeToken } from "@workspace/utils";
+import type {
+  UserRegistrationUnsubscribeMethod,
+  UserRegistrationUnsubscribeResponse,
+} from "@workspace/agent-data-api-contract";
 
 /**
  * Processes a new or returning user registration for a given ticker.
@@ -120,4 +125,56 @@ export async function confirmRegistration({
     },
   });
   return { success: true };
+}
+
+/**
+ * Applies an unsubscribe token to disable a user subscription.
+ *
+ * @param params - Token verification inputs.
+ * @param params.token - Signed unsubscribe token.
+ * @param params.secret - Shared HMAC secret.
+ * @param params.method - Unsubscribe interaction method for audit.
+ * @returns Normalized unsubscribe outcome for API callers.
+ */
+export async function processUnsubscribe({
+  token,
+  secret,
+  method,
+}: {
+  token: string;
+  secret: string;
+  method: UserRegistrationUnsubscribeMethod;
+}): Promise<UserRegistrationUnsubscribeResponse> {
+  const result = verifyUnsubscribeToken(token, secret);
+  if (!result.valid) {
+    if (result.reason === "expired") {
+      return { status: "expired" };
+    }
+    return { status: "invalid" };
+  }
+
+  const userTicker = await mediapulsePrisma.userTicker.findUnique({
+    where: { id: result.userTickerId },
+    include: { ticker: true },
+  });
+  const displaySymbol = userTicker?.ticker?.symbol ?? result.tickerSymbol;
+
+  if (!userTicker) {
+    return { status: "not_found", displaySymbol };
+  }
+
+  if (!userTicker.enabled && userTicker.unsubscribedAt != null) {
+    return { status: "already_unsubscribed", displaySymbol };
+  }
+
+  await mediapulsePrisma.userTicker.update({
+    where: { id: result.userTickerId },
+    data: {
+      enabled: false,
+      unsubscribedAt: new Date(),
+      unsubscribeMethod: method,
+    },
+  });
+
+  return { status: "unsubscribed", displaySymbol };
 }

--- a/apps/mediapulse/agents/delivery/src/config-schema.ts
+++ b/apps/mediapulse/agents/delivery/src/config-schema.ts
@@ -55,7 +55,7 @@ export const DeliveryConfigSchema = z
       /** Shared HMAC secret for signing/verifying unsubscribe tokens. */
       secret: z.string().min(1),
       /**
-       * Public base URL of the domain API (e.g. "https://mediapulse.com").
+       * Public base URL of the user-registration app (e.g. "https://register.mediapulse.com").
        * The full unsubscribe path `/api/unsubscribe` is appended at runtime.
        */
       baseUrl: z.string().url(),

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -26,8 +26,11 @@ RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registrati
 
 ENV MEDIAPULSE_ENV_BUILD_TARGETS=app.user-registration
 ARG NEXT_PUBLIC_REGISTRATION_EMAIL
+ARG AGENT_DATA_API_URL
 ENV NEXT_PUBLIC_REGISTRATION_EMAIL=$NEXT_PUBLIC_REGISTRATION_EMAIL
+ENV AGENT_DATA_API_URL=$AGENT_DATA_API_URL
 RUN test -n "$NEXT_PUBLIC_REGISTRATION_EMAIL"
+RUN test -n "$AGENT_DATA_API_URL"
 RUN pnpm exec turbo build --filter=@mediapulse/user-registration --env-mode=loose
 
 ARG NODE_VERSION=24.12.0

--- a/apps/mediapulse/user-registration/app/api/unsubscribe/route.test.ts
+++ b/apps/mediapulse/user-registration/app/api/unsubscribe/route.test.ts
@@ -1,0 +1,86 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mediapulse/env/app-user-registration", () => ({
+  env: {
+    AGENT_DATA_API_URL: "http://agent-data-api.internal",
+    NEXT_PUBLIC_REGISTRATION_EMAIL: "registration@example.com",
+  },
+}));
+
+const fetchMock = vi.fn<typeof fetch>();
+vi.stubGlobal("fetch", fetchMock);
+
+describe("user-registration unsubscribe route", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders success html for GET unsubscribe", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ status: "unsubscribed", displaySymbol: "BBCA" }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      new Request("http://localhost/api/unsubscribe?token=test-token"),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("Unsubscribed");
+    expect(body).toContain("BBCA");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://agent-data-api.internal/api/v1/user-registration-unsubscribe?token=test-token",
+      { method: "GET", cache: "no-store" },
+    );
+  });
+
+  it("returns fallback html when GET upstream fails", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network"));
+    const { GET } = await import("./route");
+
+    const response = await GET(
+      new Request("http://localhost/api/unsubscribe?token=test-token"),
+    );
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain("temporarily unavailable");
+  });
+
+  it("returns empty 200 for POST one-click and forwards token", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ status: "unsubscribed" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const { POST } = await import("./route");
+
+    const response = await POST(
+      new Request("http://localhost/api/unsubscribe?token=test-token", {
+        method: "POST",
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://agent-data-api.internal/api/v1/user-registration-unsubscribe",
+      {
+        method: "POST",
+        cache: "no-store",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token: "test-token" }),
+      },
+    );
+  });
+});

--- a/apps/mediapulse/user-registration/app/api/unsubscribe/route.ts
+++ b/apps/mediapulse/user-registration/app/api/unsubscribe/route.ts
@@ -1,0 +1,130 @@
+import { env } from "@mediapulse/env/app-user-registration";
+
+type UnsubscribeStatus =
+  | "unsubscribed"
+  | "already_unsubscribed"
+  | "not_found"
+  | "invalid"
+  | "expired";
+
+type UnsubscribeResponse = {
+  status: UnsubscribeStatus;
+  displaySymbol?: string;
+};
+
+/**
+ * Renders browser-friendly unsubscribe response pages.
+ *
+ * @param body - Inner HTML message.
+ * @returns HTML response.
+ */
+const htmlResponse = (body: string): Response =>
+  new Response(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>MediaPulse</title></head><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:480px;margin:40px auto;padding:0 16px;color:#1a1a1a">${body}</body></html>`,
+    {
+      status: 200,
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    },
+  );
+
+/**
+ * Calls agent-data-api unsubscribe endpoint.
+ *
+ * @param token - Signed unsubscribe token.
+ * @param method - Origin interaction method for audit.
+ * @returns Parsed API response.
+ */
+const requestUnsubscribe = async (
+  token: string,
+  method: "link" | "one_click",
+): Promise<UnsubscribeResponse> => {
+  const endpoint = `${env.AGENT_DATA_API_URL.replace(/\/$/, "")}/api/v1/user-registration-unsubscribe`;
+
+  if (method === "link") {
+    const response = await fetch(
+      `${endpoint}?token=${encodeURIComponent(token)}`,
+      { method: "GET", cache: "no-store" },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Unsubscribe lookup failed with status ${response.status}`,
+      );
+    }
+    return (await response.json()) as UnsubscribeResponse;
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    cache: "no-store",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+  if (!response.ok) {
+    throw new Error(`Unsubscribe update failed with status ${response.status}`);
+  }
+  return (await response.json()) as UnsubscribeResponse;
+};
+
+/**
+ * Maps API statuses to browser-readable HTML messages.
+ *
+ * @param data - Unsubscribe result from agent-data-api.
+ * @returns HTML response.
+ */
+const toBrowserHtml = (data: UnsubscribeResponse): Response => {
+  if (data.status === "unsubscribed") {
+    return htmlResponse(
+      `<p style="font-size:18px;font-weight:600;margin-bottom:8px">Unsubscribed</p><p style="color:#6b7280">You have been unsubscribed from <strong>${data.displaySymbol ?? "this ticker"}</strong> updates.</p>`,
+    );
+  }
+  if (data.status === "already_unsubscribed") {
+    return htmlResponse(
+      `<p style="color:#6b7280">You are already unsubscribed from ${data.displaySymbol ?? "this ticker"} updates.</p>`,
+    );
+  }
+  if (data.status === "expired") {
+    return htmlResponse(
+      `<p style="color:#6b7280">This unsubscribe link has expired. Please contact support or reply to this email.</p>`,
+    );
+  }
+  if (data.status === "invalid") {
+    return htmlResponse(
+      `<p style="color:#6b7280">This unsubscribe link is invalid. Please contact support or reply to this email.</p>`,
+    );
+  }
+  return htmlResponse(
+    `<p style="color:#6b7280">We couldn't find this subscription. It may have already been removed.</p>`,
+  );
+};
+
+/**
+ * Handles browser unsubscribe links.
+ */
+export const GET = async (request: Request): Promise<Response> => {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token") ?? "";
+
+  try {
+    const result = await requestUnsubscribe(token, "link");
+    return toBrowserHtml(result);
+  } catch {
+    return htmlResponse(
+      `<p style="color:#6b7280">Unsubscribe is temporarily unavailable. Please try again later.</p>`,
+    );
+  }
+};
+
+/**
+ * Handles RFC 8058 one-click unsubscribe requests.
+ */
+export const POST = async (request: Request): Promise<Response> => {
+  const url = new URL(request.url);
+  const token = url.searchParams.get("token") ?? "";
+
+  try {
+    await requestUnsubscribe(token, "one_click");
+    return new Response(null, { status: 200 });
+  } catch {
+    return new Response(null, { status: 200 });
+  }
+};

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -22,7 +22,7 @@ Provision **three** PostgreSQL logical databases (they can be three schemas on o
 | **Mediapulse (domain)**    | Tickers, newsletters, KG, subscribers, user registration data, etc. | `MEDIAPULSE_DATABASE_URL`                                                                  | `pnpm --filter @mediapulse/database db:migrate:deploy`                       |
 | **DataQueue**              | hermes-worker job queue (scheduler)                                 | `PG_DATAQUEUE_DATABASE` (same host is fine; use `?schema=dataqueue&search_path=dataqueue`) | `pnpm --filter @hermes/worker run migrate-dataqueue` (with queue URL in env) |
 
-Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (after **`db-ready`**, before image publish). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
+Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** commands from CI: workflow jobs **`db-migrate`** in **`.github/workflows/app-deploy.yml`** and **`.github/workflows/agent-deploy.yml`** (before image publish). Both workflows share the concurrency group **`prisma-migrate-production`** so only one migrate runs at a time if both workflows start together.
 
 After migrations succeed, each workflow builds and pushes per-service images to **GitHub Container Registry (GHCR)** as `ghcr.io/<owner>/<image>:sha-<commit>` and `ghcr.io/<owner>/<image>:latest`. Images are built from the repository root using each app's **`Dockerfile`**. Dockerfiles set **`MEDIAPULSE_ENV_BUILD_TARGETS`** or **`HERMES_ENV_BUILD_TARGETS`** so `@mediapulse/env` / `@hermes/env` only run `env-to-t3` for the slices that image needs (faster builds); leave those unset locally for full codegen.
 
@@ -182,7 +182,7 @@ After domain-api is live, set **`AGENT_AUTH_API_URL`** on domain-api (same auth 
 
 **Package:** `@mediapulse/user-registration` · **Path:** `apps/mediapulse/user-registration`
 
-Public-facing newsletter signup UI. The current implementation serves ticker choices from **`public/tickers.json`** and opens a prefilled **mailto** draft (no direct database or API calls in app code). The app is built with **`output: "standalone"`** for container-friendly deploys.
+Public-facing newsletter signup UI. The current implementation serves ticker choices from **`public/tickers.json`** and opens a prefilled **mailto** draft. It also hosts the public unsubscribe endpoint (`/api/unsubscribe`) and forwards token verification/update calls to agent-data-api. The app is built with **`output: "standalone"`** for container-friendly deploys.
 
 `next.config.js` loads dotenv files from **`packages/mediapulse/env`** (same directory you merge with `merge-env-examples.sh` for other Mediapulse services). If you later add server code that imports **`@mediapulse/env`**, provide the same merged variables as **domain-api** / **agent-data-api** (at minimum **`MEDIAPULSE_DATABASE_URL`** per the schema).
 
@@ -247,7 +247,7 @@ Annotated templates: **`packages/hermes/env/env.example`**, **`env.hermes-worker
 ## Summary
 
 - **Order:** Prerequisites (three DB roles + migrations) → **Hermes** (auth API → registry API → dashboard → worker, with **`HERMES_INTERNAL_API_KEY`** aligned) → **Mediapulse** (agent-data-api → domain-api → optional **user-registration** → agents).
-- **CI deploy flow:** Every merge to `main` runs `db-ready` → `db-migrate` → build and push per-service images to GHCR → trigger Coolify deploy webhooks → prune old GHCR versions (keep newest 2 per service for rollback).
+- **CI deploy flow:** Every merge to `main` runs `db-migrate` → build and push per-service images to GHCR → trigger Coolify deploy webhooks → prune old GHCR versions (keep newest 2 per service for rollback).
 - **Rollback:** Promote the previous image tag (`sha-<commit>`) in Coolify to roll back a service without a new merge.
 - **Secrets:** Never commit real values; use your platform’s secret storage. **`HERMES_INTERNAL_API_KEY`** is a deploy-time preset. **`DOMAIN_INTEGRATION_API_KEY`** on Mediapulse/agents is the API key generated in **Domain integrations** (Hermes dashboard). Apps require **`COOLIFY_WEBHOOK_APP_<SERVICE>`** secrets and agents require **`COOLIFY_WEBHOOK_AGENT_<SERVICE>`** secrets in GitHub Actions; GHCR access uses the built-in **`GITHUB_TOKEN`** with `packages: write`.
 - **JWTs:** agent-auth-api issues tokens for the internal preset and for **domain_integration** API keys (hash in DB); Hermes decrypts per-integration ciphertext for outbound domain/agent calls where configured. Verification uses **`AGENT_AUTH_API_URL`** / **`AGENT_AUTH_JWT_SECRET`** on the auth API.

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -6,7 +6,7 @@ icon: Database
 
 ## Purpose
 
-agent-data-api is a Hono server that exposes data endpoints used by agents. **The agent gets data it needs and stores output data it produces to this API via the agent-data-api-client SDK.** All routes are protected by bearer auth; the token is verified via `@workspace/agent-auth-client` against agent-auth-api.
+agent-data-api is a Hono server that exposes data endpoints used by agents. **The agent gets data it needs and stores output data it produces to this API via the agent-data-api-client SDK.** Versioned routes are protected by bearer auth (verified via `@workspace/agent-auth-client` against agent-auth-api), except the public unsubscribe endpoint used by the user-registration app.
 
 ## Features
 
@@ -43,6 +43,8 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | POST   | `/api/v1/content-generation-runs`    | Persist one content-generation run record                             |
 | POST   | `/api/v1/user-registration-register` | Process a new or returning subscription                               |
 | POST   | `/api/v1/user-registration-confirm`  | Confirm a pending subscription (double opt-in)                        |
+| GET    | `/api/v1/user-registration-unsubscribe` | Resolve an unsubscribe token status for public UI                     |
+| POST   | `/api/v1/user-registration-unsubscribe` | Apply one-click unsubscribe from public user-registration endpoint    |
 | GET    | `/api/v1/query-analysis`             | Get query-analysis context by ticker                                  |
 | POST   | `/api/v1/query-analysis`             | Store and activate a versioned query set                              |
 

--- a/packages/mediapulse/env/env.app.user-registration.example
+++ b/packages/mediapulse/env/env.app.user-registration.example
@@ -3,3 +3,6 @@ PORT=3002 #number #optional
 
 # Shown in the registration mailto flow (public)
 NEXT_PUBLIC_REGISTRATION_EMAIL=registration@mediapulse.example #required
+
+# Private base URL to call the internal agent-data-api from server routes.
+AGENT_DATA_API_URL=http://localhost:8081 #required

--- a/packages/mediapulse/env/src/app-user-registration.ts
+++ b/packages/mediapulse/env/src/app-user-registration.ts
@@ -6,6 +6,7 @@ import { z } from "zod";
 export const env = createEnv({
   server: {
     PORT: z.number({ coerce: true }).optional(),
+    AGENT_DATA_API_URL: z.string().min(1),
   },
   client: {
     NEXT_PUBLIC_REGISTRATION_EMAIL: z.string().min(1),

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -54,6 +54,9 @@ import {
   postUserRegistrationRegisterResponseSchema,
   postUserRegistrationConfirmBodySchema,
   postUserRegistrationConfirmResponseSchema,
+  postUserRegistrationUnsubscribeBodySchema,
+  userRegistrationUnsubscribeQuerySchema,
+  userRegistrationUnsubscribeResponseSchema,
 } from "./user-registration.js";
 import {
   contentGenerationRunQuerySchema,
@@ -379,6 +382,28 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postUserRegistrationConfirmBodySchema,
         response: postUserRegistrationConfirmResponseSchema,
+      },
+    },
+  },
+  userRegistrationUnsubscribe: {
+    v1: {
+      get: {
+        query: userRegistrationUnsubscribeQuerySchema,
+        response: userRegistrationUnsubscribeResponseSchema,
+      },
+      post: {
+        body: postUserRegistrationUnsubscribeBodySchema,
+        response: userRegistrationUnsubscribeResponseSchema,
+      },
+    },
+    v2: {
+      get: {
+        query: userRegistrationUnsubscribeQuerySchema,
+        response: userRegistrationUnsubscribeResponseSchema,
+      },
+      post: {
+        body: postUserRegistrationUnsubscribeBodySchema,
+        response: userRegistrationUnsubscribeResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/user-registration.ts
+++ b/packages/shared/agent-data-api-contract/src/user-registration.ts
@@ -23,6 +23,19 @@ export const postUserRegistrationConfirmBodySchema = z.object({
     .optional(),
 });
 
+export const userRegistrationUnsubscribeMethodSchema = z.enum([
+  "link",
+  "one_click",
+]);
+
+export const userRegistrationUnsubscribeQuerySchema = z.object({
+  token: z.string().min(1),
+});
+
+export const postUserRegistrationUnsubscribeBodySchema = z.object({
+  token: z.string().min(1),
+});
+
 // Response schemas
 export const postUserRegistrationRegisterResponseSchema = z.object({
   tickerKnown: z.boolean(),
@@ -33,6 +46,17 @@ export const postUserRegistrationRegisterResponseSchema = z.object({
 
 export const postUserRegistrationConfirmResponseSchema = z.object({
   success: z.boolean(),
+});
+
+export const userRegistrationUnsubscribeResponseSchema = z.object({
+  status: z.enum([
+    "unsubscribed",
+    "already_unsubscribed",
+    "not_found",
+    "invalid",
+    "expired",
+  ]),
+  displaySymbol: z.string().optional(),
 });
 
 export type PostUserRegistrationRegisterBody = z.infer<
@@ -46,4 +70,16 @@ export type PostUserRegistrationRegisterResponse = z.infer<
 >;
 export type PostUserRegistrationConfirmResponse = z.infer<
   typeof postUserRegistrationConfirmResponseSchema
+>;
+export type UserRegistrationUnsubscribeMethod = z.infer<
+  typeof userRegistrationUnsubscribeMethodSchema
+>;
+export type UserRegistrationUnsubscribeQuery = z.infer<
+  typeof userRegistrationUnsubscribeQuerySchema
+>;
+export type PostUserRegistrationUnsubscribeBody = z.infer<
+  typeof postUserRegistrationUnsubscribeBodySchema
+>;
+export type UserRegistrationUnsubscribeResponse = z.infer<
+  typeof userRegistrationUnsubscribeResponseSchema
 >;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -288,7 +288,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -303,7 +303,7 @@ importers:
         version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
-        version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -441,6 +441,9 @@ importers:
       '@workspace/logger':
         specifier: workspace:*
         version: link:../../../packages/shared/logger
+      '@workspace/utils':
+        specifier: workspace:*
+        version: link:../../../packages/shared/utils
       hono:
         specifier: 'catalog:'
         version: 4.11.9
@@ -953,7 +956,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -17082,7 +17085,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -17091,7 +17094,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -18217,12 +18220,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76
     optionalDependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   router@2.2.0:
@@ -18710,12 +18713,10 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
## Summary

This moves public unsubscribe handling to the user-registration app domain while keeping data mutations inside agent-data-api. The app now exposes `/api/unsubscribe` and forwards to a dedicated unsubscribe endpoint in agent-data-api.

## Related issues

Closes #405

## Important changes

- Added `GET/POST /api/v1/user-registration-unsubscribe` in agent-data-api, including token verification, idempotent unsubscribe handling, and audit method persistence (`link` vs `one_click`).
- Added `GET/POST /api/unsubscribe` in user-registration app that forwards to agent-data-api and preserves email-client behavior (HTML for browser links, empty 200 for one-click POST).
- Updated agent-data-api auth middleware to keep normal bearer protection for versioned routes while allowing only the unsubscribe resource to be public.

## Other changes

- Extended `@workspace/agent-data-api-contract` schemas/manifest for the unsubscribe resource.
- Added `AGENT_DATA_API_URL` to user-registration app env schema/example for server-side forwarding.
- Updated delivery config docs wording and production docs to reflect the new public unsubscribe entrypoint.
- Added `@workspace/utils` dependency to agent-data-api for token verification.

## Key files to review

- `apps/mediapulse/agent-data-api/src/index.ts` - selective auth bypass for public unsubscribe route.
- `apps/mediapulse/agent-data-api/src/services/user-registration.ts` - core unsubscribe token validation and DB update logic.
- `apps/mediapulse/user-registration/app/api/unsubscribe/route.ts` - public API forwarding and response mapping.
- `packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts` - new resource contract wiring.

## How to test

1. Run `pnpm --filter @workspace/agent-data-api-contract build`.
2. Run `pnpm --filter @workspace/utils build`.
3. Run `pnpm --filter @mediapulse/agent-data-api test:coverage`.
4. Run `pnpm --filter @mediapulse/user-registration test:coverage`.
5. Run `pnpm format:check` and `pnpm code-quality`.
6. In a deployed env, open `https://<user-registration-domain>/api/unsubscribe?token=<token>` and verify unsubscribe success/idempotency pages.
