### PR TITLE
Register newsletters list resource in domain-api (#461)

### DIFF
--- a/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
+++ b/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
@@ -7,6 +7,7 @@ import { entitiesHermesDashboardResource } from "../resources/entities/resource-
 import { entityRelationsHermesDashboardResource } from "../resources/entity-relations/resource-definition";
 import { entityTypesHermesDashboardResource } from "../resources/entity-types/resource-definition";
 import { mediapulseUsersHermesDashboardResource } from "../resources/mediapulse-users/resource-definition";
+import { newslettersHermesDashboardResource } from "../resources/newsletters/resource-definition";
 import { relationTypesHermesDashboardResource } from "../resources/relation-types/resource-definition";
 import { searchQueriesHermesDashboardResource } from "../resources/search-queries/resource-definition";
 import { tickersHermesDashboardResource } from "../resources/tickers/resource-definition";
@@ -28,6 +29,7 @@ export const hermesDashboardResources = [
   dataSourcesHermesDashboardResource,
   searchQueriesHermesDashboardResource,
   deliveryRunsHermesDashboardResource,
+  newslettersHermesDashboardResource,
 ] as const satisfies readonly HermesDashboardResourceDefinition<
   string,
   string

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -1,0 +1,31 @@
+import type { DashboardPageInput } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const newslettersHermesPathSegment = "newsletters" as const;
+
+/** Hermes `table-v1` manifest for the read-only newsletters list. */
+export const newslettersDashboardPage = {
+  id: newslettersHermesPathSegment,
+  label: "Newsletters",
+  description:
+    "Generated newsletters with delivery counts: who got it, how many, and which ticker.",
+  pathSegment: newslettersHermesPathSegment,
+  template: "table-v1" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(newslettersHermesPathSegment),
+  order: 60,
+  columns: columnsFor<ListItem>()([
+    { key: "tickerSymbol", label: "Ticker", type: "text" },
+    { key: "subject", label: "Subject", type: "text" },
+    { key: "createdAt", label: "Created", type: "date-time" },
+    { key: "deliveryDelivered", label: "Delivery", type: "text" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()(["subject"]),
+  sortableFields: rowFieldKeysFor<ListItem>()(["createdAt", "subject"]),
+  actions: { create: false, update: false, delete: false, view: true },
+} satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/newsletters/delivery-aggregate.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/delivery-aggregate.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { buildDeliveryAggregateMap } from "./delivery-aggregate";
+
+const newsletterId = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const otherId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const tickerId = "11111111-1111-4111-a111-111111111111";
+
+const makeDeps = (overrides: {
+  checkpoints?: Array<{ newsletterId: string; _count: { _all: number } }>;
+  runs?: Array<{
+    newsletterId: string | null;
+    successCount: number;
+    failureCount: number;
+    skippedCount: number;
+  }>;
+  userTickers?: Array<{ tickerId: string; _count: { _all: number } }>;
+}) => ({
+  newsletterDeliveryCheckpoint: {
+    groupBy: vi.fn().mockResolvedValue(overrides.checkpoints ?? []),
+  },
+  deliveryRun: {
+    findMany: vi.fn().mockResolvedValue(overrides.runs ?? []),
+  },
+  userTicker: {
+    groupBy: vi.fn().mockResolvedValue(overrides.userTickers ?? []),
+  },
+});
+
+describe("buildDeliveryAggregateMap", () => {
+  it("returns an empty map when given no newsletters", async () => {
+    const deps = makeDeps({});
+    const result = await buildDeliveryAggregateMap([], deps);
+    expect(result.size).toBe(0);
+    expect(deps.deliveryRun.findMany).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest DeliveryRun for the enabled-at-send-time count", async () => {
+    const deps = makeDeps({
+      checkpoints: [{ newsletterId, _count: { _all: 3 } }],
+      runs: [
+        {
+          newsletterId,
+          successCount: 3,
+          failureCount: 1,
+          skippedCount: 1,
+        },
+        {
+          newsletterId,
+          successCount: 2,
+          failureCount: 0,
+          skippedCount: 0,
+        },
+      ],
+    });
+    const result = await buildDeliveryAggregateMap(
+      [{ id: newsletterId, tickerId }],
+      deps,
+    );
+    expect(result.get(newsletterId)).toEqual({
+      deliveryDelivered: 3,
+      deliveryEnabledAtSendTime: 5,
+      deliveryHasRun: true,
+    });
+  });
+
+  it("falls back to the current enabled UserTicker count pre-run", async () => {
+    const deps = makeDeps({
+      userTickers: [{ tickerId, _count: { _all: 12 } }],
+    });
+    const result = await buildDeliveryAggregateMap(
+      [{ id: newsletterId, tickerId }],
+      deps,
+    );
+    expect(result.get(newsletterId)).toEqual({
+      deliveryDelivered: 0,
+      deliveryEnabledAtSendTime: 12,
+      deliveryHasRun: false,
+    });
+  });
+
+  it("returns a zero aggregate when no run and no enabled subscribers exist", async () => {
+    const deps = makeDeps({});
+    const result = await buildDeliveryAggregateMap(
+      [{ id: newsletterId, tickerId }],
+      deps,
+    );
+    expect(result.get(newsletterId)).toEqual({
+      deliveryDelivered: 0,
+      deliveryEnabledAtSendTime: 0,
+      deliveryHasRun: false,
+    });
+  });
+
+  it("batches multiple newsletters in a single follow-up query", async () => {
+    const deps = makeDeps({
+      checkpoints: [{ newsletterId, _count: { _all: 1 } }],
+      runs: [
+        {
+          newsletterId,
+          successCount: 1,
+          failureCount: 0,
+          skippedCount: 0,
+        },
+      ],
+      userTickers: [{ tickerId, _count: { _all: 5 } }],
+    });
+
+    await buildDeliveryAggregateMap(
+      [
+        { id: newsletterId, tickerId },
+        { id: otherId, tickerId },
+      ],
+      deps,
+    );
+
+    expect(deps.newsletterDeliveryCheckpoint.groupBy).toHaveBeenCalledTimes(1);
+    expect(deps.deliveryRun.findMany).toHaveBeenCalledTimes(1);
+    expect(deps.userTicker.groupBy).toHaveBeenCalledTimes(1);
+    expect(deps.deliveryRun.findMany.mock.calls[0]?.[0]?.where).toEqual({
+      newsletterId: { in: [newsletterId, otherId] },
+    });
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/newsletters/delivery-aggregate.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/delivery-aggregate.ts
@@ -1,0 +1,146 @@
+import type { Prisma } from "@mediapulse/database";
+
+import type { NewsletterDeliveryAggregate } from "./list-mapper";
+
+type CheckpointGroupRow = { newsletterId: string; _count: { _all: number } };
+type UserTickerGroupRow = { tickerId: string; _count: { _all: number } };
+type DeliveryRunSummaryRow = {
+  newsletterId: string | null;
+  successCount: number;
+  failureCount: number;
+  skippedCount: number;
+};
+
+/**
+ * Minimal Prisma surface required by {@link buildDeliveryAggregateMap}. Lets
+ * the caller inject fakes during unit testing.
+ */
+export type DeliveryAggregateDeps = {
+  newsletterDeliveryCheckpoint: Pick<
+    typeof import("@mediapulse/database").prisma.newsletterDeliveryCheckpoint,
+    "groupBy"
+  >;
+  deliveryRun: Pick<
+    typeof import("@mediapulse/database").prisma.deliveryRun,
+    "findMany"
+  >;
+  userTicker: Pick<
+    typeof import("@mediapulse/database").prisma.userTicker,
+    "groupBy"
+  >;
+};
+
+const ZERO_AGGREGATE: NewsletterDeliveryAggregate = {
+  deliveryDelivered: 0,
+  deliveryEnabledAtSendTime: 0,
+  deliveryHasRun: false,
+};
+
+/**
+ * Batches delivery stats for many newsletters in a single follow-up query so
+ * list endpoints stay free of N+1 reads.
+ *
+ * - `deliveryDelivered` = count of `NewsletterDeliveryCheckpoint` rows for each newsletter.
+ * - `deliveryEnabledAtSendTime` = `success + failure + skipped` from the latest
+ *   `DeliveryRun` for the newsletter; falls back to the current enabled
+ *   `UserTicker` count for the ticker when no run exists.
+ * - `deliveryHasRun` = whether any `DeliveryRun` row exists for the newsletter.
+ *
+ * @param newsletters - List of `{ id, tickerId }` pairs from the paginated list query.
+ * @param deps - Prisma collaborators (default: workspace Prisma client).
+ * @returns A map keyed by newsletter id.
+ */
+export async function buildDeliveryAggregateMap(
+  newsletters: ReadonlyArray<{ id: string; tickerId: string }>,
+  deps: DeliveryAggregateDeps,
+): Promise<Map<string, NewsletterDeliveryAggregate>> {
+  const map = new Map<string, NewsletterDeliveryAggregate>();
+  if (newsletters.length === 0) return map;
+
+  const newsletterIds = newsletters.map((newsletter) => newsletter.id);
+  const tickerIds = Array.from(
+    new Set(newsletters.map((newsletter) => newsletter.tickerId)),
+  );
+
+  const checkpointGroupArgs: Prisma.NewsletterDeliveryCheckpointGroupByArgs = {
+    by: ["newsletterId"],
+    where: { newsletterId: { in: newsletterIds } },
+    _count: { _all: true },
+  };
+  const checkpointGroups = (await deps.newsletterDeliveryCheckpoint.groupBy(
+    checkpointGroupArgs as never,
+  )) as ReadonlyArray<CheckpointGroupRow>;
+  const deliveredByNewsletter = new Map<string, number>();
+  for (const group of checkpointGroups) {
+    deliveredByNewsletter.set(group.newsletterId, group._count._all);
+  }
+
+  const deliveryRunArgs = {
+    where: { newsletterId: { in: newsletterIds } },
+    orderBy: { createdAt: "desc" },
+    select: {
+      id: true,
+      newsletterId: true,
+      successCount: true,
+      failureCount: true,
+      skippedCount: true,
+    },
+  } satisfies Prisma.DeliveryRunFindManyArgs;
+  const runs = (await deps.deliveryRun.findMany(
+    deliveryRunArgs,
+  )) as ReadonlyArray<DeliveryRunSummaryRow>;
+  const latestRunByNewsletter = new Map<
+    string,
+    { successCount: number; failureCount: number; skippedCount: number }
+  >();
+  for (const run of runs) {
+    if (run.newsletterId === null) continue;
+    if (latestRunByNewsletter.has(run.newsletterId)) continue;
+    latestRunByNewsletter.set(run.newsletterId, {
+      successCount: run.successCount,
+      failureCount: run.failureCount,
+      skippedCount: run.skippedCount,
+    });
+  }
+
+  const userTickerGroupArgs: Prisma.UserTickerGroupByArgs = {
+    by: ["tickerId"],
+    where: { tickerId: { in: tickerIds }, enabled: true },
+    _count: { _all: true },
+  };
+  const userTickerGroups = (await deps.userTicker.groupBy(
+    userTickerGroupArgs as never,
+  )) as ReadonlyArray<UserTickerGroupRow>;
+  const enabledByTicker = new Map<string, number>();
+  for (const group of userTickerGroups) {
+    enabledByTicker.set(group.tickerId, group._count._all);
+  }
+
+  for (const newsletter of newsletters) {
+    const delivered = deliveredByNewsletter.get(newsletter.id) ?? 0;
+    const latestRun = latestRunByNewsletter.get(newsletter.id);
+    if (latestRun) {
+      map.set(newsletter.id, {
+        deliveryDelivered: delivered,
+        deliveryEnabledAtSendTime:
+          latestRun.successCount +
+          latestRun.failureCount +
+          latestRun.skippedCount,
+        deliveryHasRun: true,
+      });
+      continue;
+    }
+    const enabled = enabledByTicker.get(newsletter.tickerId);
+    if (enabled === undefined) {
+      map.set(newsletter.id, ZERO_AGGREGATE);
+      continue;
+    }
+    map.set(newsletter.id, {
+      deliveryDelivered: delivered,
+      deliveryEnabledAtSendTime: enabled,
+      deliveryHasRun: false,
+    });
+  }
+
+  return map;
+}

--- a/apps/mediapulse/domain-api/src/resources/newsletters/list-filters.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/list-filters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildNewsletterListOrderBy,
+  buildNewsletterListWhere,
+} from "./list-filters";
+
+describe("buildNewsletterListWhere", () => {
+  it("returns an empty filter when no inputs are set", () => {
+    expect(buildNewsletterListWhere({})).toEqual({});
+  });
+
+  it("applies a case-insensitive subject substring search", () => {
+    const where = buildNewsletterListWhere({ q: "  apple " });
+    expect(where).toEqual({
+      subject: { contains: "apple", mode: "insensitive" },
+    });
+  });
+
+  it("ignores whitespace-only search input", () => {
+    expect(buildNewsletterListWhere({ q: "   " })).toEqual({});
+  });
+
+  it("filters by tickerId", () => {
+    expect(
+      buildNewsletterListWhere({
+        tickerId: "11111111-1111-4111-a111-111111111111",
+      }),
+    ).toEqual({ tickerId: "11111111-1111-4111-a111-111111111111" });
+  });
+
+  it("filters by a partial date range (from only)", () => {
+    const from = new Date("2026-05-01T00:00:00.000Z");
+    expect(buildNewsletterListWhere({ from })).toEqual({
+      createdAt: { gte: from },
+    });
+  });
+
+  it("filters by a partial date range (to only)", () => {
+    const to = new Date("2026-05-31T23:59:59.999Z");
+    expect(buildNewsletterListWhere({ to })).toEqual({
+      createdAt: { lte: to },
+    });
+  });
+
+  it("combines multiple filters under AND", () => {
+    const where = buildNewsletterListWhere({
+      q: "earnings",
+      tickerId: "11111111-1111-4111-a111-111111111111",
+    });
+    expect(where).toEqual({
+      AND: [
+        { subject: { contains: "earnings", mode: "insensitive" } },
+        { tickerId: "11111111-1111-4111-a111-111111111111" },
+      ],
+    });
+  });
+
+  it("ignores invalid Date inputs", () => {
+    expect(buildNewsletterListWhere({ from: new Date("not-a-date") })).toEqual(
+      {},
+    );
+  });
+});
+
+describe("buildNewsletterListOrderBy", () => {
+  it("defaults to createdAt DESC", () => {
+    expect(buildNewsletterListOrderBy(undefined, undefined)).toEqual({
+      createdAt: "desc",
+    });
+  });
+
+  it("sorts by subject when requested", () => {
+    expect(buildNewsletterListOrderBy("subject", "asc")).toEqual({
+      subject: "asc",
+    });
+  });
+
+  it("honors asc on createdAt", () => {
+    expect(buildNewsletterListOrderBy("createdAt", "asc")).toEqual({
+      createdAt: "asc",
+    });
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/newsletters/list-filters.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/list-filters.ts
@@ -1,0 +1,76 @@
+import { Prisma } from "@mediapulse/database";
+
+/**
+ * Input filters parsed from query string for the newsletter list endpoint.
+ * All fields are optional; missing values mean "no filter".
+ */
+export type NewsletterListFilters = {
+  /** Case-insensitive subject substring search. */
+  q?: string;
+  /** UUID; restricts results to a single ticker. */
+  tickerId?: string;
+  /** ISO-8601 lower bound on `createdAt` (inclusive). */
+  from?: Date;
+  /** ISO-8601 upper bound on `createdAt` (inclusive). */
+  to?: Date;
+};
+
+/** Sort direction accepted by the list endpoint. */
+export type NewsletterListSortDir = "asc" | "desc";
+
+/** Sortable fields exposed on the list endpoint. */
+export type NewsletterListSortField = "createdAt" | "subject";
+
+/**
+ * Builds a Prisma `where` for the newsletter list query from parsed filters.
+ *
+ * @param filters - Parsed filter values from the request.
+ * @returns A `Prisma.NewsletterWhereInput` (always returned, possibly empty).
+ */
+export function buildNewsletterListWhere(
+  filters: NewsletterListFilters,
+): Prisma.NewsletterWhereInput {
+  const parts: Prisma.NewsletterWhereInput[] = [];
+
+  if (filters.q && filters.q.trim().length > 0) {
+    parts.push({
+      subject: { contains: filters.q.trim(), mode: "insensitive" },
+    });
+  }
+
+  if (filters.tickerId) {
+    parts.push({ tickerId: filters.tickerId });
+  }
+
+  const createdAt: { gte?: Date; lte?: Date } = {};
+  if (filters.from && !Number.isNaN(filters.from.getTime())) {
+    createdAt.gte = filters.from;
+  }
+  if (filters.to && !Number.isNaN(filters.to.getTime())) {
+    createdAt.lte = filters.to;
+  }
+  if (createdAt.gte !== undefined || createdAt.lte !== undefined) {
+    parts.push({ createdAt });
+  }
+
+  if (parts.length === 0) return {};
+  if (parts.length === 1) return parts[0] ?? {};
+  return { AND: parts };
+}
+
+/**
+ * Builds the Prisma `orderBy` for the newsletter list, defaulting to
+ * `createdAt DESC` per the PRD.
+ *
+ * @param sortBy - Field to sort by (defaults to `createdAt`).
+ * @param sortDir - Direction (defaults to `desc`).
+ * @returns A `Prisma.NewsletterOrderByWithRelationInput`.
+ */
+export function buildNewsletterListOrderBy(
+  sortBy: NewsletterListSortField | undefined,
+  sortDir: NewsletterListSortDir | undefined,
+): Prisma.NewsletterOrderByWithRelationInput {
+  const dir: Prisma.SortOrder = sortDir === "asc" ? "asc" : "desc";
+  if (sortBy === "subject") return { subject: dir };
+  return { createdAt: dir };
+}

--- a/apps/mediapulse/domain-api/src/resources/newsletters/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/list-mapper.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { mapRowToListItem, type NewsletterListRow } from "./list-mapper";
+
+describe("newsletters list-mapper", () => {
+  const baseRow = {
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    subject: "Apple weekly digest",
+    description: null,
+    content: "# body",
+    tickerId: "11111111-1111-4111-a111-111111111111",
+    createdAt: new Date("2026-05-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T00:00:00.000Z"),
+    model: null,
+    agentVersion: null,
+    configVersion: null,
+    promptHash: null,
+    configSnapshotId: null,
+    promptTokens: null,
+    completionTokens: null,
+    totalTokens: null,
+    ticker: { symbol: "AAPL", name: "Apple Inc." },
+  } satisfies NewsletterListRow;
+
+  it("maps a row with a real delivery aggregate", () => {
+    const item = mapRowToListItem(baseRow, {
+      deliveryDelivered: 4,
+      deliveryEnabledAtSendTime: 5,
+      deliveryHasRun: true,
+    });
+    expect(item).toEqual({
+      id: baseRow.id,
+      subject: "Apple weekly digest",
+      description: null,
+      tickerId: baseRow.tickerId,
+      tickerSymbol: "AAPL",
+      tickerName: "Apple Inc.",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      deliveryDelivered: 4,
+      deliveryEnabledAtSendTime: 5,
+      deliveryHasRun: true,
+    });
+  });
+
+  it("propagates `deliveryHasRun: false` for the pre-run fallback", () => {
+    const item = mapRowToListItem(baseRow, {
+      deliveryDelivered: 0,
+      deliveryEnabledAtSendTime: 3,
+      deliveryHasRun: false,
+    });
+    expect(item.deliveryHasRun).toBe(false);
+    expect(item.deliveryEnabledAtSendTime).toBe(3);
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/newsletters/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/list-mapper.ts
@@ -1,0 +1,59 @@
+import type { Prisma } from "@mediapulse/database";
+
+/** Row shape for newsletter list (joined ticker). */
+export type NewsletterListRow = Prisma.NewsletterGetPayload<{
+  include: { ticker: { select: { symbol: true; name: true } } };
+}>;
+
+/**
+ * Aggregate of delivery stats for one newsletter. The `deliveryHasRun` flag tells
+ * the list cell whether to render "(no run yet)" or the badge.
+ */
+export type NewsletterDeliveryAggregate = {
+  deliveryDelivered: number;
+  deliveryEnabledAtSendTime: number;
+  deliveryHasRun: boolean;
+};
+
+/** Shape of one row in the newsletters list table. */
+export type ListItem = {
+  id: string;
+  subject: string;
+  description: string | null;
+  tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
+  createdAt: string;
+  deliveryDelivered: number;
+  deliveryEnabledAtSendTime: number;
+  deliveryHasRun: boolean;
+};
+
+export const listInclude = {
+  ticker: { select: { symbol: true, name: true } },
+} satisfies Prisma.NewsletterInclude;
+
+/**
+ * Maps a Prisma newsletter row plus a delivery aggregate to a table-v1 list item.
+ *
+ * @param row - Newsletter row with the joined ticker.
+ * @param aggregate - Delivery aggregate from {@link buildDeliveryAggregateMap}.
+ * @returns List item for the Hermes dashboard.
+ */
+export function mapRowToListItem(
+  row: NewsletterListRow,
+  aggregate: NewsletterDeliveryAggregate,
+): ListItem {
+  return {
+    id: row.id,
+    subject: row.subject,
+    description: row.description,
+    tickerId: row.tickerId,
+    tickerSymbol: row.ticker.symbol,
+    tickerName: row.ticker.name,
+    createdAt: row.createdAt.toISOString(),
+    deliveryDelivered: aggregate.deliveryDelivered,
+    deliveryEnabledAtSendTime: aggregate.deliveryEnabledAtSendTime,
+    deliveryHasRun: aggregate.deliveryHasRun,
+  };
+}

--- a/apps/mediapulse/domain-api/src/resources/newsletters/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/resource-definition.ts
@@ -1,0 +1,17 @@
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  newslettersDashboardPage,
+  newslettersHermesPathSegment,
+} from "./dashboard-page";
+import { newslettersRoutes } from "./routes";
+
+/** Hermes dashboard registration for the read-only newsletters list. */
+export const newslettersHermesDashboardResource = defineHermesDashboardResource(
+  {
+    resourceKey: "newsletters",
+    pathSegment: newslettersHermesPathSegment,
+    order: 60,
+    routes: newslettersRoutes,
+    dashboardPage: newslettersDashboardPage,
+  },
+);

--- a/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
@@ -1,0 +1,121 @@
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma } from "@mediapulse/database";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
+import { parsePagination } from "../../lib/list-pagination";
+import { buildDeliveryAggregateMap } from "./delivery-aggregate";
+import {
+  buildNewsletterListOrderBy,
+  buildNewsletterListWhere,
+  type NewsletterListSortField,
+} from "./list-filters";
+import { listInclude, mapRowToListItem } from "./list-mapper";
+
+const NEWSLETTERS_PATH_SEGMENT = "newsletters" as const;
+
+/**
+ * Hermes `table-v1` API for read-only newsletters (list + meta).
+ * Detail handler lands in #462 along with the manifest `detailBlocks`.
+ */
+export const newslettersRoutes = new Hono();
+
+const parseSortBy = (
+  raw: string | undefined,
+): NewsletterListSortField | undefined => {
+  if (raw === "subject") return "subject";
+  if (raw === "createdAt") return "createdAt";
+  return undefined;
+};
+
+const parseDate = (raw: string | undefined): Date | undefined => {
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const date = new Date(raw);
+  return Number.isNaN(date.getTime()) ? undefined : date;
+};
+
+newslettersRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const skip = (page - 1) * pageSize;
+
+  const tickerFilter = z
+    .string()
+    .uuid()
+    .safeParse(c.req.query("tickerId")?.trim() ?? "");
+
+  const where = buildNewsletterListWhere({
+    q: c.req.query("q"),
+    tickerId: tickerFilter.success ? tickerFilter.data : undefined,
+    from: parseDate(c.req.query("from")),
+    to: parseDate(c.req.query("to")),
+  });
+
+  const orderBy = buildNewsletterListOrderBy(
+    parseSortBy(c.req.query("sortBy")),
+    c.req.query("sortDir") === "asc" ? "asc" : "desc",
+  );
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.NewsletterFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.newsletter.findMany(findManyArgs),
+    prisma.newsletter.count({ where }),
+  ]);
+
+  const aggregates = await buildDeliveryAggregateMap(
+    rows.map((row) => ({ id: row.id, tickerId: row.tickerId })),
+    {
+      newsletterDeliveryCheckpoint: prisma.newsletterDeliveryCheckpoint,
+      deliveryRun: prisma.deliveryRun,
+      userTicker: prisma.userTicker,
+    },
+  );
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map((row) =>
+      mapRowToListItem(
+        row,
+        aggregates.get(row.id) ?? {
+          deliveryDelivered: 0,
+          deliveryEnabledAtSendTime: 0,
+          deliveryHasRun: false,
+        },
+      ),
+    ),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+newslettersRoutes.get("/meta", async (c) => {
+  const base = buildMetaPayloadForPathSegment(NEWSLETTERS_PATH_SEGMENT);
+  if (!base) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+
+  const tickerOptions = await prisma.ticker.findMany({
+    select: { id: true, symbol: true, name: true },
+    orderBy: { symbol: "asc" },
+  } satisfies Prisma.TickerFindManyArgs);
+
+  return c.json({
+    ...base,
+    tickerOptions: tickerOptions.map((ticker) => ({
+      value: ticker.id,
+      label: `${ticker.symbol} — ${ticker.name}`,
+    })),
+  });
+});

--- a/dev-docs/docs/mediapulse/apps/domain-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/domain-api.mdx
@@ -15,6 +15,7 @@ icon: Server
   - `POST /v1/preview-expansion`
   - `POST /v1/expand-step-inputs`
 - Serves **Hermes dashboard** HTTP for registered `table-v1` resources (list, meta, create/update/delete) under `/v1/hermes-dashboard/...`, including optional **custom actions** declared in the integration manifest (for example `POST /v1/hermes-dashboard/tickers/import-idx-json` with body `{ "payloadJson": "<stringified IDX JSON>" }` for IDX ticker import via `@mediapulse/idx-tickers-importer`).
+- Registered table-v1 resources include `tickers`, `mediapulse-users`, `entity-types`, `relation-types`, `entities`, `entity-relations`, `data-sources`, `search-queries`, `delivery-runs`, and `newsletters` (read-only list with subject/ticker/date filters and a delivery cell that shows checkpoint-vs-enabled counts).
 - Runs Mediapulse DB expansion logic using `@mediapulse/hermes-integration`.
 - Self-registers to Hermes via `POST /api/domain-integrations/register`.
 


### PR DESCRIPTION
## Summary

- Adds the `newsletters` table-v1 resource at `/v1/hermes-dashboard/newsletters` so the Hermes admin sidebar lists generated newsletters with the ticker, subject, created-at, and a delivery cell that shows `delivered / enabled at send time`.
- Delivery aggregate is batched in a single follow-up query (`NewsletterDeliveryCheckpoint.groupBy` + latest `DeliveryRun` per newsletter + `UserTicker` group counts). No N+1.
- Pre-run fallback for `deliveryEnabledAtSendTime` uses the current enabled-subscriber count when no `DeliveryRun` exists yet; the `deliveryHasRun: false` flag tells the list cell to render `(no run yet)` in #466.

## Important changes

- `apps/mediapulse/domain-api/src/resources/newsletters/` — new resource folder following the team convention (`dashboard-page.ts`, `list-mapper.ts`, `list-filters.ts`, `delivery-aggregate.ts`, `routes.ts`, `resource-definition.ts`).
- `apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts` — registers the new resource.
- `dev-docs/docs/mediapulse/apps/domain-api.mdx` — adds the resource to the registered-resources list.

## Other changes

- 18 new unit tests covering the list-mapper (with and without a run), the where/orderBy builders (empty filter, q, tickerId, partial date range, combined AND, invalid Date), and the delivery-aggregate batcher (empty input, run path, pre-run fallback, zero-subscriber path, single-query guard).

## Testing instructions

- `pnpm --filter @mediapulse/domain-api test` — 121 tests pass (1 failed suite is a pre-existing `@workspace/utils` issue, unrelated).
- `pnpm format:check` — clean.
- Manual: start the domain-api locally, hit `GET /v1/hermes-dashboard/newsletters` with `?q=apple&tickerId=…&from=2026-05-01&to=2026-05-31`, and check pagination + sort.

## Stack position

Second PR in the **Hermes admin newsletter visibility** stack. Depends on the contract change in #460 (PR #468). No feature flag — clicking a row opens the generic detail page which renders the base key/value view until #462 lands.

## Related issues

Closes #461. Depends on #460.
