### PR TITLE
Add MCP mutation tools with confirm gate

### DIFF
--- a/.cursor/rules/pr-sync-rebase-not-merge-main.mdc
+++ b/.cursor/rules/pr-sync-rebase-not-merge-main.mdc
@@ -1,0 +1,21 @@
+---
+description: Keep PR branches linear for GitHub Rebase/Squash merge — never merge main into the branch
+alwaysApply: true
+---
+
+# Sync PR branches with `main` using rebase, not merge
+
+This repository merges PRs with **Rebase and merge** or **Squash and merge** on GitHub. Those flows **rewrite commit SHAs** on `main`.
+
+## Do not
+
+- Run `git merge origin/main` (or merge `main`) into an open feature/stacked PR branch to “catch up”. That creates a **merge commit** whose second parent duplicates the same patches already on `main` under **different SHAs**. GitHub then often shows **“This branch cannot be rebased due to conflicts”** even when there is no real line-level conflict.
+
+## Do instead
+
+- Prefer **`git town sync --stack`** (this repo’s `.git-town.toml` sets `sync.feature-strategy = "rebase"`).
+- Or manually: `git fetch origin` then **`git rebase origin/main`** on the PR branch, then **`git push --force-with-lease`** when the branch was already published.
+
+## If the banner already appeared
+
+- Follow the recovery in **`.cursor/skills/git-town-stacked-changes/SKILL.md`** (“Rebase- or squash-merge rewrites SHAs…”, reset to `origin/main` + cherry-pick only commits unique to the PR, force-push with lease).

--- a/packages/hermes/mcp-server/README.md
+++ b/packages/hermes/mcp-server/README.md
@@ -92,6 +92,29 @@ List tools accept optional `limit` and `cursor` query parameters. `hermes_list_c
 
 Wrong or revoked API keys return Hermes error JSON in the tool result (`isError: true`).
 
+## Mutation tools (`hermes_mutate_*`)
+
+Write tools call dashboard Phase B `POST` routes with the same Bearer key. Before HTTP, the server checks `GET /api/mcp/whoami` and blocks **read-only** keys.
+
+**Destructive tools** (delete, cancel, run pipeline) require a two-step flow:
+
+1. First call **without** `confirm` (or with `confirm: false`) — returns a tool error; **no HTTP request**.
+2. Second call with `confirm: true` after explicit user approval — sends the mutation.
+
+| MCP tool                                      | Destructive (needs `confirm: true`) | POST path                                              |
+| --------------------------------------------- | ----------------------------------- | ------------------------------------------------------ |
+| `hermes_mutate_create_agent`                  | No                                  | `/dashboard/agents/actions/create`                     |
+| `hermes_mutate_delete_agent`                  | Yes                                 | `/dashboard/agents/actions/delete`                     |
+| `hermes_mutate_create_variable`               | No                                  | `/dashboard/variables/actions/create`                  |
+| `hermes_mutate_delete_variable`               | Yes                                 | `/dashboard/variables/actions/delete`                  |
+| `hermes_mutate_run_pipeline`                  | Yes                                 | `/dashboard/pipelines/actions/run-pipeline`            |
+| `hermes_mutate_cancel_pipeline_execution`     | Yes                                 | `/dashboard/pipelines/actions/cancel-manual-execution` |
+| `hermes_mutate_delete_pipeline`               | Yes                                 | `/dashboard/pipelines/actions/delete`                  |
+| `hermes_mutate_cancel_schedule_execution`     | Yes                                 | `/dashboard/schedules/actions/cancel-execution`        |
+| `hermes_mutate_delete_schedule`               | Yes                                 | `/dashboard/schedules/actions/delete`                  |
+| `hermes_mutate_cancel_http_trigger_execution` | Yes                                 | `/dashboard/http-triggers/actions/cancel-execution`    |
+| `hermes_mutate_delete_http_trigger`           | Yes                                 | `/dashboard/http-triggers/actions/delete`              |
+
 ## Tests
 
 ```bash

--- a/packages/hermes/mcp-server/src/lib/create-hermes-mcp-server.ts
+++ b/packages/hermes/mcp-server/src/lib/create-hermes-mcp-server.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { createHermesHttpClient } from "./http-client.js";
 import { getActiveProfile } from "./profiles.js";
