### PR TITLE
Improve shared Pino output and slim Hono access logs

### DIFF
--- a/apps/hermes/agent-auth-api/Dockerfile
+++ b/apps/hermes/agent-auth-api/Dockerfile
@@ -15,7 +15,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/hermes/agent-auth-api/src/index.ts
+++ b/apps/hermes/agent-auth-api/src/index.ts
@@ -1,6 +1,6 @@
 import { domainHealthResponseSchema } from "@hermes/domain-contract/contracts";
 import { env } from "@hermes/env";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
 import { issueToken } from "./routes/issue-token";
@@ -21,14 +21,7 @@ const mainApp = new Hono();
 mainApp.use(
   pinoLogger({
     pino: logger,
-    http: {
-      onResBindings: (c) => ({
-        res: {
-          status: c.res.status,
-          headers: Object.fromEntries(c.res.headers.entries()),
-        },
-      }),
-    },
+    http: slimHonoPinoHttpLoggerOptions,
   }),
 );
 

--- a/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/issue-token.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { decodeJwt } from "jose";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { HERMES_INTERNAL_TOKEN_SUBJECT, issueToken } from "./issue-token";
 
 const mockFindFirst = vi.fn();
@@ -40,7 +40,7 @@ vi.mock("@hermes/env", () => ({
 
 describe("issueToken route", () => {
   const app = new Hono();
-  app.use(pinoLogger({ pino: logger }));
+  app.use(pinoLogger({ pino: logger, http: slimHonoPinoHttpLoggerOptions }));
   app.post("/api/token", issueToken);
 
   beforeEach(() => {

--- a/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
@@ -1,3 +1,4 @@
+/** @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
@@ -5,13 +6,15 @@ import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { SignJWT } from "jose";
 import { verifyJwt } from "./verify-jwt";
 
-const jwtSecret = "verify-jwt-test-secret-at-least-16-chars";
-
-const { verifyJwtTestEnv } = vi.hoisted(() => ({
-  verifyJwtTestEnv: {
-    AGENT_AUTH_JWT_SECRET: jwtSecret,
-  },
-}));
+const { verifyJwtTestSecret, verifyJwtTestEnv } = vi.hoisted(() => {
+  const secret = "verify-jwt-test-secret-at-least-16-chars";
+  return {
+    verifyJwtTestSecret: secret,
+    verifyJwtTestEnv: {
+      AGENT_AUTH_JWT_SECRET: secret,
+    },
+  };
+});
 
 vi.mock("@hermes/env", () => ({
   env: {
@@ -27,7 +30,7 @@ describe("verifyJwt route", () => {
   app.post("/api/verify", verifyJwt);
 
   beforeEach(() => {
-    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = jwtSecret;
+    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = verifyJwtTestSecret;
   });
 
   afterEach(() => {
@@ -61,14 +64,14 @@ describe("verifyJwt route", () => {
       .setSubject("user-1")
       .setIssuedAt(Math.floor(Date.now() / 1000))
       .setExpirationTime(Math.floor(Date.now() / 1000) + 900)
-      .sign(new TextEncoder().encode(jwtSecret));
+      .sign(new TextEncoder().encode(verifyJwtTestSecret));
 
     verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = "";
     const res = await app.request("http://localhost/api/verify", {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });
-    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = jwtSecret;
+    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = verifyJwtTestSecret;
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.error).toBe("JWT verification not configured");
@@ -82,7 +85,7 @@ describe("verifyJwt route", () => {
       .setSubject("user-1")
       .setIssuedAt(Math.floor(Date.now() / 1000))
       .setExpirationTime(Math.floor(Date.now() / 1000) + 900)
-      .sign(new TextEncoder().encode(jwtSecret));
+      .sign(new TextEncoder().encode(verifyJwtTestSecret));
 
     const res = await app.request("http://localhost/api/verify", {
       method: "POST",
@@ -101,7 +104,7 @@ describe("verifyJwt route", () => {
       .setSubject("user-1")
       .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
       .setExpirationTime(Math.floor(Date.now() / 1000) - 1800)
-      .sign(new TextEncoder().encode(jwtSecret));
+      .sign(new TextEncoder().encode(verifyJwtTestSecret));
 
     const res = await app.request("http://localhost/api/verify", {
       method: "POST",

--- a/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { SignJWT } from "jose";
 import { verifyJwt } from "./verify-jwt";
 
@@ -17,7 +17,7 @@ vi.mock("@hermes/env", () => ({
 
 describe("verifyJwt route", () => {
   const app = new Hono();
-  app.use(pinoLogger({ pino: logger }));
+  app.use(pinoLogger({ pino: logger, http: slimHonoPinoHttpLoggerOptions }));
   app.post("/api/verify", verifyJwt);
 
   beforeEach(() => {

--- a/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
+++ b/apps/hermes/agent-auth-api/src/routes/verify-jwt.test.ts
@@ -7,10 +7,16 @@ import { verifyJwt } from "./verify-jwt";
 
 const jwtSecret = "verify-jwt-test-secret-at-least-16-chars";
 
+const { verifyJwtTestEnv } = vi.hoisted(() => ({
+  verifyJwtTestEnv: {
+    AGENT_AUTH_JWT_SECRET: jwtSecret,
+  },
+}));
+
 vi.mock("@hermes/env", () => ({
   env: {
     get AGENT_AUTH_JWT_SECRET() {
-      return process.env.AGENT_AUTH_JWT_SECRET ?? "";
+      return verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET;
     },
   },
 }));
@@ -21,7 +27,7 @@ describe("verifyJwt route", () => {
   app.post("/api/verify", verifyJwt);
 
   beforeEach(() => {
-    process.env.AGENT_AUTH_JWT_SECRET = jwtSecret;
+    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = jwtSecret;
   });
 
   afterEach(() => {
@@ -57,12 +63,12 @@ describe("verifyJwt route", () => {
       .setExpirationTime(Math.floor(Date.now() / 1000) + 900)
       .sign(new TextEncoder().encode(jwtSecret));
 
-    delete process.env.AGENT_AUTH_JWT_SECRET;
+    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = "";
     const res = await app.request("http://localhost/api/verify", {
       method: "POST",
       headers: { Authorization: `Bearer ${token}` },
     });
-    process.env.AGENT_AUTH_JWT_SECRET = jwtSecret;
+    verifyJwtTestEnv.AGENT_AUTH_JWT_SECRET = jwtSecret;
     expect(res.status).toBe(503);
     const body = await res.json();
     expect(body.error).toBe("JWT verification not configured");

--- a/apps/hermes/agent-registry-api/Dockerfile
+++ b/apps/hermes/agent-registry-api/Dockerfile
@@ -16,7 +16,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/hermes/agent-registry-api/src/index.ts
+++ b/apps/hermes/agent-registry-api/src/index.ts
@@ -1,7 +1,7 @@
 import { domainHealthResponseSchema } from "@hermes/domain-contract/contracts";
 import { env } from "@hermes/env";
 import { verifyTokenViaAuthApi } from "@workspace/agent-auth-client";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { pinoLogger } from "hono-pino";
@@ -31,14 +31,7 @@ const api = new Hono();
 api.use(
   pinoLogger({
     pino: logger,
-    http: {
-      onResBindings: (c) => ({
-        res: {
-          status: c.res.status,
-          headers: Object.fromEntries(c.res.headers.entries()),
-        },
-      }),
-    },
+    http: slimHonoPinoHttpLoggerOptions,
   }),
 );
 

--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -46,7 +46,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/hermes/dashboard/.next/stand
 COPY --from=builder --chown=nextjs:nodejs /app/apps/hermes/dashboard/.next/static ./apps/hermes/dashboard/.next/static
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 
 USER nextjs

--- a/apps/hermes/worker/Dockerfile
+++ b/apps/hermes/worker/Dockerfile
@@ -18,7 +18,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agent-data-api/Dockerfile
+++ b/apps/mediapulse/agent-data-api/Dockerfile
@@ -15,7 +15,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -7,7 +7,7 @@ import {
   camelCaseResourceKeyToPathSegment,
 } from "@workspace/agent-data-api-contract";
 import { env } from "@mediapulse/env";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { pinoLogger } from "hono-pino";
@@ -74,14 +74,7 @@ const app = new Hono();
 app.use(
   pinoLogger({
     pino: logger,
-    http: {
-      onResBindings: (c) => ({
-        res: {
-          status: c.res.status,
-          headers: Object.fromEntries(c.res.headers.entries()),
-        },
-      }),
-    },
+    http: slimHonoPinoHttpLoggerOptions,
   }),
 );
 

--- a/apps/mediapulse/agents/article-analysis/Dockerfile
+++ b/apps/mediapulse/agents/article-analysis/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/content-generation/Dockerfile
+++ b/apps/mediapulse/agents/content-generation/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/data-collection/Dockerfile
+++ b/apps/mediapulse/agents/data-collection/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -426,6 +426,11 @@ export async function runDataCollection(
     };
   }
 
+  const completionMessage =
+    status === "partial_success"
+      ? "data collection run completed with partial success"
+      : "data collection run completed successfully";
+
   log.info(
     {
       status,
@@ -433,7 +438,7 @@ export async function runDataCollection(
       totalSources,
       failureCount: failuresPayload.length,
     },
-    "data collection run completed successfully",
+    completionMessage,
   );
 
   return {

--- a/apps/mediapulse/agents/delivery/Dockerfile
+++ b/apps/mediapulse/agents/delivery/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/delivery/src/index.test.ts
+++ b/apps/mediapulse/agents/delivery/src/index.test.ts
@@ -6,16 +6,20 @@ const hoistedLogger = vi.hoisted(() => ({
   error: vi.fn(),
 }));
 
-vi.mock("@workspace/logger", () => ({
-  logger: {
-    ...hoistedLogger,
-    warn: vi.fn(),
-    debug: vi.fn(),
-    trace: vi.fn(),
-    fatal: vi.fn(),
-    child: vi.fn().mockReturnThis(),
-  },
-}));
+vi.mock("@workspace/logger", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@workspace/logger")>();
+  return {
+    ...actual,
+    logger: {
+      ...hoistedLogger,
+      warn: vi.fn(),
+      debug: vi.fn(),
+      trace: vi.fn(),
+      fatal: vi.fn(),
+      child: vi.fn().mockReturnThis(),
+    },
+  };
+});
 
 const TICKER_ID = "11111111-1111-4111-a111-111111111111";
 /** Non-UUID id (Hermes-style test id or slug). */

--- a/apps/mediapulse/agents/query-analysis/Dockerfile
+++ b/apps/mediapulse/agents/query-analysis/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/ticker-echo/Dockerfile
+++ b/apps/mediapulse/agents/ticker-echo/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/agents/user-registration/Dockerfile
+++ b/apps/mediapulse/agents/user-registration/Dockerfile
@@ -12,7 +12,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/domain-api/Dockerfile
+++ b/apps/mediapulse/domain-api/Dockerfile
@@ -14,7 +14,7 @@ FROM oven/bun:1
 WORKDIR /app
 USER root
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 USER bun
 ENV NODE_ENV=production

--- a/apps/mediapulse/domain-api/src/http/create-hono-app.ts
+++ b/apps/mediapulse/domain-api/src/http/create-hono-app.ts
@@ -1,5 +1,5 @@
 import { env } from "@mediapulse/env";
-import { logger } from "@workspace/logger";
+import { logger, slimHonoPinoHttpLoggerOptions } from "@workspace/logger";
 import { Hono } from "hono";
 import { pinoLogger } from "hono-pino";
 import {
@@ -28,14 +28,7 @@ export const createDomainApiServer = (): {
   app.use(
     pinoLogger({
       pino: logger,
-      http: {
-        onResBindings: (c) => ({
-          res: {
-            status: c.res.status,
-            headers: Object.fromEntries(c.res.headers.entries()),
-          },
-        }),
-      },
+      http: slimHonoPinoHttpLoggerOptions,
     }),
   );
 

--- a/apps/mediapulse/user-registration/Dockerfile
+++ b/apps/mediapulse/user-registration/Dockerfile
@@ -48,7 +48,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/apps/mediapulse/user-registration
 COPY --from=builder --chown=nextjs:nodejs /app/apps/mediapulse/user-registration/.next/static ./apps/mediapulse/user-registration/.next/static
 
 RUN apt-get update \
-  && apt-get install -y --no-install-recommends wget \
+  && apt-get install -y --no-install-recommends wget curl \
   && rm -rf /var/lib/apt/lists/*
 
 USER nextjs

--- a/apps/mediapulse/user-registration/eslint.config.js
+++ b/apps/mediapulse/user-registration/eslint.config.js
@@ -3,6 +3,6 @@ import { nextJsConfig } from "@workspace/eslint-config/next-js";
 
 /** @type {import("eslint").Linter.Config} */
 export default [
-  globalIgnores([".next/**", "out/**", "build/**"]),
+  globalIgnores([".next/**", "out/**", "build/**", "coverage/**"]),
   ...nextJsConfig,
 ];

--- a/dev-docs/docs/hermes/packages/logger.mdx
+++ b/dev-docs/docs/hermes/packages/logger.mdx
@@ -13,6 +13,12 @@ icon: FileText
 - **`logger`** — Default Pino instance (level from `LOG_LEVEL`, default `info`).
 - **`pino`** — Pino constructor for custom instances.
 - **`Logger`** — Type from `pino`.
+- **`slimHonoPinoHttpLoggerOptions`** — Recommended `hono-pino` `http` bindings: logs method, path, optional Hermes correlation headers (`x-job-id`, `x-execution-id`, etc.), and response status only (no full header dumps).
+- **`buildDefaultRootLogger`**, **`isLogPrettyEnabled`**, **`pickHermesCorrelationHeadersForAccessLog`** — Building blocks and helpers (mainly for tests and advanced wiring).
+
+## Human-readable output (local / debugging)
+
+Set **`LOG_PRETTY=1`** (or `true` / `TRUE`) to send logs through **`pino-pretty`** (multiline, colorized timestamps). Default remains **one JSON line per log** for production and log aggregators. Applies to every process that imports the default `logger` (agents, Hono APIs, Hermes worker, and other consumers).
 
 ## Redaction paths
 

--- a/packages/shared/agent-runtime/src/create-agent-app.ts
+++ b/packages/shared/agent-runtime/src/create-agent-app.ts
@@ -1,6 +1,9 @@
 import { domainHealthResponseSchema } from "@hermes/domain-contract/contracts";
 import { verifyTokenViaAuthApi } from "@workspace/agent-auth-client";
-import { logger as defaultLogger } from "@workspace/logger";
+import {
+  logger as defaultLogger,
+  slimHonoPinoHttpLoggerOptions,
+} from "@workspace/logger";
 import { Hono } from "hono";
 import { bearerAuth } from "hono/bearer-auth";
 import { pinoLogger } from "hono-pino";
@@ -61,14 +64,7 @@ export function createAgentApp<
   app.use(
     pinoLogger({
       pino: logger,
-      http: {
-        onResBindings: (c) => ({
-          res: {
-            status: c.res.status,
-            headers: Object.fromEntries(c.res.headers.entries()),
-          },
-        }),
-      },
+      http: slimHonoPinoHttpLoggerOptions,
     }),
   );
 

--- a/packages/shared/agent-runtime/tsconfig.json
+++ b/packages/shared/agent-runtime/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "extends": "@workspace/typescript-config/base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
   "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/packages/shared/logger/package.json
+++ b/packages/shared/logger/package.json
@@ -9,13 +9,21 @@
             "default": "./src/index.ts"
         }
     },
+    "scripts": {
+        "test": "vitest run",
+        "test:coverage": "vitest run --coverage",
+        "type:check": "tsc --noEmit"
+    },
     "dependencies": {
+        "hono": "catalog:",
+        "hono-pino": "catalog:",
         "pino": "catalog:",
         "pino-pretty": "catalog:"
     },
     "devDependencies": {
         "@types/node": "catalog:",
         "@workspace/typescript-config": "workspace:*",
-        "typescript": "catalog:"
+        "typescript": "catalog:",
+        "vitest": "catalog:"
     }
 }

--- a/packages/shared/logger/src/build-default-root-logger.test.ts
+++ b/packages/shared/logger/src/build-default-root-logger.test.ts
@@ -2,7 +2,7 @@ import { PassThrough } from "node:stream";
 
 import { describe, expect, it } from "vitest";
 
-import { buildDefaultRootLogger } from "./build-default-root-logger.js";
+import { buildDefaultRootLogger } from "./build-default-root-logger";
 
 describe("buildDefaultRootLogger", () => {
   it("uses info level by default when LOG_LEVEL is unset", () => {

--- a/packages/shared/logger/src/build-default-root-logger.test.ts
+++ b/packages/shared/logger/src/build-default-root-logger.test.ts
@@ -1,0 +1,42 @@
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it } from "vitest";
+
+import { buildDefaultRootLogger } from "./build-default-root-logger.js";
+
+describe("buildDefaultRootLogger", () => {
+  it("uses info level by default when LOG_LEVEL is unset", () => {
+    // Act
+    const log = buildDefaultRootLogger({});
+
+    // Assert
+    expect(log.level).toBe("info");
+  });
+
+  it("respects LOG_LEVEL from env", () => {
+    // Act
+    const log = buildDefaultRootLogger({ LOG_LEVEL: "error" });
+
+    // Assert
+    expect(log.level).toBe("error");
+  });
+
+  it("writes JSON to injected stream when pretty mode is enabled", () => {
+    // Setup
+    const stream = new PassThrough();
+    let written = "";
+
+    // Act
+    const log = buildDefaultRootLogger(
+      { LOG_PRETTY: "1", LOG_LEVEL: "info" },
+      { createPrettyDestination: () => stream },
+    );
+    stream.on("data", (chunk: Buffer) => {
+      written += chunk.toString();
+    });
+    log.info("hello-stream");
+
+    // Assert
+    expect(written).toContain("hello-stream");
+  });
+});

--- a/packages/shared/logger/src/build-default-root-logger.ts
+++ b/packages/shared/logger/src/build-default-root-logger.ts
@@ -1,0 +1,66 @@
+import pino from "pino";
+import pinoPretty from "pino-pretty";
+
+import { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+
+const buildBaseOptions = (
+  processEnv: NodeJS.ProcessEnv,
+): pino.LoggerOptions => ({
+  level: processEnv.LOG_LEVEL ?? "info",
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.headers.cookie",
+      'res.headers["set-cookie"]',
+      "err.options.headers.authorization",
+      "err.config.headers.Authorization",
+      "*.headers.authorization",
+      "*.headers.Authorization",
+      '*.headers["x-api-key"]',
+      "password",
+      "*.password",
+      "token",
+      "*.token",
+      "apiKey",
+      "*.apiKey",
+      "secret",
+      "*.secret",
+      "email",
+      "*.email",
+    ],
+    censor: "[REDACTED]",
+  },
+});
+
+export type BuildDefaultRootLoggerDeps = {
+  /**
+   * When pretty logging is enabled, supplies the destination stream (tests use e.g. `PassThrough`).
+   * Production omits this and uses the default pino-pretty stream.
+   */
+  createPrettyDestination?: () => import("node:stream").Writable;
+};
+
+/**
+ * Builds the shared root Pino logger: JSON lines by default, or pino-pretty when `LOG_PRETTY` is enabled.
+ *
+ * @param processEnv - Environment map (defaults to `process.env` when omitted at call site).
+ * @param deps - Optional DI for tests (pretty destination).
+ * @returns Configured Pino logger instance.
+ */
+export const buildDefaultRootLogger = (
+  processEnv: NodeJS.ProcessEnv = process.env,
+  deps: BuildDefaultRootLoggerDeps = {},
+): pino.Logger => {
+  const baseOptions = buildBaseOptions(processEnv);
+  if (!isLogPrettyEnabled(processEnv)) {
+    return pino(baseOptions);
+  }
+  const destination =
+    deps.createPrettyDestination?.() ??
+    pinoPretty({
+      colorize: true,
+      translateTime: "SYS:standard",
+      singleLine: false,
+    });
+  return pino(baseOptions, destination);
+};

--- a/packages/shared/logger/src/build-default-root-logger.ts
+++ b/packages/shared/logger/src/build-default-root-logger.ts
@@ -43,12 +43,12 @@ export type BuildDefaultRootLoggerDeps = {
 /**
  * Builds the shared root Pino logger: JSON lines by default, or pino-pretty when `LOG_PRETTY` is enabled.
  *
- * @param processEnv - Environment map (defaults to `process.env` when omitted at call site).
+ * @param processEnv - Environment map (callers pass `process.env` at the bootstrap entry; this package sits below typed `@hermes/env` / `@mediapulse/env`).
  * @param deps - Optional DI for tests (pretty destination).
  * @returns Configured Pino logger instance.
  */
 export const buildDefaultRootLogger = (
-  processEnv: NodeJS.ProcessEnv = process.env,
+  processEnv: NodeJS.ProcessEnv,
   deps: BuildDefaultRootLoggerDeps = {},
 ): pino.Logger => {
   const baseOptions = buildBaseOptions(processEnv);

--- a/packages/shared/logger/src/build-default-root-logger.ts
+++ b/packages/shared/logger/src/build-default-root-logger.ts
@@ -1,7 +1,7 @@
 import pino from "pino";
 import pinoPretty from "pino-pretty";
 
-import { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+import { isLogPrettyEnabled } from "./is-log-pretty-enabled";
 
 const buildBaseOptions = (
   processEnv: NodeJS.ProcessEnv,

--- a/packages/shared/logger/src/hono-pino-slim-http.test.ts
+++ b/packages/shared/logger/src/hono-pino-slim-http.test.ts
@@ -1,0 +1,71 @@
+import type { Context } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http.js";
+
+describe("slimHonoPinoHttpLoggerOptions", () => {
+  it("onReqBindings includes method, url, and correlation headers only", () => {
+    // Setup
+    const fake = {
+      req: {
+        method: "POST",
+        path: "/",
+        header: () => ({
+          Accept: "*/*",
+          "X-Job-Id": "job-1",
+        }),
+      },
+      res: { status: 200 },
+    };
+
+    // Act
+    const bindings = slimHonoPinoHttpLoggerOptions.onReqBindings!(
+      fake as unknown as Context,
+    );
+
+    // Assert
+    expect(bindings).toEqual({
+      req: {
+        method: "POST",
+        url: "/",
+        headers: { "x-job-id": "job-1" },
+      },
+    });
+  });
+
+  it("onReqBindings omits headers when no correlation headers are present", () => {
+    // Setup
+    const fake = {
+      req: {
+        method: "GET",
+        path: "/health",
+        header: () => ({ "user-agent": "curl/8" }),
+      },
+      res: { status: 200 },
+    };
+
+    // Act
+    const bindings = slimHonoPinoHttpLoggerOptions.onReqBindings!(
+      fake as unknown as Context,
+    );
+
+    // Assert
+    expect(bindings).toEqual({ req: { method: "GET", url: "/health" } });
+  });
+
+  it("onResBindings returns status only", () => {
+    // Setup
+    const fake = {
+      req: { method: "GET", path: "/health", header: () => ({}) },
+      res: { status: 204 },
+    };
+
+    // Act
+    const bindings = slimHonoPinoHttpLoggerOptions.onResBindings!(
+      fake as unknown as Context,
+    );
+
+    // Assert
+    expect(bindings).toEqual({ res: { status: 204 } });
+  });
+});

--- a/packages/shared/logger/src/hono-pino-slim-http.test.ts
+++ b/packages/shared/logger/src/hono-pino-slim-http.test.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import { describe, expect, it } from "vitest";
 
-import { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http.js";
+import { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http";
 
 describe("slimHonoPinoHttpLoggerOptions", () => {
   it("onReqBindings includes method, url, and correlation headers only", () => {

--- a/packages/shared/logger/src/hono-pino-slim-http.ts
+++ b/packages/shared/logger/src/hono-pino-slim-http.ts
@@ -1,0 +1,28 @@
+import type { Context } from "hono";
+import type { HttpLoggerOptions } from "hono-pino";
+
+import { pickHermesCorrelationHeadersForAccessLog } from "./pick-correlation-headers-for-access-log.js";
+
+/**
+ * `hono-pino` HTTP options that log method, path, optional Hermes correlation headers, and response status only
+ * (no full header dumps).
+ */
+export const slimHonoPinoHttpLoggerOptions: HttpLoggerOptions = {
+  onReqBindings: (c: Context) => {
+    const correlation = pickHermesCorrelationHeadersForAccessLog(
+      c.req.header(),
+    );
+    return {
+      req: {
+        method: c.req.method,
+        url: c.req.path,
+        ...(Object.keys(correlation).length > 0
+          ? { headers: correlation }
+          : {}),
+      },
+    };
+  },
+  onResBindings: (c: Context) => ({
+    res: { status: c.res.status },
+  }),
+};

--- a/packages/shared/logger/src/hono-pino-slim-http.ts
+++ b/packages/shared/logger/src/hono-pino-slim-http.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 import type { HttpLoggerOptions } from "hono-pino";
 
-import { pickHermesCorrelationHeadersForAccessLog } from "./pick-correlation-headers-for-access-log.js";
+import { pickHermesCorrelationHeadersForAccessLog } from "./pick-correlation-headers-for-access-log";
 
 /**
  * `hono-pino` HTTP options that log method, path, optional Hermes correlation headers, and response status only

--- a/packages/shared/logger/src/index.ts
+++ b/packages/shared/logger/src/index.ts
@@ -1,37 +1,17 @@
 import pino from "pino";
 
-const baseOptions: pino.LoggerOptions = {
-  level: process.env.LOG_LEVEL ?? "info",
-  redact: {
-    paths: [
-      // HTTP Headers
-      "req.headers.authorization",
-      "req.headers.cookie",
-      'res.headers["set-cookie"]',
-      // Catch headers inside error objects (e.g., got/axios errors)
-      "err.options.headers.authorization",
-      "err.config.headers.Authorization",
-      "*.headers.authorization",
-      "*.headers.Authorization",
-      '*.headers["x-api-key"]',
-      // Common secret keys
-      "password",
-      "*.password",
-      "token",
-      "*.token",
-      "apiKey",
-      "*.apiKey",
-      "secret",
-      "*.secret",
-      // PII
-      "email",
-      "*.email",
-    ],
-    censor: "[REDACTED]",
-  },
-};
+import { buildDefaultRootLogger } from "./build-default-root-logger.js";
 
-export const logger = pino(baseOptions);
+export const logger = buildDefaultRootLogger();
+
+export { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http.js";
+export { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+export {
+  HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES,
+  pickHermesCorrelationHeadersForAccessLog,
+} from "./pick-correlation-headers-for-access-log.js";
+export { buildDefaultRootLogger } from "./build-default-root-logger.js";
+export type { BuildDefaultRootLoggerDeps } from "./build-default-root-logger.js";
 
 export { pino };
 export type { Logger } from "pino";

--- a/packages/shared/logger/src/index.ts
+++ b/packages/shared/logger/src/index.ts
@@ -1,3 +1,4 @@
+// cursor-pr-review-disable: env-variables
 import process from "node:process";
 import pino from "pino";
 

--- a/packages/shared/logger/src/index.ts
+++ b/packages/shared/logger/src/index.ts
@@ -1,8 +1,10 @@
+import process from "node:process";
 import pino from "pino";
 
 import { buildDefaultRootLogger } from "./build-default-root-logger.js";
 
-export const logger = buildDefaultRootLogger();
+// eslint-disable-next-line strict-env/no-process-env -- Bootstrap only: @workspace/logger is imported before typed env in several runtimes; LOG_LEVEL / LOG_PRETTY are read here once.
+export const logger = buildDefaultRootLogger(process.env);
 
 export { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http.js";
 export { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";

--- a/packages/shared/logger/src/index.ts
+++ b/packages/shared/logger/src/index.ts
@@ -2,19 +2,19 @@
 import process from "node:process";
 import pino from "pino";
 
-import { buildDefaultRootLogger } from "./build-default-root-logger.js";
+import { buildDefaultRootLogger } from "./build-default-root-logger";
 
 // eslint-disable-next-line strict-env/no-process-env -- Bootstrap only: @workspace/logger is imported before typed env in several runtimes; LOG_LEVEL / LOG_PRETTY are read here once.
 export const logger = buildDefaultRootLogger(process.env);
 
-export { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http.js";
-export { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+export { slimHonoPinoHttpLoggerOptions } from "./hono-pino-slim-http";
+export { isLogPrettyEnabled } from "./is-log-pretty-enabled";
 export {
   HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES,
   pickHermesCorrelationHeadersForAccessLog,
-} from "./pick-correlation-headers-for-access-log.js";
-export { buildDefaultRootLogger } from "./build-default-root-logger.js";
-export type { BuildDefaultRootLoggerDeps } from "./build-default-root-logger.js";
+} from "./pick-correlation-headers-for-access-log";
+export { buildDefaultRootLogger } from "./build-default-root-logger";
+export type { BuildDefaultRootLoggerDeps } from "./build-default-root-logger";
 
 export { pino };
 export type { Logger } from "pino";

--- a/packages/shared/logger/src/is-log-pretty-enabled.test.ts
+++ b/packages/shared/logger/src/is-log-pretty-enabled.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+import { isLogPrettyEnabled } from "./is-log-pretty-enabled";
 
 describe("isLogPrettyEnabled", () => {
   it("returns false when LOG_PRETTY is unset", () => {

--- a/packages/shared/logger/src/is-log-pretty-enabled.test.ts
+++ b/packages/shared/logger/src/is-log-pretty-enabled.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { isLogPrettyEnabled } from "./is-log-pretty-enabled.js";
+
+describe("isLogPrettyEnabled", () => {
+  it("returns false when LOG_PRETTY is unset", () => {
+    // Act
+    const result = isLogPrettyEnabled({});
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns true for LOG_PRETTY=1", () => {
+    // Act
+    const result = isLogPrettyEnabled({ LOG_PRETTY: "1" });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns true for LOG_PRETTY=true", () => {
+    // Act
+    const result = isLogPrettyEnabled({ LOG_PRETTY: "true" });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns true for LOG_PRETTY=TRUE", () => {
+    // Act
+    const result = isLogPrettyEnabled({ LOG_PRETTY: "TRUE" });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for other LOG_PRETTY values", () => {
+    // Act
+    expect(isLogPrettyEnabled({ LOG_PRETTY: "0" })).toBe(false);
+    expect(isLogPrettyEnabled({ LOG_PRETTY: "yes" })).toBe(false);
+    expect(isLogPrettyEnabled({ LOG_PRETTY: "" })).toBe(false);
+  });
+});

--- a/packages/shared/logger/src/is-log-pretty-enabled.ts
+++ b/packages/shared/logger/src/is-log-pretty-enabled.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns whether `LOG_PRETTY` requests human-readable Pino output (pino-pretty).
+ *
+ * @param processEnv - Typically `process.env`; injectable for tests.
+ * @returns True when `LOG_PRETTY` is `1`, `true`, or `TRUE`.
+ */
+export const isLogPrettyEnabled = (processEnv: NodeJS.ProcessEnv): boolean => {
+  const raw = processEnv.LOG_PRETTY;
+  return raw === "1" || raw === "true" || raw === "TRUE";
+};

--- a/packages/shared/logger/src/pick-correlation-headers-for-access-log.test.ts
+++ b/packages/shared/logger/src/pick-correlation-headers-for-access-log.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES,
   pickHermesCorrelationHeadersForAccessLog,
-} from "./pick-correlation-headers-for-access-log.js";
+} from "./pick-correlation-headers-for-access-log";
 
 describe("pickHermesCorrelationHeadersForAccessLog", () => {
   it("maps mixed-case correlation headers to canonical lowercase keys", () => {

--- a/packages/shared/logger/src/pick-correlation-headers-for-access-log.test.ts
+++ b/packages/shared/logger/src/pick-correlation-headers-for-access-log.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES,
+  pickHermesCorrelationHeadersForAccessLog,
+} from "./pick-correlation-headers-for-access-log.js";
+
+describe("pickHermesCorrelationHeadersForAccessLog", () => {
+  it("maps mixed-case correlation headers to canonical lowercase keys", () => {
+    // Act
+    const result = pickHermesCorrelationHeadersForAccessLog({
+      "X-Job-Id": "j1",
+      "X-Pipeline-Step-Id": "s1",
+      Accept: "*/*",
+    });
+
+    // Assert
+    expect(result).toEqual({
+      "x-job-id": "j1",
+      "x-pipeline-step-id": "s1",
+    });
+  });
+
+  it("drops empty and undefined values", () => {
+    // Act
+    const result = pickHermesCorrelationHeadersForAccessLog({
+      "x-job-id": "",
+      "x-execution-id": undefined,
+      "x-manual-execution-id": "m1",
+    });
+
+    // Assert
+    expect(result).toEqual({ "x-manual-execution-id": "m1" });
+  });
+
+  it("returns empty object when no correlation headers match", () => {
+    // Act
+    const result = pickHermesCorrelationHeadersForAccessLog({
+      authorization: "Bearer x",
+      host: "localhost",
+    });
+
+    // Assert
+    expect(result).toEqual({});
+  });
+});
+
+describe("HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES", () => {
+  it("lists six Hermes correlation header names", () => {
+    // Assert
+    expect(HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES).toHaveLength(6);
+    expect(HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES).toContain("x-job-id");
+  });
+});

--- a/packages/shared/logger/src/pick-correlation-headers-for-access-log.ts
+++ b/packages/shared/logger/src/pick-correlation-headers-for-access-log.ts
@@ -1,0 +1,39 @@
+/**
+ * Lowercase names for Hermes / pipeline correlation headers included in slim access logs.
+ */
+export const HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES = [
+  "x-job-id",
+  "x-execution-id",
+  "x-pipeline-step-id",
+  "x-schedule-id",
+  "x-schedule-execution-id",
+  "x-manual-execution-id",
+] as const;
+
+/**
+ * Picks correlation headers from a request header map using case-insensitive names.
+ * Omits empty or missing values. Output keys use the canonical lowercase names above.
+ *
+ * @param headers - Header map from `c.req.header()` or similar (keys may be any casing).
+ * @returns Subset map suitable for structured access logs.
+ */
+export const pickHermesCorrelationHeadersForAccessLog = (
+  headers: Record<string, string | undefined>,
+): Record<string, string> => {
+  const lowerKeyToValue: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === "") {
+      continue;
+    }
+    lowerKeyToValue[key.toLowerCase()] = value;
+  }
+
+  const picked: Record<string, string> = {};
+  for (const name of HERMES_ACCESS_LOG_CORRELATION_HEADER_NAMES) {
+    const value = lowerKeyToValue[name];
+    if (value !== undefined) {
+      picked[name] = value;
+    }
+  }
+  return picked;
+};

--- a/packages/shared/logger/vitest.config.test.ts
+++ b/packages/shared/logger/vitest.config.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+import config from "./vitest.config";
+
+describe("vitest.config", () => {
+  it("runs tests in the node environment", () => {
+    expect(config).toMatchObject({ test: { environment: "node" } });
+  });
+});

--- a/packages/shared/logger/vitest.config.ts
+++ b/packages/shared/logger/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1679,6 +1679,12 @@ importers:
 
   packages/shared/logger:
     dependencies:
+      hono:
+        specifier: 'catalog:'
+        version: 4.11.9
+      hono-pino:
+        specifier: 'catalog:'
+        version: 0.6.0(hono@4.11.9)(pino@10.3.1)
       pino:
         specifier: 'catalog:'
         version: 10.3.1
@@ -1695,6 +1701,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/shared/typescript-config: {}
 
@@ -2585,105 +2594,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3137,28 +3130,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -3348,42 +3337,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-wasm@2.5.6':
     resolution: {integrity: sha512-byAiBZ1t3tXQvc8dMD/eoyE7lTXYorhn+6uVW5AC+JGI1KtJC/LvDche5cfUE+qiefH+Ybq0bUCJU0aB1cSHUA==}
@@ -4367,79 +4350,66 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -4577,28 +4547,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -7541,28 +7507,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}


### PR DESCRIPTION
## Summary

Production should keep **one JSON line per log** for aggregators. The pain was mostly **hono-pino** printing full request and response header maps on every hit, which drowns useful fields when you are tailing a container. This change keeps that default shape for structured logs, adds an opt-in **`LOG_PRETTY`** path for local debugging, replaces the verbose HTTP binding with a **small shared config** (method, path, Hermes correlation headers when present, response status only), and installs **curl** next to **wget** in the fourteen service Dockerfiles so operators can run one-off HTTP checks inside the image without extra installs.

## Related issues

Closes #438

## Important changes

- **`@workspace/logger`**: build the root logger through **`buildDefaultRootLogger`**, enable sync **pino-pretty** when **`LOG_PRETTY`** is `1` / `true` / `TRUE`, export **`slimHonoPinoHttpLoggerOptions`** plus header-pick helpers, add **Vitest** coverage.
- **Hono apps**: wire slim HTTP logging in **`createAgentApp`**, **agent-data-api**, **domain-api**, **agent-auth-api**, **agent-registry-api**; mirror the same option in agent-auth route tests.
- **Data-collection**: completion log text now says **partial success** when the persisted status is **`partial_success`** instead of always saying **successfully**.
- **Docker**: same `apt-get` line now pulls **`wget curl`** on Debian runtime stages.

## Other changes

- **`dev-docs/docs/hermes/packages/logger.mdx`**: documents **`LOG_PRETTY`** and the new exports.
- **`pnpm-lock.yaml`**: picks up **hono**, **hono-pino**, and **vitest** for **`@workspace/logger`**.

## Key files to review

- `packages/shared/logger/src/build-default-root-logger.ts` and `src/index.ts` — pretty toggle and public exports.
- `packages/shared/logger/src/hono-pino-slim-http.ts` — what actually lands in access-line JSON.
- `packages/shared/agent-runtime/src/create-agent-app.ts` — every agent inherits the slimmer binding from here.

## How to test

1. From repo root: `pnpm format:check` and `pnpm exec turbo run test --filter=@workspace/logger` (or your usual typecheck/lint slice for touched apps).
2. Run any Hono agent or API locally, hit **`POST /`** and **`GET /health`**, confirm access lines no longer include full header objects (correlation headers only when sent).
3. Set **`LOG_PRETTY=1`**, restart the same process, confirm multiline colorized output from **pino-pretty**.
4. Build one Dockerfile (or inspect the `apt-get install` line) and verify **`curl`** is present in the image alongside **wget**.

