### PR TITLE
Enable API key auth on Phase A read routes

### DIFF
--- a/apps/hermes/dashboard/app/api/agents/[agentId]/[agentVersion]/schemas/route.ts
+++ b/apps/hermes/dashboard/app/api/agents/[agentId]/[agentVersion]/schemas/route.ts
@@ -2,19 +2,19 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@hermes/orchestration-database";
 
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
 /**
  * GET /api/agents/[agentId]/[agentVersion]/schemas
- * Returns inputSchema and configSchema from the agent registry. Requires dashboard session.
+ * Returns inputSchema and configSchema from the agent registry. Requires dashboard session or MCP API key.
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ agentId: string; agentVersion: string }> },
 ) {
-  const session = await getDashboardSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (auth instanceof NextResponse) {
+    return auth;
   }
 
   const { agentId, agentVersion } = await context.params;

--- a/apps/hermes/dashboard/app/api/execution-detail-get-routes.contract.test.ts
+++ b/apps/hermes/dashboard/app/api/execution-detail-get-routes.contract.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/auth-dashboard", () => ({
   getDashboardSession: vi.fn(),
+  resolveDashboardPrincipal: vi.fn(),
 }));
 
 vi.mock("@/lib/schedules", () => ({
@@ -20,7 +21,10 @@ vi.mock("@/lib/pipeline-executions", () => ({
 import { GET as getHttpTriggerExecutionDetailRoute } from "@/app/api/http-triggers/[triggerId]/executions/[executionId]/route";
 import { GET as getManualPipelineExecutionDetailRoute } from "@/app/api/pipelines/[pipelineId]/executions/[executionId]/route";
 import { GET as getScheduleExecutionDetailRoute } from "@/app/api/schedules/[scheduleId]/executions/[executionId]/route";
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import {
+  getDashboardSession,
+  resolveDashboardPrincipal,
+} from "@/lib/auth-dashboard";
 import { parseExecutionDetailApiPayload } from "@/lib/execution-detail-api-json-schema";
 import { SECRET_MASK } from "@/lib/mask-json-secrets";
 import { getHttpTriggerExecutionDetail } from "@/lib/http-triggers";
@@ -96,15 +100,27 @@ const manualPipelineDetailFixture = {
 } as const;
 
 describe("execution detail GET APIs (contract)", () => {
+  beforeEach(() => {
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue({
+      authMethod: "session",
+      user: {
+        id: "admin",
+        name: "Admin",
+        email: "admin@example.com",
+        credentialVersion: 0,
+      },
+    });
+  });
+
   afterEach(() => {
     vi.mocked(getDashboardSession).mockReset();
+    vi.mocked(resolveDashboardPrincipal).mockReset();
     vi.mocked(getScheduleExecutionDetail).mockReset();
     vi.mocked(getHttpTriggerExecutionDetail).mockReset();
     vi.mocked(getManualPipelineExecutionDetail).mockReset();
   });
 
   it("schedule execution detail JSON includes execution.errors (null from DB)", async () => {
-    vi.mocked(getDashboardSession).mockResolvedValue({ id: "admin" } as never);
     vi.mocked(getScheduleExecutionDetail).mockResolvedValue(
       structuredClone(scheduleDetailFixture) as never,
     );
@@ -128,7 +144,6 @@ describe("execution detail GET APIs (contract)", () => {
   });
 
   it("HTTP trigger execution detail JSON includes execution.errors", async () => {
-    vi.mocked(getDashboardSession).mockResolvedValue({ id: "admin" } as never);
     vi.mocked(getHttpTriggerExecutionDetail).mockResolvedValue(
       structuredClone(httpTriggerDetailFixture) as never,
     );
@@ -149,7 +164,6 @@ describe("execution detail GET APIs (contract)", () => {
   });
 
   it("manual pipeline execution detail JSON includes execution.errors", async () => {
-    vi.mocked(getDashboardSession).mockResolvedValue({ id: "admin" } as never);
     vi.mocked(getManualPipelineExecutionDetail).mockResolvedValue(
       structuredClone(manualPipelineDetailFixture) as never,
     );
@@ -187,7 +201,6 @@ describe("execution detail GET APIs (contract)", () => {
       },
     };
 
-    vi.mocked(getDashboardSession).mockResolvedValue({ id: "admin" } as never);
     vi.mocked(getScheduleExecutionDetail).mockResolvedValue(
       structuredClone(fixtureWithSecret) as never,
     );

--- a/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/executions/[executionId]/route.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/[triggerId]/executions/[executionId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 import { getHttpTriggerExecutionDetail } from "@/lib/http-triggers";
 import { maskHttpTriggerExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 
@@ -9,14 +9,14 @@ import { maskHttpTriggerExecutionDetailForDisplay } from "@/lib/mask-json-secret
  * Returns execution detail (steps + invocations) for admin debugging. Requires dashboard session.
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: {
     params: Promise<{ triggerId: string; executionId: string }>;
   },
 ) {
-  const session = await getDashboardSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (auth instanceof NextResponse) {
+    return auth;
   }
 
   const { triggerId, executionId } = await context.params;

--- a/apps/hermes/dashboard/app/api/phase-a-api-key-auth.test.ts
+++ b/apps/hermes/dashboard/app/api/phase-a-api-key-auth.test.ts
@@ -1,0 +1,61 @@
+/** @vitest-environment node */
+import { NextResponse } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@hermes/orchestration-database", () => ({
+  prisma: {
+    agentRegistry: { findFirst: vi.fn() },
+  },
+}));
+
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+import { GET as getAgentSchemas } from "@/app/api/agents/[agentId]/[agentVersion]/schemas/route";
+import { prisma } from "@hermes/orchestration-database";
+
+describe("Phase A routes accept API key principal", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 when principal resolution fails", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await getAgentSchemas(
+      new Request("http://localhost/api/agents/a/1/schemas"),
+      { params: Promise.resolve({ agentId: "a", agentVersion: "1" }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 for read-only api_key principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "key-1",
+      readOnly: true,
+      label: "ro",
+    });
+    vi.mocked(prisma.agentRegistry.findFirst).mockResolvedValue({
+      inputSchema: {},
+      configSchema: null,
+    } as never);
+
+    const res = await getAgentSchemas(
+      new Request("http://localhost/api/agents/a/1/schemas", {
+        headers: { Authorization: "Bearer hmcp_x_y" },
+      }),
+      { params: Promise.resolve({ agentId: "a", agentVersion: "1" }) },
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hermes/dashboard/app/api/pipelines/[pipelineId]/executions/[executionId]/route.ts
+++ b/apps/hermes/dashboard/app/api/pipelines/[pipelineId]/executions/[executionId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 import { maskManualPipelineExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 import { getManualPipelineExecutionDetail } from "@/lib/pipeline-executions";
 
@@ -9,14 +9,14 @@ import { getManualPipelineExecutionDetail } from "@/lib/pipeline-executions";
  * Returns manual pipeline execution detail (steps + invocations) for admin debugging. Requires dashboard session.
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: {
     params: Promise<{ pipelineId: string; executionId: string }>;
   },
 ) {
-  const session = await getDashboardSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (auth instanceof NextResponse) {
+    return auth;
   }
 
   const { pipelineId, executionId } = await context.params;

--- a/apps/hermes/dashboard/app/api/pipelines/[pipelineId]/schemas/route.ts
+++ b/apps/hermes/dashboard/app/api/pipelines/[pipelineId]/schemas/route.ts
@@ -2,19 +2,19 @@ import { NextResponse } from "next/server";
 
 import { prisma } from "@hermes/orchestration-database";
 
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
 /**
  * GET /api/pipelines/[pipelineId]/schemas
- * Returns inputSchema and configSchema for each step's agent. Requires dashboard session.
+ * Returns inputSchema and configSchema for each step's agent. Requires dashboard session or MCP API key.
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: { params: Promise<{ pipelineId: string }> },
 ) {
-  const session = await getDashboardSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (auth instanceof NextResponse) {
+    return auth;
   }
 
   const { pipelineId } = await context.params;

--- a/apps/hermes/dashboard/app/api/schedules/[scheduleId]/executions/[executionId]/route.ts
+++ b/apps/hermes/dashboard/app/api/schedules/[scheduleId]/executions/[executionId]/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 
 import { maskScheduleExecutionDetailForDisplay } from "@/lib/mask-json-secrets";
 import { getScheduleExecutionDetail } from "@/lib/schedules";
-import { getDashboardSession } from "@/lib/auth-dashboard";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
 /**
  * GET /api/schedules/[scheduleId]/executions/[executionId]
@@ -13,14 +13,14 @@ import { getDashboardSession } from "@/lib/auth-dashboard";
  * (including `execution.errors` from the DB row, secret-masked).
  */
 export async function GET(
-  _request: Request,
+  request: Request,
   context: {
     params: Promise<{ scheduleId: string; executionId: string }>;
   },
 ) {
-  const session = await getDashboardSession();
-  if (!session) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  const auth = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (auth instanceof NextResponse) {
+    return auth;
   }
 
   const { scheduleId, executionId } = await context.params;

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/get/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/get/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/get/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/get/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getVariableById } from "@/lib/variables";
 
 const bodyValidator = z.object({
@@ -16,7 +16,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({


### PR DESCRIPTION
## Summary

Phase A Hermes read endpoints now accept a valid MCP API key or an existing dashboard session, with the same ADMIN and credentialVersion checks as cookie auth.

## Important changes

- Seven routes use `resolveDashboardPrincipalOrUnauthorized` or `requireDashboardPrincipalForRoute`
- Integration-style test for agent schemas with read-only API key principal

## How to test

- `pnpm exec vitest run app/api/phase-a-api-key-auth.test.ts` in `apps/hermes/dashboard`
- Bearer key against any Phase A GET route after #497 is available

## Related issues

Closes #498