### PR TITLE
Cap deploy matrix at three concurrent Coolify jobs

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -97,6 +97,7 @@ jobs:
     needs: publish
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - service: data-collection

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -100,6 +100,7 @@ jobs:
     needs: publish
     strategy:
       fail-fast: false
+      max-parallel: 3
       matrix:
         include:
           - service: agent-auth-api


### PR DESCRIPTION
## Summary

Deploy matrix jobs each bring up OpenVPN before calling Coolify. Running the whole matrix at once meant many simultaneous clients. We cap the deploy job at three concurrent matrix legs so the rest wait in queue.

## Related issues

Closes #412

## Important changes

- `strategy.max-parallel: 3` on the **deploy** job in `app-deploy.yml` and `agent-deploy.yml`.

## Other changes

- None.

## Key files to review

- `.github/workflows/app-deploy.yml` — deploy strategy only.
- `.github/workflows/agent-deploy.yml` — same pattern for agents.

## How to test

1. Merge and watch the next `main` deploy, or re-run the workflow from Actions.
2. Confirm the **Deploy … via Coolify** stage shows at most three jobs running at a time; the rest stay queued until a slot frees up.
3. Confirm the workflow still finishes green once all services have deployed.
