### PR TITLE
Fix user-registration Resend flow and subscription confirmation

### DIFF
--- a/apps/mediapulse/agents/user-registration/README.md
+++ b/apps/mediapulse/agents/user-registration/README.md
@@ -7,7 +7,7 @@ A Hermes agent that polls an Outlook inbox for newsletter subscription emails, p
 1. Lists unread messages from the configured Outlook mailbox.
 2. Parses the **subscriber email** from the message `From` address, the **ticker** from the subject (and body fallbacks), and the **display name** from the body (`Name:` from the current registration mailto, or legacy `Subscriber Name:`), using pipe/`Ticker:`/`---`/disclaimer boundaries so one-line mail clients do not swallow the footer into the name; then Graph `from.emailAddress.name` when usable, then a title-cased guess from the email local part.
 3. Calls `agent-data-api POST /api/v1/user-registration-register` to create or update the `UserTicker` row.
-4. When the subscription is new or unconfirmed, sends a plain-text confirmation notification email (Resend) and immediately confirms the subscription via `agent-data-api` (no user action required).
+4. For a **known** ticker, sends a Resend email on every processed signup: **new or unconfirmed** subscriptions get a confirmation email, then `agent-data-api POST /api/v1/user-registration-confirm` records the confirmation timestamp (no user action required). **Already confirmed** subscriptions get an “already subscribed” acknowledgment email and the confirm endpoint is **not** called again so `registration_confirmed_at` is not bumped on repeats.
 5. Archives the processed message out of the inbox (best-effort) to keep the mailbox clear.
 
 ## Archiving and retries
@@ -15,6 +15,15 @@ A Hermes agent that polls an Outlook inbox for newsletter subscription emails, p
 - **Archive on success**: After a message is processed (including invalid/unparseable cases), the agent archives it so it does not remain in the primary inbox.
 - **Confirm is best-effort**: If `user-registration-confirm` fails after a successful registration, the agent still archives the message to avoid repeated inbox clutter.
 - **Register retry (bounded)**: The agent retries the register call once on transient failures (e.g. 429/5xx or network errors). If registration cannot be completed after the retry, the message is left unarchived so it can be retried on the next run.
+- **Resend result envelope**: The Resend Node SDK resolves with `{ data, error }` and does not always reject when delivery is rejected. The agent treats `error` as a hard failure so it does **not** call `user-registration-confirm` after a failed send (otherwise the row could show confirmed with no email and nothing obvious in the Resend dashboard).
+
+## Troubleshooting (Resend dashboard empty)
+
+The Resend web app only shows activity for **HTTP requests that reached Resend’s API using that workspace’s API key**. If you see **no** rows at all for a signup you care about:
+
+1. **Confirm the agent actually called Resend** — search your logs for `user-registration: calling Resend emails.send` and `user-registration: Resend emails.send accepted` (the latter includes `resendEmailId` when Resend returns an id). If neither appears for that mailbox message, the run never reached `emails.send` (e.g. no matching inbox message, parse failure, rate limit, register/render error, or wrong Resend project when comparing dashboards).
+2. **Inbox selection** — The agent only lists messages that are **unread**, whose subject contains **`[MediaPulse] Newsletter Subscription`**, and (when a run passes a `watermark`) are **newer than the watermark**. A user-edited subject, an already-read draft, or a watermark past that message’s time means **zero messages** and therefore **no Resend traffic**, even if you created the user another way.
+3. **API key / team** — Production must use the same Resend API key as the dashboard you are watching (staging vs production keys show different workspaces).
 
 ## Environment variables
 

