### PR TITLE
Improve subscription mailto layout and display-name handling

### DIFF
--- a/apps/mediapulse/agents/user-registration/README.md
+++ b/apps/mediapulse/agents/user-registration/README.md
@@ -5,7 +5,7 @@ A Hermes agent that polls an Outlook inbox for newsletter subscription emails, p
 ## What it does
 
 1. Lists unread messages from the configured Outlook mailbox.
-2. Parses the sender email and desired ticker symbol from each message.
+2. Parses the **subscriber email** from the message `From` address (the address that actually sent the mail), the **ticker** from the subject (and body fallbacks), and the **display name** from the message body (`Name:` line from the registration mailto, or legacy `Subscriber Name:`), then Microsoft Graph `from.emailAddress.name` when usable, then a title-cased guess from the email local part.
 3. Calls `agent-data-api POST /api/v1/user-registration-register` to create or update the `UserTicker` row.
 4. When the subscription is new or unconfirmed, sends a plain-text confirmation notification email (Resend) and immediately confirms the subscription via `agent-data-api` (no user action required).
 5. Archives the processed message out of the inbox (best-effort) to keep the mailbox clear.

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
@@ -5,6 +5,9 @@ import {
   deriveNameFromEmailLocalPart,
   extractSenderEmail,
   extractTickerSymbol,
+  extractSubscriberName,
+  extractUsableFromDisplayName,
+  resolveSubscriberDisplayName,
 } from "../lib/parser";
 
 describe("Parser Helpers", () => {
@@ -151,6 +154,132 @@ describe("Parser Helpers", () => {
         extractTickerSymbol("Random email", "Just saying hello"),
       ).toBeNull();
       expect(extractTickerSymbol(null, null)).toBeNull();
+    });
+  });
+
+  describe("extractSubscriberName", () => {
+    it("returns null for empty or missing body", () => {
+      expect(extractSubscriberName(undefined)).toBeNull();
+      expect(extractSubscriberName(null)).toBeNull();
+      expect(extractSubscriberName("")).toBeNull();
+      expect(extractSubscriberName("   ")).toBeNull();
+    });
+
+    it("parses Name from plain multiline body", () => {
+      const body = "Name: Kevin Hermawan\nTicker: BUMI\n\n---\nFooter";
+      expect(extractSubscriberName(body)).toBe("Kevin Hermawan");
+    });
+
+    it("prefers Name over Subscriber Name when both appear", () => {
+      const body =
+        "Subscriber Name: Legacy\nName: Preferred User\nTicker: BBCA";
+      expect(extractSubscriberName(body)).toBe("Preferred User");
+    });
+
+    it("parses Subscriber Name line when no Name line exists", () => {
+      const body = "Ticker: TLKM\nSubscriber Name: Jane Smith\n---";
+      expect(extractSubscriberName(body)).toBe("Jane Smith");
+    });
+
+    it("parses legacy single-line body with Subscriber Name before delimiter", () => {
+      const body =
+        "Ticker: BUMI - Bumi Resources Tbk Subscriber Name: Kevin Hermawan --- Please do not modify";
+      expect(extractSubscriberName(body)).toBe("Kevin Hermawan");
+    });
+
+    it("parses Name on same line before Ticker when there are no newlines", () => {
+      const body = "Prefix Name: Pat Lee Ticker: GOTO suffix";
+      expect(extractSubscriberName(body)).toBe("Pat Lee");
+    });
+
+    it("parses Name from HTML body content", () => {
+      const body =
+        "<html><body><div>Name: HTML User</div><br/><div>Ticker: BBCA</div></body></html>";
+      expect(extractSubscriberName(body)).toBe("HTML User");
+    });
+
+    it("returns null when Name label is empty", () => {
+      expect(extractSubscriberName("Name:\nTicker: BBCA")).toBeNull();
+    });
+  });
+
+  describe("extractUsableFromDisplayName", () => {
+    it("returns trimmed name when distinct from sender email", () => {
+      expect(
+        extractUsableFromDisplayName(
+          "  Kevin From Header  ",
+          "kevin@example.com",
+        ),
+      ).toBe("Kevin From Header");
+    });
+
+    it("returns null when missing, too short, equals email, or is an email string", () => {
+      expect(extractUsableFromDisplayName(undefined, "a@b.co")).toBeNull();
+      expect(extractUsableFromDisplayName("x", "a@b.co")).toBeNull();
+      expect(extractUsableFromDisplayName("A@B.CO", "a@b.co")).toBeNull();
+      expect(
+        extractUsableFromDisplayName("other@example.com", "a@b.co"),
+      ).toBeNull();
+    });
+  });
+
+  describe("resolveSubscriberDisplayName", () => {
+    const baseMsg = {
+      id: "1",
+      subject: null,
+      receivedDateTime: "2024-01-01T00:00:00Z",
+      isRead: false,
+    };
+
+    it("uses body Name when present", () => {
+      const msg = {
+        ...baseMsg,
+        body: {
+          content: "Name: Kevin Hermawan\nTicker: BUMI",
+          contentType: "text",
+        },
+        from: {
+          emailAddress: {
+            address: "kevin.hermawan@gmail.com",
+            name: "Gmail Name",
+          },
+        },
+      };
+      expect(
+        resolveSubscriberDisplayName(msg, "kevin.hermawan@gmail.com"),
+      ).toBe("Kevin Hermawan");
+    });
+
+    it("falls back to from display name when body has no name", () => {
+      const msg = {
+        ...baseMsg,
+        body: { content: "Ticker: BBCA only", contentType: "text" },
+        from: {
+          emailAddress: {
+            address: "john.doe@example.com",
+            name: "Johnny Header",
+          },
+        },
+      };
+      expect(resolveSubscriberDisplayName(msg, "john.doe@example.com")).toBe(
+        "Johnny Header",
+      );
+    });
+
+    it("falls back to local-part derived name when body and header are unusable", () => {
+      const msg = {
+        ...baseMsg,
+        body: undefined,
+        from: {
+          emailAddress: {
+            address: "john.doe@example.com",
+            name: "john.doe@example.com",
+          },
+        },
+      };
+      expect(resolveSubscriberDisplayName(msg, "john.doe@example.com")).toBe(
+        "John Doe",
+      );
     });
   });
 });

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.ts
@@ -1,5 +1,35 @@
 import type { GraphMessage } from "@mediapulse/outlook-inbox";
 
