### PR TITLE
Register textarea format inline for agent config validation

### DIFF
--- a/apps/hermes/dashboard/lib/validate-json-schema.ts
+++ b/apps/hermes/dashboard/lib/validate-json-schema.ts
@@ -1,10 +1,17 @@
-import { registerHermesUiJsonSchemaFormats } from "@workspace/agent-runtime/register-hermes-ui-json-schema-formats";
 import Ajv, { type JSONSchemaType } from "ajv";
 import addFormats from "ajv-formats";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
-registerHermesUiJsonSchemaFormats(ajv);
+
+/**
+ * Hermes UI-only JSON Schema format for multiline prompt fields
+ * ({@link enrichConfigSchemaForHermesUi} in @workspace/agent-runtime).
+ */
+ajv.addFormat("textarea", {
+  type: "string",
+  validate: () => true,
+});
 
 /**
  * Validates data against a JSON Schema.

--- a/apps/hermes/dashboard/package.json
+++ b/apps/hermes/dashboard/package.json
@@ -31,7 +31,6 @@
     "@next/env": "catalog:",
     "@nicnocquee/dataqueue": "^1.39.0",
     "@workspace/agent-auth-client": "workspace:*",
-    "@workspace/agent-runtime": "workspace:*",
     "@workspace/agent-data-api-client": "workspace:*",
     "@workspace/json-schema-form": "workspace:*",
     "@workspace/logger": "workspace:*",

--- a/packages/hermes/scheduler/package.json
+++ b/packages/hermes/scheduler/package.json
@@ -21,7 +21,6 @@
     "@nicnocquee/dataqueue": "^1.39.0",
     "@hermes/domain-integration-crypto": "workspace:*",
     "@hermes/orchestration-database": "workspace:*",
-    "@workspace/agent-runtime": "workspace:*",
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
     "cron-parser": "^5.0.0",

--- a/packages/hermes/scheduler/src/validate-json-schema.ts
+++ b/packages/hermes/scheduler/src/validate-json-schema.ts
@@ -1,10 +1,14 @@
-import { registerHermesUiJsonSchemaFormats } from "@workspace/agent-runtime/register-hermes-ui-json-schema-formats";
 import Ajv, { type JSONSchemaType } from "ajv";
 import addFormats from "ajv-formats";
 
 const ajv = new Ajv({ allErrors: true });
 addFormats(ajv);
-registerHermesUiJsonSchemaFormats(ajv);
+
+/** Hermes UI-only format for multiline prompt fields in enriched agent config schemas. */
+ajv.addFormat("textarea", {
+  type: "string",
+  validate: () => true,
+});
 
 type JsonSchemaLike = {
   type?: string | string[];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,9 +259,6 @@ importers:
       '@workspace/agent-data-api-contract':
         specifier: workspace:*
         version: link:../../../packages/shared/agent-data-api-contract
-      '@workspace/agent-runtime':
-        specifier: workspace:*
-        version: link:../../../packages/shared/agent-runtime
       '@workspace/json-schema-form':
         specifier: workspace:*
         version: link:../../../packages/shared/json-schema-form
@@ -297,7 +294,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -312,7 +309,7 @@ importers:
         version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
-        version: 0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -992,7 +989,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1235,9 +1232,6 @@ importers:
       '@nicnocquee/dataqueue':
         specifier: ^1.39.0
         version: 1.39.0(pg@8.18.0)
-      '@workspace/agent-runtime':
-        specifier: workspace:*
-        version: link:../../shared/agent-runtime
       ajv:
         specifier: ^8.17.1
         version: 8.17.1
@@ -17182,7 +17176,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -17191,7 +17185,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -18317,12 +18311,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76
     optionalDependencies:
-      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   router@2.2.0:
@@ -18810,10 +18804,12 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
## Summary

Hermes agent config create/update was failing when the registry schema used `format: "textarea"` on `prompts.systemPrompt` and `prompts.userPromptTemplate` (added by `enrichConfigSchemaForHermesUi` for multiline prompt editing). AJV does not know that custom format unless it is registered before `compile()`.

This change registers `textarea` directly on the AJV instances in the dashboard and scheduler validation helpers, and drops the `@workspace/agent-runtime` subpath import that only existed for that registration and did not resolve cleanly in Vitest.

## Related issues

Closes #523

## Important changes

- Register `textarea` as a pass-through string format in `apps/hermes/dashboard/lib/validate-json-schema.ts` and `packages/hermes/scheduler/src/validate-json-schema.ts`.
- Remove unused `@workspace/agent-runtime` dependency from `@hermes/dashboard` and `@hermes/scheduler`.

## Other changes

- `pnpm-lock.yaml` updated after removing the scheduler/dashboard agent-runtime dependency.

## Key files to review

- `apps/hermes/dashboard/lib/validate-json-schema.ts` — AJV setup used when saving agent configs.
- `packages/hermes/scheduler/src/validate-json-schema.ts` — same format registration for pipeline step config validation.
- `apps/hermes/dashboard/package.json` / `packages/hermes/scheduler/package.json` — dependency cleanup.

## How to test

1. Restart the Hermes dashboard dev server.
2. Open Agent configs and edit a config for `content-generation`, `article-analysis`, or `query-analysis` (any agent whose schema includes `prompts.systemPrompt`).
3. Set `prompts.systemPrompt` to a multiline value and save. Expect success, not `unknown format "textarea"`.
4. From repo root: `pnpm --filter @hermes/dashboard exec vitest run lib/validate-json-schema.test.ts` and `pnpm --filter @hermes/dashboard exec vitest run app/dashboard/agent-configs/actions/update/route.post.config.test.ts`.
