### PR TITLE
Add Hyperjump credit on registration and UI verification skill

### DIFF
--- a/.cursor/rules/ui-ticket-visual-verification.mdc
+++ b/.cursor/rules/ui-ticket-visual-verification.mdc
@@ -1,0 +1,19 @@
+---
+description: >-
+  When changing user-facing UI in apps, require isolated fixtures, mocks, reproducible dev
+  commands, and screenshot or video evidence per the ui-ticket-visual-verification skill—especially
+  for ticket or issue-driven work.
+globs: apps/**/*.tsx,apps/**/*.css
+alwaysApply: false
+---
+
+# UI ticket visual verification
+
+When the task **changes user-visible UI or UX** in `apps/` (pages, components, layout, styles, flows, modals, forms, copy placement)—**especially** when the user references a GitHub issue, ticket, or acceptance criteria—you MUST:
+
+1. **Read** the project skill **`/ui-ticket-visual-verification`** before handoff and follow its checklist.
+2. **Prefer isolation** (dev fixture route, query-driven demo state, minimal dev server) over full multi-service manual setup when that proves the ticket.
+3. **Ship reproducibility**: mocks or stubs for external data, plus a documented command (e.g. `pnpm` script) and URL so reviewers can replay the same view.
+4. **Ship evidence**: screenshots for static outcomes; short video only when motion or multi-step interaction matters. Use browser tools when available; keep binaries gitignored or attach to the PR.
+
+If the change is purely non-visual (types, internal APIs, no UI contract change), this rule does not require visual artifacts unless the ticket explicitly asks for them.

--- a/.cursor/skills/ui-ticket-visual-verification/SKILL.md
+++ b/.cursor/skills/ui-ticket-visual-verification/SKILL.md
@@ -50,7 +50,7 @@ Use the **Cursor IDE browser** tools when available:
 2. Take a **snapshot** before interactions; interact (click, open modal); snapshot again.
 3. Use **screenshot** for static proof; use **video** only when the ticket needs motion (animation, toast timing, drag). If the browser tool cannot record video, use a one-line note in the PR telling reviewers to run the repro script and record locally, or add an optional Playwright/Vitest browser script if the package already supports it.
 
-Save files under something like `artifacts/ui-evidence/<ticket-or-branch-slug>/` and ensure that path is **gitignored** (or use PR attachments only). Do not rely on binary blobs living in git unless the team already commits golden images.
+Save files under something like `artifacts/ui-evidence/<ticket-or-branch-slug>/` and ensure that path is **gitignored** (or use PR attachments only). Do not rely on binary blobs living in git unless the team already commits golden images. Put **repro notes, ticket link, and capture commands** in a **`README.md` next to the dev fixture** (e.g. `app/dev/ui/<issue>/README.md`) instead of the app’s top-level `README.md`.
 
 ## Repro script contract
 

