### PR TITLE
Expose query-analysis LLM prompts in Hermes config

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -1,0 +1,54 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { queryAnalysisConfigSchema } from "./config-schema";
+import { QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH } from "./query-analysis-prompt-defaults";
+
+const minimal = { openaiApiKey: "sk-test" } satisfies Parameters<
+  typeof queryAnalysisConfigSchema.parse
+>[0];
+
+describe("queryAnalysisConfigSchema prompts", () => {
+  it("rejects unknown placeholder in systemPrompt", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      prompts: { systemPrompt: "{{allowedLanguages}} {{nope}}" },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) => i.message.includes("{{nope}}")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects unknown placeholder in userPromptTemplate", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      prompts: { userPromptTemplate: "{{queryContextBlock}} {{bad}}" },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects overlong systemPrompt", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      prompts: {
+        systemPrompt: "x".repeat(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH + 1),
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts valid prompt placeholders", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      prompts: {
+        systemPrompt: "L: {{allowedLanguages}} B:{{targetBreakingCount}}",
+        userPromptTemplate: "CTX:\n{{queryContextBlock}}",
+      },
+    });
+    expect(parsed.prompts?.systemPrompt).toContain("allowedLanguages");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+import { findUnknownLlmPromptPlaceholderTokens } from "./llm-prompt-template";
+import {
+  QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH,
+  QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS,
+  QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS,
+} from "./query-analysis-prompt-defaults";
+
 /**
  * Runtime configuration from Hermes invoke `config` (variable substitution).
  * OpenAI credentials and strategy knobs are not read from process env.
@@ -37,7 +44,66 @@ export const queryAnalysisConfigSchema = z.object({
    * LLM output token budget for generating structured query candidates.
    */
   maxTokens: z.number().int().positive().optional().default(800),
-});
+  /**
+   * Optional overrides for query-generation LLM system/user templates (Hermes).
+   * When omitted, built-in defaults are used. Do not put API keys inside prompt text.
+   */
+  prompts: z
+    .object({
+      systemPrompt: z
+        .string()
+        .max(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH, {
+          message: `prompts.systemPrompt must be at most ${String(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
+        })
+        .describe(
+          "Optional system prompt template. Placeholders: {{allowedLanguages}}, {{targetBreakingCount}}, {{targetKgCount}}, {{targetFundamentalCount}}, {{minDeterministicCount}} (derived from queryCount, allowedLanguages, minDeterministicCount, and weight* fields when overrides are absent).",
+        )
+        .optional(),
+      userPromptTemplate: z
+        .string()
+        .max(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH, {
+          message: `prompts.userPromptTemplate must be at most ${String(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
+        })
+        .describe(
+          "Optional user prompt template. Placeholder: {{queryContextBlock}} (serialized GET /query-analysis context: ticker, entities, themes, relation deltas).",
+        )
+        .optional(),
+    })
+    .strict()
+    .optional(),
+})
+  .superRefine((data, ctx) => {
+    const prompts = data.prompts;
+    if (!prompts) {
+      return;
+    }
+    const systemAllowed = new Set<string>(QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS);
+    const userAllowed = new Set<string>(QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS);
+    if (prompts.systemPrompt) {
+      for (const token of findUnknownLlmPromptPlaceholderTokens(
+        prompts.systemPrompt,
+        systemAllowed,
+      )) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unknown placeholder {{${token}}} in prompts.systemPrompt`,
+          path: ["prompts", "systemPrompt"],
+        });
+      }
+    }
+    if (prompts.userPromptTemplate) {
+      for (const token of findUnknownLlmPromptPlaceholderTokens(
+        prompts.userPromptTemplate,
+        userAllowed,
+      )) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unknown placeholder {{${token}}} in prompts.userPromptTemplate`,
+          path: ["prompts", "userPromptTemplate"],
+        });
+      }
+    }
+  });
 
 // Use Zod *input* type so `createAgentApp`'s Zod generic constraints match.
 // The agent runtime always parses with this schema, so defaults are guaranteed at runtime.

