### PR TITLE
Wire branding URLs through delivery agent config and render call

### DIFF
--- a/apps/mediapulse/agents/delivery/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/delivery/src/config-schema.test.ts
@@ -1,3 +1,7 @@
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+} from "@workspace/email-templates";
 import { describe, expect, it } from "vitest";
 
 import { DeliveryConfigSchema } from "./config-schema.js";
@@ -5,6 +9,10 @@ import { DeliveryConfigSchema } from "./config-schema.js";
 const minimalResendConfig = {
   resendApiKey: "re_test_key",
   resend: { from: "sender@example.com" },
+} as const;
+
+const minimalUnsubscribe = {
+  unsubscribe: { secret: "secret", baseUrl: "https://example.com/api" },
 } as const;
 
 describe("DeliveryConfigSchema", () => {
@@ -62,6 +70,80 @@ describe("DeliveryConfigSchema", () => {
         baseUrl: "not-a-url",
       },
     });
+    expect(r.success).toBe(false);
+  });
+
+  it("fills branding URLs with public defaults when the key is omitted", () => {
+    // Act
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      ...minimalUnsubscribe,
+    });
+
+    // Assert
+    expect(r.success).toBe(true);
+    expect(r.data?.branding.mediapulseSiteUrl).toBe(
+      DEFAULT_MEDIAPULSE_SITE_URL,
+    );
+    expect(r.data?.branding.hyperjumpSiteUrl).toBe(DEFAULT_HYPERJUMP_SITE_URL);
+  });
+
+  it("fills missing individual branding URLs with defaults", () => {
+    // Setup
+    const customMediapulse = "https://staging.mediapulse.example";
+
+    // Act
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      ...minimalUnsubscribe,
+      branding: { mediapulseSiteUrl: customMediapulse },
+    });
+
+    // Assert
+    expect(r.success).toBe(true);
+    expect(r.data?.branding.mediapulseSiteUrl).toBe(customMediapulse);
+    expect(r.data?.branding.hyperjumpSiteUrl).toBe(DEFAULT_HYPERJUMP_SITE_URL);
+  });
+
+  it("accepts operator-supplied https branding URLs", () => {
+    // Setup
+    const mediapulseSiteUrl = "https://staging.mediapulse.example";
+    const hyperjumpSiteUrl = "https://staging.hyperjump.example";
+
+    // Act
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      ...minimalUnsubscribe,
+      branding: { mediapulseSiteUrl, hyperjumpSiteUrl },
+    });
+
+    // Assert
+    expect(r.success).toBe(true);
+    expect(r.data?.branding.mediapulseSiteUrl).toBe(mediapulseSiteUrl);
+    expect(r.data?.branding.hyperjumpSiteUrl).toBe(hyperjumpSiteUrl);
+  });
+
+  it("rejects http (non-https) branding URLs", () => {
+    // Act
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      ...minimalUnsubscribe,
+      branding: { mediapulseSiteUrl: "http://insecure.example" },
+    });
+
+    // Assert
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects malformed branding URLs", () => {
+    // Act
+    const r = DeliveryConfigSchema.safeParse({
+      ...minimalResendConfig,
+      ...minimalUnsubscribe,
+      branding: { hyperjumpSiteUrl: "not-a-url" },
+    });
+
+    // Assert
     expect(r.success).toBe(false);
   });
 });

--- a/apps/mediapulse/agents/delivery/src/config-schema.ts
+++ b/apps/mediapulse/agents/delivery/src/config-schema.ts
@@ -1,9 +1,30 @@
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+} from "@workspace/email-templates";
 import { z } from "zod";
 
 const resendTagSchema = z.object({
   name: z.string().min(1).max(64),
   value: z.string().min(1).max(256),
 });
+
+const httpsUrl = z
+  .string()
+  .url()
+  .refine((value) => value.startsWith("https://"), {
+    message: "URL must use https://",
+  });
+
+const brandingSchema = z
+  .object({
+    mediapulseSiteUrl: httpsUrl.default(DEFAULT_MEDIAPULSE_SITE_URL),
+    hyperjumpSiteUrl: httpsUrl.default(DEFAULT_HYPERJUMP_SITE_URL),
+  })
+  .default({
+    mediapulseSiteUrl: DEFAULT_MEDIAPULSE_SITE_URL,
+    hyperjumpSiteUrl: DEFAULT_HYPERJUMP_SITE_URL,
+  });
 
 /**
  * Runtime config for the delivery agent, supplied by Hermes on each invocation.
@@ -50,6 +71,12 @@ export const DeliveryConfigSchema = z
         newsletterVariant: z.enum(["default"]).default("default"),
       })
       .default({ newsletterVariant: "default" }),
+    /**
+     * Branding URLs rendered in the newsletter footer (Mediapulse + Hyperjump).
+     * Ops can override these per Hermes agent config without redeploying the
+     * delivery agent; both keys fall back to the public defaults when omitted.
+     */
+    branding: brandingSchema,
     /** Unsubscribe feature config for per-subscriber token generation. */
     unsubscribe: z.object({
       /** Shared HMAC secret for signing/verifying unsubscribe tokens. */

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -1,14 +1,24 @@
 /** @vitest-environment node */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Resend } from "resend";
-import { renderNewsletterEmail } from "@workspace/email-templates";
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+  renderNewsletterEmail,
+} from "@workspace/email-templates";
 
 import { DeliveryConfigSchema } from "./config-schema.js";
 import { deliverNewsletterToSubscribers } from "./deliver-newsletter.js";
 
