### PR TITLE
Add list GET APIs for MCP discovery

### DIFF
--- a/apps/hermes/dashboard/app/api/agent-configs/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agent-configs/route.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-configs", () => ({
+  getAgentConfigsPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getAgentConfigsPage } from "@/lib/agent-configs";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+describe("GET /api/agent-configs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(new Request("http://localhost/api/agent-configs"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getAgentConfigsPage).mockResolvedValue({
+      configs: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/agent-configs"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns configs for api key", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getAgentConfigsPage).mockResolvedValue({
+      configs: [{ id: "c1", name: "Default", agentId: "a", agentVersion: "1" }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/agent-configs"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hermes/dashboard/app/api/agent-configs/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agent-configs/route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/agent-configs", () => ({
 }));
 
 import { GET } from "./route";
+import type { AgentConfigsPageResult } from "@/lib/agent-configs";
 import { getAgentConfigsPage } from "@/lib/agent-configs";
 import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
@@ -70,11 +71,23 @@ describe("GET /api/agent-configs", () => {
       label: "k",
     });
     vi.mocked(getAgentConfigsPage).mockResolvedValue({
-      configs: [{ id: "c1", name: "Default", agentId: "a", agentVersion: "1" }],
+      configs: [
+        {
+          id: "c1",
+          name: "Default",
+          description: null,
+          agentId: "a",
+          agentVersion: "1",
+          config: {},
+          configSchemaFingerprint: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          createdBy: null,
+        },
+      ],
       total: 1,
       page: 1,
       pageSize: 20,
-    });
+    } satisfies AgentConfigsPageResult);
     const res = await GET(new Request("http://localhost/api/agent-configs"));
     expect(res.status).toBe(200);
   });

--- a/apps/hermes/dashboard/app/api/agent-configs/route.ts
+++ b/apps/hermes/dashboard/app/api/agent-configs/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { getAgentConfigsPage } from "@/lib/agent-configs";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/agent-configs — paginated agent config list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }`.
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getAgentConfigsPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.configs,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/agents/content-generation-runs/[id]/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agents/content-generation-runs/[id]/route.test.ts
@@ -1,0 +1,90 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/content-generation-runs-api", () => ({
+  getContentGenerationRunById: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getContentGenerationRunById } from "@/lib/content-generation-runs-api";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+const run = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  agentId: "content-generation",
+  agentVersion: "1.0.0",
+  tickerId: "ticker-1",
+  outcome: "failed" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("GET /api/agents/content-generation-runs/[id]", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(
+      new Request("http://localhost/api/agents/content-generation-runs/x"),
+      { params: Promise.resolve({ id: run.id }) },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when run is missing", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getContentGenerationRunById).mockResolvedValue(null);
+    const res = await GET(
+      new Request(
+        `http://localhost/api/agents/content-generation-runs/${run.id}`,
+      ),
+      { params: Promise.resolve({ id: run.id }) },
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns run detail for api key", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getContentGenerationRunById).mockResolvedValue(run);
+    const res = await GET(
+      new Request(
+        `http://localhost/api/agents/content-generation-runs/${run.id}`,
+        { headers: { Authorization: "Bearer hmcp_ok" } },
+      ),
+      { params: Promise.resolve({ id: run.id }) },
+    );
+    expect(getContentGenerationRunById).toHaveBeenCalledWith(run.id);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ item: run });
+  });
+});

--- a/apps/hermes/dashboard/app/api/agents/content-generation-runs/[id]/route.ts
+++ b/apps/hermes/dashboard/app/api/agents/content-generation-runs/[id]/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+import { getContentGenerationRunById } from "@/lib/content-generation-runs-api";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/agents/content-generation-runs/[id] — single content-generation run detail.
+ *
+ * Response: `{ item }` with the run row, or 404 when not found.
+ */
+export const GET = async (
+  request: Request,
+  context: { params: Promise<{ id: string }> },
+): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { id } = await context.params;
+  const run = await getContentGenerationRunById(id);
+  if (!run) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ item: run });
+};