+/** Same shape as extractSenderEmail validation (reject if "display name" is an email string). */
+const EMAIL_SHAPE_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/**
+ * Converts Graph message body content (plain text or HTML) into newline-oriented text for line-based field parsing.
+ *
+ * @param content - Raw `body.content` from Microsoft Graph (may be HTML).
+ * @returns Plain-ish text with meaningful newlines, or empty string when missing.
+ */
+function normalizeGraphBodyContentForLineParsing(
+  content: string | null | undefined,
+): string {
+  if (!content || typeof content !== "string") return "";
+  let text = content.trim();
+  if (!text) return "";
+
+  const looksLikeHtml = /<\s*[a-z][\s\S]*>/i.test(text);
+  if (!looksLikeHtml) return text;
+
+  text = text
+    .replace(/<\s*br\s*\/?>/gi, "\n")
+    .replace(/<\/\s*(p|div|tr|li|h[1-6])\s*>/gi, "\n")
+    .replace(/<[^>]+>/g, " ");
+  return text
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t\f\v]+/g, " ")
+    .replace(/ *\n */g, "\n")
+    .trim();
+}
+
 /**
  * Normalizes an email address to trimmed lowercase.
  *
@@ -61,6 +91,103 @@ export function extractSenderEmail(graphMessage: GraphMessage): string | null {
   }
 
   return normalized;
+}
+
+/**
+ * Returns Graph `from.emailAddress.name` when it is a plausible human display name
+ * (not empty, not the same as the sender email, not itself an email address).
+ *
+ * @param fromName - Optional display name from Graph.
+ * @param normalizedSenderEmail - Already-normalized sender address for comparison.
+ * @returns Trimmed display name or null.
+ */
+export function extractUsableFromDisplayName(
+  fromName: string | null | undefined,
+  normalizedSenderEmail: string,
+): string | null {
+  if (!fromName || typeof fromName !== "string") return null;
+  const trimmed = fromName.trim();
+  if (trimmed.length < 2) return null;
+  if (normalizeEmail(trimmed) === normalizedSenderEmail) return null;
+  if (EMAIL_SHAPE_REGEX.test(normalizeEmail(trimmed))) return null;
+  return trimmed;
+}
+
+/**
+ * Extracts subscriber display name from the message body.
+ * Prefers a `Name:` line, then `Subscriber Name:` (legacy mailto), then legacy one-line bodies.
+ *
+ * @param bodyContent - Optional `body.content` from Graph (plain or HTML).
+ * @returns Trimmed name or null when absent.
+ */
+export function extractSubscriberName(
+  bodyContent?: string | null,
+): string | null {
+  const normalized = normalizeGraphBodyContentForLineParsing(bodyContent);
+  if (!normalized) return null;
+
+  const lines = normalized
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  for (const line of lines) {
+    const nameLine = line.match(/^Name:\s*(.+)$/i);
+    if (nameLine?.[1]) {
+      const value = nameLine[1].trim();
+      if (value.length > 0) return value;
+    }
+  }
+
+  for (const line of lines) {
+    const legacyLine = line.match(/^Subscriber Name:\s*(.+)$/i);
+    if (legacyLine?.[1]) {
+      const value = legacyLine[1].trim();
+      if (value.length > 0) return value;
+    }
+  }
+
+  const legacyInline = normalized.match(
+    /Subscriber Name:\s*(.+?)(?=\s+---|\s*$)/is,
+  );
+  if (legacyInline?.[1]) {
+    const value = legacyInline[1].trim();
+    if (value.length > 0) return value;
+  }
+
+  const nameInline = normalized.match(
+    /Name:[ \t]*([^\n]+?)(?=(?:\s+|\n)Ticker:|\s+Subscriber|\s+---|\s*$)/i,
+  );
+  if (nameInline?.[1]) {
+    const value = nameInline[1].trim();
+    if (value.length > 0) return value;
+  }
+
+  return null;
+}
+
+/**
+ * Resolves the display name to send to user-registration-register: body `Name:` / legacy lines first,
+ * then Graph sender display name, then title-cased local part of the email.
+ *
+ * @param graphMessage - Full Graph message (from + body).
+ * @param senderEmail - Normalized sender email from {@link extractSenderEmail}.
+ * @returns Display name or null if no source produced a value.
+ */
+export function resolveSubscriberDisplayName(
+  graphMessage: GraphMessage,
+  senderEmail: string,
+): string | null {
+  const fromBody = extractSubscriberName(graphMessage.body?.content);
+  if (fromBody) return fromBody;
+
+  const fromHeader = extractUsableFromDisplayName(
+    graphMessage.from?.emailAddress?.name,
+    senderEmail,
+  );
+  if (fromHeader) return fromHeader;
+
+  return deriveNameFromEmailLocalPart(senderEmail);
 }
 
 /**

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -171,6 +171,51 @@ describe("createRunHandler", () => {
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
   });
 
+  it("passes body Name to userRegistrationRegister when present", async () => {
+    const registerCreate = vi.fn().mockResolvedValue({
+      tickerKnown: true,
+      isNewSubscription: false,
+    });
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            subject: "[MediaPulse] Newsletter Subscription - BBCA",
+            body: {
+              content: "Name: Kevin Hermawan\nTicker: BBCA",
+              contentType: "text",
+            },
+            from: { emailAddress: { address: "k@run-test.example" } },
+          }),
+        ],
+        archiveMessage,
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn() };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: { create: registerCreate },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    await run(makeCtx() as any);
+
+    expect(registerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "k@run-test.example",
+        tickerSymbol: "BBCA",
+        name: "Kevin Hermawan",
+      }),
+    );
+  });
+
   it("archives without sending an email when subscription is already active", async () => {
     const archiveMessage = vi.fn().mockResolvedValue(undefined);
     const emailSend = vi.fn();

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -17,7 +17,7 @@ import type { UserRegistrationConfig } from "./config-schema.js";
 import {
   extractSenderEmail,
   extractTickerSymbol,
-  deriveNameFromEmailLocalPart,
+  resolveSubscriberDisplayName,
 } from "./lib/parser.js";
 
 export type Input = { maxMessagesPerRun: number; watermark?: string };
@@ -324,7 +324,7 @@ async function processMessage({
     return { id: msg.id, status: "failed_retry" };
   }
 
-  const name = deriveNameFromEmailLocalPart(senderEmail);
+  const name = resolveSubscriberDisplayName(msg, senderEmail);
 
   try {
     // Step 2: Register via API

--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -80,9 +80,8 @@ describe("RegistrationForm", () => {
     expect(calledUrl).toContain(
       encodeURIComponent("[MediaPulse] Newsletter Subscription - BBCA"),
     );
-    expect(calledUrl).toContain(
-      encodeURIComponent("Subscriber Name: John Doe"),
-    );
+    expect(calledUrl).toContain(encodeURIComponent("Name: John Doe"));
+    expect(calledUrl).toContain(encodeURIComponent("Ticker: BBCA"));
 
     // Assert Success screen rendered
     expect(screen.getByText(/Almost done/i)).toBeInTheDocument();

--- a/apps/mediapulse/user-registration/lib/tickers.test.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.test.ts
@@ -120,7 +120,7 @@ describe("buildMailtoUrl", () => {
     expect(url).toContain(encodeURIComponent("TLKM"));
   });
 
-  it("includes the Ticker: prefix and company name in the encoded body", () => {
+  it("includes Name and Ticker code lines in the encoded body", () => {
     // Setup
     const t: Ticker = {
       KodeEmiten: "AADI",
@@ -131,9 +131,12 @@ describe("buildMailtoUrl", () => {
     const url = buildMailtoUrl(t, "Jane Doe");
 
     // Assert
+    expect(url).toContain(encodeURIComponent("Name: Jane Doe"));
     expect(url).toContain(encodeURIComponent("Ticker: AADI"));
-    expect(url).toContain(encodeURIComponent("PT Adaro Andalan Indonesia Tbk"));
-    expect(url).toContain(encodeURIComponent("Subscriber Name: Jane Doe"));
+    expect(url).not.toContain(
+      encodeURIComponent("Ticker: AADI - PT Adaro Andalan Indonesia Tbk"),
+    );
+    expect(url).not.toContain(encodeURIComponent("Subscriber Name:"));
     expect(url).not.toContain(encodeURIComponent("Subscriber Email:"));
   });
 });

--- a/apps/mediapulse/user-registration/lib/tickers.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.ts
@@ -41,6 +41,7 @@ export const formatTicker = (ticker: Ticker): string =>
 /**
  * Builds a mailto URL for newsletter subscription with a fixed subject and body.
  * The subscriber's address comes from the mail client's From field when they send.
+ * Display name is included in the body as `Name:` for the registration agent to parse.
  *
  * @param ticker - Ticker the user wants to subscribe to.
  * @param name - Subscriber display name (included in the body for processing).
@@ -55,15 +56,12 @@ export const buildMailtoUrl = (
   const subject = `[MediaPulse] Newsletter Subscription - ${ticker.KodeEmiten}`;
 
   const bodyLines = [
-    `Ticker: ${ticker.KodeEmiten} - ${ticker.NamaEmiten}`,
-    `Subscriber Name: ${name.trim()}`,
-  ];
-
-  bodyLines.push(
+    `Name: ${name.trim()}`,
+    `Ticker: ${ticker.KodeEmiten}`,
     "",
     "---",
     "Please do not modify the subject or content of this email before sending.",
-  );
+  ];
 
   const body = bodyLines.join("\n");
 


### PR DESCRIPTION
## Summary

The mailto draft for newsletter signup is easier to read: name and ticker sit on their own lines before the do-not-edit footer. The user-registration agent now pulls the display name from that body when it can (including legacy `Subscriber Name:` lines and lightly normalized HTML from Graph), then falls back to the sender display name on the message, then the email local part. Subscriber email still comes from the From address.

## Related issues

Closes #440

## Important changes

- `buildMailtoUrl` emits `Name:` / `Ticker: {code}` plus spacing before the disclaimer.
- Agent registers with `resolveSubscriberDisplayName` (body → Graph from name → local-part guess) instead of only deriving from the address.

## Other changes

- README clarifies where email vs display name come from; parser and run tests cover the new paths.

## Key files to review

- `apps/mediapulse/user-registration/lib/tickers.ts` — mailto body shape sent to users.
- `apps/mediapulse/agents/user-registration/src/lib/parser.ts` — name extraction, HTML-ish normalization, fallbacks.
- `apps/mediapulse/agents/user-registration/src/run.ts` — wires resolver into `userRegistrationRegister`.

## How to test

1. `corepack pnpm --filter @mediapulse/user-registration test` and `corepack pnpm --filter @mediapulse/user-registration-agent test` (both green).
2. From the registration app, submit the form and confirm the opened draft shows `Name:` and `Ticker:` on separate lines and still targets the configured registration address.
3. Optional: send a test message through the agent path and confirm the register payload includes the body name when the draft matches the new template.