--- a/apps/mediapulse/agents/user-registration/src/index.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.test.ts
@@ -89,6 +89,7 @@ const post = async (body: unknown) => {
 describe("user-registration agent – improved run loop", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    emailSendMock.mockResolvedValue({ data: { id: "email-id" } });
   });
 
   afterEach(() => {
@@ -216,6 +217,27 @@ describe("user-registration agent – improved run loop", () => {
       }),
     );
     expect(archiveMessageMock).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("does not confirm when Resend returns an error envelope for a new subscription", async () => {
+    const msg = makeMessage({ receivedDateTime: "2024-01-01T12:00:00Z" });
+    listMessagesMock.mockResolvedValue([msg]);
+    registerCreateMock.mockResolvedValue({
+      tickerKnown: true,
+      isNewSubscription: true,
+      userTickerId: "ut-uuid-1",
+    });
+    emailSendMock.mockResolvedValue({
+      error: { message: "Invalid API key" },
+      data: null,
+    });
+
+    const res = await post({ input: {}, config: VALID_CONFIG });
+    const body = (await res.json()) as any;
+
+    expect(body.details.results[0].status).toBe("failed_retry");
+    expect(confirmCreateMock).not.toHaveBeenCalled();
+    expect(archiveMessageMock).not.toHaveBeenCalled();
   });
 
   it("returns failed_retry on unexpected error during processing", async () => {

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -171,6 +171,48 @@ describe("createRunHandler", () => {
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
   });
 
+  it("does not confirm or archive when Resend returns an error envelope for a new subscription", async () => {
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+    const emailSend = vi
+      .fn()
+      .mockResolvedValue({ error: { message: "Invalid API key" }, data: null });
+    const confirmCreate = vi.fn().mockResolvedValue(undefined);
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            from: { emailAddress: { address: "resend-fail@run-test.example" } },
+          }),
+        ],
+        archiveMessage,
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: emailSend };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: true,
+              userTickerId: "ut-fail",
+            }),
+          },
+          userRegistrationConfirm: { create: confirmCreate },
+        }) as any,
+    });
+
+    const result = (await run(makeCtx() as any)) as any;
+
+    expect(result.details.results[0].status).toBe("failed_retry");
+    expect(confirmCreate).not.toHaveBeenCalled();
+    expect(archiveMessage).not.toHaveBeenCalled();
+  });
+
   it("passes body Name to userRegistrationRegister when present", async () => {
     const registerCreate = vi.fn().mockResolvedValue({
       tickerKnown: true,
@@ -259,9 +301,10 @@ describe("createRunHandler", () => {
     );
   });
 
-  it("archives without sending an email when subscription is already active", async () => {
+  it("sends an acknowledgment email without confirm when subscription is already active", async () => {
     const archiveMessage = vi.fn().mockResolvedValue(undefined);
-    const emailSend = vi.fn();
+    const emailSend = vi.fn().mockResolvedValue({ data: { id: "email-id" } });
+    const confirmCreate = vi.fn();
 
     const run = createRunHandler({
       createInbox: () => ({
@@ -284,16 +327,64 @@ describe("createRunHandler", () => {
             create: async () => ({
               tickerKnown: true,
               isNewSubscription: false,
+              userTickerId: "ut-existing",
             }),
           },
-          userRegistrationConfirm: { create: vi.fn() },
+          userRegistrationConfirm: { create: confirmCreate },
         }) as any,
     });
 
     const result = (await run(makeCtx() as any)) as any;
 
-    expect(result.details.results[0].status).toBe("idempotent_archived");
-    expect(emailSend).not.toHaveBeenCalled();
+    expect(result.details.results[0].status).toBe("acknowledged_archived");
+    expect(emailSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Already Subscribed - MediaPulse",
+      }),
+    );
+    expect(confirmCreate).not.toHaveBeenCalled();
+    expect(archiveMessage).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("sends acknowledgment without confirm when subscription changed but row was already confirmed", async () => {
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+    const emailSend = vi.fn().mockResolvedValue({ data: { id: "e2" } });
+    const confirmCreate = vi.fn();
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            from: { emailAddress: { address: "reenable@run-test.example" } },
+          }),
+        ],
+        archiveMessage,
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: emailSend };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: false,
+              subscriptionChanged: true,
+              userTickerId: "ut-re",
+            }),
+          },
+          userRegistrationConfirm: { create: confirmCreate },
+        }) as any,
+    });
+
+    const result = (await run(makeCtx() as any)) as any;
+
+    expect(result.details.results[0].status).toBe("acknowledged_archived");
+    expect(emailSend).toHaveBeenCalledTimes(1);
+    expect(confirmCreate).not.toHaveBeenCalled();
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
   });
 

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -83,6 +83,94 @@ const isRetryable = (error: any): boolean => {
   return false;
 };
 