+import { registerHermesMutateTools } from "./register-hermes-mutate-tools.js";
 import { registerHermesTools } from "./register-hermes-tools.js";
 
 export type CreateHermesMcpServerDependencies = {
@@ -27,7 +28,7 @@ export const createHermesMcpServer = (
     },
     {
       instructions:
-        "Hermes dashboard read-only tools. Use hermes_ping to verify the API key. Use hermes_list_* to discover resources, then hermes_get_* for detail. Switch environments with hermes_set_active_profile when multiple profiles are configured.",
+        "Hermes dashboard MCP tools. Use hermes_ping to verify the API key. Use hermes_list_* / hermes_get_* for reads. Mutation tools are prefixed hermes_mutate_*; destructive tools require confirm: true on a second call. Switch environments with hermes_set_active_profile when multiple profiles are configured.",
     },
   );
 
@@ -40,6 +41,11 @@ export const createHermesMcpServer = (
     server,
     httpClient,
     getActiveProfile: getActiveProfileFn,
+  });
+
+  registerHermesMutateTools({
+    server,
+    httpClient,
   });
 
   return server;

--- a/packages/hermes/mcp-server/src/lib/format-tool-result.ts
+++ b/packages/hermes/mcp-server/src/lib/format-tool-result.ts
@@ -24,3 +24,22 @@ export const formatHermesHttpAsToolResult = (
     ...(isError ? { isError: true } : {}),
   };
 };
+
+/**
+ * Formats a client-side tool error (no Hermes HTTP call).
+ *
+ * @param message - Human-readable error for the model.
+ * @param details - Optional structured details (never includes API keys).
+ * @returns MCP tool error result.
+ */
+export const formatHermesToolError = (
+  message: string,
+  details?: unknown,
+): CallToolResult => {
+  const payload =
+    details === undefined ? { error: message } : { error: message, details };
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    isError: true,
+  };
+};

--- a/packages/hermes/mcp-server/src/lib/mutate-tool-catalog.test.ts
+++ b/packages/hermes/mcp-server/src/lib/mutate-tool-catalog.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMutationRequestBody,
+  HERMES_MUTATE_TOOL_SPECS,
+} from "./mutate-tool-catalog.js";
+
+describe("buildMutationRequestBody", () => {
+  it("omits confirm from the HTTP body", () => {
+    expect(
+      buildMutationRequestBody({
+        id: "00000000-0000-4000-8000-000000000001",
+        confirm: true,
+      }),
+    ).toEqual({
+      id: "00000000-0000-4000-8000-000000000001",
+    });
+  });
+});
+
+describe("HERMES_MUTATE_TOOL_SPECS", () => {
+  it("marks destructive routes as requiring confirm", () => {
+    const deleteAgent = HERMES_MUTATE_TOOL_SPECS.find(
+      (spec) => spec.name === "hermes_mutate_delete_agent",
+    );
+    expect(deleteAgent?.requiresConfirm).toBe(true);
+    expect(deleteAgent?.pathTemplate).toBe("/dashboard/agents/actions/delete");
+  });
+});

