### PR TITLE
Align manual pipeline runs with worker secret-variable key fallback

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -316,6 +316,7 @@ export const createRunPipelineHandler = ({
         sourceId: pipeline.id,
         expandStepInputs,
         variableSecretMasterKey: env.HERMES_INTERNAL_API_KEY,
+        variableSecretFallbackMasterKey: env.HERMES_INTERNAL_API_KEY_PREVIOUS,
         requireHttpsAgentEndpoints: false,
       });
       const executionTime = now();


### PR DESCRIPTION
## Summary

The dashboard **Run pipeline** path only handed `HERMES_INTERNAL_API_KEY` into `planPipelineInvocations`. Scheduled runs and the worker already pass `HERMES_INTERNAL_API_KEY_PREVIOUS` as a decryption fallback. After a rotation, manual runs could hit "Failed to decrypt secret variable …" while the rest of Hermes still behaved. We wire the same optional fallback through here so planning matches the worker.

## Related issues

Closes #418

## Important changes

- `run-pipeline` now sets `variableSecretFallbackMasterKey` from `env.HERMES_INTERNAL_API_KEY_PREVIOUS` when planning invocations.

## Other changes

- None.

## Key files to review

- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — single argument added next to the existing primary key.

## How to test

1. Set `HERMES_INTERNAL_API_KEY` and `HERMES_INTERNAL_API_KEY_PREVIOUS` in dashboard env (previous = old key during rotation).
2. With a secret variable ciphertext still wrapped under the previous key, trigger **Run pipeline** from the UI and confirm planning succeeds (or run the handler in a test harness with mocked env and DB if you prefer).
3. With no previous key set, confirm behavior matches the prior code path (undefined fallback is fine).
