### PR TITLE
Add ticker line and Mediapulse/Hyperjump branding to default newsletter

### DIFF
--- a/packages/shared/email-templates/src/index.ts
+++ b/packages/shared/email-templates/src/index.ts
@@ -1,6 +1,8 @@
 export {
   DefaultNewsletterEmail,
   type DefaultNewsletterEmailProps,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+  DEFAULT_HYPERJUMP_SITE_URL,
 } from "./newsletter/default-newsletter.js";
 export {
   parseNewsletterBody,

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -32,11 +32,32 @@ export interface DefaultNewsletterEmailProps {
    */
   unsubscribeUrl?: string;
   /**
-   * Ticker symbol shown in the unsubscribe link text (e.g. "AAPL").
-   * Falls back to "these" when omitted.
+   * Ticker symbol shown directly under the heading (e.g. "AAPL") and reused in
+   * the unsubscribe link text. Falls back to "these" in the unsubscribe link
+   * when omitted, and the ticker line above the body is hidden entirely.
    */
   tickerSymbol?: string;
+  /**
+   * Absolute HTTPS URL for the Mediapulse marketing site, used in the footer
+   * branding section. Defaults to the public Mediapulse site so previews and
+   * standalone renders stay correct; delivery passes operator-configured
+   * values from Hermes when available.
+   */
+  mediapulseSiteUrl?: string;
+  /**
+   * Absolute HTTPS URL for the Hyperjump marketing site, used in the footer
+   * branding section. Defaults to the public Hyperjump site so previews and
+   * standalone renders stay correct; delivery passes operator-configured
+   * values from Hermes when available.
+   */
+  hyperjumpSiteUrl?: string;
 }
+
+/** Default Mediapulse marketing site link used for previews and when Hermes config omits the URL. */
+export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.id";
+
+/** Default Hyperjump marketing site link used for previews and when Hermes config omits the URL. */
+export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
 
 /**
  * Default HTML newsletter layout for Mediapulse delivery.
@@ -45,11 +66,17 @@ export interface DefaultNewsletterEmailProps {
  * the content is rendered as labelled sections with visually separated news items.
  * Otherwise it falls back to pre-wrapped plain-text rendering.
  *
+ * The header includes a short ticker line under the title when `tickerSymbol`
+ * is set, and the footer carries a Mediapulse / Hyperjump branding block
+ * directly above the subscription disclaimer.
+ *
  * @param props.title - Heading text in the body.
  * @param props.bodyText - Main content; structured plain text or free-form.
  * @param props.footerNote - Optional footer copy.
  * @param props.unsubscribeUrl - Optional URL for the one-click unsubscribe link.
- * @param props.tickerSymbol - Ticker symbol shown in the unsubscribe link text.
+ * @param props.tickerSymbol - Ticker symbol shown under the title and in the unsubscribe link.
+ * @param props.mediapulseSiteUrl - HTTPS URL for the Mediapulse footer link.
+ * @param props.hyperjumpSiteUrl - HTTPS URL for the Hyperjump footer link.
  * @returns React Email document tree.
  */
 export const DefaultNewsletterEmail = ({
@@ -58,8 +85,12 @@ export const DefaultNewsletterEmail = ({
   footerNote = "You are receiving this because you subscribed to updates.",
   unsubscribeUrl,
   tickerSymbol,
+  mediapulseSiteUrl = DEFAULT_MEDIAPULSE_SITE_URL,
+  hyperjumpSiteUrl = DEFAULT_HYPERJUMP_SITE_URL,
 }: DefaultNewsletterEmailProps): ReactElement => {
   const parsed = parseNewsletterBody(bodyText);
+  const showTickerLine =
+    tickerSymbol !== undefined && tickerSymbol.trim().length > 0;
 
   return (
     <Html>
@@ -69,6 +100,11 @@ export const DefaultNewsletterEmail = ({
         <Container style={container}>
           <Section style={header}>
             <Heading style={heading}>{title}</Heading>
+            {showTickerLine ? (
+              <Text style={tickerLine}>
+                This digest covers <strong>{tickerSymbol}</strong>.
+              </Text>
+            ) : null}
           </Section>
           <Hr style={hr} />
           {parsed !== undefined ? (
@@ -105,6 +141,17 @@ export const DefaultNewsletterEmail = ({
             </Text>
           )}
           <Hr style={hr} />
+          <Text style={brandingLine}>
+            Brought to you by{" "}
+            <Link href={mediapulseSiteUrl} style={link}>
+              Mediapulse
+            </Link>
+            , a product of{" "}
+            <Link href={hyperjumpSiteUrl} style={link}>
+              Hyperjump
+            </Link>
+            .
+          </Text>
           <Text style={footer}>{footerNote}</Text>
           {unsubscribeUrl !== undefined && unsubscribeUrl !== "" ? (
             <Text style={footerMuted}>
@@ -143,6 +190,8 @@ DefaultNewsletterEmail.PreviewProps = {
     "You can unsubscribe from ticker updates in your account settings.",
   unsubscribeUrl: "https://mediapulse.com/api/unsubscribe?token=example",
   tickerSymbol: "AAPL",
+  mediapulseSiteUrl: DEFAULT_MEDIAPULSE_SITE_URL,
+  hyperjumpSiteUrl: DEFAULT_HYPERJUMP_SITE_URL,
 } satisfies DefaultNewsletterEmailProps;
 
 export default DefaultNewsletterEmail;
@@ -212,6 +261,20 @@ const newsItemSummary: CSSProperties = {
 const itemSeparator: CSSProperties = {
   borderColor: "#e6ebf1",
   margin: "16px 0",
+};
+
+const tickerLine: CSSProperties = {
+  color: "#4b5563",
+  fontSize: "14px",
+  lineHeight: "1.5",
+  margin: "8px 0 0",
+};
+
+const brandingLine: CSSProperties = {
+  color: "#374151",
+  fontSize: "13px",
+  lineHeight: "1.5",
+  margin: "0 0 12px",
 };
 
 const footer: CSSProperties = {

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -54,7 +54,7 @@ export interface DefaultNewsletterEmailProps {
 }
 
 /** Default Mediapulse marketing site link used for previews and when Hermes config omits the URL. */
-export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.id";
+export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.hyperjump.tech";
 
 /** Default Hyperjump marketing site link used for previews and when Hermes config omits the URL. */
 export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { renderNewsletterEmail } from "./index.js";
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+  renderNewsletterEmail,
+} from "./index.js";
 
 describe("renderNewsletterEmail", () => {
   it("returns html and plain text containing the title", async () => {
@@ -172,6 +176,113 @@ describe("renderNewsletterEmail", () => {
     expect(html).toContain("Here is your newsletter content");
     expect(html).not.toContain("Executive Summary");
     expect(html).not.toContain("Top News");
+  });
+
+  it("renders a ticker line under the heading when tickerSymbol is set", async () => {
+    // Act
+    const { html, text } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      tickerSymbol: "AAPL",
+    });
+
+    // Assert
+    const stripped = html.replace(/<!-- -->/g, "");
+    expect(stripped).toContain("This digest covers");
+    expect(stripped).toMatch(/<strong[^>]*>\s*AAPL\s*<\/strong>/i);
+    const tickerLineIndex = stripped.indexOf("This digest covers");
+    const firstHrIndex = stripped.search(/<hr[^>]*>/i);
+    expect(tickerLineIndex).toBeGreaterThan(-1);
+    expect(firstHrIndex).toBeGreaterThan(-1);
+    expect(tickerLineIndex).toBeLessThan(firstHrIndex);
+    expect(text).toMatch(/this digest covers/i);
+    expect(text).toContain("AAPL");
+  });
+
+  it("hides the ticker line when tickerSymbol is omitted", async () => {
+    // Act
+    const { html } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+    });
+
+    // Assert
+    expect(html).not.toMatch(/this digest covers/i);
+  });
+
+  it("hides the ticker line when tickerSymbol is blank", async () => {
+    // Act
+    const { html } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      tickerSymbol: "   ",
+    });
+
+    // Assert
+    expect(html).not.toMatch(/this digest covers/i);
+  });
+
+  it("renders default Mediapulse and Hyperjump branding links in the footer", async () => {
+    // Act
+    const { html, text } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+    });
+
+    // Assert
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${DEFAULT_MEDIAPULSE_SITE_URL}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        "i",
+      ),
+    );
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${DEFAULT_HYPERJUMP_SITE_URL}["']?[^>]*>\\s*Hyperjump\\s*</a>`,
+        "i",
+      ),
+    );
+    expect(text.toLowerCase()).toContain("mediapulse");
+    expect(text.toLowerCase()).toContain("hyperjump");
+  });
+
+  it("honours operator-configured branding URLs when provided", async () => {
+    // Setup
+    const mediapulseSiteUrl = "https://staging.mediapulse.example/";
+    const hyperjumpSiteUrl = "https://staging.hyperjump.example/";
+
+    // Act
+    const { html } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      mediapulseSiteUrl,
+      hyperjumpSiteUrl,
+    });
+
+    // Assert
+    expect(html).toContain(mediapulseSiteUrl);
+    expect(html).toContain(hyperjumpSiteUrl);
+    expect(html).not.toContain(DEFAULT_MEDIAPULSE_SITE_URL);
+    expect(html).not.toContain(DEFAULT_HYPERJUMP_SITE_URL);
+  });
+
+  it("places the branding block above the subscription footer note", async () => {
+    // Setup
+    const footerNote = "You are receiving this because you subscribed.";
+
+    // Act
+    const { html } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      footerNote,
+    });
+
+    // Assert
+    const brandingIndex = html.indexOf("Brought to you by");
+    const footerNoteIndex = html.indexOf(footerNote);
+    expect(brandingIndex).toBeGreaterThan(-1);
+    expect(footerNoteIndex).toBeGreaterThan(-1);
+    expect(brandingIndex).toBeLessThan(footerNoteIndex);
   });
 
   it("renders markdown links in structured summaries as HTML anchors", async () => {

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -19,6 +19,8 @@ export type RenderNewsletterEmailInput =
   | ({ variant?: "default" } & DefaultNewsletterEmailProps & {
         unsubscribeUrl?: string;
         tickerSymbol?: string;
+        mediapulseSiteUrl?: string;
+        hyperjumpSiteUrl?: string;
       })
   | ({
       variant: "registration-confirmation";
@@ -83,6 +85,8 @@ function newsletterElementForVariant(
           footerNote={input.footerNote}
           unsubscribeUrl={input.unsubscribeUrl}
           tickerSymbol={input.tickerSymbol}
+          mediapulseSiteUrl={input.mediapulseSiteUrl}
+          hyperjumpSiteUrl={input.hyperjumpSiteUrl}
         />
       );
     case "registration-confirmation":


### PR DESCRIPTION
## Summary

Adds a short ticker line directly under the default newsletter heading and a
Mediapulse/Hyperjump branding block above the subscription footer, so
subscribers can see at a glance which symbol the digest covers and who is
sending it. `renderNewsletterEmail` now threads optional
`mediapulseSiteUrl` and `hyperjumpSiteUrl` props through to the default
variant, ready for the Hermes config work in the next ticket.

## Related issues

Closes #371

## Important changes

- `DefaultNewsletterEmail` renders `This digest covers <SYMBOL>.` under the
  heading when `tickerSymbol` is non-empty; the row is hidden when the prop
  is omitted or whitespace-only so existing call sites cannot produce an
  empty band.
- New footer branding line reads `Brought to you by Mediapulse, a product of
  Hyperjump.` with two HTTPS anchors, placed above the existing
  subscription disclaimer (and above one-click unsubscribe when present).
- New optional `mediapulseSiteUrl` and `hyperjumpSiteUrl` props on the
  default template, defaulting to `https://mediapulse.id` and
  `https://hyperjump.tech`. `renderNewsletterEmail` forwards them to the
  default variant so HTML and plain-text parts stay aligned.
- Exported `DEFAULT_MEDIAPULSE_SITE_URL` and `DEFAULT_HYPERJUMP_SITE_URL`
  constants so the upcoming `DeliveryConfigSchema` work can reuse the same
  defaults without drift.

## Other changes

- Updated `PreviewProps` and JSDoc on `DefaultNewsletterEmail` so the
  React Email preview reflects the new ticker line and footer block.

## Key files to review

- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` —
  ticker line placement (before the first `<Hr />`), footer branding block,
  new props/defaults, and styling.
- `packages/shared/email-templates/src/render-newsletter-email.tsx` —
  forwards `mediapulseSiteUrl` / `hyperjumpSiteUrl` for the default variant
  only; registration variants are untouched.
- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` —
  new coverage for ticker show/hide, default and operator-configured
  branding URLs, and footer ordering (branding above subscription note).

## How to test

1. From repo root, run `pnpm --filter @workspace/email-templates test` and
   confirm all 43 tests pass.
2. Run `pnpm --filter @workspace/email-templates test:coverage` and check
   coverage stays at 100% statements/branches/functions/lines for files
   under `src/newsletter/`.
3. Spot-check `pnpm format:check` from repo root exits 0.
4. Optional manual preview: open `DefaultNewsletterEmail` in a React Email
   preview tool and verify the ticker line sits between the heading and
   the first `<Hr />`, while the Mediapulse / Hyperjump links appear
   immediately above the subscription disclaimer. Removing `tickerSymbol`
   from `PreviewProps` should leave no visible gap.
