### PR TITLE
Resolve dashboard principal from API key or session

### DIFF
--- a/apps/hermes/dashboard/app/api/mcp/whoami/route.test.ts
+++ b/apps/hermes/dashboard/app/api/mcp/whoami/route.test.ts
@@ -1,11 +1,12 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("@/lib/mcp-api-keys", () => ({
-  validateApiKey: vi.fn(),
+vi.mock("@/lib/auth-dashboard", () => ({
+  DASHBOARD_UNAUTHORIZED_BODY: { error: "Unauthorized" },
+  resolveDashboardPrincipal: vi.fn(),
 }));
 
-import { validateApiKey } from "@/lib/mcp-api-keys";
+import { resolveDashboardPrincipal } from "@/lib/auth-dashboard";
 import { GET } from "./route";
 
 describe("GET /api/mcp/whoami", () => {
@@ -13,41 +14,52 @@ describe("GET /api/mcp/whoami", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns 401 without Authorization header", async () => {
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue(null);
     const res = await GET(new Request("http://localhost/api/mcp/whoami"));
     expect(res.status).toBe(401);
   });
 
-  it("returns 401 for invalid key", async () => {
-    vi.mocked(validateApiKey).mockResolvedValue(null);
-    const res = await GET(
-      new Request("http://localhost/api/mcp/whoami", {
-        headers: { Authorization: "Bearer hmcp_bad" },
-      }),
-    );
+  it("returns 401 for session-only principal", async () => {
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue({
+      authMethod: "session",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+    });
+    const res = await GET(new Request("http://localhost/api/mcp/whoami"));
     expect(res.status).toBe(401);
   });
 
-  it("returns key metadata for valid key", async () => {
-    vi.mocked(validateApiKey).mockResolvedValue({
-      id: "key-1",
+  it("returns key metadata for api_key principal", async () => {
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "Admin",
+        email: "admin@test.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "key-1",
+      readOnly: false,
       label: "Cursor",
-      readOnly: true,
-      createdByUserId: "user-1",
     });
     const res = await GET(
       new Request("http://localhost/api/mcp/whoami", {
-        headers: { Authorization: "Bearer hmcp_ok_secret" },
+        headers: { Authorization: "Bearer hmcp_ok" },
       }),
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as Record<string, unknown>;
     expect(body).toEqual({
       label: "Cursor",
-      readOnly: true,
+      readOnly: false,
       keyId: "key-1",
-      user: { id: "user-1" },
+      user: { id: "u1", email: "admin@test.com", name: "Admin" },
     });
-    expect(JSON.stringify(body)).not.toContain("hmcp_ok_secret");
+    expect(JSON.stringify(body)).not.toContain("hmcp_ok");
   });
 });

--- a/apps/hermes/dashboard/app/api/mcp/whoami/route.ts
+++ b/apps/hermes/dashboard/app/api/mcp/whoami/route.ts
@@ -1,40 +1,27 @@
 import { NextResponse } from "next/server";
 
-import { validateApiKey } from "@/lib/mcp-api-keys";
+import {
+  DASHBOARD_UNAUTHORIZED_BODY,
+  resolveDashboardPrincipal,
+} from "@/lib/auth-dashboard";
 
 /**
- * Parses `Authorization: Bearer <token>` from a request.
- *
- * @param request - Incoming HTTP request.
- * @returns Bearer token or null.
- */
-const parseBearerToken = (request: Request): string | null => {
-  const header = request.headers.get("authorization");
-  if (!header?.toLowerCase().startsWith("bearer ")) {
-    return null;
-  }
-  const token = header.slice(7).trim();
-  return token.length > 0 ? token : null;
-};
-
-/**
- * GET /api/mcp/whoami — returns MCP key metadata for Bearer auth (no secrets).
+ * GET /api/mcp/whoami — returns MCP key and owner identity (no secrets).
  */
 export async function GET(request: Request) {
-  const token = parseBearerToken(request);
-  if (!token) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const validated = await validateApiKey(token);
-  if (!validated) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const principal = await resolveDashboardPrincipal(request);
+  if (!principal || principal.authMethod !== "api_key") {
+    return NextResponse.json(DASHBOARD_UNAUTHORIZED_BODY, { status: 401 });
   }
 
   return NextResponse.json({
-    label: validated.label,
-    readOnly: validated.readOnly,
-    keyId: validated.id,
-    user: { id: validated.createdByUserId },
+    label: principal.label,
+    readOnly: principal.readOnly,
+    keyId: principal.apiKeyId,
+    user: {
+      id: principal.user.id,
+      email: principal.user.email,
+      name: principal.user.name,
+    },
   });
 }

--- a/apps/hermes/dashboard/lib/auth-dashboard.test.ts
+++ b/apps/hermes/dashboard/lib/auth-dashboard.test.ts
@@ -8,12 +8,21 @@ import {
   createSessionClearCookieOptions,
   getCookieFromHeader,
   getDashboardSession,
+  getDashboardSessionFromRequest,
   parseDashboardUserFromAuthCookie,
+  requireDashboardPrincipalForRoute,
   requireDashboardSessionForRoute,
+  resolveDashboardPrincipal,
   resolveHermesActiveAdminDashboardAccess,
 } from "./auth-dashboard";
 
+vi.mock("@/lib/mcp-api-keys", () => ({
+  validateApiKey: vi.fn(),
+  touchMcpApiKeyLastUsed: vi.fn(),
+}));
+
 vi.mock("@hermes/orchestration-database", () => ({
+  UserRole: { ADMIN: "ADMIN", USER: "USER" },
   prisma: {
     user: {
       findUnique: vi.fn(),
@@ -396,5 +405,102 @@ describe("resolveHermesActiveAdminDashboardAccess", () => {
     });
     expect(result).toEqual({ ok: true });
     expect(prisma.user.findUnique).toHaveBeenCalled();
+  });
+});
+
+describe("getDashboardSessionFromRequest", () => {
+  it("parses auth cookies from request", () => {
+    const user = JSON.stringify({
+      id: "u1",
+      name: "A",
+      email: "a@b.com",
+      credentialVersion: 0,
+    });
+    const req = new Request("http://localhost", {
+      headers: {
+        cookie: `auth-token=tok; auth-user=${encodeURIComponent(user)}`,
+      },
+    });
+    expect(getDashboardSessionFromRequest(req)).toEqual({
+      id: "u1",
+      name: "A",
+      email: "a@b.com",
+      credentialVersion: 0,
+    });
+  });
+});
+
+describe("resolveDashboardPrincipal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns api_key principal and touches last used", async () => {
+    const { validateApiKey, touchMcpApiKeyLastUsed } = await import(
+      "@/lib/mcp-api-keys"
+    );
+    vi.mocked(validateApiKey).mockResolvedValue({
+      id: "key-1",
+      label: "Cursor",
+      readOnly: true,
+      createdByUserId: "u1",
+    });
+    vi.mocked(touchMcpApiKeyLastUsed).mockResolvedValue(undefined);
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      role: "ADMIN",
+      isActive: true,
+      credentialVersion: 0,
+      name: "Admin",
+      email: "a@b.com",
+    } as never);
+
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Bearer hmcp_x_y" },
+    });
+    const principal = await resolveDashboardPrincipal(req);
+    expect(principal).toEqual({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "Admin",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "key-1",
+      readOnly: true,
+      label: "Cursor",
+    });
+    expect(touchMcpApiKeyLastUsed).toHaveBeenCalledWith("key-1");
+  });
+
+  it("returns session principal from cookies", async () => {
+    const { validateApiKey } = await import("@/lib/mcp-api-keys");
+    vi.mocked(validateApiKey).mockResolvedValue(null);
+    const user = JSON.stringify({
+      id: "u1",
+      name: "A",
+      email: "a@b.com",
+      credentialVersion: 0,
+    });
+    vi.mocked(prisma.user.findUnique).mockResolvedValue({
+      role: "ADMIN",
+      isActive: true,
+      credentialVersion: 0,
+    } as never);
+    const req = new Request("http://localhost", {
+      headers: {
+        cookie: `auth-token=t; auth-user=${encodeURIComponent(user)}`,
+      },
+    });
+    const principal = await resolveDashboardPrincipal(req);
+    expect(principal?.authMethod).toBe("session");
+  });
+});
+
+describe("requireDashboardPrincipalForRoute", () => {
+  it("throws when unauthenticated", async () => {
+    await expect(requireDashboardPrincipalForRoute()).rejects.toThrow(
+      "Unauthorized",
+    );
   });
 });

--- a/apps/hermes/dashboard/lib/auth-dashboard.test.ts
+++ b/apps/hermes/dashboard/lib/auth-dashboard.test.ts
@@ -436,9 +436,8 @@ describe("resolveDashboardPrincipal", () => {
   });
 
   it("returns api_key principal and touches last used", async () => {
-    const { validateApiKey, touchMcpApiKeyLastUsed } = await import(
-      "@/lib/mcp-api-keys"
-    );
+    const { validateApiKey, touchMcpApiKeyLastUsed } =
+      await import("@/lib/mcp-api-keys");
     vi.mocked(validateApiKey).mockResolvedValue({
       id: "key-1",
       label: "Cursor",

--- a/apps/hermes/dashboard/lib/auth-dashboard.ts
+++ b/apps/hermes/dashboard/lib/auth-dashboard.ts
@@ -1,8 +1,11 @@
-import { prisma } from "@hermes/orchestration-database";
+import { prisma, UserRole } from "@hermes/orchestration-database";
 import type { Prisma } from "@hermes/orchestration-database";
 import { cookies, headers } from "next/headers";
 import type { NextResponse } from "next/server";
 import { z } from "zod";
+
+import { touchMcpApiKeyLastUsed, validateApiKey } from "@/lib/mcp-api-keys";
+import { parseBearerToken } from "@/lib/parse-bearer-token";
 
 /**
  * Zod schema for the JSON stored in the `auth-user` cookie.
@@ -19,6 +22,23 @@ const dashboardAuthUserCookieSchema = z.object({
 
 /** Session payload stored in `auth-user` and validated against `User.credentialVersion` in the DB. */
 export type DashboardUser = z.infer<typeof dashboardAuthUserCookieSchema>;
+
+/** Authenticated caller for MCP-eligible routes (session cookie or MCP API key). */
+export type DashboardPrincipal =
+  | {
+      authMethod: "session";
+      user: DashboardUser;
+    }
+  | {
+      authMethod: "api_key";
+      user: DashboardUser;
+      apiKeyId: string;
+      readOnly: boolean;
+      label: string;
+    };
+
+/** Stable JSON body for 401 responses from dashboard API routes. */
+export const DASHBOARD_UNAUTHORIZED_BODY = { error: "Unauthorized" } as const;
 
 /**
  * Parses the `auth-user` cookie JSON into a {@link DashboardUser}.
@@ -117,6 +137,24 @@ export const getCookieFromHeader = (
  * @param dependencies - Optional getCookieStore and getHeaders for tests.
  * @returns The authenticated user (id, name, email) or null if auth-token or auth-user is missing/invalid.
  */
+/**
+ * Reads dashboard session cookies from a `Request` (for route handlers).
+ *
+ * @param request - Incoming HTTP request.
+ * @returns Parsed session user or null.
+ */
+export const getDashboardSessionFromRequest = (
+  request: Request,
+): DashboardUser | null => {
+  const cookieHeader = request.headers.get("cookie");
+  const token = getCookieFromHeader(cookieHeader, "auth-token");
+  const raw = getCookieFromHeader(cookieHeader, "auth-user");
+  if (!token || !raw) {
+    return null;
+  }
+  return parseDashboardUserFromAuthCookie(raw);
+};
+
 export const getDashboardSession = async ({
   getCookieStore = cookies,
   getHeaders = headers,
@@ -194,6 +232,14 @@ export const createClearDashboardAuthCookies = ({
 /** Default cookie clearer using Next.js `cookies()`. */
 export const clearDashboardAuthCookies = createClearDashboardAuthCookies();
 
+type DashboardUserRecord = {
+  role: string;
+  isActive: boolean;
+  credentialVersion: number;
+  name: string;
+  email: string;
+};
+
 const defaultFindUserForDashboard = async (
   userId: string,
 ): Promise<{
@@ -206,6 +252,98 @@ const defaultFindUserForDashboard = async (
     select: { role: true, isActive: true, credentialVersion: true },
   } satisfies Prisma.UserFindUniqueArgs;
   return prisma.user.findUnique(args);
+};
+
+const defaultFindUserProfileForDashboard = async (
+  userId: string,
+): Promise<DashboardUserRecord | null> => {
+  const args = {
+    where: { id: userId },
+    select: {
+      role: true,
+      isActive: true,
+      credentialVersion: true,
+      name: true,
+      email: true,
+    },
+  } satisfies Prisma.UserFindUniqueArgs;
+  return prisma.user.findUnique(args);
+};
+
+/**
+ * Returns true when the DB user is an active Hermes admin matching the session version.
+ *
+ * @param session - Cookie session payload.
+ * @param user - Database user row.
+ * @returns Whether the session is valid for dashboard access.
+ */
+export const isActiveAdminSessionMatch = (
+  session: DashboardUser,
+  user: { role: string; isActive: boolean; credentialVersion: number },
+): boolean => {
+  return (
+    user.role === UserRole.ADMIN &&
+    user.isActive &&
+    user.credentialVersion === session.credentialVersion
+  );
+};
+
+type ResolveDashboardPrincipalDependencies = {
+  validateKey?: typeof validateApiKey;
+  touchLastUsed?: typeof touchMcpApiKeyLastUsed;
+  findUserProfile?: typeof defaultFindUserProfileForDashboard;
+};
+
+/**
+ * Resolves the dashboard principal from Bearer MCP API key or session cookies.
+ * API key is tried first. Updates `lastUsedAt` on successful API key auth.
+ *
+ * @param request - Incoming HTTP request.
+ * @param dependencies - Injectable validators and DB lookups.
+ * @returns Principal or null when credentials are missing or invalid.
+ */
+export const resolveDashboardPrincipal = async (
+  request: Request,
+  {
+    validateKey = validateApiKey,
+    touchLastUsed = touchMcpApiKeyLastUsed,
+    findUserProfile = defaultFindUserProfileForDashboard,
+  }: ResolveDashboardPrincipalDependencies = {},
+): Promise<DashboardPrincipal | null> => {
+  const bearer = parseBearerToken(request);
+  if (bearer) {
+    const key = await validateKey(bearer);
+    if (!key) {
+      return null;
+    }
+    const owner = await findUserProfile(key.createdByUserId);
+    if (!owner || owner.role !== UserRole.ADMIN || !owner.isActive) {
+      return null;
+    }
+    await touchLastUsed(key.id);
+    return {
+      authMethod: "api_key",
+      user: {
+        id: key.createdByUserId,
+        name: owner.name,
+        email: owner.email,
+        credentialVersion: owner.credentialVersion,
+      },
+      apiKeyId: key.id,
+      readOnly: key.readOnly,
+      label: key.label,
+    };
+  }
+
+  const session = getDashboardSessionFromRequest(request);
+  if (!session) {
+    return null;
+  }
+  const user = await defaultFindUserForDashboard(session.id);
+  if (!user || !isActiveAdminSessionMatch(session, user)) {
+    return null;
+  }
+  return { authMethod: "session", user: session };
 };
 
 /**
@@ -268,12 +406,49 @@ export const requireDashboardSessionForRoute = async (
   }
 
   const user = await defaultFindUserForDashboard(session.id);
-  if (!user || user.role !== "ADMIN" || !user.isActive) {
-    throw new Error("Unauthorized");
-  }
-  if (user.credentialVersion !== session.credentialVersion) {
+  if (!user || !isActiveAdminSessionMatch(session, user)) {
     throw new Error("Unauthorized");
   }
 
   return session;
+};
+
+/**
+ * Required auth for route-action-gen: MCP API key or session cookie.
+ *
+ * @param request - Incoming HTTP request (Bearer or cookies).
+ * @returns Dashboard user for the authenticated principal.
+ */
+export const requireDashboardPrincipalForRoute = async (
+  request?: Request,
+): Promise<DashboardUser> => {
+  let principal: DashboardPrincipal | null = null;
+  if (request) {
+    principal = await resolveDashboardPrincipal(request);
+  } else {
+    const session = await getDashboardSession();
+    if (session) {
+      const user = await defaultFindUserForDashboard(session.id);
+      if (user && isActiveAdminSessionMatch(session, user)) {
+        principal = { authMethod: "session", user: session };
+      }
+    }
+  }
+  if (!principal) {
+    throw new Error("Unauthorized");
+  }
+  return principal.user;
+};
+
+/**
+ * Returns the dashboard user from a resolved principal or null.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns User when authenticated; otherwise null.
+ */
+export const getDashboardPrincipalUser = async (
+  request: Request,
+): Promise<DashboardUser | null> => {
+  const principal = await resolveDashboardPrincipal(request);
+  return principal?.user ?? null;
 };

--- a/apps/hermes/dashboard/lib/parse-bearer-token.test.ts
+++ b/apps/hermes/dashboard/lib/parse-bearer-token.test.ts
@@ -1,0 +1,24 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { parseBearerToken } from "./parse-bearer-token";
+
+describe("parseBearerToken", () => {
+  it("returns token from Bearer header", () => {
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Bearer hmcp_abc_secret" },
+    });
+    expect(parseBearerToken(req)).toBe("hmcp_abc_secret");
+  });
+
+  it("returns null when header missing", () => {
+    expect(parseBearerToken(new Request("http://localhost"))).toBeNull();
+  });
+
+  it("returns null for non-Bearer scheme", () => {
+    const req = new Request("http://localhost", {
+      headers: { Authorization: "Basic abc" },
+    });
+    expect(parseBearerToken(req)).toBeNull();
+  });
+});

--- a/apps/hermes/dashboard/lib/parse-bearer-token.ts
+++ b/apps/hermes/dashboard/lib/parse-bearer-token.ts
@@ -1,0 +1,14 @@
+/**
+ * Parses `Authorization: Bearer <token>` from a request.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns Bearer token or null when missing or malformed.
+ */
+export const parseBearerToken = (request: Request): string | null => {
+  const header = request.headers.get("authorization");
+  if (!header?.toLowerCase().startsWith("bearer ")) {
+    return null;
+  }
+  const token = header.slice(7).trim();
+  return token.length > 0 ? token : null;
+};

--- a/apps/hermes/dashboard/lib/require-dashboard-principal-response.ts
+++ b/apps/hermes/dashboard/lib/require-dashboard-principal-response.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+
+import {
+  DASHBOARD_UNAUTHORIZED_BODY,
+  type DashboardPrincipal,
+  resolveDashboardPrincipal,
+} from "@/lib/auth-dashboard";
+
+/**
+ * Resolves the dashboard principal or returns a 401 JSON response.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns Principal or `NextResponse` with status 401.
+ */
+export const resolveDashboardPrincipalOrUnauthorized = async (
+  request: Request,
+): Promise<DashboardPrincipal | NextResponse> => {
+  const principal = await resolveDashboardPrincipal(request);
+  if (!principal) {
+    return NextResponse.json(DASHBOARD_UNAUTHORIZED_BODY, { status: 401 });
+  }
+  return principal;
+};


### PR DESCRIPTION
## Summary

Unifies authentication for MCP-eligible routes: Bearer MCP API keys are tried first, then existing dashboard session cookies. Successful API key auth updates `lastUsedAt` and returns the key owner as the acting admin.

## Important changes

- `resolveDashboardPrincipal`, `requireDashboardPrincipalForRoute`
- `GET /api/mcp/whoami` returns label, readOnly, keyId, and owner id/email/name
- Helper `resolveDashboardPrincipalOrUnauthorized` for JSON GET routes

## How to test

- `pnpm exec vitest run lib/auth-dashboard.test.ts app/api/mcp/whoami/route.test.ts` in `apps/hermes/dashboard`
- `curl -H "Authorization: Bearer <key>" http://localhost:3001/api/mcp/whoami`

## Related issues

Closes #497