### PR TITLE
Enforce read-only API keys on dashboard mutations

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -16,7 +16,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 import { updateHermesAdminPasswordWithCredentialBump } from "@/lib/update-hermes-admin-password";
 
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/reset-password/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { createRequireHermesAdminManagementActor } from "@/lib/require-hermes-admin-management-actor";
 
 const bodyValidator = z.object({
@@ -19,7 +19,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/admins/actions/set-active/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
@@ -41,7 +41,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
@@ -42,7 +42,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/read-only-api-key-enforcement.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/read-only-api-key-enforcement.test.ts
@@ -1,0 +1,51 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+
+vi.mock("@/lib/require-mutation-dashboard-principal-for-route", () => ({
+  requireMutationDashboardPrincipalForRoute: vi.fn(),
+}));
+
+vi.mock("@hermes/orchestration-database", () => ({
+  prisma: {
+    agentRegistry: { create: vi.fn() },
+    domainIntegration: { findUnique: vi.fn() },
+  },
+}));
+
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
+import { POST } from "./route";
+
+describe("create agent route read-only API key enforcement", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 403 with read_only_key when mutation principal rejects read-only keys", async () => {
+    // Setup
+    vi.mocked(requireMutationDashboardPrincipalForRoute).mockRejectedValue(
+      new DashboardReadOnlyApiKeyError(),
+    );
+
+    // Act
+    const response = await POST(
+      new Request("http://localhost/dashboard/agents/actions/create", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          agentId: "agent-1",
+          agentVersion: "1.0.0",
+          domainIntegrationId: "int-1",
+        }),
+      }),
+    );
+
+    // Assert
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      code: "read_only_key",
+      message: "Read-only API key cannot call mutation routes",
+    });
+  });
+});

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 /**
  * Parses JSON string into a plain object for endpoint. Rejects arrays and non-object values.
@@ -39,7 +39,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 /**
  * Parses optional JSON string into a plain object for endpoint. Rejects arrays and non-object values.
@@ -44,7 +44,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/agents/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/domain-integrations/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.post.config.ts
@@ -11,7 +11,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 
 const bodyValidator = z.object({
@@ -21,7 +21,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.test.ts
@@ -8,10 +8,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe("http-triggers cancel-execution route.ts", () => {
-  it("re-exports the generated route entrypoint", () => {
+  it("exports POST via createHermesDashboardRoute for mutation enforcement", () => {
     const routePath = join(__dirname, "route.ts");
-    expect(readFileSync(routePath, "utf8")).toContain(
-      'export * from "./.generated/route"',
-    );
+    const source = readFileSync(routePath, "utf8");
+    expect(source).toContain("createHermesDashboardRoute");
+    expect(source).toContain("export const POST");
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/cancel-execution/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { createTokenHint, hashHttpTriggerToken } from "@/lib/http-trigger-auth";
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   httpTriggerId: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { createTokenHint, hashHttpTriggerToken } from "@/lib/http-trigger-auth";
@@ -34,7 +34,7 @@ export const httpTriggerUpdateBodySchema = z.object({
 
 export const requestValidator = createRequestValidator({
   body: httpTriggerUpdateBodySchema,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/http-triggers/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { validateDataSourceExpressions } from "@/lib/step-input-expansion";
 
@@ -46,7 +46,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/add-step/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { abortManualPipelineRunIfLocal } from "@/lib/manual-pipeline-run-abort";
 import {
   finalizeManualPipelineExecutionAfterCooperativeCancel,
@@ -22,7 +22,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.test.ts
@@ -8,10 +8,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe("pipelines cancel-manual-execution route.ts", () => {
-  it("re-exports the generated route entrypoint", () => {
+  it("exports POST via createHermesDashboardRoute for mutation enforcement", () => {
     const routePath = join(__dirname, "route.ts");
-    expect(readFileSync(routePath, "utf8")).toContain(
-      'export * from "./.generated/route"',
-    );
+    const source = readFileSync(routePath, "utf8");
+    expect(source).toContain("createHermesDashboardRoute");
+    expect(source).toContain("export const POST");
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/cancel-manual-execution/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { zFormBoolean } from "@/lib/form-boolean-schema";
 
 const bodyValidator = z.object({
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   pipelineId: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 
 const bodyValidator = z.object({
@@ -17,7 +17,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/remove-step/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 
 const stepIdsSchema = z.union([
@@ -30,7 +30,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/reorder-steps/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -27,7 +27,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { createExpandStepInputsForManualPipelineRun } from "@/lib/expand-step-inputs-for-manual-pipeline";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 import { validatePipeline } from "@/lib/validate-pipeline";
@@ -75,7 +75,7 @@ const logRunPipelineIssue = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { collectEmptyRequiredStringErrors } from "@/lib/validate-required-fields";
 import { validateDataSourceExpressions } from "@/lib/step-input-expansion";
@@ -50,7 +50,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update-step/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { disableSchedulesForPipelineIfNotEnabled } from "@/lib/disable-schedules-for-pipeline";
 import { zFormBoolean } from "@/lib/form-boolean-schema";
 
@@ -38,7 +38,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.post.config.ts
@@ -11,7 +11,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getHermesJobQueue } from "@/lib/hermes-job-queue";
 
 const bodyValidator = z.object({
@@ -21,7 +21,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.test.ts
@@ -8,10 +8,10 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 describe("schedules cancel-execution route.ts", () => {
-  it("re-exports the generated route entrypoint", () => {
+  it("exports POST via createHermesDashboardRoute for mutation enforcement", () => {
     const routePath = join(__dirname, "route.ts");
-    expect(readFileSync(routePath, "utf8")).toContain(
-      'export * from "./.generated/route"',
-    );
+    const source = readFileSync(routePath, "utf8");
+    expect(source).toContain("createHermesDashboardRoute");
+    expect(source).toContain("export const POST");
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/cancel-execution/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { computeNextRunAt, ExecutionConfigSchema } from "@hermes/scheduler";
@@ -105,7 +105,7 @@ const isValidRepeatingCron = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   scheduleId: z.string().uuid(),
@@ -15,7 +15,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.post.config.ts
@@ -7,7 +7,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { getPipelineWithSteps } from "@/lib/pipelines";
 import { getPipelineStatus, validatePipeline } from "@/lib/validate-pipeline";
 import { computeNextRunAt, ExecutionConfigSchema } from "@hermes/scheduler";
@@ -103,7 +103,7 @@ const isValidRepeatingCron = (
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/schedules/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import {
   encryptSecretVariableForPayload,
   toStoredVariableValue,
@@ -28,7 +28,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/create/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.post.config.ts
@@ -6,7 +6,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 
 const bodyValidator = z.object({
   id: z.string().uuid(),
@@ -14,7 +14,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/delete/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.post.config.ts
@@ -8,7 +8,7 @@ import {
 } from "route-action-gen/lib";
 import { z } from "zod";
 
-import { requireDashboardPrincipalForRoute } from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import {
   encryptSecretVariableForPayload,
   fromStoredSecretVariableValue,
@@ -30,7 +30,7 @@ const bodyValidator = z.object({
 
 export const requestValidator = createRequestValidator({
   body: bodyValidator,
-  user: requireDashboardPrincipalForRoute,
+  user: requireMutationDashboardPrincipalForRoute,
 });
 
 export const responseValidator = z.object({

--- a/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.ts
+++ b/apps/hermes/dashboard/app/dashboard/variables/actions/update/route.ts
@@ -1,1 +1,12 @@
-export * from "./.generated/route";
+import {
+  handler,
+  requestValidator,
+  responseValidator,
+} from "./route.post.config";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+
+export const POST = createHermesDashboardRoute(
+  requestValidator,
+  responseValidator,
+  handler,
+);

--- a/apps/hermes/dashboard/lib/dashboard-read-only-api-key-error.ts
+++ b/apps/hermes/dashboard/lib/dashboard-read-only-api-key-error.ts
@@ -1,0 +1,14 @@
+/**
+ * Thrown when a read-only MCP API key calls a dashboard mutation route.
+ */
+export class DashboardReadOnlyApiKeyError extends Error {
+  readonly code = "read_only_key" as const;
+
+  /**
+   * @param message - Human-readable error for clients.
+   */
+  constructor(message = "Read-only API key cannot call mutation routes") {
+    super(message);
+    this.name = "DashboardReadOnlyApiKeyError";
+  }
+}