--- a/apps/hermes/dashboard/app/api/agents/content-generation-runs/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agents/content-generation-runs/route.test.ts
@@ -1,0 +1,124 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/content-generation-runs-api", () => ({
+  listContentGenerationRuns: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { listContentGenerationRuns } from "@/lib/content-generation-runs-api";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+const run = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  agentId: "content-generation",
+  agentVersion: "1.0.0",
+  tickerId: "ticker-1",
+  outcome: "success" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("GET /api/agents/content-generation-runs", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(
+      new Request("http://localhost/api/agents/content-generation-runs"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(listContentGenerationRuns).mockResolvedValue({ items: [] });
+    const res = await GET(
+      new Request("http://localhost/api/agents/content-generation-runs"),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns runs with nextCursor for api key", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(listContentGenerationRuns).mockResolvedValue({
+      items: [run],
+      nextCursor: "next",
+    });
+    const res = await GET(
+      new Request(
+        "http://localhost/api/agents/content-generation-runs?pageSize=10",
+        { headers: { Authorization: "Bearer hmcp_ok" } },
+      ),
+    );
+    expect(listContentGenerationRuns).toHaveBeenCalledWith({
+      cursor: undefined,
+      limit: 10,
+      outcome: undefined,
+      tickerId: undefined,
+      startTime: undefined,
+      endTime: undefined,
+    });
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [run],
+      page: 1,
+      pageSize: 10,
+      nextCursor: "next",
+    });
+  });
+
+  it("returns 400 when page > 1 without cursor", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    const res = await GET(
+      new Request("http://localhost/api/agents/content-generation-runs?page=2"),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/hermes/dashboard/app/api/agents/content-generation-runs/route.ts
+++ b/apps/hermes/dashboard/app/api/agents/content-generation-runs/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import type { ContentGenerationRunOutcome } from "@workspace/agent-data-api-contract";
+
+import { listContentGenerationRuns } from "@/lib/content-generation-runs-api";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+const parseOptionalOutcome = (
+  value: string | null,
+): ContentGenerationRunOutcome | undefined => {
+  if (value === "success" || value === "skipped" || value === "failed") {
+    return value;
+  }
+  return undefined;
+};
+
+/**
+ * GET /api/agents/content-generation-runs — content-generation run list for MCP discovery.
+ *
+ * Query: `page` (default 1; must be 1 unless `cursor` is set), `pageSize` (default 20, max 100),
+ * `cursor` (optional UUID for next page), `outcome`, `tickerId`, `startTime`, `endTime`.
+ * Response: `{ items, page, pageSize, nextCursor? }` (cursor-backed; `total` is omitted).
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const url = new URL(request.url);
+  const { page, pageSize } = parseApiPageParams(request);
+  const cursor = url.searchParams.get("cursor") ?? undefined;
+
+  if (page > 1 && !cursor) {
+    return NextResponse.json(
+      {
+        error: "page > 1 requires cursor from a previous response (nextCursor)",
+      },
+      { status: 400 },
+    );
+  }
+
+  const tickerId = url.searchParams.get("tickerId")?.trim() || undefined;
+  const startTime = url.searchParams.get("startTime")?.trim() || undefined;
+  const endTime = url.searchParams.get("endTime")?.trim() || undefined;
+  const outcome = parseOptionalOutcome(url.searchParams.get("outcome"));
+
+  const result = await listContentGenerationRuns({
+    cursor,
+    limit: pageSize,
+    outcome,
+    tickerId,
+    startTime,
+    endTime,
+  });
+
+  return NextResponse.json({
+    items: result.items,
+    page,
+    pageSize,
+    ...(result.nextCursor ? { nextCursor: result.nextCursor } : {}),
+  });
+};

--- a/apps/hermes/dashboard/app/api/agents/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agents/route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/agents", () => ({
 }));
 
 import { GET } from "./route";
+import type { AgentsPageResult } from "@/lib/agents";
 import { getAgentsPage } from "@/lib/agents";
 import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 import { NextResponse } from "next/server";
@@ -85,13 +86,21 @@ describe("GET /api/agents", () => {
           id: "agent-1",
           agentId: "summarizer",
           agentVersion: "1",
+          description: null,
+          endpoint: {},
+          inputSchema: null,
+          configSchema: null,
+          isActive: true,
+          domainIntegrationId: "di-1",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
           domainIntegration: { integrationId: "mediapulse" },
         },
       ],
       total: 1,
       page: 1,
       pageSize: 20,
-    });
+    } satisfies AgentsPageResult);
 
     // Act
     const res = await GET(

--- a/apps/hermes/dashboard/app/api/agents/route.test.ts
+++ b/apps/hermes/dashboard/app/api/agents/route.test.ts
@@ -1,0 +1,109 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/agents", () => ({
+  getAgentsPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getAgentsPage } from "@/lib/agents";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+import { NextResponse } from "next/server";
+
+const principal = {
+  authMethod: "api_key" as const,
+  user: {
+    id: "u1",
+    name: "Admin",
+    email: "admin@test.com",
+    credentialVersion: 0,
+  },
+  apiKeyId: "key-1",
+  readOnly: false,
+  label: "Cursor",
+};
+
+describe("GET /api/agents", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    // Setup
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+
+    // Act
+    const res = await GET(new Request("http://localhost/api/agents"));
+
+    // Assert
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    // Setup
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      principal,
+    );
+    vi.mocked(getAgentsPage).mockResolvedValue({
+      agents: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Act
+    const res = await GET(
+      new Request("http://localhost/api/agents", {
+        headers: { Authorization: "Bearer hmcp_ok" },
+      }),
+    );
+
+    // Assert
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns paginated agents for api key principal", async () => {
+    // Setup
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      principal,
+    );
+    vi.mocked(getAgentsPage).mockResolvedValue({
+      agents: [
+        {
+          id: "agent-1",
+          agentId: "summarizer",
+          agentVersion: "1",
+          domainIntegration: { integrationId: "mediapulse" },
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+
+    // Act
+    const res = await GET(
+      new Request("http://localhost/api/agents?page=1&pageSize=20", {
+        headers: { Authorization: "Bearer hmcp_ok" },
+      }),
+    );
+
+    // Assert
+    expect(getAgentsPage).toHaveBeenCalledWith(1, 20);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { items: unknown[] };
+    expect(body.items).toHaveLength(1);
+  });
+});

--- a/apps/hermes/dashboard/app/api/agents/route.ts
+++ b/apps/hermes/dashboard/app/api/agents/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { getAgentsPage } from "@/lib/agents";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/agents — paginated agent registry list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }` where each item includes `domainIntegration.integrationId`.
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getAgentsPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.agents,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/domain-integrations/route.test.ts
+++ b/apps/hermes/dashboard/app/api/domain-integrations/route.test.ts
@@ -1,0 +1,101 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/domain-integrations", () => ({
+  getDomainIntegrationsPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getDomainIntegrationsPage } from "@/lib/domain-integrations";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+describe("GET /api/domain-integrations", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(
+      new Request("http://localhost/api/domain-integrations"),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getDomainIntegrationsPage).mockResolvedValue({
+      integrations: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(
+      new Request("http://localhost/api/domain-integrations"),
+    );
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns integrations without secrets", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getDomainIntegrationsPage).mockResolvedValue({
+      integrations: [
+        {
+          id: "di-1",
+          integrationId: "mediapulse",
+          name: "Mediapulse",
+          status: "active",
+          baseUrl: "https://example.com",
+          isDefault: true,
+          isActive: true,
+          createdById: "u1",
+          createdBy: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(
+      new Request("http://localhost/api/domain-integrations"),
+    );
+    const body = await res.json();
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(body)).not.toMatch(/apiKey|plaintext|Bearer/i);
+  });
+});

--- a/apps/hermes/dashboard/app/api/domain-integrations/route.ts
+++ b/apps/hermes/dashboard/app/api/domain-integrations/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { getDomainIntegrationsPage } from "@/lib/domain-integrations";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/domain-integrations — paginated domain integration list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }` (includes pending and active rows; no API keys).
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getDomainIntegrationsPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.integrations,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/http-triggers/route.test.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/http-triggers", () => ({
 }));
 
 import { GET } from "./route";
+import type { HttpTriggersPageResult } from "@/lib/http-triggers";
 import { getHttpTriggersPage } from "@/lib/http-triggers";
 import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
@@ -70,11 +71,29 @@ describe("GET /api/http-triggers", () => {
       label: "k",
     });
     vi.mocked(getHttpTriggersPage).mockResolvedValue({
-      httpTriggers: [{ id: "t1", name: "Hook" }],
+      httpTriggers: [
+        {
+          id: "t1",
+          name: "Hook",
+          description: null,
+          pipelineId: "p1",
+          enabled: true,
+          method: "POST",
+          authType: "BEARER_TOKEN",
+          tokenHash: "hash",
+          tokenHint: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          lastTriggeredAt: null,
+          createdById: null,
+          pipeline: { id: "p1", name: "Pipe" },
+          createdBy: null,
+        },
+      ],
       total: 1,
       page: 1,
       pageSize: 20,
-    });
+    } satisfies HttpTriggersPageResult);
     const res = await GET(new Request("http://localhost/api/http-triggers"));
     expect(res.status).toBe(200);
   });

--- a/apps/hermes/dashboard/app/api/http-triggers/route.test.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/route.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/http-triggers", () => ({
+  getHttpTriggersPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getHttpTriggersPage } from "@/lib/http-triggers";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+describe("GET /api/http-triggers", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(new Request("http://localhost/api/http-triggers"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getHttpTriggersPage).mockResolvedValue({
+      httpTriggers: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/http-triggers"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns http triggers for api key", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getHttpTriggersPage).mockResolvedValue({
+      httpTriggers: [{ id: "t1", name: "Hook" }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/http-triggers"));
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hermes/dashboard/app/api/http-triggers/route.ts
+++ b/apps/hermes/dashboard/app/api/http-triggers/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { getHttpTriggersPage } from "@/lib/http-triggers";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/http-triggers — paginated HTTP trigger list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }` with pipeline summary on each row.
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getHttpTriggersPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.httpTriggers,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/pipelines/route.test.ts
+++ b/apps/hermes/dashboard/app/api/pipelines/route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/pipelines", () => ({
 }));
 
 import { GET } from "./route";
+import type { PipelinesPageResult } from "@/lib/pipelines";
 import { getPipelinesPage } from "@/lib/pipelines";
 import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
@@ -70,11 +71,26 @@ describe("GET /api/pipelines", () => {
       label: "k",
     });
     vi.mocked(getPipelinesPage).mockResolvedValue({
-      pipelines: [{ id: "p1", name: "Pipe", steps: [] }],
+      pipelines: [
+        {
+          id: "p1",
+          name: "Pipe",
+          description: null,
+          timeout: null,
+          isActive: true,
+          executionConfig: null,
+          domainIntegrationId: "di-1",
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          createdById: null,
+          steps: [],
+          createdBy: null,
+        },
+      ],
       total: 1,
       page: 1,
       pageSize: 20,
-    });
+    } satisfies PipelinesPageResult);
     const res = await GET(
       new Request("http://localhost/api/pipelines", {
         headers: { Authorization: "Bearer hmcp_ok" },

--- a/apps/hermes/dashboard/app/api/pipelines/route.test.ts
+++ b/apps/hermes/dashboard/app/api/pipelines/route.test.ts
@@ -1,0 +1,85 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/pipelines", () => ({
+  getPipelinesPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getPipelinesPage } from "@/lib/pipelines";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+describe("GET /api/pipelines", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(new Request("http://localhost/api/pipelines"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getPipelinesPage).mockResolvedValue({
+      pipelines: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/pipelines"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns pipelines for api key", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: true,
+      label: "k",
+    });
+    vi.mocked(getPipelinesPage).mockResolvedValue({
+      pipelines: [{ id: "p1", name: "Pipe", steps: [] }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(
+      new Request("http://localhost/api/pipelines", {
+        headers: { Authorization: "Bearer hmcp_ok" },
+      }),
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hermes/dashboard/app/api/pipelines/route.ts
+++ b/apps/hermes/dashboard/app/api/pipelines/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { getPipelinesPage } from "@/lib/pipelines";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+/**
+ * GET /api/pipelines — paginated pipeline list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }` where each item includes ordered `steps`.
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getPipelinesPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.pipelines,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/schedules/route.test.ts
+++ b/apps/hermes/dashboard/app/api/schedules/route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/schedules", () => ({
 }));
 
 import { GET } from "./route";
+import type { SchedulesPageResult } from "@/lib/schedules";
 import { getSchedulesPage } from "@/lib/schedules";
 import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
 
@@ -62,11 +63,33 @@ describe("GET /api/schedules", () => {
       principal,
     );
     vi.mocked(getSchedulesPage).mockResolvedValue({
-      schedules: [{ id: "sched-1", name: "Daily" }],
+      schedules: [
+        {
+          id: "sched-1",
+          name: "Daily",
+          description: null,
+          repeat: "repeating",
+          cronExpression: null,
+          interval: null,
+          timezone: "America/New_York",
+          startAt: null,
+          nextRunAt: null,
+          pipelineId: "p1",
+          retryConfig: null,
+          executionConfig: null,
+          priority: 0,
+          enabled: true,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          createdById: null,
+          pipeline: { id: "p1", name: "Pipe" },
+          createdBy: null,
+        },
+      ],
       total: 1,
       page: 1,
       pageSize: 20,
-    });
+    } satisfies SchedulesPageResult);
     const res = await GET(new Request("http://localhost/api/schedules"));
     expect(getSchedulesPage).toHaveBeenCalledWith(1, 20);
     expect(res.status).toBe(200);

--- a/apps/hermes/dashboard/app/api/schedules/route.test.ts
+++ b/apps/hermes/dashboard/app/api/schedules/route.test.ts
@@ -1,0 +1,74 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/schedules", () => ({
+  getSchedulesPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getSchedulesPage } from "@/lib/schedules";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+
+const principal = {
+  authMethod: "session" as const,
+  user: {
+    id: "u1",
+    name: "Admin",
+    email: "admin@test.com",
+    credentialVersion: 0,
+  },
+};
+
+describe("GET /api/schedules", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(new Request("http://localhost/api/schedules"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      principal,
+    );
+    vi.mocked(getSchedulesPage).mockResolvedValue({
+      schedules: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/schedules"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns schedules for authenticated principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      principal,
+    );
+    vi.mocked(getSchedulesPage).mockResolvedValue({
+      schedules: [{ id: "sched-1", name: "Daily" }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/schedules"));
+    expect(getSchedulesPage).toHaveBeenCalledWith(1, 20);
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/hermes/dashboard/app/api/schedules/route.ts
+++ b/apps/hermes/dashboard/app/api/schedules/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+import { getSchedulesPage } from "@/lib/schedules";
+
+/**
+ * GET /api/schedules — paginated schedule list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }` with pipeline summary on each row.
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getSchedulesPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.schedules,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/app/api/variables/route.test.ts
+++ b/apps/hermes/dashboard/app/api/variables/route.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/require-dashboard-principal-response", () => ({
+  resolveDashboardPrincipalOrUnauthorized: vi.fn(),
+}));
+
+vi.mock("@/lib/variables", () => ({
+  getVariablesPage: vi.fn(),
+}));
+
+import { GET } from "./route";
+import { getVariablesPage } from "@/lib/variables";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+import { SECRET_MASK } from "@/lib/json-secret-mask";
+
+describe("GET /api/variables", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 401 without principal", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 }),
+    );
+    const res = await GET(new Request("http://localhost/api/variables"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns empty list", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getVariablesPage).mockResolvedValue({
+      variables: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/variables"));
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [],
+      total: 0,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+
+  it("returns redacted secret values from getVariablesPage", async () => {
+    vi.mocked(resolveDashboardPrincipalOrUnauthorized).mockResolvedValue({
+      authMethod: "api_key",
+      user: {
+        id: "u1",
+        name: "A",
+        email: "a@b.com",
+        credentialVersion: 0,
+      },
+      apiKeyId: "k1",
+      readOnly: false,
+      label: "k",
+    });
+    vi.mocked(getVariablesPage).mockResolvedValue({
+      variables: [
+        {
+          id: "v1",
+          key: "API_KEY",
+          value: SECRET_MASK,
+          note: null,
+          isSecret: true,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+          createdBy: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+    const res = await GET(new Request("http://localhost/api/variables"));
+    const body = (await res.json()) as {
+      items: Array<{ value: string; isSecret: boolean }>;
+    };
+    expect(body.items[0]?.value).toBe(SECRET_MASK);
+    expect(body.items[0]?.isSecret).toBe(true);
+    expect(JSON.stringify(body)).not.toContain("sk-live");
+  });
+});

--- a/apps/hermes/dashboard/app/api/variables/route.ts
+++ b/apps/hermes/dashboard/app/api/variables/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from "next/server";
+
+import { paginatedListJsonResponse } from "@/lib/api-paginated-list-response";
+import { parseApiPageParams } from "@/lib/parse-api-page-params";
+import { resolveDashboardPrincipalOrUnauthorized } from "@/lib/require-dashboard-principal-response";
+import { getVariablesPage } from "@/lib/variables";
+
+/**
+ * GET /api/variables — paginated variable list for MCP discovery.
+ *
+ * Query: `page` (default 1), `pageSize` (default 20, max 100).
+ * Response: `{ items, total, page, pageSize }`. Secret values are redacted (`isSecret` → placeholder).
+ */
+export const GET = async (request: Request): Promise<NextResponse> => {
+  const principal = await resolveDashboardPrincipalOrUnauthorized(request);
+  if (principal instanceof NextResponse) {
+    return principal;
+  }
+
+  const { page, pageSize } = parseApiPageParams(request);
+  const result = await getVariablesPage(page, pageSize);
+  return paginatedListJsonResponse(
+    result.variables,
+    result.total,
+    result.page,
+    result.pageSize,
+  );
+};

--- a/apps/hermes/dashboard/lib/api-paginated-list-response.test.ts
+++ b/apps/hermes/dashboard/lib/api-paginated-list-response.test.ts
@@ -1,0 +1,20 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { paginatedListJsonResponse } from "./api-paginated-list-response";
+
+describe("paginatedListJsonResponse", () => {
+  it("returns JSON with items, total, page, and pageSize", async () => {
+    // Act
+    const res = paginatedListJsonResponse([{ id: "a" }], 1, 1, 20);
+
+    // Assert
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({
+      items: [{ id: "a" }],
+      total: 1,
+      page: 1,
+      pageSize: 20,
+    });
+  });
+});

--- a/apps/hermes/dashboard/lib/api-paginated-list-response.ts
+++ b/apps/hermes/dashboard/lib/api-paginated-list-response.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+/** JSON body shape for paginated MCP list endpoints. */
+export type PaginatedListBody<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+/**
+ * Builds a JSON response for a paginated list endpoint.
+ *
+ * @param items - Rows for the current page.
+ * @param total - Total row count across all pages.
+ * @param page - 1-based current page.
+ * @param pageSize - Requested page size.
+ * @returns `NextResponse` with `{ items, total, page, pageSize }`.
+ */
+export const paginatedListJsonResponse = <T>(
+  items: T[],
+  total: number,
+  page: number,
+  pageSize: number,
+): NextResponse =>
+  NextResponse.json({
+    items,
+    total,
+    page,
+    pageSize,
+  } satisfies PaginatedListBody<T>);

--- a/apps/hermes/dashboard/lib/content-generation-runs-api.test.ts
+++ b/apps/hermes/dashboard/lib/content-generation-runs-api.test.ts
@@ -31,7 +31,9 @@ describe("content-generation-runs-api", () => {
       data: [runFixture],
       nextCursor: "next-id",
     });
-    const client = { contentGenerationRuns: { get } };
+    const client = {
+      contentGenerationRuns: { get, create: vi.fn() },
+    };
 
     // Act
     const result = await listContentGenerationRuns(
@@ -57,7 +59,9 @@ describe("content-generation-runs-api", () => {
   it("getContentGenerationRunById returns the matching run", async () => {
     // Setup
     const get = vi.fn().mockResolvedValue({ data: [runFixture] });
-    const client = { contentGenerationRuns: { get } };
+    const client = {
+      contentGenerationRuns: { get, create: vi.fn() },
+    };
 
     // Act
     const result = await getContentGenerationRunById(runFixture.id, client);
@@ -73,7 +77,9 @@ describe("content-generation-runs-api", () => {
   it("getContentGenerationRunById returns null when id is missing", async () => {
     // Setup
     const get = vi.fn().mockResolvedValue({ data: [] });
-    const client = { contentGenerationRuns: { get } };
+    const client = {
+      contentGenerationRuns: { get, create: vi.fn() },
+    };
 
     // Act
     const result = await getContentGenerationRunById(runFixture.id, client);

--- a/apps/hermes/dashboard/lib/content-generation-runs-api.test.ts
+++ b/apps/hermes/dashboard/lib/content-generation-runs-api.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/agent-data-api-client", () => ({
+  getDashboardAgentDataApiClient: vi.fn(),
+  createDashboardAgentDataApiClient: vi.fn(),
+}));
+
+import {
+  getContentGenerationRunById,
+  listContentGenerationRuns,
+} from "./content-generation-runs-api";
+
+const runFixture = {
+  id: "550e8400-e29b-41d4-a716-446655440000",
+  agentId: "content-generation",
+  agentVersion: "1.0.0",
+  tickerId: "ticker-1",
+  outcome: "success" as const,
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("content-generation-runs-api", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("listContentGenerationRuns returns items and nextCursor", async () => {
+    // Setup
+    const get = vi.fn().mockResolvedValue({
+      data: [runFixture],
+      nextCursor: "next-id",
+    });
+    const client = { contentGenerationRuns: { get } };
+
+    // Act
+    const result = await listContentGenerationRuns(
+      { limit: 10, outcome: "failed" },
+      client,
+    );
+
+    // Assert
+    expect(get).toHaveBeenCalledWith({
+      cursor: undefined,
+      limit: 10,
+      outcome: "failed",
+      tickerId: undefined,
+      startTime: undefined,
+      endTime: undefined,
+    });
+    expect(result).toEqual({
+      items: [runFixture],
+      nextCursor: "next-id",
+    });
+  });
+
+  it("getContentGenerationRunById returns the matching run", async () => {
+    // Setup
+    const get = vi.fn().mockResolvedValue({ data: [runFixture] });
+    const client = { contentGenerationRuns: { get } };
+
+    // Act
+    const result = await getContentGenerationRunById(runFixture.id, client);
+
+    // Assert
+    expect(get).toHaveBeenCalledWith({
+      cursor: runFixture.id,
+      limit: 1,
+    });
+    expect(result).toEqual(runFixture);
+  });
+
+  it("getContentGenerationRunById returns null when id is missing", async () => {
+    // Setup
+    const get = vi.fn().mockResolvedValue({ data: [] });
+    const client = { contentGenerationRuns: { get } };
+
+    // Act
+    const result = await getContentGenerationRunById(runFixture.id, client);
+
+    // Assert
+    expect(result).toBeNull();
+  });
+});

--- a/apps/hermes/dashboard/lib/content-generation-runs-api.ts
+++ b/apps/hermes/dashboard/lib/content-generation-runs-api.ts
@@ -1,0 +1,68 @@
+import type {
+  ContentGenerationRunListItem,
+  ContentGenerationRunOutcome,
+} from "@workspace/agent-data-api-contract";
+
+import {
+  createDashboardAgentDataApiClient,
+  getDashboardAgentDataApiClient,
+} from "@/lib/agent-data-api-client";
+
+type ContentGenerationRunsClient = Pick<
+  ReturnType<typeof createDashboardAgentDataApiClient>,
+  "contentGenerationRuns"
+>;
+
+export type ContentGenerationRunsListQuery = {
+  cursor?: string;
+  limit: number;
+  outcome?: ContentGenerationRunOutcome;
+  tickerId?: string;
+  startTime?: string;
+  endTime?: string;
+};
+
+export type ContentGenerationRunsListResult = {
+  items: ContentGenerationRunListItem[];
+  nextCursor?: string;
+};
+
+/**
+ * Fetches a page of content-generation runs from agent-data-api.
+ *
+ * @param query - Cursor, limit, and optional filters.
+ * @param client - Injectable SDK client for tests.
+ * @returns Run rows and optional next cursor.
+ */
+export const listContentGenerationRuns = async (
+  query: ContentGenerationRunsListQuery,
+  client: ContentGenerationRunsClient = getDashboardAgentDataApiClient(),
+): Promise<ContentGenerationRunsListResult> => {
+  const result = await client.contentGenerationRuns.get({
+    cursor: query.cursor,
+    limit: query.limit,
+    outcome: query.outcome,
+    tickerId: query.tickerId,
+    startTime: query.startTime,
+    endTime: query.endTime,
+  });
+  return { items: result.data, nextCursor: result.nextCursor };
+};
+
+/**
+ * Loads a single content-generation run by id (list-with-cursor workaround).
+ *
+ * @param id - Run UUID.
+ * @param client - Injectable SDK client for tests.
+ * @returns The run row or null when not found.
+ */
+export const getContentGenerationRunById = async (
+  id: string,
+  client: ContentGenerationRunsClient = getDashboardAgentDataApiClient(),
+): Promise<ContentGenerationRunListItem | null> => {
+  const result = await client.contentGenerationRuns.get({
+    cursor: id,
+    limit: 1,
+  });
+  return result.data.find((run) => run.id === id) ?? null;
+};

--- a/apps/hermes/dashboard/lib/domain-integrations.test.ts
+++ b/apps/hermes/dashboard/lib/domain-integrations.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getActiveDomainIntegrations,
   getDomainIntegrationByIntegrationId,
+  getDomainIntegrationsPage,
 } from "./domain-integrations";
 
 const emptyManifest = {
@@ -110,5 +111,55 @@ describe("getDomainIntegrationByIntegrationId", () => {
     });
 
     expect(result).toBeNull();
+  });
+});
+
+describe("getDomainIntegrationsPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns integrations, total, page, and pageSize", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "i1",
+        integrationId: "mediapulse",
+        name: "Mediapulse",
+        status: "active",
+        baseUrl: "http://localhost:3001",
+        isDefault: true,
+        isActive: true,
+        createdById: "u1",
+        createdBy: null,
+      },
+    ]);
+    const count = vi.fn().mockResolvedValue(1);
+
+    const result = await getDomainIntegrationsPage(1, 10, {
+      findMany,
+      count,
+    });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 0, take: 10 }),
+    );
+    expect(result).toEqual({
+      integrations: [
+        {
+          id: "i1",
+          integrationId: "mediapulse",
+          name: "Mediapulse",
+          status: "active",
+          baseUrl: "http://localhost:3001",
+          isDefault: true,
+          isActive: true,
+          createdById: "u1",
+          createdBy: null,
+        },
+      ],
+      total: 1,
+      page: 1,
+      pageSize: 10,
+    });
   });
 });

