### PR TITLE
Add MCP API key schema and validation helpers

### DIFF
--- a/apps/hermes/dashboard/Dockerfile
+++ b/apps/hermes/dashboard/Dockerfile
@@ -24,6 +24,7 @@ ENV ORCHESTRATION_DATABASE_URL="postgresql://localhost:5432/dummy"
 ENV TEMP_ADMIN_USERNAME="dummy"
 ENV TEMP_ADMIN_PASSWORD="dummy"
 ENV HERMES_INTERNAL_API_KEY="dummy-internal-key"
+ENV HERMES_MCP_API_KEY_PEPPER="dummy-mcp-api-key-pepper"
 ENV AGENT_AUTH_API_URL="http://localhost:8080"
 ENV AGENT_AUTH_JWT_SECRET="dummy-jwt-secret-for-build"
 RUN rm -f apps/hermes/dashboard/.env apps/hermes/dashboard/.env.local && \

--- a/apps/hermes/dashboard/lib/mcp-api-keys.test.ts
+++ b/apps/hermes/dashboard/lib/mcp-api-keys.test.ts
@@ -1,0 +1,350 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const { TEST_PEPPER } = vi.hoisted(() => ({
+  TEST_PEPPER: "test-pepper-not-for-production",
+}));
+
+vi.mock("@hermes/env", () => ({
+  env: {
+    HERMES_MCP_API_KEY_PEPPER: TEST_PEPPER,
+  },
+}));
+
+vi.mock("@hermes/orchestration-database", () => ({
+  UserRole: { ADMIN: "ADMIN", USER: "USER" },
+  prisma: {
+    mcpApiKey: {
+      findFirst: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      updateMany: vi.fn(),
+      findMany: vi.fn(),
+      findUnique: vi.fn(),
+    },
+    user: {
+      findUnique: vi.fn(),
+    },
+  },
+}));
+
+import { UserRole } from "@hermes/orchestration-database";
+
+import {
+  buildMcpApiKeyHashInput,
+  createApiKey,
+  generateMcpApiKeyPlaintext,
+  hashMcpApiKey,
+  MCP_API_KEY_PREFIX,
+  revokeApiKey,
+  timingSafeEqualHex,
+  touchMcpApiKeyLastUsed,
+  validateApiKey,
+} from "./mcp-api-keys";
+
+describe("buildMcpApiKeyHashInput", () => {
+  it("concatenates pepper before plaintext", () => {
+    expect(buildMcpApiKeyHashInput("token", "pep")).toBe("peptoken");
+  });
+});
+
+describe("hashMcpApiKey", () => {
+  it("returns stable hex for the same input", () => {
+    const a = hashMcpApiKey("hmcp_ab_cdef", { pepper: TEST_PEPPER });
+    const b = hashMcpApiKey("hmcp_ab_cdef", { pepper: TEST_PEPPER });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("differs when pepper differs", () => {
+    const a = hashMcpApiKey("same", { pepper: "one" });
+    const b = hashMcpApiKey("same", { pepper: "two" });
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("timingSafeEqualHex", () => {
+  it("returns true for equal digests", () => {
+    const digest = hashMcpApiKey("x", { pepper: TEST_PEPPER });
+    expect(timingSafeEqualHex(digest, digest)).toBe(true);
+  });
+
+  it("returns false for different digests", () => {
+    expect(timingSafeEqualHex("aa", "ab")).toBe(false);
+  });
+
+  it("returns false for unequal lengths", () => {
+    expect(timingSafeEqualHex("a", "aa")).toBe(false);
+  });
+});
+
+describe("generateMcpApiKeyPlaintext", () => {
+  it("uses hmcp prefix and two segments", () => {
+    const { apiKeyPlaintext } = generateMcpApiKeyPlaintext();
+    expect(apiKeyPlaintext.startsWith(`${MCP_API_KEY_PREFIX}_`)).toBe(true);
+    const parts = apiKeyPlaintext.split("_");
+    expect(parts.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe("validateApiKey", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const plaintext = "hmcp_pub_secrettoken";
+  const keyHash = hashMcpApiKey(plaintext, { pepper: TEST_PEPPER });
+
+  const activeRow = {
+    id: "key-1",
+    label: "Cursor",
+    readOnly: false,
+    createdByUserId: "user-1",
+    ownerCredentialVersion: 2,
+    revokedAt: null as Date | null,
+  };
+
+  const activeOwner = {
+    role: UserRole.ADMIN,
+    isActive: true,
+    credentialVersion: 2,
+  };
+
+  it("returns metadata for a valid active key and owner", async () => {
+    const findFirst = vi.fn().mockResolvedValue(activeRow);
+    const findUnique = vi.fn().mockResolvedValue(activeOwner);
+
+    const result = await validateApiKey(plaintext, {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique },
+    });
+
+    expect(result).toEqual({
+      id: "key-1",
+      label: "Cursor",
+      readOnly: false,
+      createdByUserId: "user-1",
+    });
+    expect(findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { keyHash, revokedAt: null },
+      }),
+    );
+  });
+
+  it("returns null for unknown key hash", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const result = await validateApiKey("hmcp_x_y", {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique: vi.fn() },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when key row is revoked", async () => {
+    const findFirst = vi.fn().mockResolvedValue({
+      ...activeRow,
+      revokedAt: new Date(),
+    });
+    const result = await validateApiKey(plaintext, {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique: vi.fn().mockResolvedValue(activeOwner) },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when owner is not ADMIN", async () => {
+    const findFirst = vi.fn().mockResolvedValue(activeRow);
+    const findUnique = vi.fn().mockResolvedValue({
+      ...activeOwner,
+      role: UserRole.USER,
+    });
+    const result = await validateApiKey(plaintext, {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when owner credentialVersion mismatches snapshot", async () => {
+    const findFirst = vi.fn().mockResolvedValue(activeRow);
+    const findUnique = vi.fn().mockResolvedValue({
+      ...activeOwner,
+      credentialVersion: 99,
+    });
+    const result = await validateApiKey(plaintext, {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique },
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not log plaintext in findFirst arguments", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    await validateApiKey(plaintext, {
+      pepper: TEST_PEPPER,
+      db: {
+        findFirst,
+        create: vi.fn(),
+        update: vi.fn(),
+        findMany: vi.fn(),
+        findUnique: vi.fn(),
+      },
+      userDb: { findUnique: vi.fn() },
+    });
+    const serialized = JSON.stringify(findFirst.mock.calls);
+    expect(serialized).not.toContain(plaintext);
+    expect(serialized).toContain(keyHash);
+  });
+});
+
+describe("createApiKey", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("stores hash only and returns plaintext once", async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      role: UserRole.ADMIN,
+      isActive: true,
+      credentialVersion: 1,
+    });
+    const create = vi
+      .fn()
+      .mockImplementation(async (args: { data: { keyHash: string } }) => ({
+        id: "new-id",
+        label: "Dev",
+        readOnly: true,
+        createdByUserId: "user-1",
+        keyHash: args.data.keyHash,
+      }));
+
+    const result = await createApiKey(
+      { label: " Dev ", readOnly: true, createdByUserId: "user-1" },
+      {
+        pepper: TEST_PEPPER,
+        db: {
+          findFirst: vi.fn(),
+          create,
+          update: vi.fn(),
+          findMany: vi.fn(),
+          findUnique: vi.fn(),
+        },
+        userDb: { findUnique },
+      },
+    );
+
+    expect(result.apiKeyPlaintext.startsWith(`${MCP_API_KEY_PREFIX}_`)).toBe(
+      true,
+    );
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          label: "Dev",
+          readOnly: true,
+          ownerCredentialVersion: 1,
+          keyHash: hashMcpApiKey(result.apiKeyPlaintext, {
+            pepper: TEST_PEPPER,
+          }),
+        }),
+      }),
+    );
+    const createSerialized = JSON.stringify(create.mock.calls);
+    expect(createSerialized).not.toContain(result.apiKeyPlaintext);
+  });
+
+  it("rejects non-admin owners", async () => {
+    const findUnique = vi.fn().mockResolvedValue({
+      role: UserRole.USER,
+      isActive: true,
+      credentialVersion: 0,
+    });
+    await expect(
+      createApiKey(
+        { label: "x", readOnly: false, createdByUserId: "user-1" },
+        {
+          pepper: TEST_PEPPER,
+          db: {
+            findFirst: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            findMany: vi.fn(),
+            findUnique: vi.fn(),
+          },
+          userDb: { findUnique },
+        },
+      ),
+    ).rejects.toThrow(/active Hermes admin/);
+  });
+});
+
+describe("revokeApiKey", () => {
+  it("returns true when a row is updated", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const ok = await revokeApiKey("key-1", "admin-1", {
+      db: { updateMany },
+    });
+    expect(ok).toBe(true);
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "key-1", revokedAt: null },
+      }),
+    );
+  });
+
+  it("returns false when no row matches", async () => {
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const ok = await revokeApiKey("missing", "admin-1", {
+      db: { updateMany },
+    });
+    expect(ok).toBe(false);
+  });
+});
+
+describe("touchMcpApiKeyLastUsed", () => {
+  it("updates lastUsedAt", async () => {
+    const update = vi.fn().mockResolvedValue({});
+    await touchMcpApiKeyLastUsed("key-1", { db: { update } });
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "key-1" },
+        data: { lastUsedAt: expect.any(Date) },
+      }),
+    );
+  });
+});

