### PR TITLE
Extend tests and delivery docs; verify ticker stays out of stored body

### DIFF
--- a/dev-docs/docs/mediapulse/apps/agents/delivery.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/delivery.mdx
@@ -30,6 +30,7 @@ The pipeline may also pass:
 - **`resend.tags`** — Optional `{ name, value }[]` forwarded to Resend (dashboard filtering / analytics).
 - **`send.includeHtml` / `send.includeText`** — Default `true` each; you may turn one off for experiments, but **at least one must stay `true`** (Resend requires a body part).
 - **`rateLimit` / `retry` / `template`** — As documented in [agent-data-api](/mediapulse/apps/agent-data-api#delivery-agent-hermes-config--semantics).
+- **`branding.mediapulseSiteUrl` / `branding.hyperjumpSiteUrl`** — Optional HTTPS URLs rendered as the “Brought to you by Mediapulse, a product of Hyperjump” footer links. Both keys default to the public sites baked into `@workspace/email-templates` (`https://mediapulse.hyperjump.tech` and `https://hyperjump.tech`), so a Hermes config that omits `branding` keeps shipping mail with the same links. Override one or both per-environment in Hermes when staging or marketing redirects are needed — no agent redeploy required. Non-HTTPS values are rejected at config validation time.
 
 ### Rate limiting
 

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -244,6 +244,8 @@ describe("renderNewsletterEmail", () => {
     );
     expect(text.toLowerCase()).toContain("mediapulse");
     expect(text.toLowerCase()).toContain("hyperjump");
+    expect(text).toContain(DEFAULT_MEDIAPULSE_SITE_URL);
+    expect(text).toContain(DEFAULT_HYPERJUMP_SITE_URL);
   });
 
   it("honours operator-configured branding URLs when provided", async () => {
@@ -252,7 +254,7 @@ describe("renderNewsletterEmail", () => {
     const hyperjumpSiteUrl = "https://staging.hyperjump.example/";
 
     // Act
-    const { html } = await renderNewsletterEmail({
+    const { html, text } = await renderNewsletterEmail({
       title: "Morning Briefing",
       bodyText: "Body content",
       mediapulseSiteUrl,
@@ -260,10 +262,61 @@ describe("renderNewsletterEmail", () => {
     });
 
     // Assert
-    expect(html).toContain(mediapulseSiteUrl);
-    expect(html).toContain(hyperjumpSiteUrl);
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        "i",
+      ),
+    );
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${hyperjumpSiteUrl}["']?[^>]*>\\s*Hyperjump\\s*</a>`,
+        "i",
+      ),
+    );
     expect(html).not.toContain(DEFAULT_MEDIAPULSE_SITE_URL);
     expect(html).not.toContain(DEFAULT_HYPERJUMP_SITE_URL);
+    expect(text).toContain(mediapulseSiteUrl);
+    expect(text).toContain(hyperjumpSiteUrl);
+  });
+
+  it("renders ticker copy and branding link targets together when all props are supplied", async () => {
+    // Setup
+    const mediapulseSiteUrl = "https://staging.mediapulse.example/";
+    const hyperjumpSiteUrl = "https://staging.hyperjump.example/";
+    const tickerSymbol = "BBCA";
+
+    // Act
+    const { html, text } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      tickerSymbol,
+      mediapulseSiteUrl,
+      hyperjumpSiteUrl,
+    });
+
+    // Assert
+    const stripped = html.replace(/<!-- -->/g, "");
+    expect(stripped).toContain("This digest covers");
+    expect(stripped).toMatch(
+      new RegExp(`<strong[^>]*>\\s*${tickerSymbol}\\s*</strong>`, "i"),
+    );
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        "i",
+      ),
+    );
+    expect(html).toMatch(
+      new RegExp(
+        `<a[^>]+href=["']?${hyperjumpSiteUrl}["']?[^>]*>\\s*Hyperjump\\s*</a>`,
+        "i",
+      ),
+    );
+    expect(text).toContain(tickerSymbol);
+    expect(text).toMatch(/this digest covers/i);
+    expect(text).toContain(mediapulseSiteUrl);
+    expect(text).toContain(hyperjumpSiteUrl);
   });
 
   it("places the branding block above the subscription footer note", async () => {


### PR DESCRIPTION
## Summary

Finishes the newsletter ticker and branding initiative: stronger render-side tests for the ticker line and both branding link targets (HTML and plain text) in a single render, plus documentation for the new `config.branding` keys on the delivery agent. `formatNewsletterContent` is intentionally left alone so the ticker stays a rendering concern and does not leak into the stored newsletter body.

This is the top of a two-PR stack. The bottom PR (#458) is merged, so this branch was rebased onto `main` and now sits as a single commit ready to merge.

## Related issues

Closes #373
Refs #372

## Important changes

- `render-newsletter-email.test.tsx` gains a combined ticker + operator-branding test that asserts the ticker copy, the strong-tag symbol, both anchor `href`s, and the same content in the plain-text output, exercising `REQ-001`/`REQ-002` together in one render.
- Existing branding tests now also verify the resolved Mediapulse and Hyperjump URLs appear in the plain-text body so text-only Resend recipients still see the links.
- `dev-docs/docs/mediapulse/apps/agents/delivery.mdx` documents `branding.mediapulseSiteUrl` / `branding.hyperjumpSiteUrl`, the public defaults, HTTPS-only validation, and the per-environment Hermes override path.

## Other changes

- `formatNewsletterContent` is unchanged (no ticker coupling added), confirming `REQ-004` is honoured by this initiative.
- Repo-wide `pnpm format:check` was run after the edits.

## Key files to review

- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` - new combined test plus tightened plain-text assertions.
- `dev-docs/docs/mediapulse/apps/agents/delivery.mdx` - new `branding` bullet under the Hermes config section.

## How to test

1. `pnpm --filter @workspace/email-templates test`
2. `pnpm --filter @mediapulse/delivery test`
3. `pnpm format:check`
4. Read `dev-docs/docs/mediapulse/apps/agents/delivery.mdx` and confirm the `branding` description reads correctly under "Hermes config".
