### PR TITLE
Fix article-analysis pipeline abort on unknown entity name

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -9,6 +9,20 @@ vi.mock("@mediapulse/database", () => ({
   prisma: {},
 }));
 
+const mockLoggerWarn = vi.fn();
+vi.mock("@workspace/logger", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+    child: vi.fn(() => ({
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    })),
+  },
+}));
+
 let AnalysisPostValidationError: typeof import("./analysis.js").AnalysisPostValidationError;
 let applyAnalysisPost: typeof import("./analysis.js").applyAnalysisPost;
 let deleteAnalysisDataSource: typeof import("./analysis.js").deleteAnalysisDataSource;
@@ -563,6 +577,67 @@ describe("applyAnalysisPost", () => {
           },
         },
       }),
+    );
+  });
+
+  it("skips article entity mention when entityName is not in ticker vocabulary", async () => {
+    // Setup
+    const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const tx = {
+      dataSource: {
+        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
+      },
+      entity: {
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
+      articleEntity: { upsert: vi.fn() },
+    };
+    const db = {
+      dataSource: {
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+        findFirst: vi.fn(),
+      },
+      entityType: { findMany: vi.fn() },
+      relationType: { findMany: vi.fn() },
+      entity: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn(), count: vi.fn() },
+      $transaction: vi.fn((fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
+    };
+
+    // Act: mention references an entity name not in the vocab and not in entities list.
+    const result = await applyAnalysisPost(
+      {
+        tickerId: "ticker-1",
+        entities: [],
+        relations: [],
+        articleEntities: [
+          {
+            dataSourceId: DS,
+            entityName: "Unknown Corp",
+            mentionCount: 1,
+            confidence: 0.9,
+          },
+        ],
+        articleRelevances: [],
+      },
+      { db: db as never },
+    );
+
+    // Assert: resolves without throwing; articleEntity.upsert never called; warn logged.
+    expect(result.entitiesCreated).toBe(0);
+    expect(tx.articleEntity.upsert).not.toHaveBeenCalled();
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tickerId: "ticker-1",
+        entityName: "Unknown Corp",
+        dataSourceId: DS,
+      }),
+      expect.stringContaining("entityName not in ticker vocabulary"),
     );
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -7,6 +7,7 @@ import type {
 } from "@workspace/agent-data-api-contract";
 import { prisma } from "@mediapulse/database";
 import type { Prisma } from "@mediapulse/database";
+import { logger } from "@workspace/logger";
 
 /**
  * Thrown when the analysis POST body references data sources that do not belong to the ticker.
@@ -366,9 +367,15 @@ export const applyAnalysisPost = async (
           )) ?? undefined;
       }
       if (entityId === undefined) {
-        throw new AnalysisPostValidationError(
-          `Unknown entityName for article entity: ${mention.entityName}`,
+        logger.warn(
+          {
+            tickerId: body.tickerId,
+            entityName: mention.entityName,
+            dataSourceId: mention.dataSourceId,
+          },
+          "article entity mention skipped: entityName not in ticker vocabulary",
         );
+        continue;
       }
 
       await tx.articleEntity.upsert({

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -992,6 +992,174 @@ describe("run", () => {
     expect(result.details?.mentionPostChunks).toBe(0);
   });
 
+  it("continues to relevance scoring when article_entities POST fails", async () => {
+    // Setup
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: "u",
+            title: "T",
+            content: "c",
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [
+          {
+            entityName: "A",
+            mentionCount: 1,
+            confidence: 0.8,
+            sentiment: "NEUTRAL",
+          },
+        ],
+      }),
+    );
+
+    // ER chunk succeeds; article_entities chunk fails; relevance chunk succeeds.
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockRejectedValueOnce(
+        new Error(
+          'Agent data API error: 400 - {"error":"Unknown entityName for article entity: A"}',
+        ),
+      )
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
+
+    // Act
+    const result = await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    // Assert: run still succeeds and relevance was scored despite article_entities failure.
+    expect(result.success).toBe(true);
+    expect(result.details?.articlesScored).toBe(1);
+    expect(result.details?.articlesSelected).toBe(1);
+    expect(result.details?.relevancePostChunks).toBe(1);
+    expect(result.details?.postFailures).toHaveLength(1);
+    expect(
+      (result.details?.postFailures as { chunkKind: string }[])[0]?.chunkKind,
+    ).toBe("article_entities");
+    // 3 calls: ER chunk + article_entities chunk (failed) + relevance chunk.
+    expect(analysisCreate).toHaveBeenCalledTimes(3);
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ chunkKind: "article_entities", chunkIndex: 0 }),
+      expect.stringContaining("continuing to next chunk"),
+    );
+  });
+
+  it("continues to remaining article_entities chunks after one chunk fails", async () => {
+    // Setup: one article with two distinct entities → two article_entities chunks (batchSize=1).
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: "u",
+            title: "T",
+            content: "c",
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+
+    // LLM extracts two entities A and B, each with a mention.
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          { canonicalName: "A", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "B", typeId: TYPE_ID, aliases: [] },
+        ],
+        relations: [],
+        articleMentions: [
+          {
+            entityName: "A",
+            mentionCount: 1,
+            confidence: 0.8,
+            sentiment: "NEUTRAL",
+          },
+          {
+            entityName: "B",
+            mentionCount: 1,
+            confidence: 0.7,
+            sentiment: "NEUTRAL",
+          },
+        ],
+      }),
+    );
+
+    // ER chunk succeeds; article_entities chunk 0 (entity A) fails; chunk 1 (entity B) succeeds; relevance succeeds.
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 2,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockRejectedValueOnce(new Error("Agent data API error: 400"))
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
+
+    // Act
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { postChunkArticleEntityBatchSize: 1 },
+      }),
+    );
+
+    // Assert: second chunk was attempted, relevance proceeds, only 1 postFailure.
+    expect(result.success).toBe(true);
+    expect(result.details?.mentionPostChunks).toBe(1);
+    expect(result.details?.postFailures).toHaveLength(1);
+    expect(result.details?.relevancePostChunks).toBe(1);
+    // 4 calls: ER chunk + failed article_entities chunk 0 + article_entities chunk 1 + relevance chunk.
+    expect(analysisCreate).toHaveBeenCalledTimes(4);
+  });
+
   it("fails run when extraction successes are below runPolicy minimum", async () => {
     analysisGet.mockResolvedValue(
       analysisGetOk({

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -962,7 +962,6 @@ export const run = async ({
 
     let articleEntityRowsPosted = 0;
     let mentionPostChunksCompleted = 0;
-    let mentionPhaseFailed = false;
     let articleEntityParseErrors: string[] = [];
 
     if (!erPhaseFailed) {
@@ -1017,17 +1016,17 @@ export const run = async ({
               chunkIndex: j,
               err: toSafeLogError(err),
             },
-            "article-analysis articleEntities POST failed; aborting relevance phase",
+            // Intentionally not breaking: article_entities are KG enrichment only.
+            // Remaining chunks and the relevance phase proceed regardless.
+            "article-analysis articleEntities POST failed; continuing to next chunk",
           );
-          mentionPhaseFailed = true;
-          break;
         }
       }
     }
 
     let relevancePostChunksCompleted = 0;
 
-    if (!erPhaseFailed && !mentionPhaseFailed && perSourceSignals.length > 0) {
+    if (!erPhaseFailed && perSourceSignals.length > 0) {
       const weightMap = toRelevanceWeightMapV1(cfg);
       const relevanceDrafts = perSourceSignals.map((sig) =>
         buildDraftRelevanceRow(sig, cfg.scoreBreakdownVersion, weightMap),


### PR DESCRIPTION
## Summary

A single unknown entity name in one `article_entities` POST chunk was enough to kill the entire relevance-scoring phase for a run, leaving content generation and delivery with nothing to work with. Two separate bugs compounded the issue: the agent treated a chunk-level failure as a run-level failure, and the API rejected the whole chunk rather than skipping the one bad mention.

## Related issues

Closes #444

## Important changes

- **`run.ts` — agent resilience:** removed the `mentionPhaseFailed` gate. When an `article_entities` chunk fails (any HTTP error), the agent logs a warning and moves to the next chunk. Relevance scoring now runs regardless of article_entities outcome, since those are KG enrichment data and have no bearing on scoring logic.
- **`analysis.ts` — API graceful skip:** `applyAnalysisPost` no longer throws `AnalysisPostValidationError` when `resolveEntityIdByNameForTicker` returns null for a mention. It logs a warning with ticker, entity name, and data source ID, then continues. One unknown name no longer poisons the entire chunk.

## Other changes

- Added `logger` import to `analysis.ts` (previously the service had no logger).
- Removed the `break` from the `article_entities` catch block so all chunks in a batch are attempted even after a partial failure.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — the `mentionPhaseFailed` variable and gate are gone; the catch block no longer breaks the loop.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — the `Unknown entityName` throw is now a warn + continue.
- `apps/mediapulse/agents/article-analysis/src/run.test.ts` — two new tests: one for relevance surviving a chunk failure, one for remaining chunks being attempted after the first fails.
- `apps/mediapulse/agent-data-api/src/services/analysis.test.ts` — new test for graceful skip plus logger mock setup.

## How to test

1. Run unit tests: `pnpm --filter article-analysis --filter @mediapulse/agent-data-api test --run` — all 207 tests should pass.
2. Trigger an article-analysis run against a ticker that has articles containing entity names not in its vocabulary. Confirm the run produces relevance rows and that downstream content generation and delivery complete normally.
3. Check agent logs: the warning `"article entity mention skipped: entityName not in ticker vocabulary"` should appear for the skipped mention, with `tickerId`, `entityName`, and `dataSourceId` fields. The run summary should still show `articlesScored > 0`.
