### PR TITLE
Harden Coolify webhook curl retries in deploy workflows

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -186,7 +186,13 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent --show-error --retry 3 --retry-delay 3 --verbose \
+          curl --fail --silent --show-error --verbose \
+            --retry 6 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            --retry-max-time 300 \
+            --connect-timeout 20 \
+            --max-time 120 \
             -X GET "$COOLIFY_WEBHOOK_URL" \
             --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
 

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -189,7 +189,13 @@ jobs:
             exit 1
           fi
 
-          curl --fail --silent --show-error --retry 3 --retry-delay 3 --verbose \
+          curl --fail --silent --show-error --verbose \
+            --retry 6 \
+            --retry-all-errors \
+            --retry-delay 5 \
+            --retry-max-time 300 \
+            --connect-timeout 20 \
+            --max-time 120 \
             -X GET "$COOLIFY_WEBHOOK_URL" \
             --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
 


### PR DESCRIPTION
## Summary

Deploy jobs already waited for OpenVPN, then hit the Coolify webhook with **`curl --retry`**. That retry mode mostly helps specific HTTP status codes, not a dropped TCP connection. We align **`app-deploy`** and **`agent-deploy`** on **`--retry-all-errors`**, a few more attempts, caps on total wait and per-request time, so a brief reset against Coolify is less likely to fail the whole matrix slot.

## Related issues

Closes #428

## Important changes

- **`curl`**: **`--retry-all-errors`**, **`--retry 6`**, **`--retry-delay 5`**, **`--retry-max-time 300`**, **`--connect-timeout 20`**, **`--max-time 120`** on the webhook GET in both workflows.

## Other changes

- None.

## Key files to review

- `.github/workflows/agent-deploy.yml` — webhook step after VPN success.
- `.github/workflows/app-deploy.yml` — same block for parity.

## How to test

1. Open the two workflow files and confirm the **`curl`** blocks match.
2. Optional: run **`curl --help all | grep retry-all-errors`** on **`ubuntu-latest`** locally or in a one-off job to confirm the flag exists (runner image already ships a new enough curl).
3. Merge and watch the next deploy: a flaky reset should be absorbed within the new retry window; a hard outage should still fail after bounded time.
