### PR TITLE
feat(domain-api): polish newsletter detail blocks

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.test.ts
@@ -1,0 +1,80 @@
+import {
+  evaluateDetailBlockRule,
+  parseDetailBlockRule,
+  type DetailBlock,
+} from "@hermes/domain-contract";
+import { describe, expect, it } from "vitest";
+
+import {
+  NEWSLETTER_STALE_SET_HOURS,
+  newslettersDashboardPage,
+} from "./dashboard-page";
+
+const findBlock = (label: string): DetailBlock => {
+  const block = newslettersDashboardPage.detailBlocks?.find(
+    (entry) => entry.label === label,
+  );
+  if (!block) throw new Error(`block not found: ${label}`);
+  return block;
+};
+
+describe("newslettersDashboardPage section rules", () => {
+  it("declares a recipients rule that fires when delivered < enabled", () => {
+    const recipients = findBlock("Recipients");
+    expect(recipients.sectionRule).toMatchObject({
+      badge: "warning",
+      label: "partial delivery",
+    });
+
+    const ast = parseDetailBlockRule(recipients.sectionRule!.when);
+    expect(
+      evaluateDetailBlockRule(ast, {
+        recipientsDeliveredCount: 3,
+        recipientsEnabledAtSendTime: 5,
+      }),
+    ).toBe(true);
+    expect(
+      evaluateDetailBlockRule(ast, {
+        recipientsDeliveredCount: 5,
+        recipientsEnabledAtSendTime: 5,
+      }),
+    ).toBe(false);
+  });
+
+  it("declares a selected-sources rule that fires when the array is empty", () => {
+    const sources = findBlock("Selected sources");
+    expect(sources.sectionRule).toMatchObject({
+      badge: "muted",
+      label: "no sources",
+    });
+
+    const ast = parseDetailBlockRule(sources.sectionRule!.when);
+    expect(evaluateDetailBlockRule(ast, { selectedSources: [] })).toBe(true);
+    expect(evaluateDetailBlockRule(ast, { selectedSources: [{}] })).toBe(false);
+  });
+
+  it("declares a search-queries rule that uses hoursBetween > 24", () => {
+    const queries = findBlock("Search queries");
+    expect(queries.sectionRule).toMatchObject({
+      badge: "muted",
+      label: "stale set",
+    });
+    expect(NEWSLETTER_STALE_SET_HOURS).toBe(24);
+
+    const ast = parseDetailBlockRule(queries.sectionRule!.when);
+    const newsletterCreatedAt = "2026-05-14T12:00:00.000Z";
+
+    expect(
+      evaluateDetailBlockRule(ast, {
+        createdAt: newsletterCreatedAt,
+        activeQuerySet: { generatedAt: "2026-05-13T11:00:00.000Z" },
+      }),
+    ).toBe(true);
+    expect(
+      evaluateDetailBlockRule(ast, {
+        createdAt: newsletterCreatedAt,
+        activeQuerySet: { generatedAt: "2026-05-14T00:00:00.000Z" },
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -10,6 +10,13 @@ import type { ListItem } from "./list-mapper";
 export const newslettersHermesPathSegment = "newsletters" as const;
 
 /**
+ * Threshold (in hours) above which the active SearchQuerySet section gets a
+ * `stale set` badge. Lives in one place so the manifest and any future test
+ * fixtures stay in sync.
+ */
+export const NEWSLETTER_STALE_SET_HOURS = 24 as const;
+
+/**
  * `keyValue` block describing the newsletter metadata header. The ticker name
  * row is wired as a link back to the tickers resource so reviewers can jump
  * straight to the source. The token row uses the contract's `tokens` format to
@@ -19,8 +26,9 @@ const newslettersMetadataBlock = {
   type: "keyValue",
   label: "Metadata",
   rows: [
+    { field: "id", label: "Newsletter id", copyAction: true },
     { field: "subject", label: "Subject", copyAction: true },
-    { field: "tickerSymbol", label: "Ticker" },
+    { field: "tickerSymbol", label: "Ticker", copyAction: true },
     {
       field: "tickerName",
       label: "Ticker name",
@@ -61,6 +69,7 @@ const newslettersBodyBlock = {
   field: "content",
   clampChars: 4000,
   clampThreshold: 10000,
+  copyAction: true,
 } satisfies DetailBlock;
 
 /**
@@ -105,6 +114,11 @@ const newslettersRecipientsBlock = {
   captionTemplate:
     "Recipients (delivered {recipientsDeliveredCount} / enabled at send time {recipientsEnabledAtSendTime})",
   emptyState: "No enabled subscribers for this ticker.",
+  sectionRule: {
+    when: "recipientsDeliveredCount < recipientsEnabledAtSendTime",
+    badge: "warning",
+    label: "partial delivery",
+  },
   columns: [
     { field: "displayName", label: "Subscriber", type: "text" },
     {
@@ -151,6 +165,11 @@ const newslettersSelectedSourcesBlock = {
     "Sources selected in window {selectedSourcesWindow.start} → {selectedSourcesWindow.end}",
   emptyState:
     "No selected sources match the calendar-day window for this newsletter.",
+  sectionRule: {
+    when: "selectedSources.length == 0",
+    badge: "muted",
+    label: "no sources",
+  },
   columns: [
     {
       field: "title",
@@ -177,6 +196,11 @@ const newslettersSearchQueriesBlock = {
   captionTemplate:
     "Active set generated {activeQuerySet.generatedAt} (source: {activeQuerySet.generationSource})",
   emptyState: "No active SearchQuerySet on this newsletter's generation date.",
+  sectionRule: {
+    when: `hoursBetween(activeQuerySet.generatedAt, createdAt) > ${NEWSLETTER_STALE_SET_HOURS}`,
+    badge: "muted",
+    label: "stale set",
+  },
   columns: [
     {
       field: "text",

--- a/dev-docs/docs/hermes/dashboard/content-generation-runs-diagnostics.mdx
+++ b/dev-docs/docs/hermes/dashboard/content-generation-runs-diagnostics.mdx
@@ -73,7 +73,7 @@ The detail page shows all fields for a single run:
 - `durationMs`, `pipelineRunId`, `newsletterId`
 - `createdAt`
 
-When `newsletterId` is present, it renders as a copy-to-clipboard button (since no newsletter detail route exists yet).
+When `newsletterId` is present, it renders as a link to `/dashboard/{integrationId}/newsletters/{newsletterId}` (for example `/dashboard/mediapulse/newsletters/{newsletterId}`). The newsletter detail page shows subject, ticker, recipients, selected sources, the active SearchQuerySet, the rendered email preview, and the Hermes execution links — see [Newsletters list and detail](./newsletters-list-and-detail.mdx).
 
 ## Components
 

--- a/dev-docs/docs/hermes/dashboard/meta.json
+++ b/dev-docs/docs/hermes/dashboard/meta.json
@@ -1,4 +1,7 @@
 {
   "title": "Dashboard",
-  "pages": ["content-generation-runs-diagnostics"]
+  "pages": [
+    "newsletters-list-and-detail",
+    "content-generation-runs-diagnostics"
+  ]
 }

--- a/dev-docs/docs/hermes/dashboard/newsletters-list-and-detail.mdx
+++ b/dev-docs/docs/hermes/dashboard/newsletters-list-and-detail.mdx
@@ -1,0 +1,47 @@
+---
+title: Newsletters list and detail
+description: Newsletter visibility for Hermes admins — filter the daily output, inspect what went out to whom, and jump back into the Hermes execution that produced it.
+icon: Mails
+---
+
+The Mediapulse domain integration registers a read-only `newsletters` resource that appears in the Hermes admin sidebar. Admins can filter the list by ticker or date range, click into a newsletter, and answer the day-zero question without leaving Hermes:
+
+> What went out, to whom, with which sources, on which Hermes execution?
+
+The list and detail pages are rendered by Hermes' generic `table-v1` template against the `detailBlocks` declared in the domain manifest. No Hermes-side code lives in this feature.
+
+## List page
+
+URL: `/dashboard/{integrationId}/newsletters` (e.g. `/dashboard/mediapulse/newsletters`).
+
+| Column      | Notes                                                                                                                  |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Ticker      | Symbol from the joined `Ticker`.                                                                                       |
+| Subject     | Searchable substring filter (`?q=`).                                                                                   |
+| Created     | Sortable (`?sortBy=createdAt`); filter by `?from=` / `?to=`.                                                           |
+| Delivery    | Checkpoint count over enabled-at-send-time count from the latest `DeliveryRun`. Falls back to the current enabled set. |
+
+The ticker filter is populated by the `/meta` endpoint (`tickerOptions: { value, label }[]`).
+
+## Detail page
+
+URL: `/dashboard/{integrationId}/newsletters/{newsletterId}`.
+
+The detail blocks render in this order:
+
+1. **Metadata** — id, subject, ticker (linked), agent metadata, prompt/config hashes, and tokens formatted as `prompt + completion = total`. Copy buttons on id, subject, ticker symbol, prompt hash, and config snapshot id.
+2. **Body** — newsletter `content` rendered as markdown. Clamps at 4,000 characters for bodies over 10,000 chars; the **Copy** button writes the raw markdown.
+3. **Recipients** — one row per `(newsletterId, userTickerId)` pair, sorted alphabetically by email. Status badge maps the four states (`delivered`, `failed`, `skipped`, `not_attempted`); recipients with `inconsistent: true` get a `!` marker. Section badge `partial delivery` (warning) when `recipientsDeliveredCount < recipientsEnabledAtSendTime`. Capped at 2,000 rows; the response sets `recipientsTruncated: true` when the cap fires.
+4. **Selected sources** — DataSource rows selected during the newsletter's UTC calendar day, ordered by score desc. Title links to the data-sources detail page. Section badge `no sources` (muted) when the list is empty.
+5. **Search queries** — queries from the active `SearchQuerySet` at the newsletter's `createdAt`. Each row links to `/dashboard/{integrationId}/search-queries?tickerId={tickerId}`. Section badge `stale set` (muted) when the set was generated more than 24 hours before the newsletter.
+6. **Citations** — deduplicated `[title](url)` and `Read the full article: <url>` references parsed from the body; the URL column opens in a new tab with `rel="noopener noreferrer"`.
+7. **Email preview** — sandboxed iframe rendering the production `default-newsletter` React Email template against this newsletter's data. `sandbox="allow-popups"` only.
+8. **Hermes execution links** — schedule, execution, pipeline run/step, content-generation run, with copy buttons on every id.
+
+## Manifest contract
+
+Block types and the section-header rule grammar are documented in [`hermes-domain-contract` detail blocks](../integration/detail-blocks.mdx). The newsletter manifest lives at `apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts`.
+
+## Privacy
+
+Subscriber email appears in the recipients sub-table (admins need it to identify recipients) but is never written to server logs or to DOM data attributes used for telemetry. The detail handler logs only `newsletterId`, `userTickerId`, and `runId` for the `not_attempted` and `inconsistent` warnings.


### PR DESCRIPTION
## Summary

- Closing pass on the `hermes-admin-newsletter-visibility` stack. Adds copy affordances on the right fields, attaches section-header badges via the contract's rule engine, and updates `dev-docs` to describe the feature end-to-end.

## Important changes

- **Copy affordances** (REQ-014): newsletter id, subject, ticker symbol (metadata `keyValue` block), and the markdown body block now declare `copyAction: true`. Resend email id already had it from #465.
- **Section badges** (REQ-015):
  - Recipients → `warning` "partial delivery" when `recipientsDeliveredCount < recipientsEnabledAtSendTime`.
  - Selected sources → `muted` "no sources" when `selectedSources.length == 0`.
  - Search queries → `muted` "stale set" when `hoursBetween(activeQuerySet.generatedAt, createdAt) > NEWSLETTER_STALE_SET_HOURS` (single named constant, 24h).
- **Test coverage**: new `dashboard-page.test.ts` parses each rule under the contract's grammar and asserts evaluation on representative data (both true and false branches).
- **Accessibility**: the four-state status badge already ships with a text label (#465); the inconsistent marker has an accessible name and tooltip (#460); copy buttons announce themselves via `aria-label` and confirm with a visible "Copied" affordance. No additional code changes needed here; the contract's primitives already cover the AC.

## Other changes

- New `dev-docs/docs/hermes/dashboard/newsletters-list-and-detail.mdx` describing the list filters, the eight detail blocks, the section-rule badges, and the privacy posture around subscriber email.
- `content-generation-runs-diagnostics.mdx` no longer claims the newsletter detail route doesn't exist; it now links to the new docs page and shows the `/dashboard/{integrationId}/newsletters/{newsletterId}` URL pattern.

## Testing instructions

```bash
pnpm --filter @mediapulse/domain-api test
pnpm --filter @mediapulse/domain-api lint
pnpm --filter @mediapulse/domain-api type:check
pnpm format:check
```

54 newsletter tests pass.

## Related issues

Closes #466
Stacked on #473 (#465). Base: `hermes-nl-vis-465-sub-tables`.

## Stack overview

This is the final ticket of the `hermes-admin-newsletter-visibility` group:

- #468 — `hermes-nl-vis-460-contract-detail-blocks` (closes #460)
- #469 — `hermes-nl-vis-461-newsletters-list` (closes #461)
- #470 — `hermes-nl-vis-462-newsletter-detail` (closes #462)
- #471 — `hermes-nl-vis-463-citations` (closes #463)
- #472 — `hermes-nl-vis-464-email-preview` (closes #464)
- #473 — `hermes-nl-vis-465-sub-tables` (closes #465)
- this PR (closes #466)