--- a/.cursor/skills/ui-ticket-visual-verification/SKILL.md
+++ b/.cursor/skills/ui-ticket-visual-verification/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ui-ticket-visual-verification
+description: >-
+  Produces owner-ready visual verification for UI/UX ticket work: isolate the changed surface
+  behind dev-only fixtures, mock external data, add reproducible simulate scripts, and capture
+  screenshots or short screen recordings using browser tools. Use when implementing GitHub issues,
+  product tickets, or PRs that change Hermes/Mediapulse UI, flows, modals, forms, or layout; when
+  the user asks for screenshots, video proof, demo pages, or a way to replay what the agent verified.
+---
+
+# UI ticket visual verification (Mediapulse / Hermes)
+
+## Repo integration
+
+The project rule **`.cursor/rules/ui-ticket-visual-verification.mdc`** applies while editing **`apps/**/_.tsx`** or **`apps/\*\*/_.css`\*\*. Treat that as a signal to follow this skill for user-visible changes, especially when the task references an issue or ticket.
+
+## When to use
+
+Apply this skill whenever ticket work is **primarily UI/UX** (pages, components, client flows, styling, copy placement, modals, empty states). Skip heavy visual evidence for purely non-visual changes (types-only refactors, API-only changes with no UI contract shift) unless the ticket explicitly asks for UI proof.
+
+## Outcomes (always ship these together)
+
+1. **Isolation** — A path to view the ticket’s UI without walking the full production graph (fixture route, story-style page, query-driven demo state, or focused package dev server).
+2. **Mocks / stubs** — Scripts or small modules that fake APIs, webhooks, auth, inventory, or other backends the ticket does not own. Prefer explicit fixtures over mutating shared dev databases.
+3. **Repro script** — One entry point (e.g. `pnpm` script or `bash`/`tsx` under the touched app) that documents env vars, starts the minimal server, and states the URL to open. Devs must replay the same view the agent used.
+4. **Evidence** — At least one **screenshot** of the final state; add a **short video** only when motion, transitions, or multi-step interaction matters. Store artifacts under a **gitignored** path (see below) and **link or attach** them in the PR / ticket comment.
+
+## Isolation strategy (pick the smallest that proves the ticket)
+
+Prefer, in order:
+
+1. **Dev-only fixture route or page** — Renders only the component or flow under test with props or loader data wired to a fixture (search existing patterns: `fixture`, `demo`, `dev-only`, `preview` in the target app before inventing a new convention).
+2. **Query- or flag-driven state** — Same page as production, but `?uiFixture=sold-out` (or similar) switches mocked loaders / server data. Gate parsing so defaults stay unchanged for real users.
+3. **Package-scoped dev server** — Run the relevant Next (or other) app via workspace filter, e.g. from repo root: `pnpm dev:hermes`, `pnpm dev:user-registration`, or `pnpm --filter <package> dev` when no root alias exists.
+4. **Full journey** — Only if the ticket truly requires cross-service state; then automate setup in the repro script (create user, sign in, seed) and still prefer **background mutation via API/fixture** over manual DB surgery.
+
+For tickets like **“warning modal when Add to cart on sold-out item”**, do **not** default to a long manual E2E. Instead: render the product page or cart button **with a fixture** where stock is already zero, or toggle stock via a dev-only API handler / mock used only by the fixture route—then click once and capture the modal.
+
+## Mocks and data
+
+- **Third-party / HTTP** — MSW handlers, Next `rewrites` to a local stub route, or a tiny in-repo mock server if the team already uses that pattern. Document required env in the app’s `env.example` only when adding **new** variables (follow `@mediapulse/env` / `@hermes/env` rules elsewhere in the repo).
+- **Never** commit secrets or real customer data into fixtures.
+- **Production safety** — Fixture routes and mock endpoints must be unreachable in production builds (compile-time removal, `NODE_ENV === "development"` guards, feature flags, or static analysis the app already uses).
+
+## Browser capture workflow
+
+Use the **Cursor IDE browser** tools when available:
+
+1. List tabs; navigate to the fixture URL on the local dev server.
+2. Take a **snapshot** before interactions; interact (click, open modal); snapshot again.
+3. Use **screenshot** for static proof; use **video** only when the ticket needs motion (animation, toast timing, drag). If the browser tool cannot record video, use a one-line note in the PR telling reviewers to run the repro script and record locally, or add an optional Playwright/Vitest browser script if the package already supports it.
+
+Save files under something like `artifacts/ui-evidence/<ticket-or-branch-slug>/` and ensure that path is **gitignored** (or use PR attachments only). Do not rely on binary blobs living in git unless the team already commits golden images.
+
+## Repro script contract
+
+Each script or `package.json` script entry should:
+
+- State **prerequisites** (Node version, `pnpm i`, Docker if any).
+- Export or echo the **exact URL** (including port and query string).
+- Be **idempotent** — safe to run twice without duplicating users or dirtying shared state when avoidable.
+
+## Handoff text for PRs / tickets
+
+Include a short block:
+
+- What was isolated (route + fixture name).
+- Command to run the repro.
+- Where screenshots/video live (path or “attached below”).
+- Anything still validated only in full staging (if anything).
+
+## Further patterns
+
+See [reference.md](reference.md) for a isolation ladder summary, artifact layout, and narrative examples aligned with this monorepo’s `pnpm` / Turbo layout.

