### PR TITLE
Enable API key auth on Phase B mutation routes

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -16,7 +16,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 import { updateHermesAdminPasswordWithCredentialBump } from "@/lib/update-hermes-admin-password";
 
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
@@ -41,7 +41,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
@@ -42,7 +42,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/phase-b-api-key-auth.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/phase-b-api-key-auth.test.ts
@@ -1,0 +1,43 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createCreateAgentHandler,
+  handler,
+} from "./route.post.config";
+
+const apiKeyUser = {
+  id: "user-1",
+  name: "Admin",
+  email: "admin@test.com",
+  credentialVersion: 0,
+};
+
+describe("Phase B create agent with API key principal user", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("handler is wired for principal-based auth", () => {
+    expect(handler).toBeDefined();
+  });
+
+  it("allows create when injectable dependencies succeed", async () => {
+    const createAgent = vi.fn().mockResolvedValue({ id: "agent-1" });
+    const result = await createCreateAgentHandler({
+      createAgent,
+    } as never)({
+      body: {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        domainIntegrationId: "int-1",
+      },
+      user: apiKeyUser,
+    } as never);
+
+    expect(result.status).toBe(true);
+    if (result.status === true) {
+      expect(result.data).toEqual({ id: "agent-1" });
+    }
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/phase-b-api-key-auth.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/phase-b-api-key-auth.test.ts
@@ -1,10 +1,7 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import {
-  createCreateAgentHandler,
-  handler,
-} from "./route.post.config";
+import { createCreateAgentHandler, handler } from "./route.post.config";
 
 const apiKeyUser = {
   id: "user-1",
@@ -23,21 +20,48 @@ describe("Phase B create agent with API key principal user", () => {
   });
 
   it("allows create when injectable dependencies succeed", async () => {
-    const createAgent = vi.fn().mockResolvedValue({ id: "agent-1" });
+    const createdId = "00000000-0000-4000-8000-0000000000a1";
+    const createMock = vi.fn().mockResolvedValue({
+      id: createdId,
+      agentId: "test-agent",
+      agentVersion: "1.0.0",
+    });
+    const db = {
+      domainIntegration: { findFirst: vi.fn() },
+      agentRegistry: {
+        findUnique: vi.fn().mockResolvedValue(null),
+        create: createMock,
+      },
+    };
     const result = await createCreateAgentHandler({
-      createAgent,
-    } as never)({
+      db: db as never,
+    })({
       body: {
         agentId: "test-agent",
         agentVersion: "1.0.0",
         domainIntegrationId: "int-1",
+        endpoint: { url: "https://api.example.com/agent" },
+        isActive: false,
       },
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
       user: apiKeyUser,
     } as never);
 
     expect(result.status).toBe(true);
     if (result.status === true) {
-      expect(result.data).toEqual({ id: "agent-1" });
+      expect(result.data).toEqual({ id: createdId });
     }
+    expect(createMock).toHaveBeenCalledWith({
+      data: {
+        agentId: "test-agent",
+        agentVersion: "1.0.0",
+        description: null,
+        endpoint: { url: "https://api.example.com/agent" },
+        isActive: false,
+        domainIntegrationId: "int-1",
+      },
+    });
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 /**
  * Parses JSON string into a plain object for endpoint. Rejects arrays and non-object values.
@@ -39,7 +39,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 /**
  * Parses optional JSON string into a plain object for endpoint. Rejects arrays and non-object values.
@@ -44,7 +44,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
@@ -11,7 +11,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 
 const bodyValidator = z.object({
@@ -21,7 +21,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { createTokenHint, hashHttpTriggerToken } from "@/lib/http-trigger-auth";
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   httpTriggerId: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { createTokenHint, hashHttpTriggerToken } from "@/lib/http-trigger-auth";
@@ -34,7 +34,7 @@ export const httpTriggerUpdateBodySchema = z.object({
 
 export const requestValidator = createRequestValidator({
   body: httpTriggerUpdateBodySchema,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { validateDataSourceExpressions } from "@/lib/step-input-expansion";
 
@@ -46,7 +46,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { abortManualPipelineRunIfLocal } from "@/lib/manual-pipeline-run-abort";
 import {
   finalizeManualPipelineExecutionAfterCooperativeCancel,
@@ -22,7 +22,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { zFormBoolean } from "@/lib/form-boolean-schema";
 
 const bodyValidator = z.object({
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   pipelineId: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 
 const bodyValidator = z.object({
@@ -17,7 +17,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 
 const stepIdsSchema = z.union([
@@ -30,7 +30,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -27,7 +27,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-inputs-for-manual-pipeline";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 import { validatePipeline } from "@/lib/validate-pipeline";
@@ -75,7 +75,7 @@ const logRunPipelineIssue = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { collectEmptyRequiredStringErrors } from "@/lib/validate-required-fields";
 import { validateDataSourceExpressions } from "@/lib/step-input-expansion";
@@ -50,7 +50,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { zFormBoolean } from "@/lib/form-boolean-schema";
 
@@ -38,7 +38,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
@@ -11,7 +11,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 
 const bodyValidator = z.object({
@@ -21,7 +21,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { computeNextRunAt, ExecutionConfigSchema } from "@hermes/scheduler";
@@ -105,7 +105,7 @@ const isValidRepeatingCron = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   scheduleId: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { computeNextRunAt, ExecutionConfigSchema } from "@hermes/scheduler";
@@ -103,7 +103,7 @@ const isValidRepeatingCron = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import {
   encryptSecretVariableForPayload,
   toStoredVariableValue,
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardSessionForRoute } from "@/lib/auth-dashboard";
+import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
 import {
   encryptSecretVariableForPayload,
   fromStoredSecretVariableValue,
@@ -30,7 +30,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardSessionForRoute,
+  user: requireDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({


### PR DESCRIPTION
## Summary

Phase B dashboard mutation actions accept MCP API keys with full access, using the same principal resolution as read routes.

## Important changes

- Swapped `requireDashboardSessionForRoute` for `requireDashboardPrincipalForRoute` on dashboard mutation configs (API key management stays cookie-only)

## How to test

- Integration test under `app/dashboard/agents/actions/create/phase-b-api-key-auth.test.ts`
- POST a mutation with `Authorization: Bearer` and a non-read-only key

## Related issues

Closes #500