### PR TITLE
Parse subscriber display name from registration mailto

### DIFF
--- a/apps/mediapulse/agents/user-registration/README.md
+++ b/apps/mediapulse/agents/user-registration/README.md
@@ -5,7 +5,7 @@ A Hermes agent that polls an Outlook inbox for newsletter subscription emails, p
 ## What it does
 
 1. Lists unread messages from the configured Outlook mailbox.
-2. Parses the sender email and desired ticker symbol from each message.
+2. Parses the sender email and ticker from each message; reads display name from the `Subscriber Name:` field in the body, stopping at the next `Ticker:`, `---`, disclaimer line, or end (so one-line mail clients cannot swallow the disclaimer into the name).
 3. Calls `agent-data-api POST /api/v1/user-registration-register` to create or update the `UserTicker` row.
 4. When the subscription is new or unconfirmed, sends a plain-text confirmation notification email (Resend) and immediately confirms the subscription via `agent-data-api` (no user action required).
 5. Archives the processed message out of the inbox (best-effort) to keep the mailbox clear.

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeTickerSymbol,
   deriveNameFromEmailLocalPart,
   extractSenderEmail,
+  extractSubscriberNameFromBody,
   extractTickerSymbol,
 } from "../lib/parser";
 
@@ -121,6 +122,57 @@ describe("Parser Helpers", () => {
           from: { emailAddress: { address: "name@domain" } },
         }),
       ).toBeNull();
+    });
+  });
+
+  describe("extractSubscriberNameFromBody", () => {
+    it("parses Subscriber Name on its own line", () => {
+      const body = [
+        "Ticker: BUMI - PT Bumi Resources Tbk",
+        "Subscriber Name: Kevin Hermawan",
+        "",
+        "---",
+        "Please do not modify the subject or content of this email before sending.",
+      ].join("\n");
+      expect(extractSubscriberNameFromBody(body)).toBe("Kevin Hermawan");
+    });
+
+    it("parses Subscriber Name when the body uses pipe separators (Gmail-style one line)", () => {
+      const body = [
+        "Ticker: BUMI - PT Bumi Resources Tbk",
+        "Subscriber Name: Kevin Hermawan",
+        "---",
+        "Please do not modify the subject or content of this email before sending.",
+      ].join("  |  ");
+      expect(extractSubscriberNameFromBody(body)).toBe("Kevin Hermawan");
+    });
+
+    it("parses Subscriber Name when the body is one collapsed line", () => {
+      const body =
+        "Ticker: BUMI - PT Bumi Resources Tbk  |  Subscriber Name: Kevin Hermawan  |  ---  |  Please do not modify the subject or content of this email before sending.";
+      expect(extractSubscriberNameFromBody(body)).toBe("Kevin Hermawan");
+    });
+
+    it("parses Subscriber Name from simple HTML body", () => {
+      const body =
+        "<div>Ticker: BBCA - Bank</div><div>Subscriber Name:  Jane Doe  </div><div>---</div>";
+      expect(extractSubscriberNameFromBody(body)).toBe("Jane Doe");
+    });
+
+    it("stops at Ticker: when Subscriber Name appears before Ticker", () => {
+      const body = [
+        "Subscriber Name: Pat Lee",
+        "Ticker: IBM - International Business Machines",
+        "---",
+        "Please do not modify the subject or content of this email before sending.",
+      ].join("\n");
+      expect(extractSubscriberNameFromBody(body)).toBe("Pat Lee");
+    });
+
+    it("returns null when Subscriber Name is absent", () => {
+      expect(extractSubscriberNameFromBody("Ticker: GOTO - GoTo")).toBeNull();
+      expect(extractSubscriberNameFromBody(null)).toBeNull();
+      expect(extractSubscriberNameFromBody("")).toBeNull();
     });
   });
 

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.ts
@@ -63,6 +63,62 @@ export function extractSenderEmail(graphMessage: GraphMessage): string | null {
   return normalized;
 }
 