--- a/.cursor/skills/ui-ticket-visual-verification/reference.md
+++ b/.cursor/skills/ui-ticket-visual-verification/reference.md
@@ -1,0 +1,51 @@
+# Reference: UI ticket visual verification
+
+## Isolation ladder (quick pick)
+
+| Ticket shape                                            | Typical approach                                                                                                       |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Single component (checkbox, label, layout)              | Dev-only page that imports the component with fixture props.                                                           |
+| Form validation / legal copy                            | Same + optional mocked submit handler that never leaves the browser.                                                   |
+| Modal that depends on server truth (stock, permissions) | Fixture route or `?fixture=` that forces the server component / loader to return the edge state.                       |
+| Dashboard widget needing aggregates                     | Static JSON fixture co-located with the demo route; avoid live warehouse DB.                                           |
+| Auth-gated page                                         | Mock session in dev (existing test helpers or dev cookie) **or** fixture route that bypasses auth only in development. |
+
+## Artifact layout (suggested)
+
+```text
+artifacts/ui-evidence/<slug>/
+  README.md          # optional: 3–5 lines, how captured, date, ticket link
+  before.png         # only if ticket needs comparison
+  after.png
+  flow.webm          # optional
+```
+
+Add `artifacts/` to the app or repo `.gitignore` if not already ignored.
+
+## Monorepo dev entry points
+
+From repo root, prefer documented scripts in root `package.json` when they exist (`pnpm dev:hermes`, `pnpm dev:user-registration`, etc.). Otherwise:
+
+`pnpm --filter <workspace-package-name> dev`
+
+Discover the filter name from the app’s `package.json` `"name"` field.
+
+## Example narratives (mapping to tickets)
+
+**Terms of service checkbox on registration**
+
+- Add or extend a **dev-only** registration preview route (or dedicated minimal page) that renders the same client/server split as production registration.
+- Mock account creation POST to return success without calling the real API.
+- Repro: `pnpm dev:user-registration` (or the correct filter) + documented URL.
+- Screenshot: registration form showing the new checkbox and validation error when unchecked.
+
+**Sold-out “Add to cart” modal**
+
+- Avoid: create user → seed item → log in → deplete stock in DB → click.
+- Prefer: product or cart surface driven by **fixture stock = 0**, or dev-only PATCH that only the fixture uses; one click proves the modal.
+- Screenshot: modal visible; optional second shot of in-stock control for contrast using a second query value.
+
+## Video vs screenshot
+
+- Screenshot: default for layout, copy, single-state modals.
+- Video: loading spinners, staggered animations, multi-step wizards, drag-and-drop. Keep under ~30s when possible.

--- a/.cursor/skills/ui-ticket-visual-verification/reference.md
+++ b/.cursor/skills/ui-ticket-visual-verification/reference.md
@@ -14,11 +14,11 @@
 
 ```text
 artifacts/ui-evidence/<slug>/
-  README.md          # optional: 3–5 lines, how captured, date, ticket link
-  before.png         # only if ticket needs comparison
-  after.png
+  after.png          # optional; gitignored — attach to PR/issue
   flow.webm          # optional
 ```
+
+Prefer a **co-located `README.md` next to the dev fixture route** (e.g. `app/dev/ui/<issue>/README.md`) for ticket URL, repro, and capture commands so app-level READMEs stay clean.
 
 Add `artifacts/` to the app or repo `.gitignore` if not already ignored.
 

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,9 @@ docs-output
 
 tmp
 
+# Local UI evidence (screenshots, recordings) — attach to PRs instead of committing
+artifacts/
+
 # graphify data
 graphify*
 graphify*.*

--- a/apps/mediapulse/user-registration/app/dev/README.md
+++ b/apps/mediapulse/user-registration/app/dev/README.md
@@ -1,0 +1,7 @@
+# Dev-only routes (`app/dev`)
+
+This tree holds **development-only** Next.js App Router pages (fixtures, UI previews). Routes are gated in code (for example `env.NODE_ENV !== "development"` → `notFound()`), so they are not meant for production traffic.
+
+Each fixture folder may include a **co-located `README.md`** with the URL, env prerequisites, and how to capture screenshots or short video for tickets.
+
+Keep ticket-specific repro notes **here or in PR/issue text**, not in the app’s top-level `README.md`, so that file stays stable as more tickets land.

