### PR TITLE
Document Git Town lineage-cache hygiene for non-TTY shells

### DIFF
--- a/.cursor/skills/git-town-stacked-changes/SKILL.md
+++ b/.cursor/skills/git-town-stacked-changes/SKILL.md
@@ -160,6 +160,45 @@ Notes:
 - The cherry-picks should be clean if the feature commits do not actually touch the same lines as the rebased / squashed bottom PR. If they do, resolve the conflict once; that is a real content conflict, not the SHA-rewrite artifact.
 - If Git Town’s parent-branch metadata still points at a deleted local branch, run `git town sync --stack` once **after** the recovery to let Git Town reparent and prune.
 
+### Lineage hygiene after a parent PR merges
+
+When GitHub merges a stacked PR it usually **deletes the remote branch**. Locally you still have the branch and Git Town still has a `git-town-branch.<name>.parent` config entry that points at it. If you skip the cleanup below, the next `git town sync --stack` will either:
+
+- Prompt you interactively to choose a new parent for the orphaned child branch — which **fails in non-TTY shells** (CI runners, agent shells, automation) with `Error: no interactive terminal available`, even when `TERM` is set.
+- Rebase the child onto a stale parent (the now-merged ancestor branch), producing duplicate-patch noise and confusing fork-points on the next sync.
+
+Run these three steps after every parent PR merges, before the next sync:
+
+```bash
+# 1. Update local refs and prune deleted remote branches.
+git fetch --prune origin
+
+# 2. Delete the local branch whose PR just merged.
+git branch -D <merged-branch>
+
+# 3. Drop Git Town's stale parent-metadata for that deleted branch
+#    and reparent the immediate child onto its new actual parent
+#    (usually `main`, or the next branch down the stack).
+git config --remove-section git-town-branch.<merged-branch>
+git config git-town-branch.<immediate-child>.parent main
+```
+
+After this, either `git town sync --stack` or — in non-TTY shells — the explicit rebase cascade below will work cleanly. The patch-id detection built into `git rebase` drops the already-merged commit automatically, exactly like rebase-mode sync would.
+
+```bash
+# On the now-orphaned child:
+git rebase origin/main
+git push --force-with-lease --force-if-includes
+
+# Then walk up the stack, rebasing each branch onto the freshly fixed one below it:
+git checkout <next-child>
+git rebase <previous-fixed-branch>
+git push --force-with-lease --force-if-includes
+# ...repeat for each layer.
+```
+
+Skipping step 3 is the most common cause of `git town sync` failing in CI or an agent shell after a stacked PR merges. The actual git state is fine; only Git Town's lineage cache is stale.
+
 ### Quick decision tree
 
 | Situation                                                                                  | Action                                                                                                                                    |
@@ -189,6 +228,7 @@ When moving from tickets to code:
 6. Keep commits scoped; before pushing each layer, run the **verifier** subagent (`.cursor/agents/verifier.md`) or the **Contract** checks in that file (**`pnpm format:check`** mandatory; **`pnpm code-quality`** when feasible).
 7. Open PRs from **leaf to root** is wrong — **ship/merge from root of stack toward tip** (oldest / closest to `main` first).
 8. Check the repo for `.git-town.toml` with `feature-strategy = "rebase"`. If present (this repo has it), `git town sync --stack` is safe at any point and is the right move after each parent PR merges. If the repo is still on default **merge-mode** sync **and** uses GitHub's Rebase- or Squash-and-merge, propose adding `.git-town.toml` before continuing — see [Rebase- or squash-merge rewrites SHAs and breaks merge-based stack sync](#rebase--or-squash-merge-rewrites-shas-and-breaks-merge-based-stack-sync). Use the fallback recovery only when changing repo config isn't an option.
+9. **After every parent PR merge, prune Git Town's lineage cache** for the merged branch and reparent its immediate child before syncing — see [Lineage hygiene after a parent PR merges](#lineage-hygiene-after-a-parent-pr-merges). Otherwise `git town sync --stack` will prompt for a new parent and fail in non-TTY shells (CI, agent runs).
 
 ## Feature flags when the stack splits UI and backend (or any unsafe partial ship)
 


### PR DESCRIPTION
## Summary

Adds a "Lineage hygiene after a parent PR merges" subsection to the `git-town-stacked-changes` skill. Documents the cleanup steps required after GitHub deletes a merged stacked-PR branch, and a non-TTY rebase-cascade fallback for environments where `git town sync` can't prompt interactively.

## Why

After a stacked PR merges on GitHub, the merged branch's `git-town-branch.<name>.parent` config entry still points at the now-deleted local branch. The next `git town sync --stack` then asks the user to pick a new parent for the orphaned child. That prompt fails in CI runners and agent shells with `Error: no interactive terminal available`, even when `TERM` is set to a real value. The actual git state is fine; only Git Town's lineage cache is stale.

This caveat surfaced while shipping the `hermes-nl-vis-460..466` stack: after each parent PR merged, `git town sync --stack` failed from the agent shell until the merged branch's config section was removed and the immediate child was reparented to `main`. Following the new procedure made every subsequent merge a clean rebase cascade.

## Important changes

- Added subsection **"Lineage hygiene after a parent PR merges"** under the existing rebase/squash failure-mode section. Covers:
  - Why the next sync prompts interactively and fails in non-TTY shells.
  - The three-step cleanup: `git fetch --prune origin`, `git branch -D <merged-branch>`, `git config --remove-section git-town-branch.<merged-branch>` plus reparenting the immediate child.
  - A rebase-cascade fallback that uses `git rebase`'s built-in patch-id detection (no Git Town required), suitable for CI and agent shells.
- Extended **Agent checklist item 9** to require pruning the lineage cache before the next sync, with a link to the new subsection.

## Other changes

None. Skill file only.

## Testing instructions

- Open `.cursor/skills/git-town-stacked-changes/SKILL.md` and verify the new "Lineage hygiene after a parent PR merges" subsection renders correctly and links resolve from the agent checklist.
- `pnpm format:check` should pass (verified locally).

## Related issues

Follow-up to #475 (rebase-/squash-merge SHA rewrite section). No new issue.
