### PR TITLE
feat(domain-api): newsletter email preview htmlPreview block

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -91,6 +91,19 @@ const newslettersCitationsBlock = {
 } satisfies DetailBlock;
 
 /**
+ * `htmlPreview` block bound to `emailPreviewHtml` — the production
+ * `default-newsletter` React Email template rendered server-side against the
+ * newsletter's data. The Hermes generic renderer drops this into a sandboxed
+ * iframe (`sandbox="allow-popups"`), so the preview is a visual sanity check
+ * rather than a forensic record of what Resend received.
+ */
+const newslettersEmailPreviewBlock = {
+  type: "htmlPreview",
+  label: "Email preview",
+  field: "emailPreviewHtml",
+} satisfies DetailBlock;
+
+/**
  * `keyValue` block linking each delivery row back to the Hermes execution
  * surface. Missing template variables fall back to plain text (see
  * `renderUrlTemplate` in `@hermes/domain-contract`), which is what the
@@ -164,6 +177,7 @@ export const newslettersDashboardPage = {
     newslettersMetadataBlock,
     newslettersBodyBlock,
     newslettersCitationsBlock,
+    newslettersEmailPreviewBlock,
     newslettersHermesLinksBlock,
   ],
 } satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
@@ -39,6 +39,7 @@ export type DetailItem = {
   completionTokens: number | null;
   totalTokens: number | null;
   content: string;
+  emailPreviewHtml: string;
   citations: NewsletterCitation[];
   recipients: RecipientPayload[];
   recipientsTruncated: boolean;
@@ -58,6 +59,7 @@ export type DetailItem = {
 export const mapRowToDetailItem = (
   row: NewsletterDetailRow,
   parts: {
+    emailPreviewHtml: string;
     citations: NewsletterCitation[];
     recipients: RecipientPayload[];
     recipientsTruncated: boolean;
@@ -86,6 +88,7 @@ export const mapRowToDetailItem = (
   completionTokens: row.completionTokens,
   totalTokens: row.totalTokens,
   content: row.content,
+  emailPreviewHtml: parts.emailPreviewHtml,
   citations: parts.citations,
   recipients: parts.recipients,
   recipientsTruncated: parts.recipientsTruncated,

--- a/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { renderEmailPreview } from "./render-email-preview";
+
+describe("renderEmailPreview", () => {
+  it("returns the renderer's HTML on success", async () => {
+    const renderHtml = vi
+      .fn()
+      .mockResolvedValue({ html: "<html><body>Preview</body></html>" });
+
+    const html = await renderEmailPreview(
+      {
+        newsletterId: "nl-1",
+        subject: "Apple weekly digest",
+        bodyText: "Hello",
+        tickerSymbol: "AAPL",
+      },
+      { renderHtml },
+    );
+
+    expect(html).toBe("<html><body>Preview</body></html>");
+    expect(renderHtml).toHaveBeenCalledTimes(1);
+    expect(renderHtml).toHaveBeenCalledWith({
+      title: "Apple weekly digest",
+      bodyText: "Hello",
+      tickerSymbol: "AAPL",
+      unsubscribeUrl: "https://example.com/preview/unsubscribe",
+    });
+  });
+
+  it("returns a safe placeholder on render error and logs a warning", async () => {
+    const renderHtml = vi
+      .fn()
+      .mockRejectedValue(new Error("Template exploded"));
+    const warn = vi.fn();
+
+    const html = await renderEmailPreview(
+      {
+        newsletterId: "nl-err",
+        subject: "Subject",
+        bodyText: "Body",
+        tickerSymbol: "AAPL",
+      },
+      { renderHtml, logger: { warn } },
+    );
+
+    expect(html).toContain("<p>Email preview unavailable");
+    expect(html).toContain("Template exploded");
+    expect(warn).toHaveBeenCalledTimes(1);
+    const arg = warn.mock.calls[0]?.[0];
+    expect(arg).toMatchObject({
+      newsletterId: "nl-err",
+      error: "Template exploded",
+    });
+  });
+
+  it("escapes HTML in error messages so the placeholder cannot inject markup", async () => {
+    const renderHtml = vi
+      .fn()
+      .mockRejectedValue(new Error("<script>alert(1)</script>"));
+
+    const html = await renderEmailPreview(
+      {
+        newsletterId: "nl-x",
+        subject: "Subject",
+        bodyText: "Body",
+        tickerSymbol: "AAPL",
+      },
+      { renderHtml },
+    );
+
+    expect(html).not.toContain("<script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("does not throw when the newsletter has empty optional fields", async () => {
+    const renderHtml = vi.fn().mockResolvedValue({ html: "<html></html>" });
+
+    const html = await renderEmailPreview(
+      {
+        newsletterId: "nl-2",
+        subject: "",
+        bodyText: "",
+        tickerSymbol: "",
+      },
+      { renderHtml },
+    );
+
+    expect(html).toBe("<html></html>");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
@@ -1,0 +1,94 @@
+import { renderNewsletterEmail } from "@workspace/email-templates";
+
+import type { Logger } from "@workspace/logger";
+
+/**
+ * Input for {@link renderEmailPreview} — only the fields needed by the
+ * `default-newsletter` template. The preview never sends emails, so we omit
+ * per-recipient tokens; `unsubscribeUrl` is a deterministic placeholder so the
+ * rendered HTML is stable across invocations.
+ */
+export type RenderEmailPreviewInput = {
+  newsletterId: string;
+  subject: string;
+  bodyText: string;
+  tickerSymbol: string;
+};
+
+/**
+ * Render dependency injection — tests stub `renderHtml` to assert behavior
+ * without spinning up React Email.
+ */
+export type RenderEmailPreviewDeps = {
+  /** Async HTML renderer; defaults to `@workspace/email-templates` `renderNewsletterEmail`. */
+  renderHtml?: (input: {
+    title: string;
+    bodyText: string;
+    tickerSymbol: string;
+    unsubscribeUrl: string;
+  }) => Promise<{ html: string }>;
+  /** Pino-compatible logger; defaults to a no-op. */
+  logger?: Pick<Logger, "warn"> | { warn: (...args: unknown[]) => void };
+};
+
+/**
+ * Placeholder unsubscribe URL used by the preview render. The detail page
+ * never sends mail, so the link is informational only — the deterministic
+ * value also keeps the rendered HTML byte-stable for the same input.
+ */
+const PREVIEW_UNSUBSCRIBE_URL = "https://example.com/preview/unsubscribe";
+
+/**
+ * Renders the production `default-newsletter` React Email template for the
+ * given newsletter and returns the HTML string for the `htmlPreview` block.
+ *
+ * Rendering failures do not propagate: the function returns a tiny safe
+ * placeholder paragraph and logs a structured warning that does not contain
+ * subscriber data. The detail handler can therefore always respond 200 even
+ * when the template throws.
+ *
+ * @param input - Subject, body, ticker symbol, and newsletter id.
+ * @param deps - Optional `renderHtml` override and `logger`.
+ * @returns Rendered HTML string (real preview or placeholder).
+ */
+export const renderEmailPreview = async (
+  input: RenderEmailPreviewInput,
+  deps: RenderEmailPreviewDeps = {},
+): Promise<string> => {
+  const renderHtml =
+    deps.renderHtml ??
+    (async ({ title, bodyText, tickerSymbol, unsubscribeUrl }) => {
+      const result = await renderNewsletterEmail({
+        title,
+        bodyText,
+        tickerSymbol,
+        unsubscribeUrl,
+        variant: "default",
+      });
+      return { html: result.html };
+    });
+
+  try {
+    const { html } = await renderHtml({
+      title: input.subject,
+      bodyText: input.bodyText,
+      tickerSymbol: input.tickerSymbol,
+      unsubscribeUrl: PREVIEW_UNSUBSCRIBE_URL,
+    });
+    return html;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    deps.logger?.warn(
+      { newsletterId: input.newsletterId, error: message },
+      "Failed to render newsletter email preview",
+    );
+    return `<p>Email preview unavailable: ${escapeHtml(message)}</p>`;
+  }
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");

--- a/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
@@ -16,6 +16,7 @@ import {
 import { buildSelectedSources } from "./build-selected-sources";
 import { buildDeliveryAggregateMap } from "./delivery-aggregate";
 import { detailInclude, mapRowToDetailItem } from "./detail-mapper";
+import { renderEmailPreview } from "./render-email-preview";
 import {
   buildNewsletterListOrderBy,
   buildNewsletterListWhere,
@@ -145,24 +146,38 @@ newslettersRoutes.get("/:id", async (c) => {
     return c.json({ message: "Newsletter not found" }, 404);
   }
 
-  const [recipientsResult, selectedSourcesResult, activeQuerySet, hermesLinks] =
-    await Promise.all([
-      buildRecipients(row.id, row.tickerId, {
-        userTicker: prisma.userTicker,
-        newsletterDeliveryCheckpoint: prisma.newsletterDeliveryCheckpoint,
-        deliveryRun: prisma.deliveryRun,
-      }),
-      buildSelectedSources(row.id, row.tickerId, row.createdAt, {
-        dataSource: prisma.dataSource,
-      }),
-      findActiveQuerySetForNewsletter(row.tickerId, row.createdAt, {
-        searchQuerySet: prisma.searchQuerySet,
-      }),
-      buildHermesLinks(row.id, {
-        contentGenerationRun: prisma.contentGenerationRun,
-        deliveryRun: prisma.deliveryRun,
-      }),
-    ]);
+  const [
+    recipientsResult,
+    selectedSourcesResult,
+    activeQuerySet,
+    hermesLinks,
+    emailPreviewHtml,
+  ] = await Promise.all([
+    buildRecipients(row.id, row.tickerId, {
+      userTicker: prisma.userTicker,
+      newsletterDeliveryCheckpoint: prisma.newsletterDeliveryCheckpoint,
+      deliveryRun: prisma.deliveryRun,
+    }),
+    buildSelectedSources(row.id, row.tickerId, row.createdAt, {
+      dataSource: prisma.dataSource,
+    }),
+    findActiveQuerySetForNewsletter(row.tickerId, row.createdAt, {
+      searchQuerySet: prisma.searchQuerySet,
+    }),
+    buildHermesLinks(row.id, {
+      contentGenerationRun: prisma.contentGenerationRun,
+      deliveryRun: prisma.deliveryRun,
+    }),
+    renderEmailPreview(
+      {
+        newsletterId: row.id,
+        subject: row.subject,
+        bodyText: row.content,
+        tickerSymbol: row.ticker.symbol,
+      },
+      { logger },
+    ),
+  ]);
 
   for (const entry of recipientsResult.notAttemptedAtSendTime) {
     logger.warn(
@@ -189,6 +204,7 @@ newslettersRoutes.get("/:id", async (c) => {
 
   return c.json(
     mapRowToDetailItem(row, {
+      emailPreviewHtml,
       citations,
       recipients: recipientsResult.recipients,
       recipientsTruncated: recipientsResult.truncated,

--- a/apps/mediapulse/domain-api/tsconfig.json
+++ b/apps/mediapulse/domain-api/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@workspace/typescript-config/node16.json",
   "compilerOptions": {
     "module": "ES2022",
-    "moduleResolution": "Bundler"
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary

- Surfaces the production `default-newsletter` React Email template on the newsletter detail response as `emailPreviewHtml` so the Hermes dashboard can show a sandboxed preview iframe.
- Declares the `htmlPreview` `detailBlock` on the `newsletters` manifest — the renderer from #460 handles the sandbox (`sandbox="allow-popups"`).

## Important changes

- New `render-email-preview.ts` helper:
  - Calls `renderNewsletterEmail({ variant: "default", … })` with a deterministic placeholder unsubscribe URL so the HTML stays byte-stable for the same `(newsletterId, configSnapshotId)`.
  - On render error, returns a safe escaped `<p>Email preview unavailable: …</p>` placeholder (the detail endpoint still responds 200) and logs a structured warning containing only the newsletter id and the error message.
- Domain-api tsconfig sets `jsx: "react-jsx"` so tsc can typecheck imports from `@workspace/email-templates` (same setting `agents/delivery` uses).

## Other changes

- `routes.ts` parallelizes the preview render alongside the recipients/sources/active-set/Hermes-links fetches via `Promise.all`.

## Testing instructions

```bash
pnpm --filter @mediapulse/domain-api test
pnpm --filter @mediapulse/domain-api lint
pnpm --filter @mediapulse/domain-api type:check
pnpm format:check
```

Four new tests cover: successful render, render-throws → placeholder body + warning, HTML escaping of error messages, and empty optional newsletter fields.

## Related issues

Refs #464
Stacked on #471 (#463). Base: `hermes-nl-vis-463-citations`.