-vi.mock("@workspace/email-templates", () => ({
-  renderNewsletterEmail: vi.fn(),
-}));
+vi.mock("@workspace/email-templates", async () => {
+  const actual = await vi.importActual<
+    typeof import("@workspace/email-templates")
+  >("@workspace/email-templates");
+  return {
+    ...actual,
+    renderNewsletterEmail: vi.fn(),
+  };
+});
 
 const newsletter = {
   id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
@@ -64,6 +74,8 @@ describe("deliverNewsletterToSubscribers", () => {
         "https://example.com/api/unsubscribe",
       ),
       tickerSymbol: "AAPL",
+      mediapulseSiteUrl: DEFAULT_MEDIAPULSE_SITE_URL,
+      hyperjumpSiteUrl: DEFAULT_HYPERJUMP_SITE_URL,
     });
     expect(acquire).toHaveBeenCalledOnce();
     expect(sendWithRetry).toHaveBeenCalledOnce();
@@ -220,6 +232,44 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(sendWithRetry.mock.calls[0]?.[1]).toMatchObject({
       replyTo: "replies@example.com",
       tags: [{ name: "env", value: "test" }],
+    });
+  });
+
+  it("forwards operator-configured branding URLs to renderNewsletterEmail", async () => {
+    // Setup
+    const mediapulseSiteUrl = "https://staging.mediapulse.example";
+    const hyperjumpSiteUrl = "https://staging.hyperjump.example";
+    const cfg = DeliveryConfigSchema.parse({
+      resendApiKey: "re_k",
+      resend: { from: "from@example.com" },
+      branding: { mediapulseSiteUrl, hyperjumpSiteUrl },
+      unsubscribe: {
+        secret: "test-secret",
+        baseUrl: "https://example.com/api",
+      },
+    });
+    const sendWithRetry = vi
+      .fn()
+      .mockResolvedValue({ id: "re_brand", attempts: 1 });
+
+    // Act
+    await deliverNewsletterToSubscribers(
+      newsletter,
+      [{ userTickerId, email: "u@example.com" }],
+      [],
+      cfg,
+      {
+        resend: {} as Resend,
+        rateLimiter: { acquire: vi.fn().mockResolvedValue(0) },
+        sendWithRetry,
+      },
+    );
+
+    // Assert
+    const renderCall = vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0];
+    expect(renderCall).toMatchObject({
+      mediapulseSiteUrl,
+      hyperjumpSiteUrl,
     });
   });
 

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -141,6 +141,8 @@ export async function deliverNewsletterToSubscribers(
       variant: config.template.newsletterVariant,
       unsubscribeUrl,
       tickerSymbol: newsletter.symbol,
+      mediapulseSiteUrl: config.branding.mediapulseSiteUrl,
+      hyperjumpSiteUrl: config.branding.hyperjumpSiteUrl,
     });
     logger?.info?.(
       {


### PR DESCRIPTION
## Summary

Adds `branding.mediapulseSiteUrl` and `branding.hyperjumpSiteUrl` to the delivery agent config and passes them into `renderNewsletterEmail` so ops can change the footer link targets without redeploying. Both keys default to the public Mediapulse and Hyperjump URLs exported from `@workspace/email-templates`, so any existing Hermes agent config without a `branding` block keeps validating and rendering the same links it does today.

## Related issues

Refs #372

## Important changes

- `DeliveryConfigSchema` now exposes an optional `branding` object with HTTPS-validated URLs and baked-in defaults sourced from the email templates package, so a Hermes config that omits `branding` still parses cleanly and resolves to the shipping defaults.
- `deliverNewsletterToSubscribers` forwards `config.branding.mediapulseSiteUrl` and `config.branding.hyperjumpSiteUrl` to `renderNewsletterEmail` alongside the existing newsletter fields.

## Other changes

- Schema tests cover default fallback, partial overrides, full overrides, non-HTTPS rejection, and malformed URL rejection.
- The deliver-newsletter happy-path test now asserts the default branding URLs reach the renderer, and a new test confirms operator-supplied URLs are passed through.

## Key files to review

- `apps/mediapulse/agents/delivery/src/config-schema.ts` - new `brandingSchema` and HTTPS URL refinement; defaults pulled from `@workspace/email-templates`.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` - render call now includes the two branding URLs.
- `apps/mediapulse/agents/delivery/src/config-schema.test.ts` - default + override + rejection cases.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts` - default vs operator-supplied branding assertions.

## How to test

1. `pnpm turbo build --filter @mediapulse/delivery`
2. `pnpm --filter @mediapulse/delivery test`
3. `pnpm --filter @workspace/email-templates test`
4. `pnpm format:check`