--- a/apps/hermes/dashboard/lib/mcp-api-keys.ts
+++ b/apps/hermes/dashboard/lib/mcp-api-keys.ts
@@ -1,0 +1,292 @@
+import { type Prisma, prisma, UserRole } from "@hermes/orchestration-database";
+import { env } from "@hermes/env";
+import * as crypto from "node:crypto";
+
+/** Prefix for MCP API key plaintext (`hmcp_<publicId>_<secret>`). */
+export const MCP_API_KEY_PREFIX = "hmcp" as const;
+
+/** Result of a successful {@link validateApiKey} call (no secrets). */
+export type ValidatedMcpApiKey = {
+  id: string;
+  label: string;
+  readOnly: boolean;
+  createdByUserId: string;
+};
+
+export type CreateMcpApiKeyInput = {
+  label: string;
+  readOnly: boolean;
+  createdByUserId: string;
+};
+
+export type CreateMcpApiKeyResult = {
+  id: string;
+  label: string;
+  readOnly: boolean;
+  createdByUserId: string;
+  /** Full Bearer token; show once to the operator. */
+  apiKeyPlaintext: string;
+};
+
+type McpApiKeyDb = Pick<
+  typeof prisma.mcpApiKey,
+  "findFirst" | "create" | "update" | "findMany"
+> & {
+  findUnique: Pick<typeof prisma.mcpApiKey, "findUnique">["findUnique"];
+};
+
+type UserDb = Pick<typeof prisma.user, "findUnique">;
+
+type HashMcpApiKeyDependencies = {
+  pepper?: string;
+};
+
+type ValidateMcpApiKeyDependencies = {
+  db?: McpApiKeyDb;
+  userDb?: UserDb;
+  pepper?: string;
+};
+
+type CreateMcpApiKeyDependencies = ValidateMcpApiKeyDependencies;
+
+type RevokeMcpApiKeyDependencies = {
+  db?: Pick<typeof prisma.mcpApiKey, "updateMany">;
+};
+
+type TouchMcpApiKeyLastUsedDependencies = {
+  db?: Pick<typeof prisma.mcpApiKey, "update">;
+};
+
+/**
+ * Builds the peppered input string hashed for MCP API key storage.
+ *
+ * @param plaintext - Raw Bearer token.
+ * @param pepper - Server secret from env.
+ * @returns Bytes fed to SHA-256.
+ */
+export const buildMcpApiKeyHashInput = (
+  plaintext: string,
+  pepper: string,
+): string => `${pepper}${plaintext}`;
+
+/**
+ * Returns SHA-256 hex of the peppered MCP API key (storage format).
+ *
+ * @param plaintext - Raw Bearer token.
+ * @param dependencies - Injectable pepper (default: {@link env.HERMES_MCP_API_KEY_PEPPER}).
+ * @returns Lowercase hex digest.
+ */
+export const hashMcpApiKey = (
+  plaintext: string,
+  { pepper = env.HERMES_MCP_API_KEY_PEPPER }: HashMcpApiKeyDependencies = {},
+): string => {
+  return crypto
+    .createHash("sha256")
+    .update(buildMcpApiKeyHashInput(plaintext, pepper))
+    .digest("hex");
+};
+
+/**
+ * Constant-time comparison of two equal-length hex strings.
+ *
+ * @param a - First hex digest.
+ * @param b - Second hex digest.
+ * @returns Whether digests match.
+ */
+export const timingSafeEqualHex = (a: string, b: string): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Generates a new MCP API key plaintext (`hmcp_<id>_<secret>`).
+ *
+ * @returns Public id segment and full plaintext token.
+ */
+export const generateMcpApiKeyPlaintext = (): {
+  publicId: string;
+  apiKeyPlaintext: string;
+} => {
+  const publicId = crypto.randomBytes(6).toString("base64url");
+  const secret = crypto.randomBytes(32).toString("base64url");
+  const apiKeyPlaintext = `${MCP_API_KEY_PREFIX}_${publicId}_${secret}`;
+  return { publicId, apiKeyPlaintext };
+};
+
+const defaultFindActiveKeyByHash = async (
+  keyHash: string,
+  db: McpApiKeyDb,
+): Promise<{
+  id: string;
+  label: string;
+  readOnly: boolean;
+  createdByUserId: string;
+  ownerCredentialVersion: number;
+  revokedAt: Date | null;
+} | null> => {
+  const args = {
+    where: { keyHash, revokedAt: null },
+    select: {
+      id: true,
+      label: true,
+      readOnly: true,
+      createdByUserId: true,
+      ownerCredentialVersion: true,
+      revokedAt: true,
+    },
+  } satisfies Prisma.McpApiKeyFindFirstArgs;
+  return db.findFirst(args);
+};
+
+const defaultFindOwnerUser = async (
+  userId: string,
+  userDb: UserDb,
+): Promise<{
+  role: UserRole;
+  isActive: boolean;
+  credentialVersion: number;
+} | null> => {
+  const args = {
+    where: { id: userId },
+    select: { role: true, isActive: true, credentialVersion: true },
+  } satisfies Prisma.UserFindUniqueArgs;
+  return userDb.findUnique(args);
+};
+
+/**
+ * Validates a plaintext MCP API key and returns metadata when the key and owner are active.
+ *
+ * @param plaintext - Raw Bearer token.
+ * @param dependencies - Injectable DB and pepper.
+ * @returns Key metadata or `null` when invalid, revoked, or owner cannot authenticate.
+ */
+export const validateApiKey = async (
+  plaintext: string,
+  {
+    db = prisma.mcpApiKey,
+    userDb = prisma.user,
+    pepper = env.HERMES_MCP_API_KEY_PEPPER,
+  }: ValidateMcpApiKeyDependencies = {},
+): Promise<ValidatedMcpApiKey | null> => {
+  const keyHash = hashMcpApiKey(plaintext, { pepper });
+  const row = await defaultFindActiveKeyByHash(keyHash, db);
+  if (!row || row.revokedAt) {
+    return null;
+  }
+
+  const owner = await defaultFindOwnerUser(row.createdByUserId, userDb);
+  if (
+    !owner ||
+    owner.role !== UserRole.ADMIN ||
+    !owner.isActive ||
+    owner.credentialVersion !== row.ownerCredentialVersion
+  ) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    label: row.label,
+    readOnly: row.readOnly,
+    createdByUserId: row.createdByUserId,
+  };
+};
+
+/**
+ * Creates an MCP API key for the given admin user; returns plaintext once.
+ *
+ * @param input - Label, read-only flag, and creating user id.
+ * @param dependencies - Injectable DB, user lookup, and pepper.
+ * @returns Created row metadata and one-time plaintext key.
+ */
+export const createApiKey = async (
+  input: CreateMcpApiKeyInput,
+  {
+    db = prisma.mcpApiKey,
+    userDb = prisma.user,
+    pepper = env.HERMES_MCP_API_KEY_PEPPER,
+  }: CreateMcpApiKeyDependencies = {},
+): Promise<CreateMcpApiKeyResult> => {
+  const owner = await defaultFindOwnerUser(input.createdByUserId, userDb);
+  if (!owner || owner.role !== UserRole.ADMIN || !owner.isActive) {
+    throw new Error(
+      "MCP API keys can only be created by an active Hermes admin",
+    );
+  }
+
+  const { apiKeyPlaintext } = generateMcpApiKeyPlaintext();
+  const keyHash = hashMcpApiKey(apiKeyPlaintext, { pepper });
+
+  const createArgs = {
+    data: {
+      label: input.label.trim(),
+      keyHash,
+      readOnly: input.readOnly,
+      createdByUserId: input.createdByUserId,
+      ownerCredentialVersion: owner.credentialVersion,
+    },
+    select: {
+      id: true,
+      label: true,
+      readOnly: true,
+      createdByUserId: true,
+    },
+  } satisfies Prisma.McpApiKeyCreateArgs;
+
+  const row = await db.create(createArgs);
+
+  return {
+    id: row.id,
+    label: row.label,
+    readOnly: row.readOnly,
+    createdByUserId: row.createdByUserId,
+    apiKeyPlaintext,
+  };
+};
+
+/**
+ * Revokes an MCP API key if it is not already revoked.
+ *
+ * @param apiKeyId - Key row id.
+ * @param revokedByUserId - Admin performing the revoke.
+ * @param dependencies - Injectable DB.
+ * @returns Whether a row was updated.
+ */
+export const revokeApiKey = async (
+  apiKeyId: string,
+  revokedByUserId: string,
+  { db = prisma.mcpApiKey }: RevokeMcpApiKeyDependencies = {},
+): Promise<boolean> => {
+  const updateArgs = {
+    where: { id: apiKeyId, revokedAt: null },
+    data: {
+      revokedAt: new Date(),
+      revokedByUserId,
+    },
+  } satisfies Prisma.McpApiKeyUpdateManyArgs;
+  const result = await db.updateMany(updateArgs);
+  return result.count > 0;
+};
+
+/**
+ * Updates `lastUsedAt` for a validated key (fire-and-forget safe for request path).
+ *
+ * @param apiKeyId - Key row id.
+ * @param dependencies - Injectable DB.
+ */
+export const touchMcpApiKeyLastUsed = async (
+  apiKeyId: string,
+  { db = prisma.mcpApiKey }: TouchMcpApiKeyLastUsedDependencies = {},
+): Promise<void> => {
+  const updateArgs = {
+    where: { id: apiKeyId },
+    data: { lastUsedAt: new Date() },
+  } satisfies Prisma.McpApiKeyUpdateArgs;
+  await db.update(updateArgs);
+};

