### PR TITLE
Show domain integration id on Hermes agents table and detail

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/agent-details-content.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/agent-details-content.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AgentDetailsContent } from "./agent-details-content";
 
@@ -57,6 +57,9 @@ const createMockAgent = () => ({
   isActive: true,
   createdAt: new Date("2024-01-15"),
   updatedAt: new Date("2024-01-15"),
+  domainIntegration: {
+    integrationId: "mediapulse-local",
+  },
 });
 
 describe("AgentDetailsContent", () => {
@@ -103,17 +106,24 @@ describe("AgentDetailsContent", () => {
     render(<AgentDetailsContent agent={agent} />);
 
     // Assert
-    expect(screen.getByText("Agent ID")).toBeInTheDocument();
-    expect(screen.getByText("test-agent")).toBeInTheDocument();
-    expect(screen.getByText("Version")).toBeInTheDocument();
-    expect(screen.getByText("1.0")).toBeInTheDocument();
-    expect(screen.getByText("Description")).toBeInTheDocument();
-    expect(screen.getByText("Test description")).toBeInTheDocument();
-    expect(screen.getByText("Active")).toBeInTheDocument();
-    expect(screen.getByText("Yes")).toBeInTheDocument();
-    expect(screen.getByText("Created")).toBeInTheDocument();
-    expect(screen.getByText("Last updated")).toBeInTheDocument();
-    expect(screen.getByText("Feb 20, 2024")).toBeInTheDocument();
+    const detailsHeading = screen.getByRole("heading", { name: "Details" });
+    const detailsSection = detailsHeading.parentElement;
+    expect(detailsSection).toBeTruthy();
+    const details = within(detailsSection as HTMLElement);
+
+    expect(details.getByText("Agent ID")).toBeInTheDocument();
+    expect(details.getByText("test-agent")).toBeInTheDocument();
+    expect(details.getByText("Version")).toBeInTheDocument();
+    expect(details.getByText("1.0")).toBeInTheDocument();
+    expect(details.getByText("Description")).toBeInTheDocument();
+    expect(details.getByText("Test description")).toBeInTheDocument();
+    expect(details.getByText("Active")).toBeInTheDocument();
+    expect(details.getByText("Yes")).toBeInTheDocument();
+    expect(details.getByText("Created")).toBeInTheDocument();
+    expect(details.getByText("Last updated")).toBeInTheDocument();
+    expect(details.getByText("Feb 20, 2024")).toBeInTheDocument();
+    expect(details.getByText("Domain integration id")).toBeInTheDocument();
+    expect(details.getByText("mediapulse-local")).toBeInTheDocument();
   });
 
   it("renders Endpoint section via EndpointDisplay in General tab", () => {

--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/agent-details-content.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/agent-details-content.tsx
@@ -12,9 +12,7 @@ import {
 
 import { EndpointDisplay } from "../endpoint-display";
 import { JsonPretty } from "../json-pretty";
-import type { AgentsPageResult } from "@/lib/agents";
-
-type AgentRow = AgentsPageResult["agents"][number];
+import type { AgentDetail } from "@/lib/agents";
 
 const ROW_CLASS =
   "flex items-center justify-between gap-8 py-4 px-6 sm:px-7 border-b border-border/60 last:border-b-0 first:pt-6 last:pb-6";
@@ -24,12 +22,12 @@ const VALUE_CLASS =
   "min-w-0 flex-1 text-sm font-medium text-foreground text-right";
 
 type AgentDetailsContentProps = {
-  /** Agent from getAgentById (registry row). */
-  agent: AgentRow;
+  /** Agent from getAgentById (registry row with domain integration id). */
+  agent: AgentDetail;
 };
 
 /**
- * Renders agent details in a tabbed layout: General (details + endpoint), Input schema (pretty JSON), Config schema (pretty JSON).
+ * Renders agent details in a tabbed layout: General (details including domain integration id, endpoint), Input schema (pretty JSON), Config schema (pretty JSON).
  */
 export const AgentDetailsContent = ({ agent }: AgentDetailsContentProps) => {
   return (
@@ -84,6 +82,14 @@ export const AgentDetailsContent = ({ agent }: AgentDetailsContentProps) => {
                 <span className={LABEL_CLASS}>Last updated</span>
                 <span className="min-w-0 flex-1 text-sm text-muted-foreground normal-case font-normal text-right">
                   {format(agent.updatedAt, "LLL d, yyyy")}
+                </span>
+              </div>
+              <div className={ROW_CLASS}>
+                <span className={LABEL_CLASS}>Domain integration id</span>
+                <span
+                  className={`${VALUE_CLASS} font-mono text-xs sm:text-sm break-all`}
+                >
+                  {agent.domainIntegration.integrationId}
                 </span>
               </div>
             </div>

--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/page.tsx
@@ -6,7 +6,7 @@ import { getAgentById } from "@/lib/agents";
 import { AgentDetailsContent } from "./agent-details-content";
 
 /**
- * Agent detail page. Loads agent by id; shows 404 if not found, otherwise tabbed details (General, Input schema, Config schema).
+ * Agent detail page. Loads agent by id (with domain integration id); shows 404 if not found, otherwise tabbed details (General, Input schema, Config schema).
  */
 const AgentDetailPage = async ({
   params,

--- a/apps/hermes/dashboard/app/dashboard/agents/agent-row-actions.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/agent-row-actions.test.tsx
@@ -110,6 +110,7 @@ const createMockAgent = () => ({
   isActive: true,
   createdAt: new Date("2024-01-15"),
   updatedAt: new Date("2024-01-15"),
+  domainIntegration: { integrationId: "mediapulse-local" },
 });
 
 const getUseFormActionMock = async () => {

--- a/apps/hermes/dashboard/app/dashboard/agents/agents-table-with-edit.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/agents-table-with-edit.test.tsx
@@ -49,6 +49,7 @@ const createMockAgent = (id: string, agentId: string) => ({
   isActive: true,
   createdAt: new Date("2024-01-15"),
   updatedAt: new Date("2024-01-15"),
+  domainIntegration: { integrationId: "mediapulse-local" },
 });
 
 describe("AgentsTableWithEdit", () => {

--- a/apps/hermes/dashboard/app/dashboard/agents/agents-table.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/agents-table.test.tsx
@@ -66,6 +66,8 @@ const createMockAgent = (
     description: string | null;
     isActive: boolean;
     createdAt: Date;
+    updatedAt: Date;
+    domainIntegration: { integrationId: string };
   }>,
 ) => ({
   id: "agent-1",
@@ -80,6 +82,9 @@ const createMockAgent = (
   createdAt: new Date("2024-01-15"),
   updatedAt: new Date("2024-01-15"),
   ...overrides,
+  domainIntegration: overrides?.domainIntegration ?? {
+    integrationId: "mediapulse-local",
+  },
 });
 
 describe("AgentsTable", () => {
@@ -96,6 +101,7 @@ describe("AgentsTable", () => {
     // Assert
     expect(screen.getByText("Agent ID")).toBeInTheDocument();
     expect(screen.getByText("Version")).toBeInTheDocument();
+    expect(screen.getByText("Domain integration id")).toBeInTheDocument();
     expect(screen.getByText("Description")).toBeInTheDocument();
     expect(screen.getByText("Active")).toBeInTheDocument();
     expect(screen.getByText("Created")).toBeInTheDocument();
@@ -129,6 +135,7 @@ describe("AgentsTable", () => {
     // Assert
     expect(screen.getByText("test-agent")).toBeInTheDocument();
     expect(screen.getByText("1.0")).toBeInTheDocument();
+    expect(screen.getByText("mediapulse-local")).toBeInTheDocument();
     expect(screen.getByText("Test description")).toBeInTheDocument();
     // Created and Updated columns both show formatted dates; header "Updated" confirms the column is present
   });

--- a/apps/hermes/dashboard/app/dashboard/agents/agents-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/agents-table.tsx
@@ -54,7 +54,7 @@ type AgentsTableProps = {
 };
 
 /**
- * Renders the agents list as a table with sortable Agent ID, Version, Description, Active, Created, Updated columns and row actions.
+ * Renders the agents list as a table with sortable Agent ID, Version, Created, and Updated; a Domain integration id column; Description and Active; and row actions.
  */
 export const AgentsTable = ({
   agents,
@@ -109,6 +109,9 @@ export const AgentsTable = ({
             <TableHead className="w-[100px]">
               {sortLink("agentVersion", "Version")}
             </TableHead>
+            <TableHead className="min-w-[140px] max-w-[220px]">
+              Domain integration id
+            </TableHead>
             <TableHead>Description</TableHead>
             <TableHead className="w-[80px]">Active</TableHead>
             <TableHead className="w-[120px]">
@@ -124,7 +127,7 @@ export const AgentsTable = ({
           {agents.length === 0 ? (
             <TableRow>
               <TableCell
-                colSpan={7}
+                colSpan={8}
                 className="text-center text-muted-foreground"
               >
                 No agents yet.
@@ -153,6 +156,9 @@ export const AgentsTable = ({
                 </TableCell>
                 <TableCell className="text-muted-foreground">
                   {agent.agentVersion}
+                </TableCell>
+                <TableCell className="font-mono text-sm text-muted-foreground max-w-[220px] truncate">
+                  {agent.domainIntegration.integrationId}
                 </TableCell>
                 <TableCell className="max-w-[200px] truncate text-muted-foreground">
                   {agent.description ?? "—"}

--- a/apps/hermes/dashboard/lib/agents.test.ts
+++ b/apps/hermes/dashboard/lib/agents.test.ts
@@ -1,6 +1,10 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { getAgentById, getAgentsPage } from "./agents";
+import {
+  agentDomainIntegrationIdInclude,
+  getAgentById,
+  getAgentsPage,
+} from "./agents";
 import type { PrismaClientWithSchema } from "@hermes/orchestration-database/client";
 
 type MockDb = {
@@ -40,6 +44,7 @@ describe("getAgentsPage", () => {
       skip: 0,
       take: 10,
       orderBy: { agentId: "asc" },
+      include: agentDomainIntegrationIdInclude,
     });
     expect(db.agentRegistry.count).toHaveBeenCalledWith({ where: undefined });
   });
@@ -61,6 +66,7 @@ describe("getAgentsPage", () => {
       skip: 0,
       take: 5,
       orderBy: { agentId: "asc" },
+      include: agentDomainIntegrationIdInclude,
     });
     expect(db.agentRegistry.count).toHaveBeenCalledWith({
       where: {
@@ -92,6 +98,7 @@ describe("getAgentsPage", () => {
       skip: 15,
       take: 15,
       orderBy: { agentVersion: "desc" },
+      include: agentDomainIntegrationIdInclude,
     });
   });
 
@@ -112,6 +119,7 @@ describe("getAgentsPage", () => {
       skip: 0,
       take: 10,
       orderBy: { createdAt: "desc" },
+      include: agentDomainIntegrationIdInclude,
     });
   });
 
@@ -132,6 +140,7 @@ describe("getAgentsPage", () => {
       skip: 0,
       take: 10,
       orderBy: { updatedAt: "desc" },
+      include: agentDomainIntegrationIdInclude,
     });
   });
 
@@ -140,13 +149,19 @@ describe("getAgentsPage", () => {
     const agents = [
       {
         id: "a1",
+        domainIntegrationId: "di-1",
         agentId: "summarizer",
         agentVersion: "1.0",
         description: null,
         endpoint: {},
+        inputSchema: null,
+        configSchema: null,
         isActive: true,
         createdAt: new Date(),
         updatedAt: new Date(),
+        domainIntegration: {
+          integrationId: "mediapulse-local",
+        },
       },
     ];
     db.agentRegistry.findMany.mockResolvedValue(agents);
@@ -176,6 +191,7 @@ describe("getAgentById", () => {
 
     expect(db.agentRegistry.findUnique).toHaveBeenCalledWith({
       where: { id: "agent-uuid-1" },
+      include: agentDomainIntegrationIdInclude,
     });
   });
 
@@ -183,13 +199,19 @@ describe("getAgentById", () => {
     const db = createMockDb();
     const agent = {
       id: "agent-uuid-1",
+      domainIntegrationId: "di-uuid-1",
       agentId: "summarizer",
       agentVersion: "1.0",
       description: "Test",
       endpoint: { url: "https://example.com" },
+      inputSchema: null,
+      configSchema: null,
       isActive: true,
       createdAt: new Date(),
       updatedAt: new Date(),
+      domainIntegration: {
+        integrationId: "mediapulse-local",
+      },
     };
     db.agentRegistry.findUnique.mockResolvedValue(agent);
 

--- a/apps/hermes/dashboard/lib/agents.ts
+++ b/apps/hermes/dashboard/lib/agents.ts
@@ -1,9 +1,27 @@
+import type { Prisma } from "@hermes/orchestration-database";
 import { prisma } from "@hermes/orchestration-database";
 
 type Db = typeof prisma;
 
+/** Prisma include for agent fetches that need the domain integration stable id (list + detail). */
+export const agentDomainIntegrationIdInclude = {
+  domainIntegration: {
+    select: {
+      integrationId: true,
+    },
+  },
+} satisfies Prisma.AgentRegistryInclude;
+
+/** Registry row with `domainIntegration.integrationId` (list and detail queries). */
+export type AgentRegistryWithDomainIntegrationId =
+  Prisma.AgentRegistryGetPayload<{
+    include: typeof agentDomainIntegrationIdInclude;
+  }>;
+
+export type AgentDetail = AgentRegistryWithDomainIntegrationId;
+
 export type AgentsPageResult = {
-  agents: Awaited<ReturnType<Db["agentRegistry"]["findMany"]>>;
+  agents: AgentRegistryWithDomainIntegrationId[];
   total: number;
   page: number;
   pageSize: number;
@@ -73,7 +91,7 @@ const agentOrderBy = (
  * @param pageSize - Number of items per page.
  * @param options - Optional search term and sort (sortBy: agentId | agentVersion | created | updated, sortDir: asc | desc).
  * @param db - Prisma client (injectable for tests).
- * @returns Agents for the page plus total count and pagination info.
+ * @returns Agents for the page (each with `domainIntegration.integrationId`) plus total count and pagination info.
  */
 export const getAgentsPage = async (
   page: number,
@@ -97,6 +115,7 @@ export const getAgentsPage = async (
       skip,
       take: pageSize,
       orderBy,
+      include: agentDomainIntegrationIdInclude,
     }),
     db.agentRegistry.count({ where }),
   ]);
@@ -104,17 +123,19 @@ export const getAgentsPage = async (
 };
 
 /**
- * Fetches a single agent by id, or null if not found.
+ * Fetches a single agent by id with its domain integration id, or null if not found.
  *
  * @param agentId - UUID of the agent registry row.
  * @param db - Prisma client (injectable for tests).
- * @returns The agent or null.
+ * @returns The agent with `domainIntegration.integrationId`, or null.
  */
 export const getAgentById = async (
   agentId: string,
   db: Db = prisma,
-): Promise<Awaited<ReturnType<Db["agentRegistry"]["findUnique"]>>> => {
-  return db.agentRegistry.findUnique({
+): Promise<AgentDetail | null> => {
+  const args = {
     where: { id: agentId },
-  });
+    include: agentDomainIntegrationIdInclude,
+  } satisfies Prisma.AgentRegistryFindUniqueArgs;
+  return db.agentRegistry.findUnique(args);
 };


### PR DESCRIPTION
## Summary

Agents in Hermes are tied to a domain integration, but the dashboard never surfaced which one. The list and detail views now print the stable integration id next to the rest of the registry metadata so you can confirm scope without leaving the page.

## Related issues

Closes #424

## Important changes

- `getAgentsPage` joins `domain_integration` and selects only `integration_id` for each row; `getAgentById` uses the same include so types stay aligned (`AgentRegistryWithDomainIntegrationId`).
- Agents table gains a **Domain integration id** column (monospace, truncated); the agent detail **Details** card adds one row with the same value.

## Other changes

- Tests updated for the new column and Prisma call shapes; `Prisma` import for `agents.ts` now comes from `@hermes/orchestration-database` so dashboard `tsc` matches other lib files.

## Key files to review

- `apps/hermes/dashboard/lib/agents.ts` — shared include, list/detail payload types, `getAgentsPage` include wiring.
- `apps/hermes/dashboard/app/dashboard/agents/agents-table.tsx` — new column and empty-state colspan.
- `apps/hermes/dashboard/app/dashboard/agents/[id]/agent-details-content.tsx` — Details row for the integration id.

## How to test

1. From `apps/hermes/dashboard`, run `pnpm vitest run lib/agents.test.ts app/dashboard/agents/agents-table.test.tsx app/dashboard/agents/agents-table-with-edit.test.tsx app/dashboard/agents/agent-row-actions.test.tsx app/dashboard/agents/[id]/agent-details-content.test.tsx` and confirm green.
2. Run `pnpm exec tsc --noEmit` in the same package.
3. With seed data, open `/dashboard/agents`: confirm each row shows the expected integration id string; open an agent: the **Details** block should show the same id.