+/** Minimal shape of `resend.emails.send` resolution (SDK returns `{ data, error }` without rejecting). */
+type ResendEmailsSendResult = {
+  error?: { message: string } | null;
+  data?: unknown;
+};
+
+/**
+ * Throws when Resend returns an error in the result envelope so a failed send is not treated as success.
+ * Without this, the agent can call `user-registration-confirm` even though no email was accepted.
+ *
+ * @param result - Resolved value from {@link Resend.prototype.emails.send}.
+ * @throws Error when `result.error` is set.
+ */
+function assertResendSendSucceeded(result: ResendEmailsSendResult): void {
+  if (result.error) {
+    throw new Error(`Resend email send failed: ${result.error.message}`);
+  }
+}
+
+type ResendTransactionalPayload = {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+  text: string;
+};
+
+/**
+ * Sends one transactional email via Resend with retries, validates the SDK `{ data, error }` envelope,
+ * and logs before/after so operators can tell whether a run actually invoked Resend (the dashboard only
+ * shows traffic that reached Resend with your API key).
+ *
+ * @param params.resend - Resend client instance.
+ * @param params.payload - From, to, subject, html, and text.
+ * @param params.retryConfig - Backoff configuration for transient failures.
+ * @param params.logBase - Structured fields included on every log line (e.g. `messageId`, `senderEmail`).
+ * @returns Resend email id from `data.id` when the API returns it.
+ */
+async function sendResendTransactionalEmail(params: {
+  resend: Resend;
+  payload: ResendTransactionalPayload;
+  retryConfig: RetryConfig;
+  logBase: Record<string, unknown>;
+}): Promise<string | undefined> {
+  const { resend, payload, retryConfig, logBase } = params;
+
+  logger.info(
+    {
+      ...logBase,
+      resendFrom: payload.from,
+      resendTo: payload.to,
+      resendSubject: payload.subject,
+    },
+    "user-registration: calling Resend emails.send",
+  );
+
+  const result = await withRetry(
+    async () => {
+      const sendResult = await resend.emails.send(payload);
+      assertResendSendSucceeded(sendResult);
+      return sendResult;
+    },
+    retryConfig,
+    isRetryable,
+  );
+
+  const data = result.data;
+  const resendEmailId =
+    data !== null &&
+    data !== undefined &&
+    typeof data === "object" &&
+    "id" in data &&
+    typeof (data as { id: unknown }).id === "string"
+      ? (data as { id: string }).id
+      : undefined;
+
+  logger.info(
+    {
+      ...logBase,
+      resendEmailId,
+      resendSubject: payload.subject,
+    },
+    "user-registration: Resend emails.send accepted",
+  );
+
+  return resendEmailId;
+}
+
 /**
  * Purges expired rate limit entries to prevent memory leaks over time.
  */
@@ -354,18 +442,23 @@ async function processMessage({
         tickerSymbol,
       });
 
