### PR TITLE
Harden user-registration Docker build when Actions secrets omit API URL

### DIFF
--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -86,8 +86,8 @@ jobs:
           file: ${{ matrix.dockerfile }}
           push: true
           build-args: |
-            NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && secrets.NEXT_PUBLIC_REGISTRATION_EMAIL || '' }}
-            AGENT_DATA_API_URL=${{ matrix.service == 'user-registration' && secrets.AGENT_DATA_API_URL || '' }}
+            NEXT_PUBLIC_REGISTRATION_EMAIL=${{ matrix.service == 'user-registration' && (secrets.NEXT_PUBLIC_REGISTRATION_EMAIL || 'registration@example.com') || '' }}
+            AGENT_DATA_API_URL=${{ matrix.service == 'user-registration' && (secrets.AGENT_DATA_API_URL || 'http://127.0.0.1:8081') || '' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:sha-${{ github.sha }}
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}:latest

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -25,8 +25,8 @@ RUN rm -f apps/mediapulse/user-registration/.env apps/mediapulse/user-registrati
     touch apps/mediapulse/user-registration/.env apps/mediapulse/user-registration/.env.local
 
 ENV MEDIAPULSE_ENV_BUILD_TARGETS=app.user-registration
-ARG NEXT_PUBLIC_REGISTRATION_EMAIL
-ARG AGENT_DATA_API_URL
+ARG NEXT_PUBLIC_REGISTRATION_EMAIL=registration@example.com
+ARG AGENT_DATA_API_URL=http://127.0.0.1:8081
 ENV NEXT_PUBLIC_REGISTRATION_EMAIL=$NEXT_PUBLIC_REGISTRATION_EMAIL
 ENV AGENT_DATA_API_URL=$AGENT_DATA_API_URL
 RUN test -n "$NEXT_PUBLIC_REGISTRATION_EMAIL"

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -194,6 +194,8 @@ Public-facing newsletter signup UI. The current implementation serves ticker cho
 
 **Docker:** `apps/mediapulse/user-registration/Dockerfile`.
 
+**GitHub Actions:** For **`App Deployment`**, add repository secrets **`NEXT_PUBLIC_REGISTRATION_EMAIL`** and **`AGENT_DATA_API_URL`** (public agent-data-api base URL). If **`AGENT_DATA_API_URL`** is missing, the workflow falls back to a localhost placeholder so the Docker build still succeeds; production traffic still needs the real URL on the **running container** (e.g. Coolify env) so server routes such as unsubscribe call the correct host.
+
 ---
 
 ### 4. Mediapulse agents


### PR DESCRIPTION
## Summary

The user-registration Docker build failed when GitHub did not define **`AGENT_DATA_API_URL`**: the workflow passed an empty build-arg, so `test -n` in the Dockerfile exited 1. Defaults on the Dockerfile `ARG`s and `||`-fallbacks in **`App Deployment`** keep **`next build`** green when a secret is absent; operators should still add the real secret and set runtime env on the container for production traffic (unsubscribe → agent-data-api).

## Related issues

Closes #410

## Important changes

- **`apps/mediapulse/user-registration/Dockerfile`:** default `ARG NEXT_PUBLIC_REGISTRATION_EMAIL` and `ARG AGENT_DATA_API_URL` so local or compose builds do not need explicit build-args.
- **`.github/workflows/app-deploy.yml`:** for the user-registration matrix row, use `(secrets.* || placeholder)` so build-args are never empty when the secret is missing.

## Other changes

- **`dev-docs/docs/guide/production.mdx`:** note under user-registration linking the two Actions secrets, fallback behavior, and runtime URL on the deployed container.

## Key files to review

- `.github/workflows/app-deploy.yml` — expression truthiness for `user-registration` vs other services.
- `apps/mediapulse/user-registration/Dockerfile` — default ARG values align with PR **`docker-build.yml`** placeholders.

## How to test

1. `docker build -f apps/mediapulse/user-registration/Dockerfile .` from repo root (no `--build-arg`) and confirm the builder reaches `turbo build`.
2. In Actions, confirm **`App Deployment`** for user-registration succeeds when **`AGENT_DATA_API_URL`** is unset (fallback URL used for build); with the secret set, confirm the build-arg matches the secret.
