### PR TITLE
Render inline https markdown links in newsletter emails

### DIFF
--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -13,13 +13,15 @@ import {
 import type { CSSProperties, ReactElement } from "react";
 
 import { parseNewsletterBody } from "./parse-newsletter-body.js";
+import { renderInlineMarkdownLinks } from "./render-inline-markdown-links.js";
 
 export interface DefaultNewsletterEmailProps {
   /** Shown as the main title inside the email body (typically matches the message subject). */
   title: string;
   /**
-   * Newsletter body as plain text or minimal markdown-style lines.
-   * Rendered as pre-wrapped text (no raw HTML injection).
+   * Newsletter body as plain text with optional inline markdown links `[label](https://…)`
+   * in section copy; structured bodies also use EXECUTIVE SUMMARY / TOP N NEWS markers.
+   * Inline https links are rendered as clickable anchors (see {@link renderInlineMarkdownLinks}).
    */
   bodyText: string;
   /** Optional footer line (e.g. unsubscribe placeholder). */
@@ -74,7 +76,9 @@ export const DefaultNewsletterEmail = ({
               <Heading as="h2" style={sectionLabel}>
                 Executive Summary
               </Heading>
-              <Text style={bodyParagraph}>{parsed.executiveSummary}</Text>
+              <Text style={bodyParagraph}>
+                {renderInlineMarkdownLinks(parsed.executiveSummary, link)}
+              </Text>
               <Hr style={hr} />
               <Heading as="h2" style={sectionLabel}>
                 Top News
@@ -85,7 +89,9 @@ export const DefaultNewsletterEmail = ({
                     <Text style={newsItemTitle}>
                       {item.number}. {item.title}
                     </Text>
-                    <Text style={newsItemSummary}>{item.summary}</Text>
+                    <Text style={newsItemSummary}>
+                      {renderInlineMarkdownLinks(item.summary, link)}
+                    </Text>
                     {index < parsed.topNewsItems.length - 1 ? (
                       <Hr style={itemSeparator} />
                     ) : null}
@@ -94,7 +100,9 @@ export const DefaultNewsletterEmail = ({
               )}
             </>
           ) : (
-            <Text style={bodyParagraph}>{bodyText}</Text>
+            <Text style={bodyParagraph}>
+              {renderInlineMarkdownLinks(bodyText, link)}
+            </Text>
           )}
           <Hr style={hr} />
           <Text style={footer}>{footerNote}</Text>

--- a/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.test.tsx
+++ b/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.test.tsx
@@ -1,0 +1,102 @@
+import { Text } from "@react-email/components";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultIsAllowedNewsletterLinkUrl,
+  renderInlineMarkdownLinks,
+  type RenderInlineMarkdownLinksDependencies,
+} from "./render-inline-markdown-links.js";
+
+const linkStyle = { color: "#2563eb" };
+
+describe("defaultIsAllowedNewsletterLinkUrl", () => {
+  it("accepts https URLs with a host", () => {
+    expect(
+      defaultIsAllowedNewsletterLinkUrl("https://news.example.com/path?q=1"),
+    ).toBe(true);
+  });
+
+  it("accepts uppercase HTTPS scheme after trimming", () => {
+    expect(defaultIsAllowedNewsletterLinkUrl("  HTTPS://Example.COM/x  ")).toBe(
+      true,
+    );
+  });
+
+  it("rejects http", () => {
+    expect(defaultIsAllowedNewsletterLinkUrl("http://a.test/")).toBe(false);
+  });
+
+  it("rejects non-URL strings", () => {
+    expect(defaultIsAllowedNewsletterLinkUrl("not-a-url")).toBe(false);
+  });
+
+  it("rejects whitespace-only input", () => {
+    expect(defaultIsAllowedNewsletterLinkUrl("   ")).toBe(false);
+  });
+
+  it("rejects invalid URLs that still start with https://", () => {
+    expect(defaultIsAllowedNewsletterLinkUrl("https://%")).toBe(false);
+  });
+});
+
+describe("renderInlineMarkdownLinks", () => {
+  const renderInText = (
+    text: string,
+    deps: RenderInlineMarkdownLinksDependencies = {},
+  ) =>
+    renderToStaticMarkup(
+      <Text>{renderInlineMarkdownLinks(text, linkStyle, deps)}</Text>,
+    );
+
+  it("returns plain text when there are no markdown links", () => {
+    const html = renderInText("Hello world.");
+    expect(html).toContain("Hello world.");
+    expect(html).not.toContain("<a ");
+  });
+
+  it("renders a single https markdown link as an anchor", () => {
+    const html = renderInText("[Label](https://example.com/page) tail.");
+    expect(html).toContain('href="https://example.com/page"');
+    expect(html).toContain(">Label<");
+    expect(html).toContain(" tail.");
+    expect(html).not.toContain("[Label](");
+  });
+
+  it("renders multiple links", () => {
+    const html = renderInText(
+      "[One](https://a.test/1) mid [Two](https://b.test/2)",
+    );
+    expect(html.match(/href="https:\/\//g)?.length).toBe(2);
+  });
+
+  it("leaves http links as literal markdown text", () => {
+    const html = renderInText("[X](http://insecure.example/)");
+    expect(html).toContain("[X](http://insecure.example/)");
+    expect(html).not.toContain('href="http://');
+  });
+
+  it("uses isAllowedUrl override when provided", () => {
+    const html = renderInText("[X](http://allowed.example/)", {
+      isAllowedUrl: (h: string) => h.startsWith("http://allowed"),
+    });
+    expect(html).toContain('href="http://allowed.example/"');
+  });
+
+  it("renders adjacent links without dropping segments", () => {
+    const html = renderInText("[A](https://a.example/)[B](https://b.example/)");
+    expect(html.match(/<a /g)?.length).toBe(2);
+  });
+
+  it("returns empty output for empty input", () => {
+    const html = renderInText("");
+    expect(html).toBeDefined();
+    expect(html.length).toBeGreaterThan(0);
+  });
+
+  it("returns a single link element when the entire string is one link", () => {
+    const html = renderInText("[Only](https://only.example/hi)");
+    expect(html).toContain('href="https://only.example/hi"');
+    expect(html.match(/<a /g)?.length).toBe(1);
+  });
+});

--- a/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.tsx
+++ b/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.tsx
@@ -1,0 +1,94 @@
+import { Link } from "@react-email/components";
+import type { CSSProperties, ReactNode } from "react";
+
+/** Predicate that returns true when a markdown link target is safe to render as `href`. */
+export type IsAllowedNewsletterLinkUrl = (href: string) => boolean;
+
+const MARKDOWN_LINK = /\[([^\]]+)]\(([^)]+)\)/g;
+
+/**
+ * Returns true when `href` is an absolute `https:` URL suitable for newsletter citations.
+ *
+ * @param href - Raw URL from markdown link parentheses (may include surrounding whitespace).
+ * @returns Whether the trimmed value parses as `https:` with a host.
+ */
+export const defaultIsAllowedNewsletterLinkUrl = (href: string): boolean => {
+  const trimmed = href.trim();
+  if (!trimmed.toLowerCase().startsWith("https://")) {
+    return false;
+  }
+  try {
+    const parsed = new URL(trimmed);
+    return parsed.protocol === "https:" && parsed.hostname.length > 0;
+  } catch {
+    return false;
+  }
+};
+
+export type RenderInlineMarkdownLinksDependencies = {
+  /** Override URL policy (defaults to {@link defaultIsAllowedNewsletterLinkUrl}). */
+  isAllowedUrl?: IsAllowedNewsletterLinkUrl;
+};
+
+/**
+ * Turns inline markdown links `[label](url)` into React Email `Link` nodes; other text stays plain.
+ * Only `https:` URLs accepted by `isAllowedUrl` become links; rejected patterns stay as the original substring.
+ *
+ * @param text - Paragraph or line that may contain markdown links.
+ * @param linkStyle - CSS passed to each rendered `Link`.
+ * @param dependencies - Optional injectables for tests.
+ * @returns A string, a single element, or an array of mixed text and links suitable as `Text` children.
+ */
+export const renderInlineMarkdownLinks = (
+  text: string,
+  linkStyle: CSSProperties,
+  dependencies: RenderInlineMarkdownLinksDependencies = {},
+): ReactNode => {
+  const isAllowedUrl =
+    dependencies.isAllowedUrl ?? defaultIsAllowedNewsletterLinkUrl;
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let linkKey = 0;
+  let match: RegExpExecArray | null;
+
+  const re = new RegExp(MARKDOWN_LINK.source, MARKDOWN_LINK.flags);
+  while ((match = re.exec(text)) !== null) {
+    const full = match[0] ?? "";
+    const label = match[1] ?? "";
+    const rawHref = match[2] ?? "";
+    const start = match.index;
+
+    if (start > lastIndex) {
+      parts.push(text.slice(lastIndex, start));
+    }
+
+    const href = rawHref.trim();
+    if (label.length > 0 && isAllowedUrl(href)) {
+      parts.push(
+        <Link
+          href={href}
+          key={`newsletter-inline-link-${linkKey++}`}
+          style={linkStyle}
+        >
+          {label}
+        </Link>,
+      );
+    } else {
+      parts.push(full);
+    }
+
+    lastIndex = start + full.length;
+  }
+
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  if (parts.length === 0) {
+    return "";
+  }
+  if (parts.length === 1) {
+    return parts[0] ?? "";
+  }
+  return parts;
+};

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -173,4 +173,33 @@ describe("renderNewsletterEmail", () => {
     expect(html).not.toContain("Executive Summary");
     expect(html).not.toContain("Top News");
   });
+
+  it("renders markdown links in structured summaries as HTML anchors", async () => {
+    const articleUrl = "https://www.investing.com/equities/bnk-central-as";
+    const structuredBody = [
+      "EXECUTIVE SUMMARY",
+      "",
+      "Overview with [Bank Central Asia](" + articleUrl + ") in the lead.",
+      "",
+      "---",
+      "",
+      "TOP 1 NEWS",
+      "",
+      "1. BBCA profit strength",
+      "[Bank Central Asia](" + articleUrl + ") reported strong net profit.",
+    ].join("\n");
+
+    const { html, text } = await renderNewsletterEmail({
+      title: "BBCA digest",
+      bodyText: structuredBody,
+    });
+
+    expect(html).toMatch(
+      /<a[^>]+href=["']?https:\/\/www\.investing\.com\/equities\/bnk-central-as["']?/i,
+    );
+    expect(html).toContain("Bank Central Asia");
+    expect(html).not.toContain("[Bank Central Asia](");
+    expect(text).toContain("Bank Central Asia");
+    expect(text).toContain(articleUrl);
+  });
 });


### PR DESCRIPTION
## Summary

Newsletter messages were still carrying markdown link syntax in the HTML body. Summaries already include `[phrase](https://…)` from the phrase link injector, but `DefaultNewsletterEmail` printed those strings verbatim. Recipients saw brackets instead of a clickable citation.

## Related issues

Closes #436

## Important changes

- Added `renderInlineMarkdownLinks` in `@workspace/email-templates`: only `https` URLs that pass a small URL check become `<Link>`; everything else stays as the original characters.
- Wired that helper into the executive summary, each top-news summary, and the unstructured `bodyText` fallback so behavior matches across layouts.

## Other changes

- Extended `renderNewsletterEmail` tests with a structured fixture that mirrors real injected links (BBCA / investing.com style).

## Key files to review

- `packages/shared/email-templates/src/newsletter/render-inline-markdown-links.tsx` — parsing, allowlist, and how rejected URLs are left alone.
- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` — where the helper is applied and reuse of the existing link style.

## How to test

1. From repo root: `pnpm --filter @workspace/email-templates test` (expect all green).
2. Optional: `pnpm --filter @workspace/email-templates type:check`.
3. Spot-check: render a newsletter with a body that includes `[Label](https://example.com/path)` in a summary; exported HTML should contain `<a` with that `href` and should not contain the literal `[Label](` substring for that link.
