### PR TITLE
Fix agent config save when schema uses textarea format

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.test.ts
@@ -1,0 +1,70 @@
+/** @vitest-environment node */
+import { afterEach, describe, it, expect, vi } from "vitest";
+
+import { createUpdateAgentConfigHandler } from "./route.post.config";
+
+const mockDashboardUser = {
+  id: "u1",
+  name: "Admin",
+  email: "a@b.com",
+} as const;
+
+describe("createUpdateAgentConfigHandler", () => {
+  const configId = "00000000-0000-4000-8000-000000000001";
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("updates config when schema uses Hermes textarea format on prompts", async () => {
+    const updateMock = vi.fn().mockResolvedValue({});
+    const configSchema = {
+      type: "object",
+      properties: {
+        prompts: {
+          type: "object",
+          properties: {
+            systemPrompt: { type: "string", format: "textarea" },
+          },
+        },
+      },
+    };
+    const mockDb = {
+      agentConfig: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: configId,
+          name: "Query Analysis Config",
+        }),
+        update: updateMock,
+      },
+      agentRegistry: {
+        findFirst: vi.fn().mockResolvedValue({
+          id: "ar1",
+          configSchema,
+        }),
+      },
+    };
+    const handler = createUpdateAgentConfigHandler({
+      db: mockDb as never,
+    });
+
+    const result = await handler({
+      body: {
+        id: configId,
+        name: "Query Analysis Config",
+        agentId: "query-analysis",
+        agentVersion: "1.0.0",
+        config: {
+          prompts: { systemPrompt: "Updated\nprompt" },
+        },
+      },
+      user: mockDashboardUser,
+      params: {},
+      headers: new Headers(),
+      searchParams: {},
+    } as never);
+
+    expect(result.status).toBe(true);
+    expect(updateMock).toHaveBeenCalled();
+  });
+});

--- a/apps/hermes/dashboard/app/dev/ui/agent-config-textarea-save/page.tsx
+++ b/apps/hermes/dashboard/app/dev/ui/agent-config-textarea-save/page.tsx
@@ -1,0 +1,61 @@
+import { env } from "@hermes/env";
+import { notFound } from "next/navigation";
+
+import { validateWithJsonSchema } from "@/lib/validate-json-schema";
+
+import queryAnalysisSchema from "../mp-agent-prompts-hermes/schemas/query-analysis.json";
+
+const SAMPLE_CONFIG = {
+  openaiApiKey: "{{OPENAI_API_KEY}}",
+  openaiModel: "gpt-4o-mini",
+  queryCount: 1,
+  minDeterministicCount: 0,
+  maxTokens: 256,
+  prompts: {
+    systemPrompt: "Query analysis system prompt for #521 visual proof.",
+    userPromptTemplate: "User template with {{queryContextBlock}}.",
+  },
+};
+
+/**
+ * Dev-only page proving agent config validation accepts `format: "textarea"` (#521).
+ */
+const AgentConfigTextareaSaveDevPage = () => {
+  if (env.NODE_ENV !== "development") {
+    notFound();
+  }
+
+  const schema = queryAnalysisSchema as Record<string, unknown>;
+  const result = validateWithJsonSchema(schema, SAMPLE_CONFIG);
+
+  return (
+    <main className="mx-auto max-w-2xl space-y-4 p-8">
+      <h1 className="text-xl font-semibold">
+        Agent config save validation (#521)
+      </h1>
+      <p className="text-muted-foreground text-sm">
+        Uses the same <code>validateWithJsonSchema</code> as Hermes agent config
+        create/update when saving.
+      </p>
+      {result.valid ? (
+        <p
+          className="text-sm text-green-700"
+          role="status"
+          data-testid="save-result"
+        >
+          Config saved successfully.
+        </p>
+      ) : (
+        <p
+          className="text-destructive text-sm"
+          role="alert"
+          data-testid="save-result"
+        >
+          Config validation failed: {result.errors.join("; ")}
+        </p>
+      )}
+    </main>
+  );
+};
+
+export default AgentConfigTextareaSaveDevPage;

--- a/apps/hermes/dashboard/lib/validate-json-schema.test.ts
+++ b/apps/hermes/dashboard/lib/validate-json-schema.test.ts
@@ -61,6 +61,24 @@ describe("validateWithJsonSchema", () => {
     }
   });
 
