### PR TITLE
feat(domain-api): newsletter markdown body + citations detail blocks

### DIFF
--- a/apps/mediapulse/domain-api/package.json
+++ b/apps/mediapulse/domain-api/package.json
@@ -17,6 +17,7 @@
     "@mediapulse/env": "workspace:*",
     "@hermes/domain-contract": "workspace:*",
     "@hermes/step-input-syntax": "workspace:*",
+    "@workspace/email-templates": "workspace:*",
     "@workspace/logger": "workspace:*",
     "@workspace/utils": "workspace:*",
     "@mediapulse/hermes-integration": "workspace:*",

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -50,6 +50,47 @@ const newslettersMetadataBlock = {
 } satisfies DetailBlock;
 
 /**
+ * `markdown` block bound to the newsletter body. Clamps at 4,000 characters
+ * for bodies that exceed 10,000 characters (per PRD REQ-007); shorter bodies
+ * render fully without an expander. `copyAction` is intentionally off in this
+ * ticket; #466 turns it on after the polish review.
+ */
+const newslettersBodyBlock = {
+  type: "markdown",
+  label: "Body",
+  field: "content",
+  clampChars: 4000,
+  clampThreshold: 10000,
+} satisfies DetailBlock;
+
+/**
+ * `subTable` block bound to `citations` — deduplicated `[title](url)` and
+ * `Read the full article: <url>` references in the newsletter body. The `url`
+ * column renders as an external link with `rel="noopener noreferrer"`. The
+ * caption template surfaces the unique-count alongside the section header so
+ * reviewers can sanity-check at a glance.
+ */
+const newslettersCitationsBlock = {
+  type: "subTable",
+  label: "Citations",
+  field: "citations",
+  captionTemplate: "Citations ({citations.length} unique)",
+  emptyState: "No citations parsed from this newsletter.",
+  columns: [
+    { field: "title", label: "Title", type: "text" },
+    { field: "domain", label: "Domain", type: "text" },
+    {
+      field: "url",
+      label: "URL",
+      type: "text",
+      linkTemplate: "{url}",
+      linkExternal: true,
+      truncate: 80,
+    },
+  ],
+} satisfies DetailBlock;
+
+/**
  * `keyValue` block linking each delivery row back to the Hermes execution
  * surface. Missing template variables fall back to plain text (see
  * `renderUrlTemplate` in `@hermes/domain-contract`), which is what the
@@ -119,5 +160,10 @@ export const newslettersDashboardPage = {
   searchableFields: rowFieldKeysFor<ListItem>()(["subject"]),
   sortableFields: rowFieldKeysFor<ListItem>()(["createdAt", "subject"]),
   actions: { create: false, update: false, delete: false, view: true },
-  detailBlocks: [newslettersMetadataBlock, newslettersHermesLinksBlock],
+  detailBlocks: [
+    newslettersMetadataBlock,
+    newslettersBodyBlock,
+    newslettersCitationsBlock,
+    newslettersHermesLinksBlock,
+  ],
 } satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@mediapulse/database";
+import type { NewsletterCitation } from "@workspace/email-templates/parse-newsletter-citations";
 
 import type { ActiveQuerySetPayload } from "./active-query-set";
 import type { HermesLinksPayload } from "./build-hermes-links";
@@ -38,6 +39,7 @@ export type DetailItem = {
   completionTokens: number | null;
   totalTokens: number | null;
   content: string;
+  citations: NewsletterCitation[];
   recipients: RecipientPayload[];
   recipientsTruncated: boolean;
   recipientsCap: number;
@@ -56,6 +58,7 @@ export type DetailItem = {
 export const mapRowToDetailItem = (
   row: NewsletterDetailRow,
   parts: {
+    citations: NewsletterCitation[];
     recipients: RecipientPayload[];
     recipientsTruncated: boolean;
     recipientsCap: number;
@@ -83,6 +86,7 @@ export const mapRowToDetailItem = (
   completionTokens: row.completionTokens,
   totalTokens: row.totalTokens,
   content: row.content,
+  citations: parts.citations,
   recipients: parts.recipients,
   recipientsTruncated: parts.recipientsTruncated,
   recipientsCap: parts.recipientsCap,

--- a/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
@@ -1,5 +1,6 @@
 import { tableV1ListResponseSchema } from "@hermes/domain-contract";
 import { prisma, Prisma } from "@mediapulse/database";
+import { parseNewsletterCitations } from "@workspace/email-templates/parse-newsletter-citations";
 import { logger } from "@workspace/logger";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -184,8 +185,11 @@ newslettersRoutes.get("/:id", async (c) => {
     );
   }
 
+  const citations = parseNewsletterCitations(row.content);
+
   return c.json(
     mapRowToDetailItem(row, {
+      citations,
       recipients: recipientsResult.recipients,
       recipientsTruncated: recipientsResult.truncated,
       recipientsCap: NEWSLETTER_DETAIL_RECIPIENTS_CAP,

--- a/packages/hermes/domain-contract/src/detail-block-rules.test.ts
+++ b/packages/hermes/domain-contract/src/detail-block-rules.test.ts
@@ -158,6 +158,12 @@ describe("renderUrlTemplate", () => {
   it("returns undefined when any placeholder is missing", () => {
     expect(renderUrlTemplate("/x/{a}/{b}", { a: "one" })).toBeUndefined();
   });
+
+  it("passes through absolute http(s) URLs without re-encoding", () => {
+    expect(
+      renderUrlTemplate("{url}", { url: "https://example.com/aapl?q=1" }),
+    ).toBe("https://example.com/aapl?q=1");
+  });
 });
 
 describe("renderCaptionTemplate", () => {

--- a/packages/hermes/domain-contract/src/detail-block-rules.ts
+++ b/packages/hermes/domain-contract/src/detail-block-rules.ts
@@ -293,7 +293,11 @@ export function renderUrlTemplate(
       missing = true;
       return "";
     }
-    return encodeURIComponent(String(value));
+    const stringValue = String(value);
+    if (/^https?:\/\//i.test(stringValue)) {
+      return stringValue;
+    }
+    return encodeURIComponent(stringValue);
   });
   if (missing) return undefined;
   return result;

--- a/packages/shared/email-templates/package.json
+++ b/packages/shared/email-templates/package.json
@@ -7,6 +7,14 @@
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./parse-newsletter-body": {
+      "types": "./src/newsletter/parse-newsletter-body.ts",
+      "default": "./src/newsletter/parse-newsletter-body.ts"
+    },
+    "./parse-newsletter-citations": {
+      "types": "./src/newsletter/parse-newsletter-citations.ts",
+      "default": "./src/newsletter/parse-newsletter-citations.ts"
     }
   },
   "scripts": {

--- a/packages/shared/email-templates/src/index.ts
+++ b/packages/shared/email-templates/src/index.ts
@@ -9,6 +9,11 @@ export {
   type ParsedNewsletterBody,
 } from "./newsletter/parse-newsletter-body.js";
 export {
+  parseNewsletterCitations,
+  unwrapInlineFormatting,
+  type NewsletterCitation,
+} from "./newsletter/parse-newsletter-citations.js";
+export {
   RegistrationConfirmationEmail,
   type RegistrationConfirmationEmailProps,
 } from "./registration/registration-confirmation.js";

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseNewsletterCitations,
+  unwrapInlineFormatting,
+} from "./parse-newsletter-citations.js";
+
+describe("unwrapInlineFormatting", () => {
+  it("strips surrounding **bold**", () => {
+    expect(unwrapInlineFormatting("**Apple earnings**")).toBe("Apple earnings");
+  });
+
+  it("strips surrounding *italic*", () => {
+    expect(unwrapInlineFormatting("*Apple earnings*")).toBe("Apple earnings");
+  });
+
+  it("strips a nested __bold__ inside **wrapper**", () => {
+    expect(unwrapInlineFormatting("**__Apple Q2__**")).toBe("Apple Q2");
+  });
+
+  it("returns input unchanged when nothing wraps it", () => {
+    expect(unwrapInlineFormatting("Apple Q2 earnings")).toBe(
+      "Apple Q2 earnings",
+    );
+  });
+});
+
+describe("parseNewsletterCitations", () => {
+  it("returns [] for empty input", () => {
+    expect(parseNewsletterCitations("")).toStrictEqual([]);
+  });
+
+  it("returns [] for input with no links", () => {
+    expect(
+      parseNewsletterCitations("EXECUTIVE SUMMARY\n\nNo links today."),
+    ).toStrictEqual([]);
+  });
+
+  it("extracts markdown links and unwraps formatting in titles", () => {
+    const body = [
+      "EXECUTIVE SUMMARY",
+      "",
+      "Markets rallied — see [**Apple Q2 earnings**](https://example.com/aapl-q2).",
+      "",
+      "---",
+      "",
+      "TOP 3 NEWS",
+      "",
+      "1. Apple",
+      "Summary.",
+    ].join("\n");
+
+    const citations = parseNewsletterCitations(body);
+
+    expect(citations).toStrictEqual([
+      {
+        title: "Apple Q2 earnings",
+        url: "https://example.com/aapl-q2",
+        domain: "example.com",
+      },
+    ]);
+  });
+
+  it("pairs Read-the-full-article URLs with top-news item titles", () => {
+    const body = [
+      "EXECUTIVE SUMMARY",
+      "",
+      "Markets rallied.",
+      "",
+      "---",
+      "",
+      "TOP 2 NEWS",
+      "",
+      "1. Apple Q2 earnings",
+      "Apple posted Q2 numbers.",
+      "Read the full article: https://example.com/aapl-q2",
+      "",
+      "2. Tesla deliveries",
+      "Tesla deliveries beat estimates.",
+      "Read the full article: https://example.com/tsla-q2",
+    ].join("\n");
+
+    const citations = parseNewsletterCitations(body);
+
+    expect(citations).toStrictEqual([
+      {
+        title: "Apple Q2 earnings",
+        url: "https://example.com/aapl-q2",
+        domain: "example.com",
+      },
+      {
+        title: "Tesla deliveries",
+        url: "https://example.com/tsla-q2",
+        domain: "example.com",
+      },
+    ]);
+  });
+
+  it("deduplicates by URL while preserving the first occurrence", () => {
+    const body = [
+      "Read [Apple](https://example.com/aapl) and again [Apple again](https://example.com/aapl).",
+      "Read the full article: https://example.com/aapl",
+    ].join("\n");
+
+    const citations = parseNewsletterCitations(body);
+
+    expect(citations).toStrictEqual([
+      {
+        title: "Apple",
+        url: "https://example.com/aapl",
+        domain: "example.com",
+      },
+    ]);
+  });
+
+  it("falls back to the URL as title for read-the-full-article links without an item", () => {
+    const body = "Read the full article: https://example.com/standalone";
+
+    const citations = parseNewsletterCitations(body);
+
+    expect(citations).toStrictEqual([
+      {
+        title: "https://example.com/standalone",
+        url: "https://example.com/standalone",
+        domain: "example.com",
+      },
+    ]);
+  });
+
+  it("does not throw on malformed markdown links", () => {
+    const body = "Half-link [missing close (https://example.com/x)";
+    expect(() => parseNewsletterCitations(body)).not.toThrow();
+    expect(parseNewsletterCitations(body)).toStrictEqual([]);
+  });
+
+  it("includes both markdown and Read-the-full-article links in document order", () => {
+    const body = [
+      "Markets rallied — see [Apple](https://example.com/aapl).",
+      "",
+      "---",
+      "",
+      "TOP 1 NEWS",
+      "",
+      "1. Tesla deliveries",
+      "Tesla deliveries beat estimates.",
+      "Read the full article: https://example.com/tsla",
+    ].join("\n");
+
+    const citations = parseNewsletterCitations(body);
+
+    expect(citations.map((c) => c.url)).toStrictEqual([
+      "https://example.com/aapl",
+      "https://example.com/tsla",
+    ]);
+  });
+});

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.ts
@@ -1,0 +1,108 @@
+import { parseNewsletterBody } from "./parse-newsletter-body.js";
+
+/** A single citation extracted from a newsletter body. */
+export interface NewsletterCitation {
+  /** Display title (link text or top-news item title). */
+  title: string;
+  /** Absolute URL of the cited article. */
+  url: string;
+  /** Hostname (e.g. `example.com`), or empty string when the URL is unparsable. */
+  domain: string;
+}
+
+/** Matches a markdown link `[title](url)`. Title may contain bold/italic markers. */
+const MARKDOWN_LINK_REGEX = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+
+/** Matches a `Read the full article: <url>` line anywhere in the body. */
+const READ_FULL_ARTICLE_INLINE_REGEX =
+  /Read the full article:\s*(https?:\/\/\S+)/gi;
+
+/**
+ * Removes surrounding bold/italic markers (`**`, `__`, `*`, `_`) from link text,
+ * including a single nested layer. Returns the trimmed inner text.
+ *
+ * @param value - Raw link text captured between the `[]` of a markdown link.
+ * @returns The cleaned title text.
+ */
+export const unwrapInlineFormatting = (value: string): string => {
+  let current = value.trim();
+  for (let step = 0; step < 4; step += 1) {
+    const before = current;
+    current = current.replace(/^\*\*(.+)\*\*$/s, "$1").trim();
+    current = current.replace(/^__(.+)__$/s, "$1").trim();
+    current = current.replace(/^\*(.+)\*$/s, "$1").trim();
+    current = current.replace(/^_(.+)_$/s, "$1").trim();
+    if (current === before) break;
+  }
+  return current;
+};
+
+/**
+ * Extracts the hostname from a URL for the citations sub-table. Returns `""`
+ * when the URL is unparsable (the parser never throws).
+ *
+ * @param url - Absolute URL (the regex only accepts `http(s)://…`).
+ */
+const extractDomain = (url: string): string => {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return "";
+  }
+};
+
+/**
+ * Extracts a deduplicated list of citations from a newsletter body.
+ *
+ * Sources, in document order:
+ *
+ * 1. Inline `[title](url)` markdown links (with bold/italic unwrapped).
+ * 2. `Read the full article: <url>` lines, paired with the top-news item title
+ *    when {@link parseNewsletterBody} returns structured items, or the URL
+ *    itself otherwise.
+ *
+ * The result deduplicates by URL, preserving the first occurrence. The function
+ * never throws — malformed markdown yields fewer citations rather than an error.
+ *
+ * @param body - Newsletter content string.
+ * @returns Ordered, deduplicated citations.
+ */
+export const parseNewsletterCitations = (
+  body: string,
+): NewsletterCitation[] => {
+  if (typeof body !== "string" || body.length === 0) return [];
+
+  const items = parseNewsletterBody(body);
+  const titleByUrl = new Map<string, string>();
+  if (items) {
+    for (const item of items.topNewsItems) {
+      if (item.url && !titleByUrl.has(item.url)) {
+        titleByUrl.set(item.url, item.title);
+      }
+    }
+  }
+
+  const seen = new Set<string>();
+  const citations: NewsletterCitation[] = [];
+
+  const markdownMatches = [...body.matchAll(MARKDOWN_LINK_REGEX)];
+  for (const match of markdownMatches) {
+    const rawTitle = match[1] ?? "";
+    const url = match[2] ?? "";
+    if (url.length === 0 || seen.has(url)) continue;
+    const title = unwrapInlineFormatting(rawTitle) || url;
+    seen.add(url);
+    citations.push({ title, url, domain: extractDomain(url) });
+  }
+
+  const articleLinkMatches = [...body.matchAll(READ_FULL_ARTICLE_INLINE_REGEX)];
+  for (const match of articleLinkMatches) {
+    const url = match[1] ?? "";
+    if (url.length === 0 || seen.has(url)) continue;
+    const title = titleByUrl.get(url) ?? url;
+    seen.add(url);
+    citations.push({ title, url, domain: extractDomain(url) });
+  }
+
+  return citations;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -899,6 +899,9 @@ importers:
       '@mediapulse/idx-tickers-importer':
         specifier: workspace:*
         version: link:../../../packages/mediapulse/idx-tickers-importer
+      '@workspace/email-templates':
+        specifier: workspace:*
+        version: link:../../../packages/shared/email-templates
       '@workspace/logger':
         specifier: workspace:*
         version: link:../../../packages/shared/logger


### PR DESCRIPTION
## Summary

- Adds a shared `parseNewsletterCitations` helper to `@workspace/email-templates` (new `./parse-newsletter-citations` subpath export) so the domain-api can extract citations without pulling in the JSX email modules.
- Surfaces `citations` on the newsletter detail response and declares the **markdown** body block and the **citations** subTable block on the `newsletters` manifest.
- Fixes `renderUrlTemplate` in `@hermes/domain-contract` to pass through absolute `http(s)://` values unchanged, so a column with `linkTemplate: "{url}"` produces a working `href`.

## Important changes

- `parseNewsletterCitations(body)` returns `{ title, url, domain }[]`, deduplicated by URL:
  - Matches inline `[title](url)` markdown links and unwraps bold/italic in the title (e.g. `[**Apple Q2**](…)`).
  - Adds trailing `Read the full article: <url>` lines, pairing each URL with the parsed top-news item title when available.
  - Never throws on malformed markdown — partial or broken syntax yields fewer citations.
- Markdown body block: `clampChars: 4000`, `clampThreshold: 10000` per PRD REQ-007. `copyAction` stays off here (turned on by #466).
- Citations subTable: caption template `Citations ({citations.length} unique)`, columns `title` / `domain` / `url` (external link, truncated to 80 chars).
- New subpath export `@workspace/email-templates/parse-newsletter-citations` lets the domain-api consume the parser without dragging the JSX index into its non-JSX `tsc` build.

## Other changes

- New test cases for `renderUrlTemplate` confirming the absolute-URL pass-through.

## Testing instructions

```bash
pnpm --filter @workspace/email-templates test
pnpm --filter @hermes/domain-contract test
pnpm --filter @mediapulse/domain-api test
pnpm --filter @mediapulse/domain-api lint
pnpm --filter @mediapulse/domain-api type:check
pnpm format:check
```

12 new tests cover the citations parser (empty input, markdown links with bold/italic, `Read the full article` lines pairing with top-news titles, dedup, malformed input fallback, document-order preservation).

## Related issues

Refs #463
Stacked on #470 (#462). Base: `hermes-nl-vis-462-newsletter-detail`.