--- a/apps/hermes/dashboard/lib/hermes-dashboard-route-process.test.ts
+++ b/apps/hermes/dashboard/lib/hermes-dashboard-route-process.test.ts
@@ -1,0 +1,115 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+import { createHermesDashboardRoute } from "@/lib/hermes-dashboard-route-process";
+import { createRequestValidator, successResponse } from "route-action-gen/lib";
+import { z } from "zod";
+
+describe("createHermesDashboardRoute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 403 with read_only_key body for read-only API keys", async () => {
+    // Setup
+    const auth = vi.fn().mockRejectedValue(new DashboardReadOnlyApiKeyError());
+    const requestValidator = createRequestValidator({
+      body: z.object({ name: z.string() }),
+      user: auth,
+    });
+    const responseValidator = z.object({ ok: z.boolean() });
+    const handler = vi.fn();
+    const route = createHermesDashboardRoute(
+      requestValidator,
+      responseValidator,
+      handler,
+    );
+
+    // Act
+    const response = await route(
+      new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "x" }),
+      }),
+    );
+
+    // Assert
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      code: "read_only_key",
+      message: "Read-only API key cannot call mutation routes",
+    });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 for other auth failures", async () => {
+    // Setup
+    const auth = vi.fn().mockRejectedValue(new Error("Unauthorized"));
+    const requestValidator = createRequestValidator({
+      body: z.object({ name: z.string() }),
+      user: auth,
+    });
+    const responseValidator = z.object({ ok: z.boolean() });
+    const route = createHermesDashboardRoute(
+      requestValidator,
+      responseValidator,
+      vi.fn(),
+    );
+
+    // Act
+    const response = await route(
+      new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "x" }),
+      }),
+    );
+
+    // Assert
+    expect(response.status).toBe(401);
+    expect(await response.json()).toEqual({
+      message: "Unauthorized",
+      statusCode: 401,
+    });
+  });
+
+  it("runs handler when auth succeeds", async () => {
+    // Setup
+    const user = {
+      id: "u1",
+      email: "a@b.com",
+      name: "A",
+      credentialVersion: 0,
+    };
+    const auth = vi.fn().mockResolvedValue(user);
+    const requestValidator = createRequestValidator({
+      body: z.object({ name: z.string() }),
+      user: auth,
+    });
+    const responseValidator = z.object({ ok: z.boolean() });
+    const handler = vi.fn().mockResolvedValue(successResponse({ ok: true }));
+    const route = createHermesDashboardRoute(
+      requestValidator,
+      responseValidator,
+      handler,
+    );
+
+    // Act
+    const response = await route(
+      new Request("http://localhost/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "agent" }),
+      }),
+    );
+
+    // Assert
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ ok: true });
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ user, body: { name: "agent" } }),
+    );
+  });
+});