+  it("compiles and validates config schema with Hermes textarea format on prompt fields", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        prompts: {
+          type: "object",
+          properties: {
+            systemPrompt: { type: "string", format: "textarea" },
+          },
+        },
+      },
+    };
+    const result = validateWithJsonSchema(schema, {
+      prompts: { systemPrompt: "line one\nline two" },
+    });
+    expect(result.valid).toBe(true);
+  });
+
   it("accepts date-time format when ajv-formats is used", () => {
     const schema = {
       type: "object",

--- a/apps/hermes/dashboard/lib/validate-json-schema.ts
+++ b/apps/hermes/dashboard/lib/validate-json-schema.ts
@@ -1,8 +1,10 @@
+import { registerHermesUiJsonSchemaFormats } from "@workspace/agent-runtime/register-hermes-ui-json-schema-formats";
 import Ajv, { type JSONSchemaType } from "ajv";
 import addFormats from "ajv-formats";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
+registerHermesUiJsonSchemaFormats(ajv);
 
 /**
  * Validates data against a JSON Schema.

--- a/apps/hermes/dashboard/package.json
+++ b/apps/hermes/dashboard/package.json
@@ -31,6 +31,7 @@
     "@next/env": "catalog:",
     "@nicnocquee/dataqueue": "^1.39.0",
     "@workspace/agent-auth-client": "workspace:*",
+    "@workspace/agent-runtime": "workspace:*",
     "@workspace/agent-data-api-client": "workspace:*",
     "@workspace/json-schema-form": "workspace:*",
     "@workspace/logger": "workspace:*",

--- a/apps/hermes/dashboard/scripts/capture-agent-config-textarea-save-video.mjs
+++ b/apps/hermes/dashboard/scripts/capture-agent-config-textarea-save-video.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Records #521 proof: validateWithJsonSchema accepts textarea format on prompts.
+ * Prerequisites: `pnpm dev:hermes` on port 3001, `npx playwright install chromium` once.
+ */
+
+import { spawnSync } from "node:child_process";
+import { mkdir, readdir, rename } from "node:fs/promises";
+import { mkdtemp } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import process from "node:process";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+const outDir = join(
+  repoRoot,
+  "artifacts/ui-evidence/agent-config-textarea-save-521",
+);
+const url = "http://127.0.0.1:3001/dev/ui/agent-config-textarea-save";
+
+const workDir = await mkdtemp(join(tmpdir(), "pw-521-"));
+const install = spawnSync(
+  "npm",
+  ["install", "--no-save", "playwright@1.51.0"],
+  { cwd: workDir, stdio: "inherit" },
+);
+if (install.status !== 0) {
+  process.exit(install.status ?? 1);
+}
+
+const playwright = await import(
+  pathToFileURL(join(workDir, "node_modules/playwright/index.js")).href
+);
+const { chromium } = playwright.default;
+
+await mkdir(outDir, { recursive: true });
+
+const browser = await chromium.launch({ headless: true });
+const context = await browser.newContext({
+  viewport: { width: 1280, height: 900 },
+  recordVideo: {
+    dir: outDir,
+    size: { width: 1280, height: 900 },
+  },
+});
+const page = await context.newPage();
+
+try {
+  await page.goto(url, { waitUntil: "networkidle" });
+  await page.getByTestId("save-result").waitFor({ timeout: 15_000 });
+  const text = await page.getByTestId("save-result").textContent();
+  if (!text?.includes("Config saved successfully")) {
+    throw new Error(`Unexpected result: ${text ?? "(empty)"}`);
+  }
+  await page.waitForTimeout(1500);
+} catch (error) {
+  await page.screenshot({ path: join(outDir, "failure.png"), fullPage: true });
+  throw error;
+} finally {
+  await context.close();
+  await browser.close();
+}
+
+const videoPath = join(outDir, "521-agent-config-textarea-save.webm");
+const entries = await readdir(outDir);
+const webm = entries.find((f) => f.endsWith(".webm"));
+if (webm && webm !== "521-agent-config-textarea-save.webm") {
+  await rename(join(outDir, webm), videoPath);
+}
+
+console.log(`Recorded video: ${videoPath}`);

--- a/packages/hermes/scheduler/package.json
+++ b/packages/hermes/scheduler/package.json
@@ -21,6 +21,7 @@
     "@nicnocquee/dataqueue": "^1.39.0",
     "@hermes/domain-integration-crypto": "workspace:*",
     "@hermes/orchestration-database": "workspace:*",
+    "@workspace/agent-runtime": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "cron-parser": "^5.0.0",

--- a/packages/hermes/scheduler/src/validate-json-schema.test.ts
+++ b/packages/hermes/scheduler/src/validate-json-schema.test.ts
@@ -58,6 +58,25 @@ describe("validateWithJsonSchema", () => {
     }
   });
 
+  it("compiles schema with Hermes textarea format on prompt fields", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        prompts: {
+          type: "object",
+          properties: {
+            systemPrompt: { type: "string", format: "textarea" },
+          },
+        },
+      },
+    };
+    expect(
+      validateWithJsonSchema(schema, {
+        prompts: { systemPrompt: "a\nb" },
+      }).valid,
+    ).toBe(true);
+  });
+
   it("accepts date-time format when ajv-formats is registered", () => {
     const schema = {
       type: "object",

--- a/packages/hermes/scheduler/src/validate-json-schema.ts
+++ b/packages/hermes/scheduler/src/validate-json-schema.ts
@@ -1,8 +1,10 @@
+import { registerHermesUiJsonSchemaFormats } from "@workspace/agent-runtime/register-hermes-ui-json-schema-formats";
 import Ajv, { type JSONSchemaType } from "ajv";
 import addFormats from "ajv-formats";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
+registerHermesUiJsonSchemaFormats(ajv);
 
 type JsonSchemaLike = {
   type?: string | string[];

--- a/packages/shared/agent-runtime/package.json
+++ b/packages/shared/agent-runtime/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@workspace/typescript-config": "workspace:*",
+    "ajv": "^8.17.1",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/shared/agent-runtime/package.json
+++ b/packages/shared/agent-runtime/package.json
@@ -6,7 +6,8 @@
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./register-hermes-ui-json-schema-formats": "./src/register-hermes-ui-json-schema-formats.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/shared/agent-runtime/src/index.ts
+++ b/packages/shared/agent-runtime/src/index.ts
@@ -1,6 +1,10 @@
 export { createAgentApp } from "./create-agent-app.js";
 export { enrichConfigSchemaForHermesUi } from "./enrich-config-schema-for-hermes-ui.js";
 export {
+  HERMES_UI_TEXTAREA_FORMAT,
+  registerHermesUiJsonSchemaFormats,
+} from "./register-hermes-ui-json-schema-formats.js";
+export {
   hermesTickerIdSchema,
   type HermesTickerId,
 } from "./schemas/hermes-ticker-id.js";

--- a/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.test.ts
+++ b/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HERMES_UI_TEXTAREA_FORMAT,
+  registerHermesUiJsonSchemaFormats,
+} from "./register-hermes-ui-json-schema-formats";
+
+describe("registerHermesUiJsonSchemaFormats", () => {
+  it("registers textarea format so AJV compiles schemas with prompts.systemPrompt", () => {
+    const formats = new Map<string, unknown>();
+    const ajv = {
+      addFormat: (name: string, format: unknown) => {
+        formats.set(name, format);
+        return ajv;
+      },
+    };
+
+    registerHermesUiJsonSchemaFormats(ajv);
+
+    expect(formats.has(HERMES_UI_TEXTAREA_FORMAT)).toBe(true);
+    const textarea = formats.get(HERMES_UI_TEXTAREA_FORMAT) as {
+      type?: string;
+      validate: (data: unknown) => boolean;
+    };
+    expect(textarea.type).toBe("string");
+    expect(textarea.validate("multi\nline")).toBe(true);
+  });
+});

--- a/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.test.ts
+++ b/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.test.ts
@@ -1,3 +1,4 @@
+import Ajv from "ajv";
 import { describe, expect, it } from "vitest";
 
 import {
@@ -7,22 +8,17 @@ import {
 
 describe("registerHermesUiJsonSchemaFormats", () => {
   it("registers textarea format so AJV compiles schemas with prompts.systemPrompt", () => {
-    const formats = new Map<string, unknown>();
-    const ajv = {
-      addFormat: (name: string, format: unknown) => {
-        formats.set(name, format);
-        return ajv;
-      },
-    };
-
+    const ajv = new Ajv({ allErrors: true });
     registerHermesUiJsonSchemaFormats(ajv);
 
-    expect(formats.has(HERMES_UI_TEXTAREA_FORMAT)).toBe(true);
-    const textarea = formats.get(HERMES_UI_TEXTAREA_FORMAT) as {
-      type?: string;
-      validate: (data: unknown) => boolean;
-    };
-    expect(textarea.type).toBe("string");
-    expect(textarea.validate("multi\nline")).toBe(true);
+    const validate = ajv.compile({
+      type: "object",
+      properties: {
+        systemPrompt: { type: "string", format: HERMES_UI_TEXTAREA_FORMAT },
+      },
+    });
+
+    expect(validate({ systemPrompt: "multi\nline" })).toBe(true);
+    expect(validate({ systemPrompt: 1 })).toBe(false);
   });
 });

--- a/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.ts
+++ b/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.ts
@@ -1,0 +1,29 @@
+/** JSON Schema `format` value used by {@link enrichConfigSchemaForHermesUi} for multiline prompt fields. */
+export const HERMES_UI_TEXTAREA_FORMAT = "textarea";
+
+type AjvFormatRegistrar = {
+  addFormat: (
+    name: string,
+    format:
+      | boolean
+      | {
+          type?: string;
+          validate: (data: unknown) => boolean;
+        },
+  ) => unknown;
+};
+
+/**
+ * Registers Hermes UI-only JSON Schema formats on an Ajv instance so schemas from
+ * {@link enrichConfigSchemaForHermesUi} compile and validate (e.g. agent config save).
+ *
+ * @param ajv - Ajv instance (after `ajv-formats` when standard formats are needed).
+ */
+export const registerHermesUiJsonSchemaFormats = (
+  ajv: AjvFormatRegistrar,
+): void => {
+  ajv.addFormat(HERMES_UI_TEXTAREA_FORMAT, {
+    type: "string",
+    validate: () => true,
+  });
+};

--- a/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.ts
+++ b/packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.ts
@@ -1,17 +1,7 @@
+import type Ajv from "ajv";
+
 /** JSON Schema `format` value used by {@link enrichConfigSchemaForHermesUi} for multiline prompt fields. */
 export const HERMES_UI_TEXTAREA_FORMAT = "textarea";
-
-type AjvFormatRegistrar = {
-  addFormat: (
-    name: string,
-    format:
-      | boolean
-      | {
-          type?: string;
-          validate: (data: unknown) => boolean;
-        },
-  ) => unknown;
-};
 
 /**
  * Registers Hermes UI-only JSON Schema formats on an Ajv instance so schemas from
@@ -20,7 +10,7 @@ type AjvFormatRegistrar = {
  * @param ajv - Ajv instance (after `ajv-formats` when standard formats are needed).
  */
 export const registerHermesUiJsonSchemaFormats = (
-  ajv: AjvFormatRegistrar,
+  ajv: Pick<Ajv, "addFormat">,
 ): void => {
   ajv.addFormat(HERMES_UI_TEXTAREA_FORMAT, {
     type: "string",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -312,7 +312,7 @@ importers:
         version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
-        version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -992,7 +992,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1568,6 +1568,9 @@ importers:
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -17179,7 +17182,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -17188,7 +17191,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -18314,12 +18317,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76
     optionalDependencies:
-      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   router@2.2.0:
@@ -18807,12 +18810,10 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   supports-color@10.2.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,6 +259,9 @@ importers:
       '@workspace/agent-data-api-contract':
         specifier: workspace:*
         version: link:../../../packages/shared/agent-data-api-contract
+      '@workspace/agent-runtime':
+        specifier: workspace:*
+        version: link:../../../packages/shared/agent-runtime
       '@workspace/json-schema-form':
         specifier: workspace:*
         version: link:../../../packages/shared/json-schema-form
@@ -1232,6 +1235,9 @@ importers:
       '@nicnocquee/dataqueue':
         specifier: ^1.39.0
         version: 1.39.0(pg@8.18.0)
+      '@workspace/agent-runtime':
+        specifier: workspace:*
+        version: link:../../shared/agent-runtime
       ajv:
         specifier: ^8.17.1
         version: 8.17.1


### PR DESCRIPTION
## Summary

Saving an agent config in Hermes failed when the registry schema used `format: "textarea"` on prompt fields. That format is added for multiline SchemaForm inputs, but AJV did not recognize it and refused to compile the schema.

This registers `textarea` as a string format on the shared AJV instances used for agent config validation (dashboard and scheduler).

## Related issues

Closes #521

## Important changes

- Add `registerHermesUiJsonSchemaFormats` in `@workspace/agent-runtime` and call it from Hermes `validateWithJsonSchema`.
- Add regression tests for textarea format on `prompts.systemPrompt`.
- Add an update-handler test that mirrors the failing save path.

## Other changes

- Dev page at `/dev/ui/agent-config-textarea-save` and a Playwright script to record proof.

## Key files to review

- `packages/shared/agent-runtime/src/register-hermes-ui-json-schema-formats.ts` — format registration paired with `enrichConfigSchemaForHermesUi`.
- `apps/hermes/dashboard/lib/validate-json-schema.ts` — dashboard validation entry point.
- `packages/hermes/scheduler/src/validate-json-schema.ts` — scheduler validation entry point.

## Visual verification

![Agent config validation passes with textarea format](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/agent-config-textarea-save-521/521-validation-success.png)

**Video:** [521-agent-config-textarea-save.webm](https://raw.githubusercontent.com/hyperjumptech/mediapulse/issue-proofs/agent-config-textarea-save-521/521-agent-config-textarea-save.webm) — dev page showing successful validation (same `validateWithJsonSchema` as production save).

Repro: `pnpm dev:hermes`, open `http://localhost:3001/dev/ui/agent-config-textarea-save`, or run `node apps/hermes/dashboard/scripts/capture-agent-config-textarea-save-video.mjs`.

## How to test

1. `pnpm --filter @workspace/agent-runtime test` and `pnpm --filter @hermes/dashboard exec vitest run lib/validate-json-schema.test.ts app/dashboard/agent-configs/actions/update/route.post.config.test.ts`
2. With Hermes running locally, edit **Query Analysis Config** under Agent configs and click **Save changes** — the textarea format error should be gone.
3. Confirm the dev proof page shows **Config saved successfully.**