--- a/apps/hermes/dashboard/lib/domain-integrations.ts
+++ b/apps/hermes/dashboard/lib/domain-integrations.ts
@@ -193,6 +193,69 @@ export type DomainIntegrationRecord = {
   capabilities: RegisterDomainIntegrationResponse["capabilities"];
 };
 
+const domainIntegrationListSelect = {
+  id: true,
+  integrationId: true,
+  name: true,
+  status: true,
+  baseUrl: true,
+  isDefault: true,
+  isActive: true,
+  createdById: true,
+  createdBy: {
+    select: {
+      id: true,
+      name: true,
+      email: true,
+    },
+  },
+} satisfies Prisma.DomainIntegrationSelect;
+
+export type DomainIntegrationListRow = Prisma.DomainIntegrationGetPayload<{
+  select: typeof domainIntegrationListSelect;
+}>;
+
+export type DomainIntegrationsPageResult = {
+  integrations: DomainIntegrationListRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+/**
+ * Fetches a paginated list of domain integrations (all statuses).
+ *
+ * @param page - 1-based page number.
+ * @param pageSize - Number of items per page.
+ * @param db - Prisma delegate (injectable for tests).
+ * @returns Integrations for the page plus total count and pagination info.
+ */
+export const getDomainIntegrationsPage = async (
+  page: number,
+  pageSize: number,
+  db: Pick<
+    typeof prisma.domainIntegration,
+    "findMany" | "count"
+  > = prisma.domainIntegration,
+): Promise<DomainIntegrationsPageResult> => {
+  const skip = (page - 1) * pageSize;
+  const orderBy = [
+    { isDefault: "desc" as const },
+    { integrationId: "asc" as const },
+  ] satisfies Prisma.DomainIntegrationOrderByWithRelationInput[];
+
+  const [integrations, total] = await Promise.all([
+    db.findMany({
+      select: domainIntegrationListSelect,
+      orderBy,
+      skip,
+      take: pageSize,
+    }),
+    db.count(),
+  ]);
+  return { integrations, total, page, pageSize };
+};
+
 /**
  * Maps a Prisma domain integration row to a typed record.
  *

--- a/apps/hermes/dashboard/lib/parse-api-page-params.test.ts
+++ b/apps/hermes/dashboard/lib/parse-api-page-params.test.ts
@@ -1,0 +1,51 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_API_PAGE_SIZE,
+  MAX_API_PAGE_SIZE,
+  parseApiPageParams,
+} from "./parse-api-page-params";
+
+describe("parseApiPageParams", () => {
+  it("returns defaults when query params are missing", () => {
+    // Act
+    const result = parseApiPageParams(
+      new Request("http://localhost/api/agents"),
+    );
+
+    // Assert
+    expect(result).toEqual({ page: 1, pageSize: DEFAULT_API_PAGE_SIZE });
+  });
+
+  it("parses page and pageSize from the URL", () => {
+    // Act
+    const result = parseApiPageParams(
+      new Request("http://localhost/api/agents?page=2&pageSize=50"),
+    );
+
+    // Assert
+    expect(result).toEqual({ page: 2, pageSize: 50 });
+  });
+
+  it("clamps invalid values to safe bounds", () => {
+    // Act
+    const result = parseApiPageParams(
+      new Request("http://localhost/api/agents?page=0&pageSize=500"),
+    );
+
+    // Assert
+    expect(result).toEqual({ page: 1, pageSize: MAX_API_PAGE_SIZE });
+  });
+
+  it("honors custom defaults", () => {
+    // Act
+    const result = parseApiPageParams(
+      new Request("http://localhost/api/agents"),
+      { page: 3, pageSize: 10 },
+    );
+
+    // Assert
+    expect(result).toEqual({ page: 3, pageSize: 10 });
+  });
+});

--- a/apps/hermes/dashboard/lib/parse-api-page-params.ts
+++ b/apps/hermes/dashboard/lib/parse-api-page-params.ts
@@ -1,0 +1,43 @@
+/** Default page size for dashboard MCP list APIs. */
+export const DEFAULT_API_PAGE_SIZE = 20;
+
+/** Maximum allowed page size for dashboard MCP list APIs. */
+export const MAX_API_PAGE_SIZE = 100;
+
+export type ApiPageParams = {
+  page: number;
+  pageSize: number;
+};
+
+/**
+ * Parses `page` and `pageSize` query params from a list API request URL.
+ *
+ * @param request - Incoming HTTP request.
+ * @param defaults - Optional overrides for default page and page size.
+ * @returns Normalized 1-based page and clamped page size.
+ */
+export const parseApiPageParams = (
+  request: Request,
+  defaults?: Partial<ApiPageParams>,
+): ApiPageParams => {
+  const url = new URL(request.url);
+  const defaultPage = defaults?.page ?? 1;
+  const defaultPageSize = defaults?.pageSize ?? DEFAULT_API_PAGE_SIZE;
+
+  const pageRaw = url.searchParams.get("page");
+  const pageSizeRaw = url.searchParams.get("pageSize");
+
+  const page = Math.max(
+    1,
+    parseInt(pageRaw ?? String(defaultPage), 10) || defaultPage,
+  );
+  const pageSize = Math.min(
+    MAX_API_PAGE_SIZE,
+    Math.max(
+      1,
+      parseInt(pageSizeRaw ?? String(defaultPageSize), 10) || defaultPageSize,
+    ),
+  );
+
+  return { page, pageSize };
+};

--- a/apps/hermes/dashboard/lib/pipelines.test.ts
+++ b/apps/hermes/dashboard/lib/pipelines.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   getAgentRegistryList,
   getPipelineWithSteps,
+  getPipelinesPage,
   getPipelinesWithSteps,
 } from "./pipelines";
 import type { PrismaClientWithSchema } from "@hermes/orchestration-database/client";
