### PR TITLE
feat(domain-api): newsletter recipients, sources, queries subTable blocks

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-recipients.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-recipients.test.ts
@@ -6,6 +6,12 @@ import {
   type BuildRecipientsDeps,
 } from "./build-recipients";
 
+const enabled = (
+  id: string,
+  email: string | null = `${id}@example.com`,
+  name: string | null = null,
+) => ({ id, user: { email, name } });
+
 const makeDeps = (
   overrides: Partial<BuildRecipientsDeps>,
 ): BuildRecipientsDeps => ({
@@ -22,37 +28,38 @@ const makeDeps = (
 });
 
 describe("buildRecipients", () => {
-  it("returns delivered for users with a checkpoint", async () => {
+  it("returns delivered with success badge and the checkpoint deliveredAt", async () => {
+    const deliveredAt = new Date("2026-05-14T11:30:00.000Z");
     const deps = makeDeps({
       userTicker: {
-        findMany: vi.fn().mockResolvedValue([{ id: "ut-1" }]),
+        findMany: vi.fn().mockResolvedValue([enabled("ut-1")]),
       },
       newsletterDeliveryCheckpoint: {
-        findMany: vi.fn().mockResolvedValue([{ userTickerId: "ut-1" }]),
+        findMany: vi
+          .fn()
+          .mockResolvedValue([{ userTickerId: "ut-1", deliveredAt }]),
       },
     });
 
     const result = await buildRecipients("nl-1", "tk-1", deps);
 
-    expect(result.recipients).toStrictEqual([
-      {
-        userTickerId: "ut-1",
-        status: "delivered",
-        attempts: 0,
-        lastErrorCode: null,
-        errorCategory: null,
-        resendEmailId: null,
-        inconsistent: false,
-      },
-    ]);
-    expect(result.truncated).toBe(false);
-    expect(result.notAttemptedAtSendTime).toStrictEqual([]);
+    expect(result.recipients).toHaveLength(1);
+    expect(result.recipients[0]).toMatchObject({
+      userTickerId: "ut-1",
+      email: "ut-1@example.com",
+      displayName: "ut-1@example.com",
+      status: "delivered",
+      statusBadge: "success",
+      deliveredAt: deliveredAt.toISOString(),
+      inconsistent: false,
+    });
+    expect(result.deliveredCount).toBe(1);
   });
 
   it("flags inconsistent when latest outcome is success without a checkpoint", async () => {
     const deps = makeDeps({
       userTicker: {
-        findMany: vi.fn().mockResolvedValue([{ id: "ut-2" }]),
+        findMany: vi.fn().mockResolvedValue([enabled("ut-2")]),
       },
       deliveryRun: {
         findMany: vi.fn().mockResolvedValue([
@@ -65,6 +72,7 @@ describe("buildRecipients", () => {
                 status: "success",
                 attempts: 1,
                 lastErrorCode: null,
+                lastErrorMessage: null,
                 errorCategory: null,
                 resendEmailId: "rs-9",
               },
@@ -79,16 +87,17 @@ describe("buildRecipients", () => {
     expect(result.recipients[0]).toMatchObject({
       userTickerId: "ut-2",
       status: "delivered",
+      statusBadge: "success",
       inconsistent: true,
       resendEmailId: "rs-9",
     });
     expect(result.inconsistentUserTickerIds).toStrictEqual(["ut-2"]);
   });
 
-  it("returns failed and skipped from latest outcome when no checkpoint", async () => {
+  it("returns failed/skipped from latest outcome with matching badges", async () => {
     const deps = makeDeps({
       userTicker: {
-        findMany: vi.fn().mockResolvedValue([{ id: "ut-3" }, { id: "ut-4" }]),
+        findMany: vi.fn().mockResolvedValue([enabled("ut-3"), enabled("ut-4")]),
       },
       deliveryRun: {
         findMany: vi.fn().mockResolvedValue([
@@ -101,6 +110,7 @@ describe("buildRecipients", () => {
                 status: "failed",
                 attempts: 2,
                 lastErrorCode: "ERR_X",
+                lastErrorMessage: "rate limited",
                 errorCategory: "transient",
                 resendEmailId: null,
               },
@@ -109,6 +119,7 @@ describe("buildRecipients", () => {
                 status: "skipped",
                 attempts: 0,
                 lastErrorCode: null,
+                lastErrorMessage: null,
                 errorCategory: null,
                 resendEmailId: null,
               },
@@ -121,15 +132,22 @@ describe("buildRecipients", () => {
     const result = await buildRecipients("nl-1", "tk-1", deps);
 
     const byId = new Map(result.recipients.map((r) => [r.userTickerId, r]));
-    expect(byId.get("ut-3")?.status).toBe("failed");
-    expect(byId.get("ut-3")?.lastErrorCode).toBe("ERR_X");
-    expect(byId.get("ut-4")?.status).toBe("skipped");
+    expect(byId.get("ut-3")).toMatchObject({
+      status: "failed",
+      statusBadge: "destructive",
+      lastErrorCode: "ERR_X",
+      lastErrorMessage: "rate limited",
+    });
+    expect(byId.get("ut-4")).toMatchObject({
+      status: "skipped",
+      statusBadge: "muted",
+    });
   });
 
-  it("returns not_attempted for enabled subscribers missing from the run", async () => {
+  it("returns not_attempted with outline badge and null attempts", async () => {
     const deps = makeDeps({
       userTicker: {
-        findMany: vi.fn().mockResolvedValue([{ id: "ut-5" }]),
+        findMany: vi.fn().mockResolvedValue([enabled("ut-5")]),
       },
       deliveryRun: {
         findMany: vi.fn().mockResolvedValue([
@@ -147,17 +165,102 @@ describe("buildRecipients", () => {
     expect(result.recipients[0]).toMatchObject({
       userTickerId: "ut-5",
       status: "not_attempted",
-      attempts: 0,
+      statusBadge: "outline",
+      attempts: null,
+      deliveredAt: null,
     });
     expect(result.notAttemptedAtSendTime).toStrictEqual([
       { userTickerId: "ut-5", runId: "run-3" },
     ]);
+    expect(result.enabledAtSendTime).toBe(0);
+  });
+
+  it("builds displayName as `Name <email>` when name is present", async () => {
+    const deps = makeDeps({
+      userTicker: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([enabled("ut-x", "x@example.com", "Alice")]),
+      },
+      newsletterDeliveryCheckpoint: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            userTickerId: "ut-x",
+            deliveredAt: new Date("2026-05-14T12:00:00.000Z"),
+          },
+        ]),
+      },
+    });
+
+    const result = await buildRecipients("nl-1", "tk-1", deps);
+
+    expect(result.recipients[0]?.displayName).toBe("Alice <x@example.com>");
+  });
+
+  it("sorts recipients alphabetically by email", async () => {
+    const deps = makeDeps({
+      userTicker: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            enabled("ut-zed", "zed@example.com"),
+            enabled("ut-alice", "alice@example.com"),
+          ]),
+      },
+    });
+
+    const result = await buildRecipients("nl-1", "tk-1", deps);
+
+    expect(result.recipients.map((r) => r.email)).toStrictEqual([
+      "alice@example.com",
+      "zed@example.com",
+    ]);
+  });
+
+  it("computes enabledAtSendTime from the latest run recipient count", async () => {
+    const deps = makeDeps({
+      userTicker: {
+        findMany: vi.fn().mockResolvedValue([enabled("ut-a")]),
+      },
+      deliveryRun: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            id: "run-late",
+            createdAt: new Date("2026-05-14T10:00:00.000Z"),
+            recipients: [
+              {
+                userTickerId: "ut-a",
+                status: "success",
+                attempts: 1,
+                lastErrorCode: null,
+                lastErrorMessage: null,
+                errorCategory: null,
+                resendEmailId: "rs-1",
+              },
+              {
+                userTickerId: "ut-extinct",
+                status: "skipped",
+                attempts: 0,
+                lastErrorCode: null,
+                lastErrorMessage: null,
+                errorCategory: null,
+                resendEmailId: null,
+              },
+            ],
+          },
+        ]),
+      },
+    });
+
+    const result = await buildRecipients("nl-1", "tk-1", deps);
+
+    expect(result.enabledAtSendTime).toBe(2);
   });
 
   it("only keeps the latest run outcome per user across runs", async () => {
     const deps = makeDeps({
       userTicker: {
-        findMany: vi.fn().mockResolvedValue([{ id: "ut-6" }]),
+        findMany: vi.fn().mockResolvedValue([enabled("ut-6")]),
       },
       deliveryRun: {
         findMany: vi.fn().mockResolvedValue([
@@ -170,6 +273,7 @@ describe("buildRecipients", () => {
                 status: "failed",
                 attempts: 3,
                 lastErrorCode: "LATE",
+                lastErrorMessage: "boom",
                 errorCategory: null,
                 resendEmailId: null,
               },
@@ -184,6 +288,7 @@ describe("buildRecipients", () => {
                 status: "skipped",
                 attempts: 0,
                 lastErrorCode: null,
+                lastErrorMessage: null,
                 errorCategory: null,
                 resendEmailId: null,
               },
@@ -199,11 +304,11 @@ describe("buildRecipients", () => {
     expect(result.recipients[0]?.lastErrorCode).toBe("LATE");
   });
 
-  it("truncates results to the configured cap and sets truncated=true", async () => {
+  it("truncates results to the configured cap and sets totalCount before capping", async () => {
     const total = NEWSLETTER_DETAIL_RECIPIENTS_CAP + 5;
-    const enabledRows = Array.from({ length: total }, (_, idx) => ({
-      id: `ut-${idx}`,
-    }));
+    const enabledRows = Array.from({ length: total }, (_, idx) =>
+      enabled(`ut-${String(idx).padStart(5, "0")}`),
+    );
     const deps = makeDeps({
       userTicker: {
         findMany: vi.fn().mockResolvedValue(enabledRows),
@@ -214,5 +319,6 @@ describe("buildRecipients", () => {
 
     expect(result.truncated).toBe(true);
     expect(result.recipients).toHaveLength(NEWSLETTER_DETAIL_RECIPIENTS_CAP);
+    expect(result.totalCount).toBe(total);
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-recipients.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-recipients.ts
@@ -12,11 +12,17 @@ export const NEWSLETTER_DETAIL_RECIPIENTS_CAP = 2000;
 /** Shape of one recipient entry in the detail payload. */
 export type RecipientPayload = {
   userTickerId: string;
+  email: string | null;
+  name: string | null;
+  displayName: string;
   status: "delivered" | "failed" | "skipped" | "not_attempted";
-  attempts: number;
+  statusBadge: "success" | "destructive" | "muted" | "outline";
+  attempts: number | null;
   lastErrorCode: string | null;
+  lastErrorMessage: string | null;
   errorCategory: string | null;
   resendEmailId: string | null;
+  deliveredAt: string | null;
   inconsistent: boolean;
 };
 
@@ -24,6 +30,9 @@ export type RecipientPayload = {
 export type BuildRecipientsResult = {
   recipients: RecipientPayload[];
   truncated: boolean;
+  totalCount: number;
+  deliveredCount: number;
+  enabledAtSendTime: number;
   inconsistentUserTickerIds: string[];
   notAttemptedAtSendTime: Array<{ userTickerId: string; runId: string | null }>;
 };
@@ -37,6 +46,16 @@ export type BuildRecipientsDeps = {
   >;
   deliveryRun: Pick<typeof prisma.deliveryRun, "findMany">;
 };
+
+const STATUS_TO_BADGE = {
+  delivered: "success",
+  failed: "destructive",
+  skipped: "muted",
+  not_attempted: "outline",
+} as const satisfies Record<
+  RecipientPayload["status"],
+  RecipientPayload["statusBadge"]
+>;
 
 /**
  * Builds the recipients section of the newsletter detail payload by combining
@@ -64,12 +83,15 @@ export const buildRecipients = async (
 ): Promise<BuildRecipientsResult> => {
   const enabledArgs = {
     where: { tickerId, enabled: true },
-    select: { id: true },
+    select: {
+      id: true,
+      user: { select: { email: true, name: true } },
+    },
   } satisfies Prisma.UserTickerFindManyArgs;
 
   const checkpointArgs = {
     where: { newsletterId },
-    select: { userTickerId: true },
+    select: { userTickerId: true, deliveredAt: true },
   } satisfies Prisma.NewsletterDeliveryCheckpointFindManyArgs;
 
   const deliveryRunsArgs = {
@@ -83,6 +105,7 @@ export const buildRecipients = async (
           status: true,
           attempts: true,
           lastErrorCode: true,
+          lastErrorMessage: true,
           errorCategory: true,
           resendEmailId: true,
         },
@@ -97,13 +120,18 @@ export const buildRecipients = async (
     deps.deliveryRun.findMany(deliveryRunsArgs),
   ]);
 
-  const checkpointSet = new Set(checkpointRows.map((row) => row.userTickerId));
+  const checkpointDeliveredAtById = new Map<string, Date>();
+  for (const row of checkpointRows) {
+    checkpointDeliveredAtById.set(row.userTickerId, row.deliveredAt);
+  }
+  const checkpointSet = new Set(checkpointDeliveredAtById.keys());
 
   type OutcomeRow = {
     userTickerId: string;
     status: "success" | "failed" | "skipped";
     attempts: number;
     lastErrorCode: string | null;
+    lastErrorMessage: string | null;
     errorCategory: string | null;
     resendEmailId: string | null;
     runId: string;
@@ -121,7 +149,15 @@ export const buildRecipients = async (
     }
   }
 
-  const enabledIds = new Set(enabledRows.map((row) => row.id));
+  type EnabledUser = { email: string | null; name: string | null };
+  const enabledUserById = new Map<string, EnabledUser>();
+  for (const row of enabledRows) {
+    enabledUserById.set(row.id, {
+      email: row.user?.email ?? null,
+      name: row.user?.name ?? null,
+    });
+  }
+  const enabledIds = new Set(enabledUserById.keys());
   const observedIds = new Set<string>([
     ...checkpointSet,
     ...latestOutcomeByUserTicker.keys(),
@@ -144,14 +180,28 @@ export const buildRecipients = async (
       hasCheckpoint: checkpointSet.has(userTickerId),
       latestOutcomeStatus: outcome?.status ?? null,
     });
+    const user = enabledUserById.get(userTickerId) ?? null;
+    const deliveredAt = checkpointDeliveredAtById.get(userTickerId) ?? null;
+    const displayName =
+      user?.name && user.name.trim().length > 0
+        ? user.email
+          ? `${user.name} <${user.email}>`
+          : user.name
+        : (user?.email ?? userTickerId);
 
     recipients.push({
       userTickerId,
+      email: user?.email ?? null,
+      name: user?.name ?? null,
+      displayName,
       status,
-      attempts: outcome?.attempts ?? 0,
+      statusBadge: STATUS_TO_BADGE[status],
+      attempts: status === "not_attempted" ? null : (outcome?.attempts ?? 0),
       lastErrorCode: outcome?.lastErrorCode ?? null,
+      lastErrorMessage: outcome?.lastErrorMessage ?? null,
       errorCategory: outcome?.errorCategory ?? null,
       resendEmailId: outcome?.resendEmailId ?? null,
+      deliveredAt: deliveredAt ? deliveredAt.toISOString() : null,
       inconsistent,
     });
 
@@ -167,14 +217,33 @@ export const buildRecipients = async (
     }
   }
 
-  const truncated = recipients.length > NEWSLETTER_DETAIL_RECIPIENTS_CAP;
+  recipients.sort((left, right) => {
+    const leftKey = (left.email ?? left.displayName ?? "").toLowerCase();
+    const rightKey = (right.email ?? right.displayName ?? "").toLowerCase();
+    return leftKey.localeCompare(rightKey);
+  });
+
+  const totalCount = recipients.length;
+  const truncated = totalCount > NEWSLETTER_DETAIL_RECIPIENTS_CAP;
   const capped = truncated
     ? recipients.slice(0, NEWSLETTER_DETAIL_RECIPIENTS_CAP)
     : recipients;
 
+  const deliveredCount = recipients.filter(
+    (r) => r.status === "delivered",
+  ).length;
+  const enabledAtSendTime =
+    deliveryRuns[0] &&
+    (deliveryRuns[0] as { recipients?: unknown[] }).recipients
+      ? (deliveryRuns[0] as { recipients: unknown[] }).recipients.length
+      : enabledIds.size;
+
   return {
     recipients: capped,
     truncated,
+    totalCount,
+    deliveredCount,
+    enabledAtSendTime,
     inconsistentUserTickerIds,
     notAttemptedAtSendTime,
   };

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -91,6 +91,108 @@ const newslettersCitationsBlock = {
 } satisfies DetailBlock;
 
 /**
+ * `subTable` block bound to `recipients` (PRD §5). Each row carries
+ * `displayName` (`Name <email>` or email), the four-state status badge with
+ * its `inconsistent` marker, the Resend email id, attempts, error category,
+ * a truncated last-error message, and the checkpoint deliveredAt timestamp.
+ * The caption template reuses the numerator/denominator from the list cell
+ * via the response fields seeded by `buildRecipients`.
+ */
+const newslettersRecipientsBlock = {
+  type: "subTable",
+  label: "Recipients",
+  field: "recipients",
+  captionTemplate:
+    "Recipients (delivered {recipientsDeliveredCount} / enabled at send time {recipientsEnabledAtSendTime})",
+  emptyState: "No enabled subscribers for this ticker.",
+  columns: [
+    { field: "displayName", label: "Subscriber", type: "text" },
+    {
+      field: "status",
+      label: "Status",
+      type: "badge",
+      badgeVariants: {
+        delivered: "success",
+        failed: "destructive",
+        skipped: "muted",
+        not_attempted: "outline",
+      },
+      inconsistentField: "inconsistent",
+    },
+    {
+      field: "resendEmailId",
+      label: "Resend id",
+      type: "text",
+      truncate: 16,
+      copyAction: true,
+    },
+    { field: "attempts", label: "Attempts", type: "number" },
+    { field: "errorCategory", label: "Error category", type: "text" },
+    {
+      field: "lastErrorMessage",
+      label: "Last error",
+      type: "text",
+      truncate: 80,
+    },
+    { field: "deliveredAt", label: "Delivered at", type: "date-time" },
+  ],
+} satisfies DetailBlock;
+
+/**
+ * `subTable` block bound to `selectedSources` (PRD §5). The Title column
+ * links to the data-sources detail page so reviewers can jump straight to
+ * the source row. Window boundaries appear in the section caption.
+ */
+const newslettersSelectedSourcesBlock = {
+  type: "subTable",
+  label: "Selected sources",
+  field: "selectedSources",
+  captionTemplate:
+    "Sources selected in window {selectedSourcesWindow.start} → {selectedSourcesWindow.end}",
+  emptyState:
+    "No selected sources match the calendar-day window for this newsletter.",
+  columns: [
+    {
+      field: "title",
+      label: "Title",
+      type: "text",
+      truncate: 80,
+      linkTemplate: "/dashboard/{integrationId}/data-sources/{id}",
+    },
+    { field: "domain", label: "Domain", type: "text" },
+    { field: "score", label: "Score", type: "number" },
+    { field: "scoredAt", label: "Scored at", type: "date-time" },
+  ],
+} satisfies DetailBlock;
+
+/**
+ * `subTable` block bound to `activeQuerySet.queries` (PRD §5). Each row links
+ * to the search-queries page filtered by this newsletter's ticker. The caption
+ * shows the active set's generation date and source.
+ */
+const newslettersSearchQueriesBlock = {
+  type: "subTable",
+  label: "Search queries",
+  field: "activeQuerySet.queries",
+  captionTemplate:
+    "Active set generated {activeQuerySet.generatedAt} (source: {activeQuerySet.generationSource})",
+  emptyState: "No active SearchQuerySet on this newsletter's generation date.",
+  columns: [
+    {
+      field: "text",
+      label: "Query",
+      type: "text",
+      truncate: 80,
+      linkTemplate:
+        "/dashboard/{integrationId}/search-queries?tickerId={tickerId}",
+    },
+    { field: "intent", label: "Intent", type: "text" },
+    { field: "source", label: "Source", type: "text" },
+    { field: "rank", label: "Rank", type: "number" },
+  ],
+} satisfies DetailBlock;
+
+/**
  * `htmlPreview` block bound to `emailPreviewHtml` — the production
  * `default-newsletter` React Email template rendered server-side against the
  * newsletter's data. The Hermes generic renderer drops this into a sandboxed
@@ -176,6 +278,9 @@ export const newslettersDashboardPage = {
   detailBlocks: [
     newslettersMetadataBlock,
     newslettersBodyBlock,
+    newslettersRecipientsBlock,
+    newslettersSelectedSourcesBlock,
+    newslettersSearchQueriesBlock,
     newslettersCitationsBlock,
     newslettersEmailPreviewBlock,
     newslettersHermesLinksBlock,

--- a/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/detail-mapper.ts
@@ -44,6 +44,9 @@ export type DetailItem = {
   recipients: RecipientPayload[];
   recipientsTruncated: boolean;
   recipientsCap: number;
+  recipientsTotalCount: number;
+  recipientsDeliveredCount: number;
+  recipientsEnabledAtSendTime: number;
   selectedSources: SelectedSourcePayload[];
   selectedSourcesWindow: { start: string; end: string };
   activeQuerySet: ActiveQuerySetPayload;
@@ -64,6 +67,9 @@ export const mapRowToDetailItem = (
     recipients: RecipientPayload[];
     recipientsTruncated: boolean;
     recipientsCap: number;
+    recipientsTotalCount: number;
+    recipientsDeliveredCount: number;
+    recipientsEnabledAtSendTime: number;
     selectedSources: SelectedSourcePayload[];
     selectedSourcesWindow: { start: string; end: string };
     activeQuerySet: ActiveQuerySetPayload;
@@ -93,6 +99,9 @@ export const mapRowToDetailItem = (
   recipients: parts.recipients,
   recipientsTruncated: parts.recipientsTruncated,
   recipientsCap: parts.recipientsCap,
+  recipientsTotalCount: parts.recipientsTotalCount,
+  recipientsDeliveredCount: parts.recipientsDeliveredCount,
+  recipientsEnabledAtSendTime: parts.recipientsEnabledAtSendTime,
   selectedSources: parts.selectedSources,
   selectedSourcesWindow: parts.selectedSourcesWindow,
   activeQuerySet: parts.activeQuerySet,

--- a/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/routes.ts
@@ -209,6 +209,9 @@ newslettersRoutes.get("/:id", async (c) => {
       recipients: recipientsResult.recipients,
       recipientsTruncated: recipientsResult.truncated,
       recipientsCap: NEWSLETTER_DETAIL_RECIPIENTS_CAP,
+      recipientsTotalCount: recipientsResult.totalCount,
+      recipientsDeliveredCount: recipientsResult.deliveredCount,
+      recipientsEnabledAtSendTime: recipientsResult.enabledAtSendTime,
       selectedSources: selectedSourcesResult.sources,
       selectedSourcesWindow: {
         start: selectedSourcesResult.windowStart,


### PR DESCRIPTION
## Summary

- Adds three `subTable` `detailBlocks` to the `newsletters` manifest — `recipients`, `selectedSources`, and `activeQuerySet.queries` — rendered by the Hermes generic `subTable` renderer from #460.
- Enriches `buildRecipients` so the recipients sub-table can show `Name <email>`, the four-state status badge with its `inconsistent` marker, the truncated Resend id with a copy affordance, attempts, error category, the truncated last-error message, and the checkpoint `deliveredAt`.

## Important changes

- `build-recipients.ts`:
  - Joins `UserTicker.user` (email + name) and `NewsletterDeliveryCheckpoint.deliveredAt`.
  - Adds `displayName` (`Name <email>` or email), `statusBadge` (`success`/`destructive`/`muted`/`outline`), and `lastErrorMessage`.
  - Returns `totalCount`, `deliveredCount`, and `enabledAtSendTime` (computed from the latest run's recipient list, matching #461's list cell rule). Sorts recipients alphabetically by email.
- `detail-mapper.ts` + `routes.ts` propagate the three aggregates so the manifest caption template (`Recipients (delivered N / enabled at send time M)`) resolves them off the response.
- Recipients sub-table uses `type: "badge"` with `badgeVariants` and `inconsistentField: "inconsistent"` (the `!` adornment ships from #460).
- Selected sources sub-table links Title to `/dashboard/{integrationId}/data-sources/{id}` and captions `Sources selected in window … → …` (window comes from the detail response).
- Search queries sub-table reads `activeQuerySet.queries`, links each row to `/dashboard/{integrationId}/search-queries?tickerId={tickerId}`, and captions with the active set's `generatedAt` + `generationSource`.

## Other changes

- `build-recipients.test.ts` rewritten to cover the enriched output: displayName composition, badge mapping, alphabetical sort, `enabledAtSendTime` from the latest run, and the cap with `totalCount`.

## Testing instructions

```bash
pnpm --filter @mediapulse/domain-api test
pnpm --filter @mediapulse/domain-api lint
pnpm --filter @mediapulse/domain-api type:check
pnpm format:check
```

9 recipient tests (3 added) plus the existing 42 newsletter tests all pass.

## Related issues

Refs #465
Stacked on #472 (#464). Base: `hermes-nl-vis-464-email-preview`.
