### PR TITLE
Add Mediapulse agent registry descriptions and pin user-registration to 1.0.0

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/index.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.ts
@@ -25,6 +25,8 @@ const app = createAgentApp<
   {
     agentId: "content-generation",
     agentVersion: AGENT_VERSION,
+    description:
+      "Generates newsletter and structured content for a ticker from configured sources and templates.",
     inputSchema: BodySchema,
     configSchema: ContentGenerationConfigSchema,
     run,

--- a/apps/mediapulse/agents/data-collection/src/index.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.ts
@@ -14,6 +14,8 @@ const app = createAgentApp<
   {
     agentId: "data-collection",
     agentVersion: "1.0.0",
+    description:
+      "Fetches market and news data for a ticker and persists it through agent-data-api.",
     inputSchema: BodySchema,
     configSchema: ConfigSchema,
     run: runDataCollection,

--- a/apps/mediapulse/agents/query-analysis/src/index.ts
+++ b/apps/mediapulse/agents/query-analysis/src/index.ts
@@ -22,6 +22,8 @@ const app = createAgentApp<
   {
     agentId: "query-analysis",
     agentVersion: "1.0.0",
+    description:
+      "Runs analytical and knowledge-graph queries for a ticker against stored Mediapulse data.",
     inputSchema,
     configSchema: queryAnalysisConfigSchema,
     run: runQueryAnalysis,

--- a/apps/mediapulse/agents/user-registration/src/index.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.ts
@@ -76,7 +76,9 @@ const app = createAgentApp<
 >(
   {
     agentId: "user-registration",
-    agentVersion: "1.1.0",
+    agentVersion: "1.0.0",
+    description:
+      "Reads Outlook for newsletter signup messages, registers users and tickers via agent-data-api, and sends confirmation email.",
     inputSchema: BodySchema,
     configSchema: ConfigSchema,
     run,


### PR DESCRIPTION
## Summary

Four Mediapulse agents now pass a short **`description`** into **`createAgentApp`**, which flows to **agent-registry-api** on auto-register so the Hermes agents list is readable. **user-registration** also drops **`agentVersion`** back to **1.0.0** so the registry matches the current shipping line until you intentionally bump semver.

## Related issues

Closes #432

## Important changes

- **`data-collection`**, **`content-generation`**, **`query-analysis`**: new **`description`** strings next to **`agentId`** / **`agentVersion`**.
- **`user-registration`**: **`description`** plus **`agentVersion: "1.0.0"`** (was **1.1.0**).

## Other changes

- None.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/index.ts`
- `apps/mediapulse/agents/content-generation/src/index.ts`
- `apps/mediapulse/agents/query-analysis/src/index.ts`
- `apps/mediapulse/agents/user-registration/src/index.ts`

## How to test

1. From each agent directory under **`apps/mediapulse/agents/<name>`**, run **`pnpm vitest run`** (already green locally for the four packages touched).
2. Optional: with auto-register env set, start an agent and confirm the registry POST body includes **`description`** and the expected **`agentVersion`** for **user-registration**.