--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/README.md
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/README.md
@@ -1,0 +1,43 @@
+# Dev fixture: full registration + Hyperjump attribution
+
+**Route:** `/dev/ui/issue-483` (see [`page.tsx`](./page.tsx)) — only when `NODE_ENV` is `development`; otherwise **404**.
+
+Renders the same shell as production `/`: **RegistrationForm** with fixture tickers (no agent-data-api) plus **HyperjumpProductAttribution**.
+
+**Ticket:** https://github.com/hyperjumptech/mediapulse/issues/483
+
+## Run locally
+
+From the monorepo root:
+
+```bash
+pnpm dev:user-registration
+```
+
+Open http://localhost:3002/dev/ui/issue-483
+
+Set env vars per `packages/mediapulse/env/env.app.user-registration.example` (monorepo root paths; at minimum `NEXT_PUBLIC_REGISTRATION_EMAIL` and `AGENT_DATA_API_URL`).
+
+## UI evidence (screenshots / video)
+
+Store binaries under gitignored `artifacts/ui-evidence/issue-483/` or attach them to the PR / GitHub issue.
+
+### Example: headless Chrome screenshot
+
+From `apps/mediapulse/user-registration`, with env set as in the example file:
+
+```bash
+NEXT_PUBLIC_REGISTRATION_EMAIL=registration@mediapulse.example \
+AGENT_DATA_API_URL=http://localhost:8081 \
+NODE_ENV=development \
+pnpm exec next dev --turbopack -p 3002
+```
+
+Then (adjust paths as needed):
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
+  --headless=new --disable-gpu --window-size=1280,2200 \
+  --screenshot=artifacts/ui-evidence/issue-483/after.png \
+  "http://127.0.0.1:3002/dev/ui/issue-483"
+```

--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
@@ -1,0 +1,70 @@
+/** @vitest-environment jsdom */
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { notFound } from "next/navigation";
+
+const envState: {
+  NODE_ENV: string | undefined;
+  AGENT_DATA_API_URL: string;
+  PORT: number | undefined;
+  NEXT_PUBLIC_REGISTRATION_EMAIL: string;
+} = {
+  NODE_ENV: "development",
+  AGENT_DATA_API_URL: "http://localhost:8081",
+  PORT: undefined,
+  NEXT_PUBLIC_REGISTRATION_EMAIL: "registration@test.example",
+};
+
+vi.mock("@mediapulse/env/app-user-registration", () => ({
+  get env() {
+    return envState;
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: vi.fn(() => {
+    throw new Error("NEXT_NOT_FOUND");
+  }),
+}));
+
+describe("DevUiIssue483Page", () => {
+  beforeEach(() => {
+    envState.NODE_ENV = "development";
+    vi.mocked(notFound).mockClear();
+    vi.mocked(notFound).mockImplementation(() => {
+      throw new Error("NEXT_NOT_FOUND");
+    });
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("renders the registration form and Hyperjump attribution when NODE_ENV is development", async () => {
+    const Page = (await import("./page")).default;
+
+    // Act
+    const ui = Page();
+    render(ui);
+
+    // Assert
+    expect(screen.getByLabelText(/Your name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Open email app to subscribe/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /^Hyperjump$/i }),
+    ).toBeInTheDocument();
+    expect(notFound).not.toHaveBeenCalled();
+  });
+
+  it("calls notFound when NODE_ENV is not development", async () => {
+    envState.NODE_ENV = "test";
+    const Page = (await import("./page")).default;
+
+    // Act & Assert
+    expect(() => Page()).toThrow("NEXT_NOT_FOUND");
+    expect(notFound).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.tsx
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+
+import { env } from "@mediapulse/env/app-user-registration";
+
+import { HyperjumpProductAttribution } from "@/components/hyperjump-product-attribution";
+import { RegistrationForm } from "@/components/registration-form";
+import type { Ticker } from "@/lib/tickers";
+
+/**
+ * Sample IDX-style tickers for the dev-only registration preview (no agent-data-api).
+ */
+const DEV_REGISTRATION_TICKERS: Ticker[] = [
+  { KodeEmiten: "BBCA", NamaEmiten: "Bank Central Asia Tbk" },
+  { KodeEmiten: "TLKM", NamaEmiten: "Telkom Indonesia Tbk" },
+];
+
+/**
+ * Development-only page that mirrors the real registration layout: full
+ * `RegistrationForm` with fixture tickers plus Hyperjump attribution. Use for
+ * screenshots and UI review without calling agent-data-api. Returns 404
+ * outside `development`.
+ *
+ * @returns The registration preview layout.
+ */
+const DevUiIssue483Page = () => {
+  if (env.NODE_ENV !== "development") {
+    notFound();
+  }
+
+  return (
+    <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
+      <div className="flex w-full max-w-sm flex-col items-center">
+        <RegistrationForm tickers={DEV_REGISTRATION_TICKERS} />
+        <HyperjumpProductAttribution />
+      </div>
+    </div>
+  );
+};
+
+export default DevUiIssue483Page;

--- a/apps/mediapulse/user-registration/app/page.test.tsx
+++ b/apps/mediapulse/user-registration/app/page.test.tsx
@@ -42,4 +42,16 @@ describe("Page", () => {
       "1",
     );
   });
+
+  it("renders Hyperjump product attribution with an external link", async () => {
+    const Page = (await import("./page")).default;
+
+    const ui = await Page();
+    render(ui);
+
+    const link = screen.getByRole("link", { name: /^Hyperjump$/i });
+    expect(link).toHaveAttribute("href", "https://hyperjump.tech");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
 });

--- a/apps/mediapulse/user-registration/app/page.tsx
+++ b/apps/mediapulse/user-registration/app/page.tsx
@@ -1,3 +1,4 @@
+import { HyperjumpProductAttribution } from "@/components/hyperjump-product-attribution";
 import { RegistrationForm } from "@/components/registration-form";
 import { loadRegistrationTickers } from "@/lib/load-registration-tickers";
 
@@ -15,8 +16,9 @@ const Page = async () => {
 
   return (
     <div className="flex min-h-svh flex-col items-center justify-center gap-6 bg-background p-6 md:p-10">
-      <div className="w-full max-w-sm">
+      <div className="flex w-full max-w-sm flex-col items-center">
         <RegistrationForm tickers={tickers} />
+        <HyperjumpProductAttribution />
       </div>
     </div>
   );

--- a/apps/mediapulse/user-registration/components/hyperjump-product-attribution.test.tsx
+++ b/apps/mediapulse/user-registration/components/hyperjump-product-attribution.test.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  HyperjumpProductAttribution,
+} from "./hyperjump-product-attribution";
+
+describe("HyperjumpProductAttribution", () => {
+  it("renders Mediapulse copy with a Hyperjump link to the default URL", () => {
+    // Act
+    render(<HyperjumpProductAttribution />);
+
+    // Assert
+    expect(screen.getByText(/Mediapulse is a product by/i)).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: /^Hyperjump$/i });
+    expect(link).toHaveAttribute("href", DEFAULT_HYPERJUMP_SITE_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("uses the injected company site URL for the link href", () => {
+    // Act
+    render(
+      <HyperjumpProductAttribution companySiteUrl="https://example.test/hj" />,
+    );
+
+    // Assert
+    expect(screen.getByRole("link", { name: /^Hyperjump$/i })).toHaveAttribute(
+      "href",
+      "https://example.test/hj",
+    );
+  });
+});

--- a/apps/mediapulse/user-registration/components/hyperjump-product-attribution.tsx
+++ b/apps/mediapulse/user-registration/components/hyperjump-product-attribution.tsx
@@ -1,0 +1,36 @@
+type HyperjumpProductAttributionProps = {
+  /**
+   * Hyperjump marketing site URL used for the link `href`.
+   * Defaults to the canonical production URL.
+   */
+  companySiteUrl?: string;
+};
+
+const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
+
+/**
+ * Renders a short footer line that Mediapulse is a Hyperjump product, with an
+ * external link to the Hyperjump website.
+ *
+ * @param props - Component props.
+ * @param props.companySiteUrl - Optional override for the Hyperjump link target URL.
+ * @returns The attribution paragraph element.
+ */
+const HyperjumpProductAttribution = ({
+  companySiteUrl = DEFAULT_HYPERJUMP_SITE_URL,
+}: HyperjumpProductAttributionProps = {}) => (
+  <p className="mt-6 max-w-sm text-balance text-center text-xs text-muted-foreground">
+    Mediapulse is a product by{" "}
+    <a
+      href={companySiteUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-medium text-foreground underline-offset-4 hover:underline"
+    >
+      Hyperjump
+    </a>
+    .
+  </p>
+);
+
+export { HyperjumpProductAttribution, DEFAULT_HYPERJUMP_SITE_URL };

--- a/packages/mediapulse/env/env.app.user-registration.example
+++ b/packages/mediapulse/env/env.app.user-registration.example
@@ -1,4 +1,7 @@
 # Next.js user-registration web app (Fly: mediapulse-user-registration, local port 3002)
+# Runtime mode (set automatically by Next.js / Node; exposed for typed guards such as dev-only UI fixtures).
+NODE_ENV=development #optional
+
 PORT=3002 #number #optional
 
 # Shown in the registration mailto flow (public)

--- a/packages/mediapulse/env/src/app-user-registration.ts
+++ b/packages/mediapulse/env/src/app-user-registration.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
+    NODE_ENV: z.string().optional(),
     PORT: z.number({ coerce: true }).optional(),
     AGENT_DATA_API_URL: z.string().min(1),
   },

--- a/turbo.json
+++ b/turbo.json
@@ -9,10 +9,7 @@
     },
     "build": {
       "dependsOn": ["^db:generate", "^build", "generate"],
-      "env": [
-        "ORCHESTRATION_DATABASE_URL",
-        "MEDIAPULSE_DATABASE_URL"
-      ],
+      "env": ["ORCHESTRATION_DATABASE_URL", "MEDIAPULSE_DATABASE_URL"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
       "outputs": [".next/**", "!.next/cache/**", "dist/**"]
     },
@@ -36,20 +33,15 @@
     "dev": {
       "dependsOn": ["generate", "^build"],
       "cache": false,
-      "persistent": true
+      "persistent": true,
+      "env": ["NODE_ENV"]
     },
     "db:migrate:deploy": {
-      "env": [
-        "ORCHESTRATION_DATABASE_URL",
-        "MEDIAPULSE_DATABASE_URL"
-      ]
+      "env": ["ORCHESTRATION_DATABASE_URL", "MEDIAPULSE_DATABASE_URL"]
     },
     "db:migrate:dev": {},
     "db:generate": {
-      "env": [
-        "ORCHESTRATION_DATABASE_URL",
-        "MEDIAPULSE_DATABASE_URL"
-      ],
+      "env": ["ORCHESTRATION_DATABASE_URL", "MEDIAPULSE_DATABASE_URL"],
       "cache": false
     },
     "db:push": {


### PR DESCRIPTION
## Summary

Ships the Hyperjump footer on the Mediapulse user-registration page and adds a dev-only preview route that mirrors the real form with fixture tickers so reviewers can screenshot without agent-data-api. This branch also introduces the repo `ui-ticket-visual-verification` skill and matching Cursor rule so UI ticket work keeps fixtures, repro steps, and evidence in one place.

## Related issues

Closes #483

## Important changes

- Registration home renders `HyperjumpProductAttribution` under `RegistrationForm`, with tests and an external link to https://hyperjump.tech (`noopener noreferrer`).
- `app/dev/ui/issue-483` is a development-only full-form fixture; `NODE_ENV` is wired through `@mediapulse/env/app-user-registration`, `turbo.json` lists it for the `dev` task, and `artifacts/` stays gitignored for local captures.
- Adds `.cursor/skills/ui-ticket-visual-verification/` plus `.cursor/rules/ui-ticket-visual-verification.mdc` for the visual verification workflow.

## Other changes

- Regenerated `packages/mediapulse/env/src/app-user-registration.ts` from the updated example file.

## Key files to review

- `apps/mediapulse/user-registration/app/page.tsx` — wires footer under the live form.
- `apps/mediapulse/user-registration/components/hyperjump-product-attribution.tsx` — copy, link, and optional `companySiteUrl` for tests.
- `apps/mediapulse/user-registration/app/dev/ui/issue-483/page.tsx` — dev fixture parity with production layout.
- `.cursor/skills/ui-ticket-visual-verification/SKILL.md` — expectations for isolation, repro, and evidence.

## How to test

1. From repo root: `pnpm dev:user-registration` with env from `packages/mediapulse/env/env.app.user-registration.example`.
2. Open http://localhost:3002/dev/ui/issue-483 and confirm the full form plus footer line and working Hyperjump link.
3. With a reachable `AGENT_DATA_API_URL`, open `/` and confirm the same footer appears under the real ticker list.
4. Run `pnpm --filter @mediapulse/user-registration test` and `pnpm format:check`.