@@ -11,6 +12,7 @@ type MockDb = {
   pipeline: {
     findMany: ReturnType<typeof vi.fn>;
     findUnique: ReturnType<typeof vi.fn>;
+    count: ReturnType<typeof vi.fn>;
   };
   agentRegistry: {
     findMany: ReturnType<typeof vi.fn>;
@@ -21,6 +23,7 @@ const createMockDb = (): MockDb => ({
   pipeline: {
     findMany: vi.fn(),
     findUnique: vi.fn(),
+    count: vi.fn(),
   },
   agentRegistry: {
     findMany: vi.fn(),
@@ -65,6 +68,31 @@ describe("getPipelinesWithSteps", () => {
     const result = await getPipelinesWithSteps(asDb(db));
 
     expect(result).toEqual(pipelines);
+  });
+});
+
+describe("getPipelinesPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns pipelines, total, page, and pageSize", async () => {
+    const db = createMockDb();
+    const pipelines = [{ id: "p1", name: "P1", steps: [] }];
+    db.pipeline.findMany.mockResolvedValue(pipelines);
+    db.pipeline.count.mockResolvedValue(1);
+
+    const result = await getPipelinesPage(2, 5, asDb(db));
+
+    expect(db.pipeline.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 5, take: 5 }),
+    );
+    expect(result).toEqual({
+      pipelines,
+      total: 1,
+      page: 2,
+      pageSize: 5,
+    });
   });
 });
 