+const MAX_SUBSCRIBER_NAME_LENGTH = 500;
+
+/**
+ * Normalizes Graph message body to plain text with line breaks for structured parsing.
+ *
+ * @param body - Raw body (plain text or HTML from Microsoft Graph).
+ * @returns Approximate plain text.
+ */
+function graphBodyApproxPlainText(body: string): string {
+  if (!body.includes("<")) {
+    return body;
+  }
+
+  return body
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|tr|li)>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+/g, " ")
+    .trim();
+}
+
+/**
+ * Extracts the subscriber display name from the registration mailto body.
+ * The registration app emits `Subscriber Name:` (the `Name:` segment of that label).
+ * The value runs until the next boundary: spaced pipe segments (`  |  `) from the web
+ * mailto, a later `Ticker:`, the `---` separator (after optional newlines), the
+ * “Please do not modify” disclaimer, or end of text.
+ *
+ * @param body - Message body content (plain or HTML).
+ * @returns Trimmed name or null when the label is missing or empty.
+ */
+export function extractSubscriberNameFromBody(
+  body?: string | null,
+): string | null {
+  if (!body || typeof body !== "string") return null;
+
+  const text = graphBodyApproxPlainText(body).trim();
+  if (!text) return null;
+
+  const m = text.match(
+    /Subscriber Name:\s*(.+?)(?=\s+\|\s+|[\r\n]+\s*---|\s*---|\s*Ticker:|\s*Please do not modify|$)/is,
+  );
+  if (!m?.[1]) return null;
+
+  const trimmed = m[1].replace(/\s+/g, " ").trim();
+  if (!trimmed) return null;
+  return trimmed.length > MAX_SUBSCRIBER_NAME_LENGTH
+    ? trimmed.slice(0, MAX_SUBSCRIBER_NAME_LENGTH).trim()
+    : trimmed;
+}
+
 /**
  * Extracts a normalized ticker symbol from an email subject or body.
  * Primary: matches "Newsletter Subscription - {SYMBOL}" in the subject.

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -171,6 +171,49 @@ describe("createRunHandler", () => {
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
   });
 
+  it("passes Subscriber Name from a one-line body to register", async () => {
+    const registerCreate = vi.fn().mockResolvedValue({
+      tickerKnown: true,
+      isNewSubscription: false,
+    });
+    const oneLineBody =
+      "Ticker: AAPL - Apple  |  Subscriber Name: Kevin Hermawan  |  ---  |  Please do not modify the subject or content of this email before sending.";
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            subject: "Newsletter Subscription - AAPL",
+            body: { content: oneLineBody, contentType: "text" },
+            from: { emailAddress: { address: "blob@run-test.example" } },
+          }),
+        ],
+        archiveMessage: vi.fn().mockResolvedValue(undefined),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn() };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: { create: registerCreate },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    await run(makeCtx() as any);
+
+    expect(registerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "blob@run-test.example",
+        name: "Kevin Hermawan",
+        tickerSymbol: "AAPL",
+      }),
+    );
+  });
+
   it("archives without sending an email when subscription is already active", async () => {
     const archiveMessage = vi.fn().mockResolvedValue(undefined);
     const emailSend = vi.fn();

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -18,6 +18,7 @@ import {
   extractSenderEmail,
   extractTickerSymbol,
   deriveNameFromEmailLocalPart,
+  extractSubscriberNameFromBody,
 } from "./lib/parser.js";
 
 export type Input = { maxMessagesPerRun: number; watermark?: string };
@@ -324,7 +325,9 @@ async function processMessage({
     return { id: msg.id, status: "failed_retry" };
   }
 
-  const name = deriveNameFromEmailLocalPart(senderEmail);
+  const name =
+    extractSubscriberNameFromBody(msg.body?.content) ??
+    deriveNameFromEmailLocalPart(senderEmail);
 
   try {
     // Step 2: Register via API

--- a/apps/mediapulse/user-registration/lib/tickers.test.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.test.ts
@@ -4,6 +4,7 @@ import {
   filterTickers,
   formatTicker,
   buildMailtoUrl,
+  MAILTO_BODY_SECTION_SEPARATOR,
   type Ticker,
 } from "./tickers";
 
@@ -118,6 +119,11 @@ describe("buildMailtoUrl", () => {
     // Assert
     expect(url).toContain("subject=");
     expect(url).toContain(encodeURIComponent("TLKM"));
+  });
+
+  it("joins body sections with spaced pipes for single-line mail clients", () => {
+    const url = buildMailtoUrl(ticker, "Jane Doe");
+    expect(url).toContain(encodeURIComponent(MAILTO_BODY_SECTION_SEPARATOR));
   });
 
   it("includes the Ticker: prefix and company name in the encoded body", () => {

--- a/apps/mediapulse/user-registration/lib/tickers.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.ts
@@ -38,9 +38,14 @@ export const filterTickers = (tickers: Ticker[], query: string): Ticker[] => {
 export const formatTicker = (ticker: Ticker): string =>
   `${ticker.KodeEmiten} - ${ticker.NamaEmiten}`;
 
+/** Spaced pipe segments keep mailto bodies readable when clients (e.g. Gmail app) flatten newlines. */
+export const MAILTO_BODY_SECTION_SEPARATOR = "  |  ";
+
 /**
  * Builds a mailto URL for newsletter subscription with a fixed subject and body.
  * The subscriber's address comes from the mail client's From field when they send.
+ * Body sections are joined with spaced pipes so Gmail and similar clients still show
+ * clear separation when they collapse the draft to a single line.
  *
  * @param ticker - Ticker the user wants to subscribe to.
  * @param name - Subscriber display name (included in the body for processing).
@@ -54,18 +59,12 @@ export const buildMailtoUrl = (
 ): string => {
   const subject = `[MediaPulse] Newsletter Subscription - ${ticker.KodeEmiten}`;
 
-  const bodyLines = [
+  const body = [
     `Ticker: ${ticker.KodeEmiten} - ${ticker.NamaEmiten}`,
     `Subscriber Name: ${name.trim()}`,
-  ];
-
-  bodyLines.push(
-    "",
     "---",
     "Please do not modify the subject or content of this email before sending.",
-  );
-
-  const body = bodyLines.join("\n");
+  ].join(MAILTO_BODY_SECTION_SEPARATOR);
 
   return `mailto:${registrationEmail}?subject=${encodeURIComponent(
     subject,


### PR DESCRIPTION
## Summary

The registration site already asks for a display name and puts it in the mailto body, but the user-registration agent never read that field. It only title-cased the sender address local part, so real names were wrong or missing. Gmail and similar clients also tend to squash the draft into one long line, which made a strict line-based parse risky.

## Related issues

Closes #442

## Important changes

- Agent: `extractSubscriberNameFromBody` reads **Subscriber Name:** from the body (including HTML from Graph), stops at pipes, `Ticker:`, `---`, or the disclaimer, then falls back to `deriveNameFromEmailLocalPart`.
- Web mailto: body sections are joined with **`  |  `** (`MAILTO_BODY_SECTION_SEPARATOR`) so a single-line compose view still shows clear segments.

## Other changes

- Agent README step 2 updated to describe name parsing.
- New and extended Vitest coverage in the agent parser/run tests and `tickers.test.ts`.

## Key files to review

- `apps/mediapulse/user-registration/lib/tickers.ts` — mailto body shape and exported separator constant.
- `apps/mediapulse/agents/user-registration/src/lib/parser.ts` — `extractSubscriberNameFromBody` and HTML-ish normalization.
- `apps/mediapulse/agents/user-registration/src/run.ts` — wire-up for `processRegistration` `name`.

## How to test

1. `pnpm --filter @mediapulse/user-registration-agent exec vitest run`
2. `pnpm --filter @mediapulse/user-registration exec vitest run`
3. Optional: open the registration form, submit with a ticker, confirm the mailto `body` contains spaced pipes and `Subscriber Name:` with your typed name.