-      await withRetry(
-        () =>
-          resend.emails.send({
-            from: config.resendSender,
-            to: senderEmail,
-            subject: "Invalid Ticker Selection - MediaPulse",
-            html,
-            text,
-          }),
+      await sendResendTransactionalEmail({
+        resend,
         retryConfig,
-        isRetryable,
-      );
+        logBase: {
+          messageId: msg.id,
+          senderEmail,
+          tickerSymbol,
+          template: "invalid-ticker",
+        },
+        payload: {
+          from: config.resendSender,
+          to: senderEmail,
+          subject: "Invalid Ticker Selection - MediaPulse",
+          html,
+          text,
+        },
+      });
 
       await withRetry(
         () => inboxClient.archiveMessage(msg.id!),
@@ -375,27 +468,46 @@ async function processMessage({
       return { id: msg.id, status: "invalid_ticker_archived" };
     }
 
-    if (registerResponse.isNewSubscription) {
-      logger.info({ senderEmail, tickerSymbol }, "Sending confirmation email.");
+    const isNewSubscription = registerResponse.isNewSubscription;
+    logger.info(
+      { senderEmail, tickerSymbol, isNewSubscription },
+      isNewSubscription
+        ? "Sending confirmation email for new or unconfirmed subscription."
+        : "Sending acknowledgment email for existing confirmed subscription.",
+    );
 
-      const { html, text } = await renderNewsletterEmail({
-        variant: "registration-confirmation",
+    const { html, text } = await renderNewsletterEmail(
+      isNewSubscription
+        ? { variant: "registration-confirmation", tickerSymbol }
+        : { variant: "already-subscribed", tickerSymbol },
+    );
+
+    const confirmationSubject = isNewSubscription
+      ? "Subscription Confirmed - MediaPulse"
+      : "Already Subscribed - MediaPulse";
+
+    await sendResendTransactionalEmail({
+      resend,
+      retryConfig,
+      logBase: {
+        messageId: msg.id,
+        senderEmail,
         tickerSymbol,
-      });
+        isNewSubscription,
+        template: isNewSubscription
+          ? "registration-confirmation"
+          : "already-subscribed",
+      },
+      payload: {
+        from: config.resendSender,
+        to: senderEmail,
+        subject: confirmationSubject,
+        html,
+        text,
+      },
+    });
 
-      await withRetry(
-        () =>
-          resend.emails.send({
-            from: config.resendSender,
-            to: senderEmail,
-            subject: "Subscription Confirmed - MediaPulse",
-            html,
-            text,
-          }),
-        retryConfig,
-        isRetryable,
-      );
-
+    if (isNewSubscription) {
       await withRetry(
         () =>
           dataApiClient.userRegistrationConfirm.create({
@@ -407,28 +519,30 @@ async function processMessage({
         retryConfig,
         isRetryable,
       );
-
-      await withRetry(
-        () => inboxClient.archiveMessage(msg.id!),
-        retryConfig,
-        isRetryable,
-      );
-      return { id: msg.id, status: "confirmed_archived" };
-    } else {
-      logger.info(
-        { senderEmail, tickerSymbol },
-        "Subscription already active, archiving with no email.",
-      );
-      await withRetry(
-        () => inboxClient.archiveMessage(msg.id!),
-        retryConfig,
-        isRetryable,
-      );
-      return { id: msg.id, status: "idempotent_archived" };
     }
+
+    await withRetry(
+      () => inboxClient.archiveMessage(msg.id!),
+      retryConfig,
+      isRetryable,
+    );
+    return {
+      id: msg.id,
+      status: isNewSubscription
+        ? "confirmed_archived"
+        : "acknowledged_archived",
+    };
   } catch (error) {
     logger.error(
-      { error, messageId: msg.id },
+      {
+        messageId: msg.id,
+        senderEmail,
+        tickerSymbol,
+        err:
+          error instanceof Error
+            ? { message: error.message, name: error.name, stack: error.stack }
+            : error,
+      },
       "Failed processing message during agent run. Leaving unarchived for retry.",
     );
     return { id: msg.id, status: "failed_retry" };

--- a/dev-docs/docs/mediapulse/apps/user-registration.mdx
+++ b/dev-docs/docs/mediapulse/apps/user-registration.mdx
@@ -37,7 +37,7 @@ Because MediaPulse supports login-less registration over email, the flow works l
 2. The front-end generates a `mailto:` link allowing the user to send their subscription choice.
 3. The `user-registration` agent reads a shared Microsoft Outlook inbox via `@mediapulse/outlook-inbox`.
 4. The agent parses the desired ticker. Waitlist / Unknown tickers trigger an outbound email.
-5. On successful registration, a confirmation Resend email loop validates the user successfully.
+5. On successful registration for a known ticker, the agent always sends a Resend email: first-time or still-unconfirmed rows get a confirmation email plus `user-registration-confirm`; already-confirmed rows get an acknowledgment only (no confirm call), so repeat signup messages still show up in Resend without changing the stored confirmation time.
 
 ### Inbox hygiene (archiving + retries)
 

--- a/packages/shared/email-templates/src/index.ts
+++ b/packages/shared/email-templates/src/index.ts
@@ -15,6 +15,10 @@ export {
   type InvalidTickerEmailProps,
 } from "./registration/invalid-ticker.js";
 export {
+  AlreadySubscribedEmail,
+  type AlreadySubscribedEmailProps,
+} from "./registration/already-subscribed.js";
+export {
   renderNewsletterEmail,
   type NewsletterTemplateVariant,
   type RenderNewsletterEmailInput,

--- a/packages/shared/email-templates/src/registration/already-subscribed.test.tsx
+++ b/packages/shared/email-templates/src/registration/already-subscribed.test.tsx
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { renderNewsletterEmail } from "../index.js";
+
+describe("AlreadySubscribedEmail", () => {
+  it("renders with ticker symbol in HTML and text", async () => {
+    const { html, text } = await renderNewsletterEmail({
+      variant: "already-subscribed",
+      tickerSymbol: "BBCA",
+    });
+    expect(html).toContain("BBCA");
+    expect(html).toContain("Already Subscribed");
+    expect(text).toContain("BBCA");
+    expect(text).toMatch(/Already Subscribed/i);
+  });
+});

--- a/packages/shared/email-templates/src/registration/already-subscribed.tsx
+++ b/packages/shared/email-templates/src/registration/already-subscribed.tsx
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Preview,
+  Section,
+  Text,
+} from "@react-email/components";
+import type { CSSProperties, ReactElement } from "react";
+
+export interface AlreadySubscribedEmailProps {
+  /** The ticker symbol the user is already subscribed to. */
+  tickerSymbol: string;
+}
+
+/**
+ * Email sent when a signup message is processed but the user already has an active,
+ * confirmed subscription for the requested ticker.
+ *
+ * @param props.tickerSymbol - The ticker symbol for the existing subscription.
+ * @returns The already-subscribed email React Email component.
+ */
+export const AlreadySubscribedEmail = ({
+  tickerSymbol,
+}: AlreadySubscribedEmailProps): ReactElement => {
+  return (
+    <Html>
+      <Head />
+      <Preview>You are already subscribed - MediaPulse</Preview>
+      <Body style={main}>
+        <Container style={container}>
+          <Section style={header}>
+            <Heading style={heading}>Already Subscribed</Heading>
+          </Section>
+          <Hr style={hr} />
+          <Text style={bodyParagraph}>
+            Hello,
+            {"\n\n"}
+            You already have an active subscription to the '{tickerSymbol}'
+            newsletter. No further action is needed.
+            {"\n\n"}
+            Thank you,
+            {"\n"}
+            MediaPulse Team
+          </Text>
+          <Hr style={hr} />
+          <Text style={footer}>
+            You are receiving this because you sent a subscription request on
+            MediaPulse.
+          </Text>
+        </Container>
+      </Body>
+    </Html>
+  );
+};
+
+AlreadySubscribedEmail.PreviewProps = {
+  tickerSymbol: "AAPL",
+} satisfies AlreadySubscribedEmailProps;
+
+export default AlreadySubscribedEmail;
+
+const main: CSSProperties = {
+  backgroundColor: "#f6f9fc",
+  fontFamily:
+    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
+};
+
+const container: CSSProperties = {
+  backgroundColor: "#ffffff",
+  margin: "0 auto",
+  padding: "24px 20px 32px",
+  marginBottom: "32px",
+  maxWidth: "600px",
+};
+
+const header: CSSProperties = {
+  padding: "8px 0",
+};
+
+const heading: CSSProperties = {
+  color: "#1a1a1a",
+  fontSize: "24px",
+  fontWeight: "600",
+  lineHeight: "1.3",
+  margin: "0",
+};
+
+const hr: CSSProperties = {
+  borderColor: "#e6ebf1",
+  margin: "20px 0",
+};
+
+const bodyParagraph: CSSProperties = {
+  color: "#374151",
+  fontSize: "16px",
+  lineHeight: "1.6",
+  margin: "0",
+  whiteSpace: "pre-wrap",
+};
+
+const footer: CSSProperties = {
+  color: "#6b7280",
+  fontSize: "12px",
+  lineHeight: "1.5",
+  margin: "0 0 8px",
+};

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -8,11 +8,14 @@ import RegistrationConfirmationEmail from "./registration/registration-confirmat
 import type { RegistrationConfirmationEmailProps } from "./registration/registration-confirmation.js";
 import InvalidTickerEmail from "./registration/invalid-ticker.js";
 import type { InvalidTickerEmailProps } from "./registration/invalid-ticker.js";
+import AlreadySubscribedEmail from "./registration/already-subscribed.js";
+import type { AlreadySubscribedEmailProps } from "./registration/already-subscribed.js";
 
 /** Supported newsletter template variants for rendering. */
 export type NewsletterTemplateVariant =
   | "default"
   | "registration-confirmation"
+  | "already-subscribed"
   | "invalid-ticker";
 
 export type RenderNewsletterEmailInput =
@@ -23,6 +26,7 @@ export type RenderNewsletterEmailInput =
   | ({
       variant: "registration-confirmation";
     } & RegistrationConfirmationEmailProps)
+  | ({ variant: "already-subscribed" } & AlreadySubscribedEmailProps)
   | ({ variant: "invalid-ticker" } & InvalidTickerEmailProps);
 
 type RenderEmailToHtml = (element: ReactElement) => Promise<string>;
@@ -89,6 +93,8 @@ function newsletterElementForVariant(
       return (
         <RegistrationConfirmationEmail tickerSymbol={input.tickerSymbol} />
       );
+    case "already-subscribed":
+      return <AlreadySubscribedEmail tickerSymbol={input.tickerSymbol} />;
     case "invalid-ticker":
       return <InvalidTickerEmail tickerSymbol={input.tickerSymbol} />;
     default: {


### PR DESCRIPTION
## Summary

The agent now sends a Resend message for every known-ticker signup it actually processes, uses the new already-subscribed template when the row is already confirmed, and only hits `user-registration-confirm` when the register response says the row still needs a timestamp. We also treat Resend’s `{ data, error }` response as a hard failure so a rejected send cannot advance to confirm, and we log right before and after each send so you can line up logs with the Resend UI.

## Related issues

Closes #450

## Important changes

- Gate `user-registration-confirm` on `isNewSubscription` while still sending mail for repeat signups (`acknowledged_archived` replaces the old silent idempotent path).
- Throw when `resend.emails.send` returns `error`, so the DB does not show confirmed without an accepted send.
- Centralize sends in `sendResendTransactionalEmail` with structured `calling` / `accepted` logs including `resendEmailId` when present.

## Other changes

- Add `already-subscribed` React Email variant and render wiring.
- Expand agent README troubleshooting (unread, subject prefix, watermark, API key/workspace).
- Touch dev-docs user-registration ingest section to match behavior.

## Key files to review

- `apps/mediapulse/agents/user-registration/src/run.ts` — Resend helper, assert envelope, confirm gating, logging, error serialization in `catch`.
- `packages/shared/email-templates/src/registration/already-subscribed.tsx` — copy and layout for repeat signups.
- `apps/mediapulse/agents/user-registration/README.md` — operator-facing troubleshooting.

## How to test

1. `export ASDF_NODEJS_VERSION=22.18.0` (or your Node 22) then `pnpm --filter @mediapulse/user-registration-agent test` and `pnpm --filter @workspace/email-templates test`.
2. Optional: run the agent against a test mailbox; confirm logs show `user-registration: calling Resend emails.send` then `Resend emails.send accepted` with an id when Resend returns one.
3. Confirm a forced `{ error: { message: "..." } }` mock leaves the message unarchived and skips confirm (covered in `run.test.ts` / `index.test.ts`).