--- a/packages/hermes/mcp-server/src/lib/mutate-tool-catalog.ts
+++ b/packages/hermes/mcp-server/src/lib/mutate-tool-catalog.ts
@@ -1,0 +1,163 @@
+import { z } from "zod";
+
+/** Describes one Hermes mutation MCP tool and its backing dashboard POST route. */
+export type HermesMutateToolSpec = {
+  name: string;
+  description: string;
+  pathTemplate: string;
+  inputSchema: z.ZodRawShape;
+  /** When true, `confirm: true` is required or no HTTP request is sent. */
+  requiresConfirm: boolean;
+};
+
+const confirmField = {
+  confirm: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true on a second call to run destructive actions (delete, cancel, run).",
+    ),
+};
+
+const idField = {
+  id: z.string().uuid().describe("Resource id"),
+};
+
+/**
+ * Phase B mutation tools mapped to dashboard `route-action-gen` POST routes.
+ */
+export const HERMES_MUTATE_TOOL_SPECS: HermesMutateToolSpec[] = [
+  {
+    name: "hermes_mutate_create_agent",
+    description: "Register a new agent in the Hermes registry.",
+    pathTemplate: "/dashboard/agents/actions/create",
+    requiresConfirm: false,
+    inputSchema: {
+      agentId: z.string().min(1).describe("Agent id"),
+      agentVersion: z.string().min(1).describe("Agent version"),
+      description: z.string().optional().describe("Optional description"),
+      endpoint: z
+        .string()
+        .optional()
+        .describe("JSON object string for agent endpoint config"),
+      domainIntegrationId: z
+        .string()
+        .uuid()
+        .optional()
+        .describe("Domain integration id"),
+      isActive: z.boolean().optional().describe("Whether the agent is active"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_delete_agent",
+    description: "Delete an agent registry entry (destructive).",
+    pathTemplate: "/dashboard/agents/actions/delete",
+    requiresConfirm: true,
+    inputSchema: { ...idField, ...confirmField },
+  },
+  {
+    name: "hermes_mutate_create_variable",
+    description: "Create an orchestration variable.",
+    pathTemplate: "/dashboard/variables/actions/create",
+    requiresConfirm: false,
+    inputSchema: {
+      key: z.string().min(1).describe("Variable key"),
+      value: z.string().describe("Variable value"),
+      note: z.string().optional().describe("Optional note"),
+      isSecret: z.boolean().optional().describe("Store as secret"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_delete_variable",
+    description: "Delete a variable (destructive).",
+    pathTemplate: "/dashboard/variables/actions/delete",
+    requiresConfirm: true,
+    inputSchema: { ...idField, ...confirmField },
+  },
+  {
+    name: "hermes_mutate_run_pipeline",
+    description: "Enqueue a manual pipeline run (destructive side effects).",
+    pathTemplate: "/dashboard/pipelines/actions/run-pipeline",
+    requiresConfirm: true,
+    inputSchema: {
+      pipelineId: z.string().uuid().describe("Pipeline id"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_cancel_pipeline_execution",
+    description: "Cancel a manual pipeline execution (destructive).",
+    pathTemplate: "/dashboard/pipelines/actions/cancel-manual-execution",
+    requiresConfirm: true,
+    inputSchema: {
+      pipelineId: z.string().uuid().describe("Pipeline id"),
+      manualExecutionId: z
+        .string()
+        .uuid()
+        .describe("Manual pipeline execution id"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_delete_pipeline",
+    description: "Delete a pipeline (destructive).",
+    pathTemplate: "/dashboard/pipelines/actions/delete",
+    requiresConfirm: true,
+    inputSchema: { ...idField, ...confirmField },
+  },
+  {
+    name: "hermes_mutate_cancel_schedule_execution",
+    description: "Cancel a schedule execution (destructive).",
+    pathTemplate: "/dashboard/schedules/actions/cancel-execution",
+    requiresConfirm: true,
+    inputSchema: {
+      scheduleId: z.string().uuid().describe("Schedule id"),
+      scheduleExecutionId: z.string().uuid().describe("Schedule execution id"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_delete_schedule",
+    description: "Delete a schedule (destructive).",
+    pathTemplate: "/dashboard/schedules/actions/delete",
+    requiresConfirm: true,
+    inputSchema: { ...idField, ...confirmField },
+  },
+  {
+    name: "hermes_mutate_cancel_http_trigger_execution",
+    description: "Cancel an HTTP trigger execution (destructive).",
+    pathTemplate: "/dashboard/http-triggers/actions/cancel-execution",
+    requiresConfirm: true,
+    inputSchema: {
+      httpTriggerId: z.string().uuid().describe("HTTP trigger id"),
+      httpTriggerExecutionId: z
+        .string()
+        .uuid()
+        .describe("HTTP trigger execution id"),
+      ...confirmField,
+    },
+  },
+  {
+    name: "hermes_mutate_delete_http_trigger",
+    description: "Delete an HTTP trigger (destructive).",
+    pathTemplate: "/dashboard/http-triggers/actions/delete",
+    requiresConfirm: true,
+    inputSchema: { ...idField, ...confirmField },
+  },
+];
+
+/**
+ * Builds the JSON body for a mutation route from tool arguments (excludes `confirm`).
+ *
+ * @param args - Tool arguments from the MCP client.
+ * @returns Request body for route-action-gen POST handlers.
+ */
+export const buildMutationRequestBody = (
+  args: Record<string, unknown>,
+): Record<string, unknown> => {
+  const body = { ...args };
+  delete body.confirm;
+  return body;
+};

--- a/packages/hermes/mcp-server/src/lib/mutation-access.test.ts
+++ b/packages/hermes/mcp-server/src/lib/mutation-access.test.ts
@@ -1,0 +1,71 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { HermesHttpClient } from "./http-client.js";
+import {
+  assertMutationAllowed,
+  isReadOnlyKeyHttpResponse,
+  parseWhoamiReadOnly,
+} from "./mutation-access.js";
+
+describe("parseWhoamiReadOnly", () => {
+  it("returns readOnly when present", () => {
+    expect(parseWhoamiReadOnly({ readOnly: true })).toBe(true);
+    expect(parseWhoamiReadOnly({ readOnly: false })).toBe(false);
+  });
+
+  it("returns null for invalid bodies", () => {
+    expect(parseWhoamiReadOnly(null)).toBeNull();
+    expect(parseWhoamiReadOnly({})).toBeNull();
+  });
+});
+
+describe("isReadOnlyKeyHttpResponse", () => {
+  it("detects read_only_key 403", () => {
+    expect(
+      isReadOnlyKeyHttpResponse(403, {
+        code: "read_only_key",
+        message: "nope",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for other responses", () => {
+    expect(isReadOnlyKeyHttpResponse(401, { error: "Unauthorized" })).toBe(
+      false,
+    );
+  });
+});
+
+describe("assertMutationAllowed", () => {
+  it("allows when whoami reports full-access key", async () => {
+    const httpClient: HermesHttpClient = {
+      request: async () => ({
+        status: 200,
+        body: { readOnly: false, label: "full" },
+        text: "{}",
+      }),
+    };
+
+    const result = await assertMutationAllowed({ httpClient });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it("blocks read-only keys before mutations", async () => {
+    const httpClient: HermesHttpClient = {
+      request: async () => ({
+        status: 200,
+        body: { readOnly: true },
+        text: "{}",
+      }),
+    };
+
+    const result = await assertMutationAllowed({ httpClient });
+    expect(result).toMatchObject({ isError: true });
+    const text =
+      "content" in result && result.content[0]?.type === "text"
+        ? result.content[0].text
+        : "";
+    expect(text).toContain("Read-only");
+  });
+});

--- a/packages/hermes/mcp-server/src/lib/mutation-access.ts
+++ b/packages/hermes/mcp-server/src/lib/mutation-access.ts
@@ -1,0 +1,86 @@
+import type { HermesHttpClient } from "./http-client.js";
+import { formatHermesToolError } from "./format-tool-result.js";
+
+/** Parsed whoami fields used before mutation HTTP calls. */
+export type HermesWhoamiSnapshot = {
+  readOnly: boolean;
+};
+
+/**
+ * Parses the whoami JSON body for the read-only flag.
+ *
+ * @param body - Response body from GET `/api/mcp/whoami`.
+ * @returns Read-only flag when present; otherwise null.
+ */
+export const parseWhoamiReadOnly = (body: unknown): boolean | null => {
+  if (typeof body !== "object" || body === null || !("readOnly" in body)) {
+    return null;
+  }
+  return Boolean((body as { readOnly: unknown }).readOnly);
+};
+
+/**
+ * Returns true when the HTTP body is Hermes read-only key rejection.
+ *
+ * @param status - HTTP status code.
+ * @param body - Parsed response body.
+ * @returns Whether the response is a read-only API key error.
+ */
+export const isReadOnlyKeyHttpResponse = (
+  status: number,
+  body: unknown,
+): boolean => {
+  if (status !== 403 || typeof body !== "object" || body === null) {
+    return false;
+  }
+  const record = body as { code?: unknown };
+  return record.code === "read_only_key";
+};
+
+export type AssertMutationAllowedDependencies = {
+  httpClient: HermesHttpClient;
+};
+
+/**
+ * Verifies the active API key may call mutation routes (whoami, read-only check).
+ *
+ * @param dependencies - HTTP client for whoami.
+ * @returns Success or a formatted MCP tool error result (no HTTP mutation yet).
+ */
+export const assertMutationAllowed = async ({
+  httpClient,
+}: AssertMutationAllowedDependencies) => {
+  const whoami = await httpClient.request({
+    method: "GET",
+    path: "/api/mcp/whoami",
+  });
+
+  if (isReadOnlyKeyHttpResponse(whoami.status, whoami.body)) {
+    return formatHermesToolError(
+      "Read-only API key cannot call mutation tools. Create a full-access key in Hermes → API keys.",
+    );
+  }
+
+  if (whoami.status === 401 || whoami.status === 403) {
+    return formatHermesToolError(
+      "API key rejected by Hermes. Check the profile API key and base URL.",
+      whoami.body,
+    );
+  }
+
+  if (whoami.status < 200 || whoami.status >= 300) {
+    return formatHermesToolError(
+      `whoami failed with HTTP ${whoami.status}`,
+      whoami.body,
+    );
+  }
+
+  const readOnly = parseWhoamiReadOnly(whoami.body);
+  if (readOnly === true) {
+    return formatHermesToolError(
+      "Read-only API key cannot call mutation tools. Create a full-access key in Hermes → API keys.",
+    );
+  }
+
+  return { allowed: true as const };
+};

--- a/packages/hermes/mcp-server/src/lib/register-hermes-mutate-tools.test.ts
+++ b/packages/hermes/mcp-server/src/lib/register-hermes-mutate-tools.test.ts
@@ -1,0 +1,79 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+import type { HermesHttpClient } from "./http-client.js";
+import { HERMES_MUTATE_TOOL_SPECS } from "./mutate-tool-catalog.js";
+import { handleHermesMutateToolCall } from "./register-hermes-mutate-tools.js";
+
+const deleteAgentSpec = HERMES_MUTATE_TOOL_SPECS.find(
+  (spec) => spec.name === "hermes_mutate_delete_agent",
+);
+
+describe("handleHermesMutateToolCall", () => {
+  it("does not call HTTP when confirm is missing on destructive tools", async () => {
+    const request = vi.fn();
+    const httpClient: HermesHttpClient = { request };
+
+    const result = await handleHermesMutateToolCall(
+      deleteAgentSpec!,
+      { id: "00000000-0000-4000-8000-000000000001" },
+      {
+        httpClient,
+        assertMutationAllowed: async () => ({ allowed: true as const }),
+      },
+    );
+
+    expect(request).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+
+  it("calls HTTP when confirm is true", async () => {
+    const request = vi.fn().mockResolvedValue({
+      status: 200,
+      body: { ok: true },
+      text: '{"ok":true}',
+    });
+    const httpClient: HermesHttpClient = { request };
+
+    await handleHermesMutateToolCall(
+      deleteAgentSpec!,
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        confirm: true,
+      },
+      {
+        httpClient,
+        assertMutationAllowed: async () => ({ allowed: true as const }),
+      },
+    );
+
+    expect(request).toHaveBeenCalledWith({
+      method: "POST",
+      path: "/dashboard/agents/actions/delete",
+      body: { id: "00000000-0000-4000-8000-000000000001" },
+    });
+  });
+
+  it("blocks read-only keys via assertMutationAllowed", async () => {
+    const request = vi.fn();
+    const httpClient: HermesHttpClient = { request };
+
+    const result = await handleHermesMutateToolCall(
+      deleteAgentSpec!,
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        confirm: true,
+      },
+      {
+        httpClient,
+        assertMutationAllowed: async () => ({
+          content: [{ type: "text" as const, text: '{"error":"ro"}' }],
+          isError: true,
+        }),
+      },
+    );
+
+    expect(request).not.toHaveBeenCalled();
+    expect(result.isError).toBe(true);
+  });
+});

--- a/packages/hermes/mcp-server/src/lib/register-hermes-mutate-tools.ts
+++ b/packages/hermes/mcp-server/src/lib/register-hermes-mutate-tools.ts
@@ -1,0 +1,94 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+import {
+  formatHermesHttpAsToolResult,
+  formatHermesToolError,
+} from "./format-tool-result.js";
+import type { HermesHttpClient } from "./http-client.js";
+import { assertMutationAllowed } from "./mutation-access.js";
+import {
+  buildMutationRequestBody,
+  type HermesMutateToolSpec,
+  HERMES_MUTATE_TOOL_SPECS,
+} from "./mutate-tool-catalog.js";
+
+const DESTRUCTIVE_CONFIRM_MESSAGE =
+  "Destructive Hermes mutation blocked. Call this tool again with confirm: true after the user approves. No HTTP request was sent.";
+
+export type HandleHermesMutateToolCallDependencies = {
+  httpClient: HermesHttpClient;
+  assertMutationAllowed?: typeof assertMutationAllowed;
+};
+
+/**
+ * Runs one Hermes mutation tool (confirm gate, read-only check, HTTP POST).
+ *
+ * @param spec - Mutation tool specification.
+ * @param args - Tool arguments from the MCP client.
+ * @param dependencies - HTTP client and optional access guard.
+ * @returns MCP tool result.
+ */
+export const handleHermesMutateToolCall = async (
+  spec: HermesMutateToolSpec,
+  args: Record<string, unknown>,
+  {
+    httpClient,
+    assertMutationAllowed: assertMutationAllowedFn = assertMutationAllowed,
+  }: HandleHermesMutateToolCallDependencies,
+): Promise<CallToolResult> => {
+  if (spec.requiresConfirm && args.confirm !== true) {
+    return formatHermesToolError(DESTRUCTIVE_CONFIRM_MESSAGE, {
+      requiredField: "confirm",
+      requiredValue: true,
+    });
+  }
+
+  const access = await assertMutationAllowedFn({ httpClient });
+  if (!("allowed" in access)) {
+    return access;
+  }
+
+  const response = await httpClient.request({
+    method: "POST",
+    path: spec.pathTemplate,
+    body: buildMutationRequestBody(args),
+  });
+
+  return formatHermesHttpAsToolResult(response);
+};
+
+export type RegisterHermesMutateToolsDependencies = {
+  server: McpServer;
+  httpClient: HermesHttpClient;
+  assertMutationAllowed?: typeof assertMutationAllowed;
+};
+
+/**
+ * Registers Hermes mutation MCP tools with confirm gate and read-only checks.
+ *
+ * @param dependencies - MCP server, HTTP client, and optional access guard for tests.
+ */
+export const registerHermesMutateTools = ({
+  server,
+  httpClient,
+  assertMutationAllowed: assertMutationAllowedFn = assertMutationAllowed,
+}: RegisterHermesMutateToolsDependencies): void => {
+  for (const spec of HERMES_MUTATE_TOOL_SPECS) {
+    server.registerTool(
+      spec.name,
+      {
+        description: spec.description,
+        inputSchema: spec.inputSchema,
+        annotations: spec.requiresConfirm
+          ? { destructiveHint: true }
+          : undefined,
+      },
+      async (args: Record<string, unknown>) =>
+        handleHermesMutateToolCall(spec, args, {
+          httpClient,
+          assertMutationAllowed: assertMutationAllowedFn,
+        }),
+    );
+  }
+};


### PR DESCRIPTION
## Summary

Extends `@hermes/mcp-server` with `hermes_mutate_*` tools for dashboard Phase B routes. Destructive actions need `confirm: true` on a second call; read-only API keys are blocked before HTTP via whoami.

## Important changes

- Mutation tool catalog for agents, variables, pipelines, schedules, and HTTP triggers.
- Client-side confirm gate (no HTTP until `confirm: true` on delete/cancel/run tools).
- Read-only key check via `GET /api/mcp/whoami` before mutations.
- Unit tests for confirm gate, read-only block, and body building.

## How to test

- `pnpm --filter @hermes/mcp-server test`
- Call `hermes_mutate_delete_agent` without `confirm` → tool error, no network.
- Repeat with `confirm: true` and a full-access key against a dev Hermes instance.

## Related issues

Closes #503