### PR TITLE
Raise GHCR package retention to five versions in deploy workflows

### DIFF
--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -218,5 +218,5 @@ jobs:
         with:
           package-name: ${{ matrix.image }}
           package-type: container
-          min-versions-to-keep: 2
+          min-versions-to-keep: 5
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -221,5 +221,5 @@ jobs:
         with:
           package-name: ${{ matrix.image }}
           package-type: container
-          min-versions-to-keep: 2
+          min-versions-to-keep: 5
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -26,7 +26,7 @@ Pushes to **main** run the same two **`pnpm --filter … db:migrate:deploy`** co
 
 After migrations succeed, each workflow builds and pushes per-service images to **GitHub Container Registry (GHCR)** as `ghcr.io/<owner>/<image>:sha-<commit>` and `ghcr.io/<owner>/<image>:latest`. Images are built from the repository root using each app's **`Dockerfile`**. Dockerfiles set **`MEDIAPULSE_ENV_BUILD_TARGETS`** or **`HERMES_ENV_BUILD_TARGETS`** so `@mediapulse/env` / `@hermes/env` only run `env-to-t3` for the slices that image needs (faster builds); leave those unset locally for full codegen.
 
-Once an image is published, CI triggers a **Coolify deploy webhook** for each service. Coolify pulls the new image from GHCR and rolls it out. A **cleanup job** runs after all deploys succeed and deletes older GHCR package versions, retaining the **two newest versions** per service for rollback.
+Once an image is published, CI triggers a **Coolify deploy webhook** for each service. Coolify pulls the new image from GHCR and rolls it out. A **cleanup job** runs after all deploys succeed and deletes older GHCR package versions, retaining the **five newest versions** per service for rollback.
 
 Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
@@ -269,7 +269,7 @@ Annotated templates: **`packages/hermes/env/env.example`**, **`env.hermes-worker
 ## Summary
 
 - **Order:** Prerequisites (three DB roles + migrations) → **Hermes** (auth API → registry API → dashboard → worker, with **`HERMES_INTERNAL_API_KEY`** aligned) → **Mediapulse** (agent-data-api → domain-api → optional **user-registration** → agents).
-- **CI deploy flow:** Every merge to `main` runs `db-migrate` → build and push per-service images to GHCR → trigger Coolify deploy webhooks → prune old GHCR versions (keep newest 2 per service for rollback).
+- **CI deploy flow:** Every merge to `main` runs `db-migrate` → build and push per-service images to GHCR → trigger Coolify deploy webhooks → prune old GHCR versions (keep newest 5 per service for rollback).
 - **Rollback:** Promote the previous image tag (`sha-<commit>`) in Coolify to roll back a service without a new merge.
 - **Secrets:** Never commit real values; use your platform’s secret storage. **`HERMES_INTERNAL_API_KEY`** is a deploy-time preset. **`DOMAIN_INTEGRATION_API_KEY`** on Mediapulse/agents is the API key generated in **Domain integrations** (Hermes dashboard). Apps require **`COOLIFY_WEBHOOK_APP_<SERVICE>`** secrets and agents require **`COOLIFY_WEBHOOK_AGENT_<SERVICE>`** secrets in GitHub Actions; GHCR access uses the built-in **`GITHUB_TOKEN`** with `packages: write`.
 - **JWTs:** agent-auth-api issues tokens for the internal preset and for **domain_integration** API keys (hash in DB); Hermes decrypts per-integration ciphertext for outbound domain/agent calls where configured. Verification uses **`AGENT_AUTH_API_URL`** / **`AGENT_AUTH_JWT_SECRET`** on the auth API.


### PR DESCRIPTION
## Summary

Deploy cleanup was only keeping **two** GHCR container versions per app and agent image. That is tight for rollback and it breaks **manual Coolify redeploys** when the saved ref is an older **`sha-*`** digest that pruning already removed. **`min-versions-to-keep`** moves to **5** in both workflows, and the production guide matches so nobody reads the old “two versions” line.

## Related issues

Closes #430

## Important changes

- **`agent-deploy.yml`** / **`app-deploy.yml`**: **`actions/delete-package-versions`** now uses **`min-versions-to-keep: 5`**.
- **`production.mdx`**: retention wording updated from two to five.

## Other changes

- None.

## Key files to review

- `.github/workflows/agent-deploy.yml` and **`app-deploy.yml`** — cleanup job only.
- **`dev-docs/docs/guide/production.mdx`** — two sentences that mention retention count.

## How to test

1. Diff the two workflow files and confirm **`min-versions-to-keep: 5`** appears in each cleanup matrix.
2. Grep **`production.mdx`** for **`two`** / **`2`** in the GHCR retention context and confirm it now says five.
3. After merge, run a normal **`main`** deploy once and confirm cleanup still runs without action errors (watch the **Prune old GHCR versions** job logs).