--- a/apps/mediapulse/agents/query-analysis/src/llm-prompt-template.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-prompt-template.test.ts
@@ -1,0 +1,30 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  findUnknownLlmPromptPlaceholderTokens,
+  listLlmPromptPlaceholderNames,
+  substituteLlmPromptTemplate,
+} from "./llm-prompt-template";
+
+describe("listLlmPromptPlaceholderNames", () => {
+  it("returns sorted unique names", () => {
+    const names = listLlmPromptPlaceholderNames("{{a}} {{b}} {{a}}");
+    expect(names).toEqual(["a", "b"]);
+  });
+});
+
+describe("findUnknownLlmPromptPlaceholderTokens", () => {
+  it("returns names not in the allowed set", () => {
+    const unknown = findUnknownLlmPromptPlaceholderTokens("{{x}}", new Set(["y"]));
+    expect(unknown).toEqual(["x"]);
+  });
+});
+
+describe("substituteLlmPromptTemplate", () => {
+  it("replaces known placeholders", () => {
+    const out = substituteLlmPromptTemplate("a={{k}}", { k: "v" });
+    expect(out).toBe("a=v");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/llm-prompt-template.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-prompt-template.ts
@@ -1,0 +1,50 @@
+/** Pattern source for `{{token}}` placeholders (token: letter + alphanumerics/underscore). */
+const PLACEHOLDER_TOKEN_SOURCE = String.raw`\{\{([a-zA-Z][a-zA-Z0-9_]*)\}\}`;
+
+/**
+ * Lists unique placeholder token names found in `template` (without braces).
+ *
+ * @param template - Prompt string that may contain `{{name}}` tokens.
+ * @returns Sorted unique token names.
+ */
+export const listLlmPromptPlaceholderNames = (template: string): string[] => {
+  const re = new RegExp(PLACEHOLDER_TOKEN_SOURCE, "g");
+  const found = new Set<string>();
+  for (const match of template.matchAll(re)) {
+    const name = match[1];
+    if (name) {
+      found.add(name);
+    }
+  }
+  return [...found].sort();
+};
+
+/**
+ * Returns placeholder names in `template` that are not in `allowed`.
+ *
+ * @param template - Prompt string to scan.
+ * @param allowed - Set of permitted token names (without braces).
+ * @returns Sorted unknown token names for error messages.
+ */
+export const findUnknownLlmPromptPlaceholderTokens = (
+  template: string,
+  allowed: ReadonlySet<string>,
+): string[] =>
+  listLlmPromptPlaceholderNames(template).filter((n) => !allowed.has(n));
+
+/**
+ * Replaces each `{{name}}` in `template` with `replacements[name]` when present.
+ *
+ * @param template - Source template.
+ * @param replacements - Map from token name to replacement string.
+ * @returns Template after substitution.
+ */
+export const substituteLlmPromptTemplate = (
+  template: string,
+  replacements: Readonly<Record<string, string>>,
+): string =>
+  template.replace(new RegExp(PLACEHOLDER_TOKEN_SOURCE, "g"), (_full, name: string) =>
+    Object.prototype.hasOwnProperty.call(replacements, name)
+      ? replacements[name]!
+      : `{{${name}}}`,
+  );

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -5,7 +5,75 @@ import {
   buildQueryAnalysisSystemContent,
   buildQueryAnalysisUserContent,
   fetchLlmQueryCandidates,
+  resolveQueryAnalysisSystemContent,
+  resolveQueryAnalysisUserContent,
 } from "./llm-queries";
+
+describe("resolveQueryAnalysisSystemContent", () => {
+  it("matches buildQueryAnalysisSystemContent when Hermes omits override", () => {
+    const strategy = {
+      queryCount: 10,
+      allowedLanguages: ["en", "de"],
+      minDeterministicCount: 3,
+      weights: { breaking: 1, kgChange: 1, fundamental: 1 } as const,
+    };
+
+    const resolved = resolveQueryAnalysisSystemContent(undefined, strategy);
+    const legacy = buildQueryAnalysisSystemContent(strategy);
+
+    expect(resolved).toBe(legacy);
+  });
+});
+
+describe("resolveQueryAnalysisUserContent", () => {
+  it("matches buildQueryAnalysisUserContent when Hermes omits override", () => {
+    const ctx = {
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "ACME",
+        name: "Acme Co",
+        metadata: null,
+      },
+      topEntities: [] as {
+        canonicalName: string;
+        typeName: string;
+        relevanceWeight: number;
+      }[],
+      recentThemes: [] as { theme: string; articleCount: number }[],
+      recentRelationDeltas: [] as {
+        fromEntity: string;
+        toEntity: string;
+        relationType: string;
+        change: "added";
+      }[],
+    };
+
+    const resolved = resolveQueryAnalysisUserContent(undefined, ctx);
+    const legacy = buildQueryAnalysisUserContent(ctx);
+    expect(resolved).toBe(legacy);
+  });
+
+  it("wraps context with a custom user template", () => {
+    const ctx = {
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "SYM",
+        name: "N",
+        metadata: null,
+      },
+      topEntities: [],
+      recentThemes: [],
+      recentRelationDeltas: [],
+    };
+    const text = resolveQueryAnalysisUserContent(
+      "START\n{{queryContextBlock}}\nEND",
+      ctx,
+    );
+    expect(text.startsWith("START\n")).toBe(true);
+    expect(text).toContain("SYM");
+    expect(text.endsWith("END")).toBe(true);
+  });
+});
 
 describe("buildQueryAnalysisSystemContent", () => {
   it("includes languages, intent mix hints, and schema instructions", () => {

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -8,6 +8,12 @@ import {
 } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
+import {
+  QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
+  QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
+} from "./query-analysis-prompt-defaults";
+import { substituteLlmPromptTemplate } from "./llm-prompt-template";
+
 /** Zod schema for structured LLM output (validated by AI SDK). */
 export const llmQueriesOutputSchema = z.object({
   queries: z.array(
@@ -30,14 +36,14 @@ export type LlmQueryStrategyPrompt = {
 };
 
 /**
- * Builds the system prompt describing JSON shape, intent mix targets, languages, and strategy knobs.
+ * Builds replacement map for the default query-analysis system prompt template.
  *
  * @param strategy - Counts, languages, deterministic floor, and relative intent weights.
- * @returns System message content for the chat model.
+ * @returns String values for each supported `{{token}}` in the system template.
  */
-export const buildQueryAnalysisSystemContent = (
+export const buildQueryAnalysisSystemTemplateReplacements = (
   strategy: LlmQueryStrategyPrompt,
-): string => {
+): Record<string, string> => {
   const sum =
     strategy.weights.breaking +
     strategy.weights.kgChange +
@@ -45,17 +51,65 @@ export const buildQueryAnalysisSystemContent = (
   const ratioBreaking = sum > 0 ? strategy.weights.breaking / sum : 1 / 3;
   const ratioKg = sum > 0 ? strategy.weights.kgChange / sum : 1 / 3;
   const ratioFund = sum > 0 ? strategy.weights.fundamental / sum : 1 / 3;
-  const langList = strategy.allowedLanguages.join(", ");
-  return [
-    "You generate finance search queries for news and data retrieval.",
-    'Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": "breaking" | "kg_change" | "fundamental" } ] }.',
-    "Each query must be concise web-search style text.",
-    `Write queries in these languages (BCP-47 codes as configured): ${langList}. If multiple, you may mix languages across queries.`,
-    `Target roughly ${Math.round(ratioBreaking * strategy.queryCount)} breaking, ${Math.round(ratioKg * strategy.queryCount)} kg_change, ${Math.round(ratioFund * strategy.queryCount)} fundamental queries (approximate; total queries should not exceed the remaining budget after the deterministic baseline).`,
-    `At least ${strategy.minDeterministicCount} high-quality queries will be added deterministically by the system; your queries complement that set (avoid duplicating obvious symbol+news patterns).`,
-    "Intent meanings: breaking = timely news/events; kg_change = knowledge-graph style relation or entity changes; fundamental = earnings, guidance, regulatory, balance-sheet style.",
-  ].join("\n");
+  return {
+    allowedLanguages: strategy.allowedLanguages.join(", "),
+    targetBreakingCount: String(
+      Math.round(ratioBreaking * strategy.queryCount),
+    ),
+    targetKgCount: String(Math.round(ratioKg * strategy.queryCount)),
+    targetFundamentalCount: String(
+      Math.round(ratioFund * strategy.queryCount),
+    ),
+    minDeterministicCount: String(strategy.minDeterministicCount),
+  };
 };
+
+/**
+ * Resolves the query-analysis system prompt (Hermes override or built-in default template).
+ *
+ * @param configuredSystemPrompt - Optional `prompts.systemPrompt` from Hermes.
+ * @param strategy - Strategy knobs used to fill template placeholders.
+ * @returns System message content for the chat model.
+ */
+export const resolveQueryAnalysisSystemContent = (
+  configuredSystemPrompt: string | undefined,
+  strategy: LlmQueryStrategyPrompt,
+): string => {
+  const template =
+    configuredSystemPrompt ?? QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT;
+  return substituteLlmPromptTemplate(
+    template,
+    buildQueryAnalysisSystemTemplateReplacements(strategy),
+  );
+};
+
+/**
+ * Resolves the query-analysis user prompt (Hermes override or built-in default template).
+ *
+ * @param configuredUserPromptTemplate - Optional `prompts.userPromptTemplate` from Hermes.
+ * @param context - Serialized GET /query-analysis context for `{{queryContextBlock}}`.
+ * @returns User message content for the chat model.
+ */
+export const resolveQueryAnalysisUserContent = (
+  configuredUserPromptTemplate: string | undefined,
+  context: GetQueryAnalysisResponse,
+): string => {
+  const template =
+    configuredUserPromptTemplate ?? QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT;
+  return substituteLlmPromptTemplate(template, {
+    queryContextBlock: buildQueryAnalysisUserContent(context),
+  });
+};
+
+/**
+ * Builds the system prompt describing JSON shape, intent mix targets, languages, and strategy knobs.
+ *
+ * @param strategy - Counts, languages, deterministic floor, and relative intent weights.
+ * @returns System message content for the chat model.
+ */
+export const buildQueryAnalysisSystemContent = (
+  strategy: LlmQueryStrategyPrompt,
+): string => resolveQueryAnalysisSystemContent(undefined, strategy);
 
 /**
  * Serializes GET /query-analysis context for the user message (ticker, entities, themes, relation deltas).

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
@@ -1,0 +1,34 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
+  QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
+} from "./query-analysis-prompt-defaults";
+
+describe("query-analysis default prompt templates", () => {
+  it("system default lists all system placeholders", () => {
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{allowedLanguages}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{targetBreakingCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{targetKgCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{targetFundamentalCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{minDeterministicCount}}",
+    );
+  });
+
+  it("user default is queryContextBlock only", () => {
+    expect(QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT).toBe(
+      "{{queryContextBlock}}",
+    );
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
@@ -1,0 +1,31 @@
+/** Maximum characters allowed for each Hermes `prompts.*` string on query-analysis. */
+export const QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
+
+/** Allowed `{{...}}` names in `prompts.systemPrompt`. */
+export const QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS = [
+  "allowedLanguages",
+  "targetBreakingCount",
+  "targetKgCount",
+  "targetFundamentalCount",
+  "minDeterministicCount",
+] as const;
+
+/** Allowed `{{...}}` names in `prompts.userPromptTemplate`. */
+export const QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS = ["queryContextBlock"] as const;
+
+/**
+ * Default system prompt template when Hermes omits `prompts.systemPrompt`.
+ * Substitutes strategy-derived counts and the configured language list.
+ */
+export const QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
+  "You generate finance search queries for news and data retrieval.",
+  'Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": "breaking" | "kg_change" | "fundamental" } ] }.',
+  "Each query must be concise web-search style text.",
+  "Write queries in these languages (BCP-47 codes as configured): {{allowedLanguages}}. If multiple, you may mix languages across queries.",
+  "Target roughly {{targetBreakingCount}} breaking, {{targetKgCount}} kg_change, {{targetFundamentalCount}} fundamental queries (approximate; total queries should not exceed the remaining budget after the deterministic baseline).",
+  "At least {{minDeterministicCount}} high-quality queries will be added deterministically by the system; your queries complement that set (avoid duplicating obvious symbol+news patterns).",
+  "Intent meanings: breaking = timely news/events; kg_change = knowledge-graph style relation or entity changes; fundamental = earnings, guidance, regulatory, balance-sheet style.",
+].join("\n\n");
+
+/** Default user prompt template: full serialized GET context. */
+export const QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT = "{{queryContextBlock}}";

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -4,8 +4,8 @@ import { logger } from "@workspace/logger";
 import { env } from "@mediapulse/env/agents-query-analysis";
 import type { QueryAnalysisConfig } from "./config-schema";
 import {
-  buildQueryAnalysisSystemContent,
-  buildQueryAnalysisUserContent,
+  resolveQueryAnalysisSystemContent,
+  resolveQueryAnalysisUserContent,
   fetchLlmQueryCandidates,
 } from "./llm-queries";
 import { mergeQueryCandidates } from "./merge-query-candidates";
@@ -67,17 +67,23 @@ export const runQueryAnalysis = async (
   const openaiModel = config.openaiModel!;
   const maxTokens = config.maxTokens!;
 
-  const systemContent = buildQueryAnalysisSystemContent({
-    queryCount,
-    allowedLanguages,
-    minDeterministicCount,
-    weights: {
-      breaking: weightBreaking,
-      kgChange: weightKgChange,
-      fundamental: weightFundamental,
+  const systemContent = resolveQueryAnalysisSystemContent(
+    config.prompts?.systemPrompt,
+    {
+      queryCount,
+      allowedLanguages,
+      minDeterministicCount,
+      weights: {
+        breaking: weightBreaking,
+        kgChange: weightKgChange,
+        fundamental: weightFundamental,
+      },
     },
-  });
-  const userContent = buildQueryAnalysisUserContent(queryContext);
+  );
+  const userContent = resolveQueryAnalysisUserContent(
+    config.prompts?.userPromptTemplate,
+    queryContext,
+  );
 
   let llmCandidates: Awaited<ReturnType<typeof fetchLlmQueryCandidates>> = [];
   try {

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -45,6 +45,17 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | `allowedLanguages` | No | Target languages as BCP-47 codes (default `["en"]`). |
 | `weightBreaking` / `weightKgChange` / `weightFundamental` | No | Intent mix weights (default `1`, `0.8`, `0.6`). |
 | `maxTokens` | No | LLM output token budget (default `800`). |
+| `prompts.systemPrompt` | No | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
+| `prompts.userPromptTemplate` | No | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context). |
+
+### Weights vs prompt overrides (REQ-010)
+
+| Situation | What still affects the LLM |
+| --------- | --------------------------- |
+| **No `prompts` fields** | Package defaults: system text includes approximate breaking / kg_change / fundamental counts computed from **`queryCount`** and **`weightBreaking`** / **`weightKgChange`** / **`weightFundamental`**; user text is the GET context. **`allowedLanguages`** and **`minDeterministicCount`** appear in the default system prompt. |
+| **`prompts.systemPrompt` set** | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{minDeterministicCount}}`** are still filled from the same strategy fields so you can reference numeric targets without redeploying. |
+| **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data. |
+| **Merge / persistence** | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math. |
 
 ## Pipeline usage
 


### PR DESCRIPTION
## Summary

Query-analysis picks up the same optional `prompts` pattern as article-analysis, with regression coverage so empty config still matches the previous system and user prompt text.

## Important changes

- Config schema, defaults, and merge helpers for query-analysis LLM prompts.
- Dev-docs call out how static weights relate to full-string overrides.

## How to test

- `pnpm vitest run` under `apps/mediapulse/agents/query-analysis`.

## Stack

This is **layer 2 of 4**, on top of `issue-478-479-article-analysis-prompts`. PRD: [https://github.com/hyperjumptech/mediapulse/blob/prds/mediapulse-agent-prompts-hermes-config.prd.md](https://github.com/hyperjumptech/mediapulse/blob/prds/mediapulse-agent-prompts-hermes-config.prd.md).

## Visual verification

Hermes **Agent configs** → **query-analysis**: optional `prompts` overrides (layer 2).

![query-analysis SchemaForm — prompt fields as textareas](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/mp-agent-prompts-hermes/480-query-analysis-prompts-textarea.png)

**Reproduce:** `pnpm dev:hermes` → Agent configs → query-analysis. [issue-proofs archive](https://github.com/hyperjumptech/mediapulse/tree/issue-proofs/mp-agent-prompts-hermes).


## Related issues

Closes #480


