### PR TITLE
Add LLM prompt fingerprints and safer logging

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
@@ -1,0 +1,42 @@
+/** @vitest-environment node */
+
+import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveArticleAnalysisExtractionSystemContent,
+  resolveArticleAnalysisExtractionUserContent,
+} from "./llm-extract-entities.js";
+
+const TID = "11111111-1111-4111-a111-111111111111";
+const RID = "22222222-2222-4222-a222-222222222222";
+
+describe("agent prompt fingerprinting (REQ-011)", () => {
+  it("differs when Hermes system prompt override differs but user and context match", () => {
+    const ctx = {
+      entityTypes: [{ id: TID, name: "Company", description: null }],
+      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
+    };
+    const userArgs = {
+      tickerId: "t-1",
+      title: "Title",
+      contentTruncated: "Body",
+    };
+    const user = resolveArticleAnalysisExtractionUserContent(
+      undefined,
+      userArgs,
+    );
+    const sysA = resolveArticleAnalysisExtractionSystemContent(undefined, ctx);
+    const sysB = resolveArticleAnalysisExtractionSystemContent(
+      "Custom intro\n\nENTITY TYPES (uuid — label):\n{{entityTypesBlock}}\n\nRELATION TYPES (uuid — label):\n{{relationTypesBlock}}",
+      ctx,
+    );
+
+    // Act
+    const fpA = computeLlmPromptFingerprint(sysA, user);
+    const fpB = computeLlmPromptFingerprint(sysB, user);
+
+    // Assert
+    expect(fpA).not.toBe(fpB);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -200,6 +200,34 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     });
   });
 