--- a/apps/hermes/dashboard/vitest.config.mjs
+++ b/apps/hermes/dashboard/vitest.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
       TEMP_ADMIN_PASSWORD: "testtest",
       HERMES_DATA_SOURCE_MAX_TAKE: "5000",
       HERMES_INTERNAL_API_KEY: "test-hermes-internal-api-key",
+      HERMES_MCP_API_KEY_PEPPER: "test-mcp-api-key-pepper",
       AGENT_DATA_API_URL: "http://localhost:8081",
       HERMES_CGA_DIAGNOSTICS_ENABLED: "true",
     },

--- a/dev-setup-local.sh
+++ b/dev-setup-local.sh
@@ -296,6 +296,9 @@ main() {
   if [[ -z "$(read_dotenv_value "$HERMES_ENV_FILE" "HERMES_INTERNAL_API_KEY")" ]]; then
     upsert_env_var "$HERMES_ENV_FILE" "HERMES_INTERNAL_API_KEY" "$(openssl rand -base64 32)"
   fi
+  if [[ -z "$(read_dotenv_value "$HERMES_ENV_FILE" "HERMES_MCP_API_KEY_PEPPER")" ]]; then
+    upsert_env_var "$HERMES_ENV_FILE" "HERMES_MCP_API_KEY_PEPPER" "$(openssl rand -base64 32)"
+  fi
   upsert_env_var "$MEDIAPULSE_ENV_FILE" "AGENT_AUTH_JWT_SECRET" "$JWT_SECRET"
   upsert_env_var "$MEDIAPULSE_ENV_FILE" "AGENT_AUTH_API_URL" "$AGENT_AUTH_API_URL"
   pnpm --filter @hermes/env build && pnpm --filter @mediapulse/env build
@@ -324,6 +327,10 @@ main() {
     if [[ -z "$(read_dotenv_value "$HERMES_ENV_FILE" "HERMES_INTERNAL_API_KEY")" ]]; then
       echo "Warning: HERMES_INTERNAL_API_KEY is empty in $HERMES_ENV_FILE."
       echo "Hermes worker and dashboard need it to mint JWTs (run dev-setup without --skip-admin or set it manually)."
+    fi
+    if [[ -z "$(read_dotenv_value "$HERMES_ENV_FILE" "HERMES_MCP_API_KEY_PEPPER")" ]]; then
+      echo "Warning: HERMES_MCP_API_KEY_PEPPER is empty in $HERMES_ENV_FILE."
+      echo "Hermes dashboard needs it to hash MCP API keys (run dev-setup without --skip-admin or set it manually)."
     fi
     if [[ -z "$(read_dotenv_value "$MEDIAPULSE_ENV_FILE" "DOMAIN_INTEGRATION_API_KEY")" ]]; then
       echo "Warning: DOMAIN_INTEGRATION_API_KEY is empty in $MEDIAPULSE_ENV_FILE."
@@ -374,6 +381,7 @@ main() {
   echo "  - AGENT_AUTH_JWT_SECRET"
   echo "  - AGENT_AUTH_API_URL=$AGENT_AUTH_API_URL"
   echo "  - HERMES_INTERNAL_API_KEY (Hermes worker, dashboard, agent-auth; preset secret)"
+  echo "  - HERMES_MCP_API_KEY_PEPPER (Hermes dashboard MCP API key hashing)"
   echo "  - DOMAIN_INTEGRATION_ID"
   echo "  - DOMAIN_INTEGRATION_API_KEY (generated once; stored encrypted in orchestration DB)"
   echo "Updated apps/mediapulse/agents/*/.env.local with:"

--- a/packages/hermes/env/env.example
+++ b/packages/hermes/env/env.example
@@ -53,3 +53,6 @@ AGENT_DATA_API_URL= #optional
 
 # --- Feature flag: CGA diagnostics UI (content-generation-run list & detail pages). Remove after MP-CGA-007 merges. ---
 HERMES_CGA_DIAGNOSTICS_ENABLED=false #optional #default
+
+# --- Hermes dashboard MCP API keys: server pepper for SHA-256 hashing at rest (never store plaintext). Generate per environment (e.g. openssl rand -base64 32). ---
+HERMES_MCP_API_KEY_PEPPER= #required

--- a/packages/hermes/env/src/index.ts
+++ b/packages/hermes/env/src/index.ts
@@ -22,6 +22,7 @@ export const env = createEnv({
     HERMES_RESEND_FROM: z.string().optional(),
     AGENT_DATA_API_URL: z.string().optional(),
     HERMES_CGA_DIAGNOSTICS_ENABLED: z.string().optional(),
+    HERMES_MCP_API_KEY_PEPPER: z.string().min(1),
   },
   client: {
   },

--- a/packages/hermes/orchestration-database/prisma/migrations/20260515135245_add_mcp_api_key/migration.sql
+++ b/packages/hermes/orchestration-database/prisma/migrations/20260515135245_add_mcp_api_key/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "mcp_api_key" (
+    "id" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "key_hash" TEXT NOT NULL,
+    "read_only" BOOLEAN NOT NULL DEFAULT false,
+    "created_by_user_id" TEXT NOT NULL,
+    "owner_credential_version" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "revoked_at" TIMESTAMP(3),
+    "revoked_by_user_id" TEXT,
+    "last_used_at" TIMESTAMP(3),
+
+    CONSTRAINT "mcp_api_key_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "mcp_api_key_key_hash_key" ON "mcp_api_key"("key_hash");
+
+-- CreateIndex
+CREATE INDEX "mcp_api_key_created_by_user_id_idx" ON "mcp_api_key"("created_by_user_id");
+
+-- AddForeignKey
+ALTER TABLE "mcp_api_key" ADD CONSTRAINT "mcp_api_key_created_by_user_id_fkey" FOREIGN KEY ("created_by_user_id") REFERENCES "user"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "mcp_api_key" ADD CONSTRAINT "mcp_api_key_revoked_by_user_id_fkey" FOREIGN KEY ("revoked_by_user_id") REFERENCES "user"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/hermes/orchestration-database/prisma/schema.prisma
+++ b/packages/hermes/orchestration-database/prisma/schema.prisma
@@ -28,8 +28,32 @@ model User {
   pipelineStepsCreated                PipelineStep[]                @relation("PipelineStepCreatedBy")
   dataSourceExpansionTemplatesCreated DataSourceExpansionTemplate[] @relation("DataSourceExpansionTemplateCreatedBy")
   hermesAdminPasswordResetTokens      HermesAdminPasswordResetToken[]
+  mcpApiKeysCreated                   McpApiKey[]                   @relation("McpApiKeyCreatedBy")
+  mcpApiKeysRevoked                   McpApiKey[]                   @relation("McpApiKeyRevokedBy")
 
   @@map("user")
+}
+
+/// Hashed MCP API key for Hermes dashboard programmatic access (Cursor MCP). Plaintext shown only at creation.
+model McpApiKey {
+  id                     String    @id @default(uuid())
+  label                  String
+  /// SHA-256 hex of `HERMES_MCP_API_KEY_PEPPER` concatenated with the raw Bearer token.
+  keyHash                String    @unique @map("key_hash")
+  readOnly               Boolean   @default(false) @map("read_only")
+  createdByUserId        String    @map("created_by_user_id")
+  /// Snapshot of owner `User.credentialVersion` at key creation; invalidates key on password reset.
+  ownerCredentialVersion Int       @map("owner_credential_version")
+  createdAt              DateTime  @default(now()) @map("created_at")
+  revokedAt              DateTime? @map("revoked_at")
+  revokedByUserId        String?   @map("revoked_by_user_id")
+  lastUsedAt             DateTime? @map("last_used_at")
+
+  createdBy User  @relation("McpApiKeyCreatedBy", fields: [createdByUserId], references: [id], onDelete: Cascade)
+  revokedBy User? @relation("McpApiKeyRevokedBy", fields: [revokedByUserId], references: [id], onDelete: SetNull)
+
+  @@index([createdByUserId])
+  @@map("mcp_api_key")
 }
 
 /// Single-use token for Hermes dashboard admin self-service password reset (secret stored hashed only).


### PR DESCRIPTION
## Summary

Adds the `mcp_api_key` table and shared helpers to create, validate, and revoke Hermes dashboard MCP API keys. Keys are stored as peppered SHA-256 hashes; plaintext is only returned at creation.

## Important changes

- Prisma `McpApiKey` model with owner credential version snapshot
- `HERMES_MCP_API_KEY_PEPPER` in `@hermes/env`
- `apps/hermes/dashboard/lib/mcp-api-keys.ts` with `validateApiKey`, `createApiKey`, `revokeApiKey`
- Unit tests for valid, revoked, wrong, and owner-invalidation cases

## How to test

- `pnpm exec vitest run lib/mcp-api-keys.test.ts` in `apps/hermes/dashboard`
- `pnpm --filter @hermes/orchestration-database db:migrate:dev` with Postgres running

## Related issues

Closes #495