--- a/apps/hermes/dashboard/lib/hermes-dashboard-route-process.ts
+++ b/apps/hermes/dashboard/lib/hermes-dashboard-route-process.ts
@@ -1,6 +1,14 @@
-import { errorResponse } from "route-action-gen/lib";
+import {
+  createRequestValidator,
+  errorResponse,
+  type HandlerFunc,
+  type HandlerResponse,
+} from "route-action-gen/lib";
+import type { z } from "zod";
 
 import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+
+type Validator = ReturnType<typeof createRequestValidator>;
 
 type RequestValidator = {
   body?: { parseAsync: (value: unknown) => Promise<unknown> };
@@ -9,19 +17,6 @@ type RequestValidator = {
   searchParams?: { parseAsync: (value: unknown) => Promise<unknown> };
   user?: (request?: Request) => Promise<unknown>;
 };
-
-type RouteHandler = (data: {
-  body: unknown;
-  headers: unknown;
-  params: unknown;
-  searchParams: unknown;
-  user: unknown;
-}) => Promise<{
-  status: boolean;
-  statusCode: number;
-  data?: unknown;
-  message?: unknown;
-}>;
 
 /**
  * Authenticates the dashboard route user, mapping read-only MCP keys to HTTP 403.
@@ -43,11 +38,7 @@ const authenticateDashboardRouteUser = async (
   } catch (error) {
     if (error instanceof DashboardReadOnlyApiKeyError) {
       return {
-        error: errorResponse(
-          { code: error.code, message: error.message },
-          undefined,
-          403,
-        ),
+        error: errorResponse(error.message, { code: error.code }, 403),
       };
     }
     return { error: errorResponse("Unauthorized", undefined, 401) };
@@ -166,34 +157,48 @@ const validateSearchParamsFromRequest = async (
  * @returns JSON HTTP response.
  */
 const toErrorHttpResponse = (response: ReturnType<typeof errorResponse>) => {
-  const body =
-    typeof response.message === "object" &&
-    response.message !== null &&
-    "code" in response.message &&
-    (response.message as { code: string }).code === "read_only_key"
-      ? response.message
-      : {
-          message: response.message,
-          statusCode: response.statusCode,
-        };
+  const code =
+    typeof response.object === "object" &&
+    response.object !== null &&
+    "code" in response.object
+      ? (response.object as { code: string }).code
+      : undefined;
 
-  return new Response(JSON.stringify(body), {
-    status: response.statusCode,
-    headers: { "Content-Type": "application/json" },
-  });
+  if (code === "read_only_key") {
+    return new Response(
+      JSON.stringify({ code: "read_only_key", message: response.message }),
+      {
+        status: response.statusCode,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      message: response.message,
+      statusCode: response.statusCode,
+    }),
+    {
+      status: response.statusCode,
+      headers: { "Content-Type": "application/json" },
+    },
+  );
 };
 
 /**
  * Converts a route-action-gen handler result into a Next.js `Response`.
  *
+ * @typeParam TResponse - Zod schema for successful response body.
+ * @typeParam Input - Optional traced input carried on success responses.
  * @param response - Success or error payload from a route handler.
  * @returns JSON HTTP response.
  */
-const toHttpResponse = (response: Awaited<ReturnType<RouteHandler>>) => {
+const toHttpResponse = <TResponse extends z.ZodType, Input>(
+  response: HandlerResponse<TResponse, Input>,
+) => {
   if (response.status === false) {
-    return toErrorHttpResponse(
-      response as ReturnType<typeof errorResponse> & { status: false },
-    );
+    return toErrorHttpResponse(response as ReturnType<typeof errorResponse>);
   }
 
   return new Response(JSON.stringify(response.data), {
@@ -204,15 +209,22 @@ const toHttpResponse = (response: Awaited<ReturnType<RouteHandler>>) => {
 /**
  * Processes a dashboard POST route with read-only API key → 403 support.
  *
+ * @typeParam RV - Request validator from `createRequestValidator`.
+ * @typeParam TV - Zod schema for successful response body.
+ * @typeParam Input - Optional traced handler input metadata.
  * @param requestValidator - Route request validator.
  * @param responseValidator - Route response validator (unused; kept for parity with route-action-gen).
  * @param handler - Business handler.
- * @returns Next.js App Router POST handler.
+ * @returns Next.js App Router POST processor.
  */
-export const processHermesDashboardRequest = (
-  requestValidator: RequestValidator,
-  responseValidator: unknown,
-  handler: RouteHandler,
+export const processHermesDashboardRequest = <
+  RV extends Validator,
+  TV extends z.ZodType,
+  Input,
+>(
+  requestValidator: RV,
+  responseValidator: TV,
+  handler: HandlerFunc<RV, TV, Input>,
 ) => {
   void responseValidator;
 
@@ -238,28 +250,37 @@ export const processHermesDashboardRequest = (
       validateSearchParamsFromRequest(requestValidator.searchParams, request),
     ]);
 
+    type HandlerParameters = Parameters<HandlerFunc<RV, TV, Input>>[0];
+
     return handler({
       body: validatedBody,
       headers: validatedHeaders,
       params: validatedParams,
       searchParams: validatedSearchParams,
       user,
-    });
+    } as HandlerParameters).then(toHttpResponse);
   };
 };
 
 /**
  * Creates a dashboard POST route with read-only API key → 403 support.
  *
+ * @typeParam RV - Request validator from `createRequestValidator`.
+ * @typeParam TV - Zod schema for successful response body.
+ * @typeParam Input - Optional traced handler input metadata.
  * @param requestValidator - Route request validator.
  * @param responseValidator - Route response validator.
  * @param handler - Business handler.
  * @returns Next.js App Router POST export.
  */
-export const createHermesDashboardRoute = (
-  requestValidator: RequestValidator,
-  responseValidator: unknown,
-  handler: RouteHandler,
+export const createHermesDashboardRoute = <
+  RV extends Validator,
+  TV extends z.ZodType,
+  Input,
+>(
+  requestValidator: RV,
+  responseValidator: TV,
+  handler: HandlerFunc<RV, TV, Input>,
 ) => {
   return async (
     request: Request,

--- a/apps/hermes/dashboard/lib/hermes-dashboard-route-process.ts
+++ b/apps/hermes/dashboard/lib/hermes-dashboard-route-process.ts
@@ -1,0 +1,280 @@
+import { errorResponse } from "route-action-gen/lib";
+
+import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+
+type RequestValidator = {
+  body?: { parseAsync: (value: unknown) => Promise<unknown> };
+  params?: { parseAsync: (value: unknown) => Promise<unknown> };
+  headers?: { parseAsync: (value: unknown) => Promise<unknown> };
+  searchParams?: { parseAsync: (value: unknown) => Promise<unknown> };
+  user?: (request?: Request) => Promise<unknown>;
+};
+
+type RouteHandler = (data: {
+  body: unknown;
+  headers: unknown;
+  params: unknown;
+  searchParams: unknown;
+  user: unknown;
+}) => Promise<{
+  status: boolean;
+  statusCode: number;
+  data?: unknown;
+  message?: unknown;
+}>;
+
+/**
+ * Authenticates the dashboard route user, mapping read-only MCP keys to HTTP 403.
+ *
+ * @param auth - Optional user validator from `createRequestValidator`.
+ * @param request - Incoming HTTP request when present.
+ * @returns Authenticated user or an error response for the route layer.
+ */
+const authenticateDashboardRouteUser = async (
+  auth: RequestValidator["user"],
+  request?: Request,
+): Promise<{ user: unknown } | { error: ReturnType<typeof errorResponse> }> => {
+  if (!auth) {
+    return { user: null };
+  }
+  try {
+    const user = request ? await auth(request) : await auth();
+    return { user };
+  } catch (error) {
+    if (error instanceof DashboardReadOnlyApiKeyError) {
+      return {
+        error: errorResponse(
+          { code: error.code, message: error.message },
+          undefined,
+          403,
+        ),
+      };
+    }
+    return { error: errorResponse("Unauthorized", undefined, 401) };
+  }
+};
+
+/**
+ * Parses JSON or form bodies from an HTTP request.
+ *
+ * @param request - Incoming HTTP request.
+ * @returns Parsed body payload or null.
+ */
+const parseRequestBody = async (request: Request): Promise<unknown> => {
+  const requestType = request.headers.get("content-type");
+  if (requestType?.includes("application/json")) {
+    return request.json();
+  }
+  if (
+    requestType?.includes("application/x-www-form-urlencoded") ||
+    requestType?.includes("multipart/form-data")
+  ) {
+    const formData = await request.formData();
+    return Object.fromEntries(formData.entries());
+  }
+  if (requestType?.includes("text/plain")) {
+    return request.text();
+  }
+  return null;
+};
+
+/**
+ * Validates the request body when the method supports one.
+ *
+ * @param bodyValidator - Zod body schema.
+ * @param request - Incoming HTTP request.
+ * @returns Parsed body or null.
+ */
+const validateBodyFromRequest = async (
+  bodyValidator: RequestValidator["body"],
+  request: Request,
+): Promise<unknown> => {
+  const method = request.method.toLowerCase();
+  const isBodyMethod =
+    method === "post" || method === "put" || method === "patch";
+  if (!bodyValidator || !isBodyMethod) {
+    return null;
+  }
+  const requestBody = await parseRequestBody(request);
+  return bodyValidator.parseAsync(requestBody);
+};
+
+/**
+ * Validates request headers against a Zod schema.
+ *
+ * @param headersValidator - Zod headers schema.
+ * @param headersSource - Header map from the request.
+ * @returns Parsed headers or null.
+ */
+const validateHeaders = async (
+  headersValidator: RequestValidator["headers"],
+  headersSource: Headers,
+): Promise<unknown> => {
+  if (!headersValidator) {
+    return null;
+  }
+  const headersObj: Record<string, string> = {};
+  for (const [key, value] of headersSource.entries()) {
+    headersObj[key.toLowerCase()] = value;
+  }
+  return headersValidator.parseAsync(headersObj);
+};
+
+/**
+ * Validates route params against a Zod schema.
+ *
+ * @param paramsValidator - Zod params schema.
+ * @param params - Route params from Next.js.
+ * @returns Parsed params or null.
+ */
+const validateParams = async (
+  paramsValidator: RequestValidator["params"],
+  params: unknown,
+): Promise<unknown> => {
+  if (!paramsValidator || !params) {
+    return null;
+  }
+  return paramsValidator.parseAsync(params);
+};
+
+/**
+ * Validates URL search params against a Zod schema.
+ *
+ * @param searchParamsValidator - Zod search params schema.
+ * @param request - Incoming HTTP request.
+ * @returns Parsed search params or null.
+ */
+const validateSearchParamsFromRequest = async (
+  searchParamsValidator: RequestValidator["searchParams"],
+  request: Request,
+): Promise<unknown> => {
+  if (!searchParamsValidator) {
+    return null;
+  }
+  const url = new URL(request.url);
+  const searchParamsObj: Record<string, string> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    searchParamsObj[key] = value;
+  }
+  return searchParamsValidator.parseAsync(searchParamsObj);
+};
+
+/**
+ * Converts a route-action-gen error payload into a Next.js `Response`.
+ *
+ * @param response - Error payload from `errorResponse`.
+ * @returns JSON HTTP response.
+ */
+const toErrorHttpResponse = (response: ReturnType<typeof errorResponse>) => {
+  const body =
+    typeof response.message === "object" &&
+    response.message !== null &&
+    "code" in response.message &&
+    (response.message as { code: string }).code === "read_only_key"
+      ? response.message
+      : {
+          message: response.message,
+          statusCode: response.statusCode,
+        };
+
+  return new Response(JSON.stringify(body), {
+    status: response.statusCode,
+    headers: { "Content-Type": "application/json" },
+  });
+};
+
+/**
+ * Converts a route-action-gen handler result into a Next.js `Response`.
+ *
+ * @param response - Success or error payload from a route handler.
+ * @returns JSON HTTP response.
+ */
+const toHttpResponse = (response: Awaited<ReturnType<RouteHandler>>) => {
+  if (response.status === false) {
+    return toErrorHttpResponse(
+      response as ReturnType<typeof errorResponse> & { status: false },
+    );
+  }
+
+  return new Response(JSON.stringify(response.data), {
+    status: response.statusCode,
+  });
+};
+
+/**
+ * Processes a dashboard POST route with read-only API key → 403 support.
+ *
+ * @param requestValidator - Route request validator.
+ * @param responseValidator - Route response validator (unused; kept for parity with route-action-gen).
+ * @param handler - Business handler.
+ * @returns Next.js App Router POST handler.
+ */
+export const processHermesDashboardRequest = (
+  requestValidator: RequestValidator,
+  responseValidator: unknown,
+  handler: RouteHandler,
+) => {
+  void responseValidator;
+
+  return async (request: Request, params?: unknown) => {
+    const authResult = await authenticateDashboardRouteUser(
+      requestValidator.user,
+      request,
+    );
+    if ("error" in authResult) {
+      return toErrorHttpResponse(authResult.error);
+    }
+
+    const { user } = authResult;
+    const [
+      validatedBody,
+      validatedHeaders,
+      validatedParams,
+      validatedSearchParams,
+    ] = await Promise.all([
+      validateBodyFromRequest(requestValidator.body, request),
+      validateHeaders(requestValidator.headers, request.headers),
+      validateParams(requestValidator.params, params),
+      validateSearchParamsFromRequest(requestValidator.searchParams, request),
+    ]);
+
+    return handler({
+      body: validatedBody,
+      headers: validatedHeaders,
+      params: validatedParams,
+      searchParams: validatedSearchParams,
+      user,
+    });
+  };
+};
+
+/**
+ * Creates a dashboard POST route with read-only API key → 403 support.
+ *
+ * @param requestValidator - Route request validator.
+ * @param responseValidator - Route response validator.
+ * @param handler - Business handler.
+ * @returns Next.js App Router POST export.
+ */
+export const createHermesDashboardRoute = (
+  requestValidator: RequestValidator,
+  responseValidator: unknown,
+  handler: RouteHandler,
+) => {
+  return async (
+    request: Request,
+    context?: { params?: Promise<Record<string, string | string[]>> },
+  ) => {
+    const processFunc = processHermesDashboardRequest(
+      requestValidator,
+      responseValidator,
+      handler,
+    );
+    const params = await context?.params;
+    const response = await processFunc(request, params);
+    if (response instanceof Response) {
+      return response;
+    }
+    return toHttpResponse(response);
+  };
+};

--- a/apps/hermes/dashboard/lib/require-mutation-dashboard-principal-for-route.test.ts
+++ b/apps/hermes/dashboard/lib/require-mutation-dashboard-principal-for-route.test.ts
@@ -1,0 +1,99 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+
+vi.mock("@/lib/auth-dashboard", () => ({
+  requireDashboardPrincipalForRoute: vi.fn(),
+  resolveDashboardPrincipal: vi.fn(),
+}));
+
+import {
+  requireDashboardPrincipalForRoute,
+  resolveDashboardPrincipal,
+} from "@/lib/auth-dashboard";
+import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
+
+const sessionUser = {
+  id: "user-1",
+  name: "Admin",
+  email: "admin@test.com",
+  credentialVersion: 0,
+};
+
+describe("requireMutationDashboardPrincipalForRoute", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates to session auth when request is omitted", async () => {
+    // Setup
+    vi.mocked(requireDashboardPrincipalForRoute).mockResolvedValue(sessionUser);
+
+    // Act
+    const user = await requireMutationDashboardPrincipalForRoute();
+
+    // Assert
+    expect(user).toEqual(sessionUser);
+    expect(requireDashboardPrincipalForRoute).toHaveBeenCalledOnce();
+    expect(resolveDashboardPrincipal).not.toHaveBeenCalled();
+  });
+
+  it("returns user for full-access API key principals", async () => {
+    // Setup
+    const request = new Request(
+      "http://localhost/dashboard/agents/actions/create",
+      {
+        headers: { Authorization: "Bearer hmcp_test" },
+      },
+    );
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue({
+      authMethod: "api_key",
+      user: sessionUser,
+      apiKeyId: "key-1",
+      readOnly: false,
+      label: "full",
+    });
+
+    // Act
+    const user = await requireMutationDashboardPrincipalForRoute(request);
+
+    // Assert
+    expect(user).toEqual(sessionUser);
+  });
+
+  it("throws DashboardReadOnlyApiKeyError for read-only API keys", async () => {
+    // Setup
+    const request = new Request(
+      "http://localhost/dashboard/agents/actions/create",
+      {
+        headers: { Authorization: "Bearer hmcp_ro" },
+      },
+    );
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue({
+      authMethod: "api_key",
+      user: sessionUser,
+      apiKeyId: "key-ro",
+      readOnly: true,
+      label: "read-only",
+    });
+
+    // Act / Assert
+    await expect(
+      requireMutationDashboardPrincipalForRoute(request),
+    ).rejects.toBeInstanceOf(DashboardReadOnlyApiKeyError);
+  });
+
+  it("throws when principal resolution fails", async () => {
+    // Setup
+    const request = new Request(
+      "http://localhost/dashboard/agents/actions/create",
+    );
+    vi.mocked(resolveDashboardPrincipal).mockResolvedValue(null);
+
+    // Act / Assert
+    await expect(
+      requireMutationDashboardPrincipalForRoute(request),
+    ).rejects.toThrow("Unauthorized");
+  });
+});

--- a/apps/hermes/dashboard/lib/require-mutation-dashboard-principal-for-route.ts
+++ b/apps/hermes/dashboard/lib/require-mutation-dashboard-principal-for-route.ts
@@ -1,0 +1,30 @@
+import {
+  requireDashboardPrincipalForRoute,
+  resolveDashboardPrincipal,
+} from "@/lib/auth-dashboard";
+import { DashboardReadOnlyApiKeyError } from "@/lib/dashboard-read-only-api-key-error";
+
+/**
+ * Requires a full-access dashboard principal for Phase B mutation routes.
+ *
+ * @param request - Incoming HTTP request (Bearer or cookies).
+ * @returns Dashboard user for the authenticated principal.
+ */
+export const requireMutationDashboardPrincipalForRoute = async (
+  request?: Request,
+): Promise<Awaited<ReturnType<typeof requireDashboardPrincipalForRoute>>> => {
+  if (!request) {
+    return requireDashboardPrincipalForRoute();
+  }
+
+  const principal = await resolveDashboardPrincipal(request);
+  if (!principal) {
+    throw new Error("Unauthorized");
+  }
+
+  if (principal.authMethod === "api_key" && principal.readOnly) {
+    throw new DashboardReadOnlyApiKeyError();
+  }
+
+  return principal.user;
+};


### PR DESCRIPTION
## Summary

Read-only MCP keys can still call Phase A read routes, but any Phase B dashboard mutation now returns HTTP 403 with a stable `read_only_key` payload. Full-access keys and cookie sessions behave as before.

## Important changes

- Added `requireMutationDashboardPrincipalForRoute` and `DashboardReadOnlyApiKeyError`.
- Wired all Phase B mutation `route.post.config.ts` files to the mutation principal guard (API key create/revoke and Phase A `get` actions stay on session or read-capable principals).
- Replaced generated `POST` exports with `createHermesDashboardRoute` so route-action-gen no longer maps read-only auth failures to 401.
- Added unit and route-level tests for 403 shape, full-key success path, and unchanged Phase A read-only access.

## How to test

- `cd apps/hermes/dashboard && pnpm exec vitest run lib/require-mutation-dashboard-principal-for-route.test.ts lib/hermes-dashboard-route-process.test.ts app/dashboard/agents/actions/create/read-only-api-key-enforcement.test.ts app/api/phase-a-api-key-auth.test.ts`
- With a read-only key: `POST /dashboard/agents/actions/create` → 403 `{ "code": "read_only_key", ... }`; Phase A route (e.g. agent schemas GET) → 200.
- With a full-access key or admin session: mutations succeed when the payload is valid.

## Related issues

Closes #501