+  it("includes llmPromptFingerprint when provided", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 1,
+      extractionSuccessCount: 1,
+      extractionFailures: [],
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 1,
+      llmPromptFingerprint: "a1b2c3d4e5f6a7b8",
+    });
+
+    expect(payload.llmPromptFingerprint).toBe("a1b2c3d4e5f6a7b8");
+  });
+
   it("omits LLM usage keys when usage is null", () => {
     const payload = buildArticleAnalysisRunSummaryPayload({
       outcome: "success",

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -232,6 +232,8 @@ export type ArticleAnalysisRunSummaryInput = {
   runStatusLabel?: string;
   semanticFailureReason?: string;
   topLevelError?: ReturnType<typeof toSafeLogError>;
+  /** Fingerprint of the last extraction system+user prompts sent to the LLM (REQ-011). */
+  llmPromptFingerprint?: string;
 };
 
 /**
@@ -346,6 +348,10 @@ export const buildArticleAnalysisRunSummaryPayload = (
     extractionCalls,
     avgExtractionLatencyMs,
   };
+
+  if (input.llmPromptFingerprint !== undefined) {
+    base.llmPromptFingerprint = input.llmPromptFingerprint;
+  }
 
   if (input.runStatusLabel !== undefined) {
     base.runStatus = input.runStatusLabel;

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -2,6 +2,7 @@ import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
+import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import crypto from "node:crypto";
 
 import {
@@ -278,6 +279,7 @@ export const run = async ({
   let llmUsageAccumulated = false;
   let extractionLatencyMsTotal = 0;
   let extractionCalls = 0;
+  let lastLlmPromptFingerprint: string | undefined;
   let relevanceRowsForObservability: ArticleRelevanceRow[] | null = null;
   const extractionFailures: ArticleAnalysisExtractionFailureRecord[] = [];
   let extractionSuccessCount = 0;
@@ -561,6 +563,19 @@ export const run = async ({
 
       try {
         const t0 = Date.now();
+        const extractionUserContent =
+          resolveArticleAnalysisExtractionUserContent(
+            cfg.prompts?.userPromptTemplate,
+            {
+              tickerId: input.tickerId,
+              title: source.title,
+              contentTruncated: truncated,
+            },
+          );
+        lastLlmPromptFingerprint = computeLlmPromptFingerprint(
+          systemContent,
+          extractionUserContent,
+        );
         const extractedResult = await extractEntitiesAndRelationsForSource({
           apiKey: cfg.openaiApiKey,
           model: cfg.openaiModel,
@@ -569,14 +584,7 @@ export const run = async ({
             { role: "system", content: systemContent },
             {
               role: "user",
-              content: resolveArticleAnalysisExtractionUserContent(
-                cfg.prompts?.userPromptTemplate,
-                {
-                  tickerId: input.tickerId,
-                  title: source.title,
-                  contentTruncated: truncated,
-                },
-              ),
+              content: extractionUserContent,
             },
           ],
         });
@@ -1218,6 +1226,9 @@ export const run = async ({
       extractionLatencyMsTotal,
       extractionCalls,
       runStatusLabel: runStatus,
+      ...(lastLlmPromptFingerprint !== undefined
+        ? { llmPromptFingerprint: lastLlmPromptFingerprint }
+        : {}),
     });
 
     return {
@@ -1250,6 +1261,9 @@ export const run = async ({
         articleEntityParseErrors: articleEntityParseErrors.slice(0, 20),
         reanalyze,
         vocabularyFailures,
+        ...(lastLlmPromptFingerprint !== undefined
+          ? { llmPromptFingerprint: lastLlmPromptFingerprint }
+          : {}),
       },
     };
   } catch (error) {
@@ -1276,6 +1290,9 @@ export const run = async ({
       extractionLatencyMsTotal,
       extractionCalls,
       topLevelError: toSafeLogError(error),
+      ...(lastLlmPromptFingerprint !== undefined
+        ? { llmPromptFingerprint: lastLlmPromptFingerprint }
+        : {}),
     });
     return { success: false, message };
   }

--- a/apps/mediapulse/agents/content-generation/src/compute-prompt-hash.ts
+++ b/apps/mediapulse/agents/content-generation/src/compute-prompt-hash.ts
@@ -1,14 +1,10 @@
-import { createHash } from "node:crypto";
+import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 
 /**
  * Computes a deterministic short hash of the exact prompts sent to the LLM.
  *
- * Algorithm: SHA-256(systemPrompt + "\n\n" + resolvedUserPrompt) → first 16 hex chars.
- *
- * The hash captures the concatenation of both prompt strings **after**
- * placeholder substitution (i.e. `{{sourceSummaries}}`, `{{tickerId}}`, and
- * `{{date}}` have already been resolved), so any change to either the prompt
- * template or the source content will produce a different hash.
+ * Delegates to {@link computeLlmPromptFingerprint} from `@workspace/agent-llm-prompt-template`
+ * so all agents share one algorithm (MP-CGA-008, REQ-011).
  *
  * @param systemPrompt - The system-role prompt sent to the model.
  * @param resolvedUserPrompt - The user-role prompt after all placeholder substitution.
@@ -18,6 +14,5 @@ export function computePromptHash(
   systemPrompt: string,
   resolvedUserPrompt: string,
 ): string {
-  const combined = `${systemPrompt}\n\n${resolvedUserPrompt}`;
-  return createHash("sha256").update(combined).digest("hex").slice(0, 16);
+  return computeLlmPromptFingerprint(systemPrompt, resolvedUserPrompt);
 }

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -418,5 +418,5 @@ export async function run({
     pipelineRunId,
     executionId,
   });
-  return { success: true };
+  return { success: true, details: { promptHash } };
 }

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -105,6 +105,26 @@ describe("query-analysis run", () => {
     );
   });
 
+  it("returns llmPromptFingerprint on success details", async () => {
+    const result = await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: baseConfig,
+      token: "Bearer t",
+    });
+
+    expect(result.success).toBe(true);
+    if (result.success && result.details) {
+      expect(
+        typeof (result.details as { llmPromptFingerprint?: string })
+          .llmPromptFingerprint,
+      ).toBe("string");
+      expect(
+        (result.details as { llmPromptFingerprint: string })
+          .llmPromptFingerprint,
+      ).toHaveLength(16);
+    }
+  });
+
   it("omits agentJobId when correlation is absent", async () => {
     // Act
     await runQueryAnalysis({

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -1,5 +1,6 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
+import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import { logger } from "@workspace/logger";
 import { env } from "@mediapulse/env/agents-query-analysis";
 import type { QueryAnalysisConfig } from "./config-schema";
@@ -85,6 +86,11 @@ export const runQueryAnalysis = async (
     queryContext,
   );
 
+  const llmPromptFingerprint = computeLlmPromptFingerprint(
+    systemContent,
+    userContent,
+  );
+
   let llmCandidates: Awaited<ReturnType<typeof fetchLlmQueryCandidates>> = [];
   try {
     llmCandidates = await fetchLlmQueryCandidates({
@@ -143,5 +149,8 @@ export const runQueryAnalysis = async (
     { tickerId: input.tickerId, created: response.created },
     "query analysis set persisted",
   );
-  return { success: true, details: response };
+  return {
+    success: true,
+    details: { ...response, llmPromptFingerprint },
+  };
 };

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -60,7 +60,7 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 | Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |
 | KG tallies | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected` |
 | Relevance stats | When relevance rows were built: `relevanceRowCount`, `scoreMin` / `scoreMax` / `scoreMean`, **`scoreBuckets`**, **`breakdownVersion`** (or `mixed`), **`breakdownKeyMeans`** / mins / maxes over canonical keys |
-| LLM | **`llmPromptTokens`**, **`llmCompletionTokens`**, **`llmTotalTokens`** summed over extraction calls **only if** the AI SDK reports usage for those calls; fields are **omitted** when the provider returns no token counts |
+| LLM | **`llmPromptTokens`**, **`llmCompletionTokens`**, **`llmTotalTokens`** summed over extraction calls **only if** the AI SDK reports usage for those calls; fields are **omitted** when the provider returns no token counts; **`llmPromptFingerprint`** (16-char hex) identifies the **last** extraction system+user prompt pair sent to the model (Hermes `details.llmPromptFingerprint` on success responses) |
 | Timing | **`extractionLatencyMsTotal`**, **`extractionCalls`**, **`avgExtractionLatencyMs`** |
 | Top-level throw | Summary includes `error: { type, message }`; **`warn` / `error` logs use the same safe shape**—never attach raw `Error` objects (avoids leaking rich provider payloads) |
 

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -18,14 +18,14 @@ Core responsibilities:
 
 The **article-analysis** agent stores subscores in `article_relevance.score_breakdown` JSON. Required keys for charts and observability (MP-ART-ANALYSIS-006):
 
-| Key               | Role (product order)                                      |
-| ----------------- | ----------------------------------------------------------- |
-| `breakingNews`    | Timely / market-moving event signal                         |
-| `kgRelation`      | Strength of extracted KG relations for the article          |
-| `fundamental`     | Earnings, filings, guidance-style fundamentals              |
-| `tickerSalience`  | How strongly the ticker / entities show up in the piece   |
-| `sourceQuality`   | Trust / tier prior for the source                           |
-| `_version`        | Integer schema version (Hermes `scoreBreakdownVersion`)     |
+| Key              | Role (product order)                                    |
+| ---------------- | ------------------------------------------------------- |
+| `breakingNews`   | Timely / market-moving event signal                     |
+| `kgRelation`     | Strength of extracted KG relations for the article      |
+| `fundamental`    | Earnings, filings, guidance-style fundamentals          |
+| `tickerSalience` | How strongly the ticker / entities show up in the piece |
+| `sourceQuality`  | Trust / tier prior for the source                       |
+| `_version`       | Integer schema version (Hermes `scoreBreakdownVersion`) |
 
 Optional additional numeric keys may appear for experiments. **Weighted `score`** is in `[0, 1]` and defaults to equal weights (`0.2` each) over the five dimensions; tune via Hermes config (`relevanceWeight*` keys).
 
@@ -35,10 +35,10 @@ Optional additional numeric keys may appear for experiments. **Weighted `score`*
 
 Hermes config **`runPolicy`** mirrors data-collection semantics:
 
-| Field | Default | Meaning |
-| ----- | ------- | ------- |
-| `minSuccessfulSources` | `1` | Minimum sources that must complete LLM + vocabulary validation before any `POST` |
-| `failOnZeroSuccess` | `true` | When true, the run returns **`success: false`** if fewer than `minSuccessfulSources` extract successfully |
+| Field                  | Default | Meaning                                                                                                   |
+| ---------------------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `minSuccessfulSources` | `1`     | Minimum sources that must complete LLM + vocabulary validation before any `POST`                          |
+| `failOnZeroSuccess`    | `true`  | When true, the run returns **`success: false`** if fewer than `minSuccessfulSources` extract successfully |
 
 Per-source **LLM** or **vocabulary** errors are **skipped** (no whole-run abort); the response includes **`extractionFailures`** (`dataSourceId`, `stage`, `message`) and **`extractionSuccessCount`**. If some sources succeed, the run can continue with **`details.runStatus`: `partial_success`**.
 
@@ -50,19 +50,19 @@ Per-source **LLM** or **vocabulary** errors are **skipped** (no whole-run abort)
 
 Every run emits a structured **info** log with message `article_analysis.run.summary` and payload fields suitable for metrics backends or log pipelines.
 
-| Area | Fields (examples) |
-| ---- | ----------------- |
-| Correlation | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present |
-| Outcome | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**, pre-POST **`relevance_row_validation`**, relevance chunk build **`relevance_chunk_parse`**) |
-| Stages | **`stageMetrics.extract`** (`articlesProcessed`, `articlesSucceeded`, `articlesFailedExtraction`), **`stageMetrics.scorePrepare.schemaValidationFailures`**, **`stageMetrics.persist`** (`postChunkFailures`, `articlesScored`, `articlesSelected`) |
-| Extraction | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`** |
-| Validation | **`relevanceRowValidationFailures`**, **`chunkParseErrors*`**, rolled-up **`schemaValidationFailureCount`**; **`failureCountsByKind`** splits **`llm`**, **`vocabulary`**, **`schemaValidation`**, **`persistenceHttp`**, **`persistenceOther`** from POST failures |
-| Persist | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`) |
-| KG tallies | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected` |
-| Relevance stats | When relevance rows were built: `relevanceRowCount`, `scoreMin` / `scoreMax` / `scoreMean`, **`scoreBuckets`**, **`breakdownVersion`** (or `mixed`), **`breakdownKeyMeans`** / mins / maxes over canonical keys |
-| LLM | **`llmPromptTokens`**, **`llmCompletionTokens`**, **`llmTotalTokens`** summed over extraction calls **only if** the AI SDK reports usage for those calls; fields are **omitted** when the provider returns no token counts; **`llmPromptFingerprint`** (16-char hex) identifies the **last** extraction system+user prompt pair sent to the model (Hermes `details.llmPromptFingerprint` on success responses) |
-| Timing | **`extractionLatencyMsTotal`**, **`extractionCalls`**, **`avgExtractionLatencyMs`** |
-| Top-level throw | Summary includes `error: { type, message }`; **`warn` / `error` logs use the same safe shape**—never attach raw `Error` objects (avoids leaking rich provider payloads) |
+| Area            | Fields (examples)                                                                                                                                                                                                                                                                                                                                                                                              |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Correlation     | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present                                                                                                                                                                                                                  |
+| Outcome         | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**, pre-POST **`relevance_row_validation`**, relevance chunk build **`relevance_chunk_parse`**)                                                                       |
+| Stages          | **`stageMetrics.extract`** (`articlesProcessed`, `articlesSucceeded`, `articlesFailedExtraction`), **`stageMetrics.scorePrepare.schemaValidationFailures`**, **`stageMetrics.persist`** (`postChunkFailures`, `articlesScored`, `articlesSelected`)                                                                                                                                                            |
+| Extraction      | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`**                                                                                                                                                                                                                                                                     |
+| Validation      | **`relevanceRowValidationFailures`**, **`chunkParseErrors*`**, rolled-up **`schemaValidationFailureCount`**; **`failureCountsByKind`** splits **`llm`**, **`vocabulary`**, **`schemaValidation`**, **`persistenceHttp`**, **`persistenceOther`** from POST failures                                                                                                                                            |
+| Persist         | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`)                                                                                                                                                                                                                                                                                      |
+| KG tallies      | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected`                                                                                                                                                                                                                                                                                          |
+| Relevance stats | When relevance rows were built: `relevanceRowCount`, `scoreMin` / `scoreMax` / `scoreMean`, **`scoreBuckets`**, **`breakdownVersion`** (or `mixed`), **`breakdownKeyMeans`** / mins / maxes over canonical keys                                                                                                                                                                                                |
+| LLM             | **`llmPromptTokens`**, **`llmCompletionTokens`**, **`llmTotalTokens`** summed over extraction calls **only if** the AI SDK reports usage for those calls; fields are **omitted** when the provider returns no token counts; **`llmPromptFingerprint`** (16-char hex) identifies the **last** extraction system+user prompt pair sent to the model (Hermes `details.llmPromptFingerprint` on success responses) |
+| Timing          | **`extractionLatencyMsTotal`**, **`extractionCalls`**, **`avgExtractionLatencyMs`**                                                                                                                                                                                                                                                                                                                            |
+| Top-level throw | Summary includes `error: { type, message }`; **`warn` / `error` logs use the same safe shape**—never attach raw `Error` objects (avoids leaking rich provider payloads)                                                                                                                                                                                                                                        |
 
 **Security:** Logs intentionally exclude raw article `content`, API keys, and bearer tokens. Chunk and summary payloads use ids and counts only.
 
@@ -98,10 +98,10 @@ Tuning for extraction, chunking, **`scoreBreakdownVersion`** (maps to `_version`
 
 Optional **`prompts.systemPrompt`** and **`prompts.userPromptTemplate`** in Hermes override the **built-in default** extraction wording. When a field is omitted, the agent uses the package default template (same behavior as before this feature). **`openaiApiKey`** and model settings stay in their dedicated config fields—**do not** embed secrets inside prompt text.
 
-| Hermes field | Role when set | Placeholders (must be spelled exactly) |
-| ------------ | -------------- | --------------------------------------- |
-| **`prompts.systemPrompt`** | Full system message template | `{{entityTypesBlock}}`, `{{relationTypesBlock}}` (formatted lists from analysis GET vocabulary) |
-| **`prompts.userPromptTemplate`** | Full user message template | `{{tickerId}}`, `{{title}}`, `{{articleContent}}` (body is truncated per **`maxContentChars`**) |
+| Hermes field                     | Role when set                | Placeholders (must be spelled exactly)                                                          |
+| -------------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| **`prompts.systemPrompt`**       | Full system message template | `{{entityTypesBlock}}`, `{{relationTypesBlock}}` (formatted lists from analysis GET vocabulary) |
+| **`prompts.userPromptTemplate`** | Full user message template   | `{{tickerId}}`, `{{title}}`, `{{articleContent}}` (body is truncated per **`maxContentChars`**) |
 
 **Scalar knobs that still affect extraction** when prompts are empty (defaults): **`maxContentChars`**, **`maxOutputTokens`**, **`openaiModel`**, caps (`maxEntitiesPerArticle`, …), and vocabulary from GET—these are independent of prompt wording. When you set full-string overrides, you replace the instruction text only; caps and truncation still apply before substitution.
 
@@ -109,16 +109,16 @@ Unknown `{{token}}` values fail **config validation** in Hermes with the bad tok
 
 ## Deployment environment (`@mediapulse/env/agents-article-analysis`)
 
-| Variable                     | Required | Notes                                                      |
-| ---------------------------- | -------- | ---------------------------------------------------------- |
-| `PORT`                       | Yes      | Agent HTTP port                                            |
-| `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                          |
-| `AGENT_DATA_API_URL`         | Yes      | Base URL for agent-data-api                                |
-| `AGENT_REGISTRY_URL`         | No       | Needed for auto-register                                   |
+| Variable                     | Required | Notes                                                          |
+| ---------------------------- | -------- | -------------------------------------------------------------- |
+| `PORT`                       | Yes      | Agent HTTP port                                                |
+| `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                              |
+| `AGENT_DATA_API_URL`         | Yes      | Base URL for agent-data-api                                    |
+| `AGENT_REGISTRY_URL`         | No       | Needed for auto-register                                       |
 | `DOMAIN_INTEGRATION_API_KEY` | No       | Hermes domain integration API key for auto-register (mint JWT) |
-| `AGENT_PUBLIC_URL`           | No       | Needed for auto-register                                   |
-| `DOMAIN_INTEGRATION_ID`      | No       | Domain id (default `mediapulse`)                           |
-| `ALLOW_ANY_BEARER_FOR_LOCAL` | No       | Local-only; never use in production                        |
+| `AGENT_PUBLIC_URL`           | No       | Needed for auto-register                                       |
+| `DOMAIN_INTEGRATION_ID`      | No       | Domain id (default `mediapulse`)                               |
+| `ALLOW_ANY_BEARER_FOR_LOCAL` | No       | Local-only; never use in production                            |
 
 ## Pipeline usage
 

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -24,6 +24,10 @@ The content-generation agent takes **selected data sources** (scored by the anal
 
 - **Main:** `src/index.ts` — Exports a Bun/Hono-compatible `fetch` and `port` (default **4002**).
 
+## Hermes run payload (success)
+
+Successful runs include `details.promptHash` (16-character hex, same algorithm as stored newsletter provenance) so operators can correlate the invoke response with persisted rows without logging full prompts.
+
 ## Port
 
 - **4002** (default from `env.PORT`).

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -34,38 +34,38 @@ Successful runs include `details.promptHash` (16-character hex, same algorithm a
 
 ## Config schema
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `openai.apiKey` | `string` | ✅ | — | OpenAI API key. Required if `openaiApiKey` is omitted. |
-| `openai.model` | `string` | ❌ | `gpt-4o-mini` | Chat model id. |
-| `openai.baseUrl` | `string (url)` | ❌ | official | OpenAI-compatible API base URL. |
-| `openai.timeoutMs` | `number` | ❌ | `120000` | Per-request timeout in milliseconds. |
-| `openaiApiKey` | `string` | ❌ | — | **Deprecated**: Use `openai.apiKey`. |
-| `openaiModel` | `string` | ❌ | — | **Deprecated**: Use `openai.model`. |
-| `prompts.systemPrompt` | `string` | ❌ | built-in default | Full system template. Allowed placeholders: `{{topNewsCount}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`. Hermes JSON schema lists them for SchemaForm. Max length enforced at parse time (`CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH`). **Not for secrets** — use `openai.apiKey` only. |
-| `prompts.userPromptTemplate` | `string` | ❌ | built-in default | User template. Allowed placeholders: `{{sourceSummaries}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`, `{{date}}`, `{{topNewsCount}}`. Same max length and validation as system. **Not for secrets.** |
-| `llmRetry.maxAttempts` | `number` | ❌ | `3` | Max retry attempts (including first). |
-| `llmRetry.baseDelayMs` | `number` | ❌ | `500` | Base backoff delay in ms. |
-| `llmRetry.maxDelayMs` | `number` | ❌ | `8000` | Max backoff delay cap in ms. |
-| `llmRetry.jitter` | `boolean` | ❌ | `true` | Apply ±50% jitter to delays. |
-| `persistRetry.maxAttempts` | `number` | ❌ | `2` | Max persist retry attempts (including first). |
-| `persistRetry.baseDelayMs` | `number` | ❌ | `200` | Base backoff delay in ms. |
-| `persistRetry.maxDelayMs` | `number` | ❌ | `2000` | Max backoff delay cap in ms. No jitter (unlike llmRetry). |
+| Field                        | Type           | Required | Default          | Description                                                                                                                                                                                                                                                                                               |
+| ---------------------------- | -------------- | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openai.apiKey`              | `string`       | ✅       | —                | OpenAI API key. Required if `openaiApiKey` is omitted.                                                                                                                                                                                                                                                    |
+| `openai.model`               | `string`       | ❌       | `gpt-4o-mini`    | Chat model id.                                                                                                                                                                                                                                                                                            |
+| `openai.baseUrl`             | `string (url)` | ❌       | official         | OpenAI-compatible API base URL.                                                                                                                                                                                                                                                                           |
+| `openai.timeoutMs`           | `number`       | ❌       | `120000`         | Per-request timeout in milliseconds.                                                                                                                                                                                                                                                                      |
+| `openaiApiKey`               | `string`       | ❌       | —                | **Deprecated**: Use `openai.apiKey`.                                                                                                                                                                                                                                                                      |
+| `openaiModel`                | `string`       | ❌       | —                | **Deprecated**: Use `openai.model`.                                                                                                                                                                                                                                                                       |
+| `prompts.systemPrompt`       | `string`       | ❌       | built-in default | Full system template. Allowed placeholders: `{{topNewsCount}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`. Hermes JSON schema lists them for SchemaForm. Max length enforced at parse time (`CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH`). **Not for secrets** — use `openai.apiKey` only. |
+| `prompts.userPromptTemplate` | `string`       | ❌       | built-in default | User template. Allowed placeholders: `{{sourceSummaries}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`, `{{date}}`, `{{topNewsCount}}`. Same max length and validation as system. **Not for secrets.**                                                                                          |
+| `llmRetry.maxAttempts`       | `number`       | ❌       | `3`              | Max retry attempts (including first).                                                                                                                                                                                                                                                                     |
+| `llmRetry.baseDelayMs`       | `number`       | ❌       | `500`            | Base backoff delay in ms.                                                                                                                                                                                                                                                                                 |
+| `llmRetry.maxDelayMs`        | `number`       | ❌       | `8000`           | Max backoff delay cap in ms.                                                                                                                                                                                                                                                                              |
+| `llmRetry.jitter`            | `boolean`      | ❌       | `true`           | Apply ±50% jitter to delays.                                                                                                                                                                                                                                                                              |
+| `persistRetry.maxAttempts`   | `number`       | ❌       | `2`              | Max persist retry attempts (including first).                                                                                                                                                                                                                                                             |
+| `persistRetry.baseDelayMs`   | `number`       | ❌       | `200`            | Base backoff delay in ms.                                                                                                                                                                                                                                                                                 |
+| `persistRetry.maxDelayMs`    | `number`       | ❌       | `2000`           | Max backoff delay cap in ms. No jitter (unlike llmRetry).                                                                                                                                                                                                                                                 |
 
 ## Error taxonomy
 
 Every run exit path maps to a canonical `OutcomeCode` (defined in `src/types/outcome.ts`):
 
-| Code | Description |
-|---|---|
-| `no_sources` | No data sources found; run skipped without calling OpenAI |
-| `skipped_fresh_newsletter_exists` | Fresh newsletter exists; run skipped (MP-CGA-006) |
-| `openai_retry_exhausted` | LLM returned retryable errors and all retries were exhausted |
-| `openai_non_retryable` | LLM returned a non-retryable error (auth, bad request, etc.) |
-| `openai_invalid_response` | LLM returned HTTP 200 but no structured object was produced |
-| `validation_failed` | LLM output failed Zod schema validation (`TypeValidationError`) |
-| `persist_transient` | agent-data-api returned 429 or 5xx on newsletter create and all persist retries were exhausted |
-| `persist_client_error` | agent-data-api returned a non-retryable 4xx client error on newsletter create (no retry attempted) |
+| Code                              | Description                                                                                        |
+| --------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `no_sources`                      | No data sources found; run skipped without calling OpenAI                                          |
+| `skipped_fresh_newsletter_exists` | Fresh newsletter exists; run skipped (MP-CGA-006)                                                  |
+| `openai_retry_exhausted`          | LLM returned retryable errors and all retries were exhausted                                       |
+| `openai_non_retryable`            | LLM returned a non-retryable error (auth, bad request, etc.)                                       |
+| `openai_invalid_response`         | LLM returned HTTP 200 but no structured object was produced                                        |
+| `validation_failed`               | LLM output failed Zod schema validation (`TypeValidationError`)                                    |
+| `persist_transient`               | agent-data-api returned 429 or 5xx on newsletter create and all persist retries were exhausted     |
+| `persist_client_error`            | agent-data-api returned a non-retryable 4xx client error on newsletter create (no retry attempted) |
 
 The `AgentRunResult` envelope returned to Hermes is unchanged: `{ success: false, message: "..." }` for all failure/skip paths. The `AgentOutcome` internal type (with `OutcomeCode` and `skipped` flag) is available for future diagnostic writes (MP-CGA-007). Persist retry logic uses `persistRetry` config (MP-CGA-009); the `stage` field in diagnostic records is `"persist"` for both persist outcome codes (MP-CGA-007).
 

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -57,6 +57,10 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data. |
 | **Merge / persistence** | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math. |
 
+## Hermes run payload
+
+Successful runs return `details` including the agent-data-api create response fields plus **`llmPromptFingerprint`** (16-character hex, same algorithm as content-generation `promptHash`) so operators can tell runs apart when only prompt templates changed in Hermes config.
+
 ## Pipeline usage
 
 - Included in **Pipeline A: Query Analysis**

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -22,40 +22,40 @@ It uses:
 
 ## Environment variables
 
-| Variable                     | Required | Notes                                                      |
-| ---------------------------- | -------- | ---------------------------------------------------------- |
-| `PORT`                       | Yes      | Agent HTTP port                                            |
-| `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                          |
-| `AGENT_DATA_API_URL`         | Yes      | Base URL for data API calls                                |
-| `AGENT_REGISTRY_URL`         | Yes      | Agent-registry-api base URL (startup auto-register)        |
-| `AGENT_PUBLIC_URL`           | Yes      | Public URL of this agent (registry `endpoint`)             |
+| Variable                     | Required | Notes                                                          |
+| ---------------------------- | -------- | -------------------------------------------------------------- |
+| `PORT`                       | Yes      | Agent HTTP port                                                |
+| `AGENT_AUTH_API_URL`         | Yes      | JWT/API-key verification endpoint                              |
+| `AGENT_DATA_API_URL`         | Yes      | Base URL for data API calls                                    |
+| `AGENT_REGISTRY_URL`         | Yes      | Agent-registry-api base URL (startup auto-register)            |
+| `AGENT_PUBLIC_URL`           | Yes      | Public URL of this agent (registry `endpoint`)                 |
 | `DOMAIN_INTEGRATION_API_KEY` | Yes      | Hermes domain integration API key for auto-register (mint JWT) |
-| `DOMAIN_INTEGRATION_ID`      | Yes      | Stable Hermes domain integration id (e.g. `mediapulse`)      |
+| `DOMAIN_INTEGRATION_ID`      | Yes      | Stable Hermes domain integration id (e.g. `mediapulse`)        |
 
 ## Hermes agent `config` (strategy + LLM)
 
 This agent is configured per pipeline step via the Hermes invoke request body `config`.
 
-| Field | Required | Notes |
-| --- | --- | --- |
-| `openaiApiKey` | Yes | OpenAI API key (never stored in `packages/mediapulse/env` for this agent). |
-| `openaiModel` | No | Defaults to `gpt-4o-mini`. |
-| `queryCount` | No | Total queries to persist (default `10`). |
-| `minDeterministicCount` | No | Deterministic “floor” before LLM complement (default `4`). |
-| `allowedLanguages` | No | Target languages as BCP-47 codes (default `["en"]`). |
-| `weightBreaking` / `weightKgChange` / `weightFundamental` | No | Intent mix weights (default `1`, `0.8`, `0.6`). |
-| `maxTokens` | No | LLM output token budget (default `800`). |
-| `prompts.systemPrompt` | No | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
-| `prompts.userPromptTemplate` | No | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context). |
+| Field                                                     | Required | Notes                                                                                                                                                                                                                                        |
+| --------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `openaiApiKey`                                            | Yes      | OpenAI API key (never stored in `packages/mediapulse/env` for this agent).                                                                                                                                                                   |
+| `openaiModel`                                             | No       | Defaults to `gpt-4o-mini`.                                                                                                                                                                                                                   |
+| `queryCount`                                              | No       | Total queries to persist (default `10`).                                                                                                                                                                                                     |
+| `minDeterministicCount`                                   | No       | Deterministic “floor” before LLM complement (default `4`).                                                                                                                                                                                   |
+| `allowedLanguages`                                        | No       | Target languages as BCP-47 codes (default `["en"]`).                                                                                                                                                                                         |
+| `weightBreaking` / `weightKgChange` / `weightFundamental` | No       | Intent mix weights (default `1`, `0.8`, `0.6`).                                                                                                                                                                                              |
+| `maxTokens`                                               | No       | LLM output token budget (default `800`).                                                                                                                                                                                                     |
+| `prompts.systemPrompt`                                    | No       | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
+| `prompts.userPromptTemplate`                              | No       | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context).                                                                                                                         |
 
 ### Weights vs prompt overrides (REQ-010)
 
-| Situation | What still affects the LLM |
-| --------- | --------------------------- |
-| **No `prompts` fields** | Package defaults: system text includes approximate breaking / kg_change / fundamental counts computed from **`queryCount`** and **`weightBreaking`** / **`weightKgChange`** / **`weightFundamental`**; user text is the GET context. **`allowedLanguages`** and **`minDeterministicCount`** appear in the default system prompt. |
-| **`prompts.systemPrompt` set** | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{minDeterministicCount}}`** are still filled from the same strategy fields so you can reference numeric targets without redeploying. |
-| **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data. |
-| **Merge / persistence** | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math. |
+| Situation                            | What still affects the LLM                                                                                                                                                                                                                                                                                                       |
+| ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **No `prompts` fields**              | Package defaults: system text includes approximate breaking / kg_change / fundamental counts computed from **`queryCount`** and **`weightBreaking`** / **`weightKgChange`** / **`weightFundamental`**; user text is the GET context. **`allowedLanguages`** and **`minDeterministicCount`** appear in the default system prompt. |
+| **`prompts.systemPrompt` set**       | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{minDeterministicCount}}`** are still filled from the same strategy fields so you can reference numeric targets without redeploying.                 |
+| **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data.                                                                                                                                                                                             |
+| **Merge / persistence**              | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math.                                                                                                                               |
 
 ## Hermes run payload
 

--- a/packages/shared/agent-llm-prompt-template/README.md
+++ b/packages/shared/agent-llm-prompt-template/README.md
@@ -4,5 +4,6 @@ Shared helpers for Mediapulse/Hermes agent configs that use `{{placeholder}}` st
 
 - `listLlmPromptPlaceholderNames` / `findUnknownLlmPromptPlaceholderTokens` — validate templates at Zod parse time.
 - `substituteLlmPromptTemplate` — replace known tokens with runtime values.
+- `computeLlmPromptFingerprint` — SHA-256 fingerprint (16 hex chars) of `system + "\n\n" + resolvedUser` for run diagnostics (REQ-011).
 
 Build: `pnpm build` in this package (emits `dist/`). Consumers import from `@workspace/agent-llm-prompt-template`.

--- a/packages/shared/agent-llm-prompt-template/src/compute-llm-prompt-fingerprint.test.ts
+++ b/packages/shared/agent-llm-prompt-template/src/compute-llm-prompt-fingerprint.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { computeLlmPromptFingerprint } from "./compute-llm-prompt-fingerprint.js";
+
+describe("computeLlmPromptFingerprint", () => {
+  it("returns the same value for identical prompt pairs", () => {
+    const a = computeLlmPromptFingerprint("sys", "user");
+    const b = computeLlmPromptFingerprint("sys", "user");
+    expect(a).toBe(b);
+    expect(a).toHaveLength(16);
+  });
+
+  it("differs when only system prompt changes", () => {
+    const u = "user";
+    const h1 = computeLlmPromptFingerprint("sys-a", u);
+    const h2 = computeLlmPromptFingerprint("sys-b", u);
+    expect(h1).not.toBe(h2);
+  });
+
+  it("differs when system and user are concatenated differently than swapped order", () => {
+    const h1 = computeLlmPromptFingerprint("a", "b");
+    const h2 = computeLlmPromptFingerprint("b", "a");
+    expect(h1).not.toBe(h2);
+  });
+});

--- a/packages/shared/agent-llm-prompt-template/src/compute-llm-prompt-fingerprint.ts
+++ b/packages/shared/agent-llm-prompt-template/src/compute-llm-prompt-fingerprint.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Computes a deterministic short fingerprint of the exact prompts sent to an LLM.
+ *
+ * Algorithm: SHA-256(`systemPrompt` + "\n\n" + `resolvedUserPrompt`) → first 16 hex chars.
+ * Matches content-generation provenance `promptHash` semantics (MP-CGA-008).
+ *
+ * @param systemPrompt - The system-role prompt sent to the model.
+ * @param resolvedUserPrompt - The user-role prompt after placeholder substitution.
+ * @returns 16-character hex string identifying the prompt pair.
+ */
+export const computeLlmPromptFingerprint = (
+  systemPrompt: string,
+  resolvedUserPrompt: string,
+): string => {
+  const combined = `${systemPrompt}\n\n${resolvedUserPrompt}`;
+  return createHash("sha256").update(combined).digest("hex").slice(0, 16);
+};

--- a/packages/shared/agent-llm-prompt-template/src/index.ts
+++ b/packages/shared/agent-llm-prompt-template/src/index.ts
@@ -3,3 +3,4 @@ export {
   listLlmPromptPlaceholderNames,
   substituteLlmPromptTemplate,
 } from "./llm-prompt-template.js";
+export { computeLlmPromptFingerprint } from "./compute-llm-prompt-fingerprint.js";


### PR DESCRIPTION
## Summary

Resolved LLM prompts now get a stable SHA-256 fingerprint (system plus user) for all three agents. Run `details` and summary paths expose the hash; info-level logs avoid shipping full prompt bodies.

## Important changes

- `computeLlmPromptFingerprint` in `@workspace/agent-llm-prompt-template`; content-generation delegates its existing hash helper.
- Fingerprints on successful runs for article-analysis, query-analysis, and content-generation.
- Tests cover differing prompts and observability wiring.

## How to test

- `pnpm vitest run` in the three agent packages and `packages/shared/agent-llm-prompt-template`.
- `pnpm format:check` at repo root.

## Stack

This is **layer 4 of 4**, on top of `issue-481-content-generation-prompt-hardening`. PRD: [https://github.com/hyperjumptech/mediapulse/blob/prds/mediapulse-agent-prompts-hermes-config.prd.md](https://github.com/hyperjumptech/mediapulse/blob/prds/mediapulse-agent-prompts-hermes-config.prd.md).

## Visual verification

Layer 4 adds prompt fingerprints in run `details` (no new SchemaForm fields). SchemaForm proof for all three agents from this stack:

**article-analysis**

![article-analysis SchemaForm](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/mp-agent-prompts-hermes/478-article-analysis-schemaform.png)

**query-analysis**

![query-analysis SchemaForm](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/mp-agent-prompts-hermes/480-query-analysis-schemaform.png)

**content-generation**

![content-generation SchemaForm](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/mp-agent-prompts-hermes/481-content-generation-schemaform.png)

**Reproduce:** `pnpm dev:hermes` → Agent configs. [issue-proofs archive](https://github.com/hyperjumptech/mediapulse/tree/issue-proofs/mp-agent-prompts-hermes).


## Related issues

Closes #482