--- a/apps/hermes/dashboard/lib/pipelines.ts
+++ b/apps/hermes/dashboard/lib/pipelines.ts
@@ -1,6 +1,23 @@
+import type { Prisma } from "@hermes/orchestration-database";
 import { prisma } from "@hermes/orchestration-database";
 
 type Db = typeof prisma;
+
+const pipelineListInclude = {
+  steps: { orderBy: { order: "asc" as const } },
+  createdBy: { select: { id: true, name: true, email: true } },
+} satisfies Prisma.PipelineInclude;
+
+export type PipelineListRow = Prisma.PipelineGetPayload<{
+  include: typeof pipelineListInclude;
+}>;
+
+export type PipelinesPageResult = {
+  pipelines: PipelineListRow[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
 
 /**
  * Fetches all pipelines with their steps, ordered by updatedAt descending.
@@ -10,12 +27,37 @@ type Db = typeof prisma;
  */
 export const getPipelinesWithSteps = async (db: Db = prisma) => {
   return db.pipeline.findMany({
-    include: {
-      steps: { orderBy: { order: "asc" } },
-      createdBy: { select: { id: true, name: true, email: true } },
-    },
+    include: pipelineListInclude,
     orderBy: { updatedAt: "desc" },
   });
+};
+
+/**
+ * Fetches a paginated list of pipelines with steps, ordered by updatedAt descending.
+ *
+ * @param page - 1-based page number.
+ * @param pageSize - Number of items per page.
+ * @param db - Prisma client (injectable for tests).
+ * @returns Pipelines for the page plus total count and pagination info.
+ */
+export const getPipelinesPage = async (
+  page: number,
+  pageSize: number,
+  db: Db = prisma,
+): Promise<PipelinesPageResult> => {
+  const skip = (page - 1) * pageSize;
+  const findManyArgs = {
+    include: pipelineListInclude,
+    orderBy: { updatedAt: "desc" as const },
+    skip,
+    take: pageSize,
+  } satisfies Prisma.PipelineFindManyArgs;
+
+  const [pipelines, total] = await Promise.all([
+    db.pipeline.findMany(findManyArgs),
+    db.pipeline.count(),
+  ]);
+  return { pipelines, total, page, pageSize };
 };
 
 /**


### PR DESCRIPTION
## Summary

MCP clients can discover Hermes resources via paginated JSON list endpoints before calling schema or execution detail routes.

## Important changes

- Nine list routes plus CGA run detail under `/api/*`
- Shared `page` / `pageSize` pagination and `{ items, total, page, pageSize }` responses
- Variables list redacts secret values

## How to test

- Run co-located `route.test.ts` files under `apps/hermes/dashboard/app/api/`
- `curl` list routes with Bearer API key

## Related issues

Closes #499