### PR TITLE
Run publish and deploy per service in CI

### DIFF
--- a/.github/actions/remote-deploy/action.yml
+++ b/.github/actions/remote-deploy/action.yml
@@ -1,0 +1,101 @@
+name: Remote deploy
+description: Connect over VPN and trigger a deployment webhook.
+
+inputs:
+  webhook-url:
+    description: Deployment webhook URL.
+    required: true
+  webhook-secret:
+    description: Bearer token for the deployment webhook.
+    required: true
+  vpn-config-b64:
+    description: Base64-encoded VPN client configuration.
+    required: true
+  vpn-password:
+    description: VPN key passphrase.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Trigger deployment
+      shell: bash
+      env:
+        WEBHOOK_URL: ${{ inputs.webhook-url }}
+        WEBHOOK_SECRET: ${{ inputs.webhook-secret }}
+        VPN_CONFIG_B64: ${{ inputs.vpn-config-b64 }}
+        VPN_PASSWORD: ${{ inputs.vpn-password }}
+      run: |
+        set -euo pipefail
+
+        if ! command -v openvpn >/dev/null 2>&1; then
+          sudo apt-get update
+          sudo apt-get install -y openvpn
+        fi
+
+        WORKDIR="$(mktemp -d)"
+        cleanup() {
+          if [ -f "$WORKDIR/vpn.pid" ]; then
+            sudo kill "$(sudo cat "$WORKDIR/vpn.pid")" >/dev/null 2>&1 || true
+          fi
+          rm -rf "$WORKDIR"
+        }
+        trap cleanup EXIT
+
+        printf "%s" "$VPN_CONFIG_B64" | base64 --decode >"$WORKDIR/client.ovpn"
+        printf "%s\n" "$VPN_PASSWORD" >"$WORKDIR/passphrase.txt"
+        chmod 600 "$WORKDIR/passphrase.txt"
+
+        vpn_connected="false"
+        for attempt in 1 2 3; do
+          if [ -f "$WORKDIR/vpn.pid" ]; then
+            sudo kill "$(sudo cat "$WORKDIR/vpn.pid")" >/dev/null 2>&1 || true
+            sudo rm -f "$WORKDIR/vpn.pid"
+          fi
+          sudo rm -f "$WORKDIR/vpn.log"
+
+          sudo openvpn \
+            --config "$WORKDIR/client.ovpn" \
+            --askpass "$WORKDIR/passphrase.txt" \
+            --daemon \
+            --writepid "$WORKDIR/vpn.pid" \
+            --log "$WORKDIR/vpn.log"
+
+          connected="false"
+          for _ in {1..30}; do
+            if sudo grep -q "Initialization Sequence Completed" "$WORKDIR/vpn.log"; then
+              connected="true"
+              break
+            fi
+            if [ -f "$WORKDIR/vpn.pid" ] && ! sudo kill -0 "$(sudo cat "$WORKDIR/vpn.pid")" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ "$connected" = "true" ]; then
+            vpn_connected="true"
+            break
+          fi
+
+          echo "::warning::VPN did not connect (attempt ${attempt}/3)." >&2
+          sudo cat "$WORKDIR/vpn.log" || true
+          if [ "$attempt" -lt 3 ]; then
+            echo "Retrying VPN in 15s..." >&2
+            sleep 15
+          fi
+        done
+
+        if [ "$vpn_connected" != "true" ]; then
+          exit 1
+        fi
+
+        curl --fail --silent --show-error --verbose \
+          --retry 6 \
+          --retry-all-errors \
+          --retry-delay 5 \
+          --retry-max-time 300 \
+          --connect-timeout 20 \
+          --max-time 120 \
+          -X GET "$WEBHOOK_URL" \
+          --header "Authorization: Bearer $WEBHOOK_SECRET"

--- a/.github/scripts/detect-changed-services.sh
+++ b/.github/scripts/detect-changed-services.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Detect which deployable services changed between two commits and emit a GitHub Actions matrix.
+#
+# Usage:
+#   WORKFLOW=app BASE_SHA=<sha> HEAD_SHA=<sha> ./detect-changed-services.sh
+#   WORKFLOW=agent BASE_SHA=<sha> HEAD_SHA=<sha> ./detect-changed-services.sh
+#
+# Outputs (GITHUB_OUTPUT):
+#   any=true|false
+#   matrix=[{service,dockerfile,image,webhook_secret}, ...]
+
+set -euo pipefail
+
+workflow="${WORKFLOW:?WORKFLOW must be app or agent}"
+base_sha="${BASE_SHA:?BASE_SHA is required}"
+head_sha="${HEAD_SHA:?HEAD_SHA is required}"
+
+if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+  echo "any=true" >>"${GITHUB_OUTPUT:?GITHUB_OUTPUT is required}"
+  case "$workflow" in
+    app)
+      echo 'matrix=[{"service":"agent-auth-api","dockerfile":"apps/hermes/agent-auth-api/Dockerfile","image":"app-agent-auth-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_AUTH_API"},{"service":"agent-data-api","dockerfile":"apps/mediapulse/agent-data-api/Dockerfile","image":"app-agent-data-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_DATA_API"},{"service":"domain-api","dockerfile":"apps/mediapulse/domain-api/Dockerfile","image":"app-domain-api","webhook_secret":"COOLIFY_WEBHOOK_APP_DOMAIN_API"},{"service":"agent-registry-api","dockerfile":"apps/hermes/agent-registry-api/Dockerfile","image":"app-agent-registry-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_REGISTRY_API"},{"service":"user-registration","dockerfile":"apps/mediapulse/user-registration/Dockerfile","image":"app-user-registration","webhook_secret":"COOLIFY_WEBHOOK_APP_USER_REGISTRATION"},{"service":"hermes","dockerfile":"apps/hermes/dashboard/Dockerfile","image":"app-hermes","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES"},{"service":"hermes-worker","dockerfile":"apps/hermes/worker/Dockerfile","image":"app-hermes-worker","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES_WORKER"}]' >>"$GITHUB_OUTPUT"
+      ;;
+    agent)
+      echo 'matrix=[{"service":"data-collection","dockerfile":"apps/mediapulse/agents/data-collection/Dockerfile","image":"agent-data-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION"},{"service":"content-generation","dockerfile":"apps/mediapulse/agents/content-generation/Dockerfile","image":"agent-content-generation","webhook_secret":"COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION"},{"service":"article-analysis","dockerfile":"apps/mediapulse/agents/article-analysis/Dockerfile","image":"agent-article-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS"},{"service":"query-analysis","dockerfile":"apps/mediapulse/agents/query-analysis/Dockerfile","image":"agent-query-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS"},{"service":"delivery","dockerfile":"apps/mediapulse/agents/delivery/Dockerfile","image":"agent-delivery","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DELIVERY"},{"service":"ticker-echo","dockerfile":"apps/mediapulse/agents/ticker-echo/Dockerfile","image":"agent-ticker-echo","webhook_secret":"COOLIFY_WEBHOOK_AGENT_TICKER_ECHO"},{"service":"agent-user-registration","dockerfile":"apps/mediapulse/agents/user-registration/Dockerfile","image":"agent-user-registration","webhook_secret":"COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION"}]' >>"$GITHUB_OUTPUT"
+      ;;
+    *)
+      echo "Unsupported WORKFLOW: $workflow" >&2
+      exit 1
+      ;;
+  esac
+  exit 0
+fi
+
+changed_files="$(git diff --name-only "$base_sha" "$head_sha")"
+
+if [ -z "$changed_files" ]; then
+  echo "any=false" >>"$GITHUB_OUTPUT"
+  echo "matrix=[]" >>"$GITHUB_OUTPUT"
+  exit 0
+fi
+
+shared_changed=false
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  case "$f" in
+    packages/* | pnpm-lock.yaml | pnpm-workspace.yaml | turbo.json)
+      shared_changed=true
+      break
+      ;;
+  esac
+done <<<"$changed_files"
+
+services_list=""
+
+append_service() {
+  local name="$1"
+  if ! grep -qx "$name" <<<"$services_list"; then
+    services_list+="${name}"$'\n'
+  fi
+}
+
+if [ "$shared_changed" = "true" ]; then
+  case "$workflow" in
+    app)
+      services_list=$'agent-auth-api\nagent-data-api\ndomain-api\nagent-registry-api\nuser-registration\nhermes\nhermes-worker\n'
+      ;;
+    agent)
+      services_list=$'data-collection\ncontent-generation\narticle-analysis\nquery-analysis\ndelivery\nticker-echo\nagent-user-registration\n'
+      ;;
+  esac
+else
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    case "$f" in
+      apps/mediapulse/user-registration/*)
+        [ "$workflow" = "app" ] && append_service "user-registration"
+        ;;
+      apps/mediapulse/domain-api/*)
+        [ "$workflow" = "app" ] && append_service "domain-api"
+        ;;
+      apps/mediapulse/agent-data-api/*)
+        [ "$workflow" = "app" ] && append_service "agent-data-api"
+        ;;
+      apps/hermes/agent-auth-api/*)
+        [ "$workflow" = "app" ] && append_service "agent-auth-api"
+        ;;
+      apps/hermes/agent-registry-api/*)
+        [ "$workflow" = "app" ] && append_service "agent-registry-api"
+        ;;
+      apps/hermes/dashboard/*)
+        [ "$workflow" = "app" ] && append_service "hermes"
+        ;;
+      apps/hermes/worker/*)
+        [ "$workflow" = "app" ] && append_service "hermes-worker"
+        ;;
+      apps/mediapulse/agents/data-collection/*)
+        [ "$workflow" = "agent" ] && append_service "data-collection"
+        ;;
+      apps/mediapulse/agents/content-generation/*)
+        [ "$workflow" = "agent" ] && append_service "content-generation"
+        ;;
+      apps/mediapulse/agents/delivery/*)
+        [ "$workflow" = "agent" ] && append_service "delivery"
+        ;;
+      apps/mediapulse/agents/ticker-echo/*)
+        [ "$workflow" = "agent" ] && append_service "ticker-echo"
+        ;;
+      apps/mediapulse/agents/article-analysis/*)
+        [ "$workflow" = "agent" ] && append_service "article-analysis"
+        ;;
+      apps/mediapulse/agents/query-analysis/*)
+        [ "$workflow" = "agent" ] && append_service "query-analysis"
+        ;;
+      apps/mediapulse/agents/user-registration/*)
+        [ "$workflow" = "agent" ] && append_service "agent-user-registration"
+        ;;
+    esac
+  done <<<"$changed_files"
+fi
+
+services_list="$(echo "$services_list" | sort -u | grep -v '^$' || true)"
+
+if [ -z "$services_list" ]; then
+  echo "any=false" >>"$GITHUB_OUTPUT"
+  echo "matrix=[]" >>"$GITHUB_OUTPUT"
+  exit 0
+fi
+
+lookup_service_config() {
+  local service="$1"
+  case "$service" in
+    agent-auth-api)
+      echo '{"service":"agent-auth-api","dockerfile":"apps/hermes/agent-auth-api/Dockerfile","image":"app-agent-auth-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_AUTH_API"}'
+      ;;
+    agent-data-api)
+      echo '{"service":"agent-data-api","dockerfile":"apps/mediapulse/agent-data-api/Dockerfile","image":"app-agent-data-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_DATA_API"}'
+      ;;
+    domain-api)
+      echo '{"service":"domain-api","dockerfile":"apps/mediapulse/domain-api/Dockerfile","image":"app-domain-api","webhook_secret":"COOLIFY_WEBHOOK_APP_DOMAIN_API"}'
+      ;;
+    agent-registry-api)
+      echo '{"service":"agent-registry-api","dockerfile":"apps/hermes/agent-registry-api/Dockerfile","image":"app-agent-registry-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_REGISTRY_API"}'
+      ;;
+    user-registration)
+      echo '{"service":"user-registration","dockerfile":"apps/mediapulse/user-registration/Dockerfile","image":"app-user-registration","webhook_secret":"COOLIFY_WEBHOOK_APP_USER_REGISTRATION"}'
+      ;;
+    hermes)
+      echo '{"service":"hermes","dockerfile":"apps/hermes/dashboard/Dockerfile","image":"app-hermes","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES"}'
+      ;;
+    hermes-worker)
+      echo '{"service":"hermes-worker","dockerfile":"apps/hermes/worker/Dockerfile","image":"app-hermes-worker","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES_WORKER"}'
+      ;;
+    data-collection)
+      echo '{"service":"data-collection","dockerfile":"apps/mediapulse/agents/data-collection/Dockerfile","image":"agent-data-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION"}'
+      ;;
+    content-generation)
+      echo '{"service":"content-generation","dockerfile":"apps/mediapulse/agents/content-generation/Dockerfile","image":"agent-content-generation","webhook_secret":"COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION"}'
+      ;;
+    article-analysis)
+      echo '{"service":"article-analysis","dockerfile":"apps/mediapulse/agents/article-analysis/Dockerfile","image":"agent-article-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS"}'
+      ;;
+    query-analysis)
+      echo '{"service":"query-analysis","dockerfile":"apps/mediapulse/agents/query-analysis/Dockerfile","image":"agent-query-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS"}'
+      ;;
+    delivery)
+      echo '{"service":"delivery","dockerfile":"apps/mediapulse/agents/delivery/Dockerfile","image":"agent-delivery","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DELIVERY"}'
+      ;;
+    ticker-echo)
+      echo '{"service":"ticker-echo","dockerfile":"apps/mediapulse/agents/ticker-echo/Dockerfile","image":"agent-ticker-echo","webhook_secret":"COOLIFY_WEBHOOK_AGENT_TICKER_ECHO"}'
+      ;;
+    agent-user-registration)
+      echo '{"service":"agent-user-registration","dockerfile":"apps/mediapulse/agents/user-registration/Dockerfile","image":"agent-user-registration","webhook_secret":"COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION"}'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+matrix_items=""
+while IFS= read -r service; do
+  [ -z "$service" ] && continue
+  item="$(lookup_service_config "$service")"
+  if [ -n "$matrix_items" ]; then
+    matrix_items+=","
+  fi
+  matrix_items+="$item"
+done <<<"$services_list"
+
+echo "any=true" >>"$GITHUB_OUTPUT"
+printf 'matrix=[%s]\n' "$matrix_items" >>"$GITHUB_OUTPUT"

--- a/.github/workflows/agent-deploy.yml
+++ b/.github/workflows/agent-deploy.yml
@@ -10,9 +10,30 @@ permissions:
   packages: write
 
 jobs:
+  changes:
+    name: Detect changed agent services
+    runs-on: ubuntu-latest
+    outputs:
+      any: ${{ steps.detect.outputs.any }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect which agent services changed
+        id: detect
+        env:
+          WORKFLOW: agent
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: bash .github/scripts/detect-changed-services.sh
+
   db-migrate:
     name: Apply Prisma migrations (production DBs)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
     concurrency:
       group: prisma-migrate-production
       cancel-in-progress: false
@@ -38,35 +59,15 @@ jobs:
       - name: Migrate deploy (mediapulse)
         run: pnpm --filter=@mediapulse/database run db:migrate:deploy
 
-  publish:
-    name: Publish ${{ matrix.service }}
+  publish-and-deploy:
+    name: Publish & deploy ${{ matrix.service }}
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: [changes, db-migrate]
+    if: needs.changes.outputs.any == 'true'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        include:
-          - service: data-collection
-            dockerfile: apps/mediapulse/agents/data-collection/Dockerfile
-            image: agent-data-collection
-          - service: content-generation
-            dockerfile: apps/mediapulse/agents/content-generation/Dockerfile
-            image: agent-content-generation
-          - service: article-analysis
-            dockerfile: apps/mediapulse/agents/article-analysis/Dockerfile
-            image: agent-article-analysis
-          - service: query-analysis
-            dockerfile: apps/mediapulse/agents/query-analysis/Dockerfile
-            image: agent-query-analysis
-          - service: delivery
-            dockerfile: apps/mediapulse/agents/delivery/Dockerfile
-            image: agent-delivery
-          - service: ticker-echo
-            dockerfile: apps/mediapulse/agents/ticker-echo/Dockerfile
-            image: agent-ticker-echo
-          - service: agent-user-registration
-            dockerfile: apps/mediapulse/agents/user-registration/Dockerfile
-            image: agent-user-registration
+        include: ${{ fromJson(needs.changes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -91,130 +92,16 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
-  deploy:
-    name: Deploy ${{ matrix.service }} via Coolify
-    runs-on: ubuntu-latest
-    needs: publish
-    strategy:
-      fail-fast: false
-      max-parallel: 3
-      matrix:
-        include:
-          - service: data-collection
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION
-          - service: content-generation
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION
-          - service: article-analysis
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS
-          - service: query-analysis
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS
-          - service: delivery
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_DELIVERY
-          - service: ticker-echo
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_TICKER_ECHO
-          - service: agent-user-registration
-            webhook_secret: COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION
-    steps:
-      - name: Trigger Coolify deployment over OpenVPN
-        env:
-          COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
-          COOLIFY_WEBHOOK_SECRET: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
-          OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
-          OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
-        run: |
-          set -euo pipefail
+      - name: Deploy
+        uses: ./.github/actions/remote-deploy
+        with:
+          webhook-url: ${{ secrets[matrix.webhook_secret] }}
+          webhook-secret: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
+          vpn-config-b64: ${{ secrets.OPENVPN_CONFIG_B64 }}
+          vpn-password: ${{ secrets.OPENVPN_PASSWORD }}
 
-          if ! command -v openvpn >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y openvpn
-          fi
-
-          WORKDIR="$(mktemp -d)"
-          cleanup() {
-            if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
-            fi
-            rm -rf "$WORKDIR"
-          }
-          trap cleanup EXIT
-
-          printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
-          printf "%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/passphrase.txt"
-          chmod 600 "$WORKDIR/passphrase.txt"
-
-          vpn_connected="false"
-          for attempt in 1 2 3; do
-            if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
-              sudo rm -f "$WORKDIR/openvpn.pid"
-            fi
-            sudo rm -f "$WORKDIR/openvpn.log"
-
-            sudo openvpn \
-              --config "$WORKDIR/client.ovpn" \
-              --askpass "$WORKDIR/passphrase.txt" \
-              --daemon \
-              --writepid "$WORKDIR/openvpn.pid" \
-              --log "$WORKDIR/openvpn.log"
-
-            connected="false"
-            for _ in {1..30}; do
-              if sudo grep -q "Initialization Sequence Completed" "$WORKDIR/openvpn.log"; then
-                connected="true"
-                break
-              fi
-              if [ -f "$WORKDIR/openvpn.pid" ] && ! sudo kill -0 "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1; then
-                break
-              fi
-              sleep 2
-            done
-
-            if [ "$connected" = "true" ]; then
-              vpn_connected="true"
-              break
-            fi
-
-            echo "::warning::OpenVPN did not reach Initialization Sequence Completed (attempt ${attempt}/3)." >&2
-            sudo cat "$WORKDIR/openvpn.log" || true
-            if [ "$attempt" -lt 3 ]; then
-              echo "Retrying VPN in 15s..." >&2
-              sleep 15
-            fi
-          done
-
-          if [ "$vpn_connected" != "true" ]; then
-            exit 1
-          fi
-
-          curl --fail --silent --show-error --verbose \
-            --retry 6 \
-            --retry-all-errors \
-            --retry-delay 5 \
-            --retry-max-time 300 \
-            --connect-timeout 20 \
-            --max-time 120 \
-            -X GET "$COOLIFY_WEBHOOK_URL" \
-            --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
-
-  cleanup:
-    name: Prune old GHCR versions (${{ matrix.image }})
-    runs-on: ubuntu-latest
-    needs: deploy
-    permissions:
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - agent-data-collection
-          - agent-content-generation
-          - agent-article-analysis
-          - agent-query-analysis
-          - agent-delivery
-          - agent-ticker-echo
-          - agent-user-registration
-    steps:
-      - uses: actions/delete-package-versions@v5
+      - name: Prune old GHCR versions
+        uses: actions/delete-package-versions@v5
         with:
           package-name: ${{ matrix.image }}
           package-type: container

--- a/.github/workflows/app-deploy.yml
+++ b/.github/workflows/app-deploy.yml
@@ -10,9 +10,30 @@ permissions:
   packages: write
 
 jobs:
+  changes:
+    name: Detect changed app services
+    runs-on: ubuntu-latest
+    outputs:
+      any: ${{ steps.detect.outputs.any }}
+      matrix: ${{ steps.detect.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect which app services changed
+        id: detect
+        env:
+          WORKFLOW: app
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: bash .github/scripts/detect-changed-services.sh
+
   db-migrate:
     name: Apply Prisma migrations (production DBs)
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.any == 'true'
     concurrency:
       group: prisma-migrate-production
       cancel-in-progress: false
@@ -38,35 +59,15 @@ jobs:
       - name: Migrate deploy (mediapulse)
         run: pnpm --filter=@mediapulse/database run db:migrate:deploy
 
-  publish:
-    name: Publish ${{ matrix.service }}
+  publish-and-deploy:
+    name: Publish & deploy ${{ matrix.service }}
     runs-on: ubuntu-latest
-    needs: db-migrate
+    needs: [changes, db-migrate]
+    if: needs.changes.outputs.any == 'true'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        include:
-          - service: agent-auth-api
-            dockerfile: apps/hermes/agent-auth-api/Dockerfile
-            image: app-agent-auth-api
-          - service: agent-data-api
-            dockerfile: apps/mediapulse/agent-data-api/Dockerfile
-            image: app-agent-data-api
-          - service: domain-api
-            dockerfile: apps/mediapulse/domain-api/Dockerfile
-            image: app-domain-api
-          - service: agent-registry-api
-            dockerfile: apps/hermes/agent-registry-api/Dockerfile
-            image: app-agent-registry-api
-          - service: user-registration
-            dockerfile: apps/mediapulse/user-registration/Dockerfile
-            image: app-user-registration
-          - service: hermes
-            dockerfile: apps/hermes/dashboard/Dockerfile
-            image: app-hermes
-          - service: hermes-worker
-            dockerfile: apps/hermes/worker/Dockerfile
-            image: app-hermes-worker
+        include: ${{ fromJson(needs.changes.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -94,130 +95,16 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
-  deploy:
-    name: Deploy ${{ matrix.service }} via Coolify
-    runs-on: ubuntu-latest
-    needs: publish
-    strategy:
-      fail-fast: false
-      max-parallel: 3
-      matrix:
-        include:
-          - service: agent-auth-api
-            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_AUTH_API
-          - service: agent-data-api
-            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_DATA_API
-          - service: domain-api
-            webhook_secret: COOLIFY_WEBHOOK_APP_DOMAIN_API
-          - service: agent-registry-api
-            webhook_secret: COOLIFY_WEBHOOK_APP_AGENT_REGISTRY_API
-          - service: user-registration
-            webhook_secret: COOLIFY_WEBHOOK_APP_USER_REGISTRATION
-          - service: hermes
-            webhook_secret: COOLIFY_WEBHOOK_APP_HERMES
-          - service: hermes-worker
-            webhook_secret: COOLIFY_WEBHOOK_APP_HERMES_WORKER
-    steps:
-      - name: Trigger Coolify deployment over OpenVPN
-        env:
-          COOLIFY_WEBHOOK_URL: ${{ secrets[matrix.webhook_secret] }}
-          COOLIFY_WEBHOOK_SECRET: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
-          OPENVPN_CONFIG_B64: ${{ secrets.OPENVPN_CONFIG_B64 }}
-          OPENVPN_PASSWORD: ${{ secrets.OPENVPN_PASSWORD }}
-        run: |
-          set -euo pipefail
+      - name: Deploy
+        uses: ./.github/actions/remote-deploy
+        with:
+          webhook-url: ${{ secrets[matrix.webhook_secret] }}
+          webhook-secret: ${{ secrets.COOLIFY_WEBHOOK_SECRET }}
+          vpn-config-b64: ${{ secrets.OPENVPN_CONFIG_B64 }}
+          vpn-password: ${{ secrets.OPENVPN_PASSWORD }}
 
-          if ! command -v openvpn >/dev/null 2>&1; then
-            sudo apt-get update
-            sudo apt-get install -y openvpn
-          fi
-
-          WORKDIR="$(mktemp -d)"
-          cleanup() {
-            if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
-            fi
-            rm -rf "$WORKDIR"
-          }
-          trap cleanup EXIT
-
-          printf "%s" "$OPENVPN_CONFIG_B64" | base64 --decode > "$WORKDIR/client.ovpn"
-          printf "%s\n" "$OPENVPN_PASSWORD" > "$WORKDIR/passphrase.txt"
-          chmod 600 "$WORKDIR/passphrase.txt"
-
-          vpn_connected="false"
-          for attempt in 1 2 3; do
-            if [ -f "$WORKDIR/openvpn.pid" ]; then
-              sudo kill "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1 || true
-              sudo rm -f "$WORKDIR/openvpn.pid"
-            fi
-            sudo rm -f "$WORKDIR/openvpn.log"
-
-            sudo openvpn \
-              --config "$WORKDIR/client.ovpn" \
-              --askpass "$WORKDIR/passphrase.txt" \
-              --daemon \
-              --writepid "$WORKDIR/openvpn.pid" \
-              --log "$WORKDIR/openvpn.log"
-
-            connected="false"
-            for _ in {1..30}; do
-              if sudo grep -q "Initialization Sequence Completed" "$WORKDIR/openvpn.log"; then
-                connected="true"
-                break
-              fi
-              if [ -f "$WORKDIR/openvpn.pid" ] && ! sudo kill -0 "$(sudo cat "$WORKDIR/openvpn.pid")" >/dev/null 2>&1; then
-                break
-              fi
-              sleep 2
-            done
-
-            if [ "$connected" = "true" ]; then
-              vpn_connected="true"
-              break
-            fi
-
-            echo "::warning::OpenVPN did not reach Initialization Sequence Completed (attempt ${attempt}/3)." >&2
-            sudo cat "$WORKDIR/openvpn.log" || true
-            if [ "$attempt" -lt 3 ]; then
-              echo "Retrying VPN in 15s..." >&2
-              sleep 15
-            fi
-          done
-
-          if [ "$vpn_connected" != "true" ]; then
-            exit 1
-          fi
-
-          curl --fail --silent --show-error --verbose \
-            --retry 6 \
-            --retry-all-errors \
-            --retry-delay 5 \
-            --retry-max-time 300 \
-            --connect-timeout 20 \
-            --max-time 120 \
-            -X GET "$COOLIFY_WEBHOOK_URL" \
-            --header "Authorization: Bearer $COOLIFY_WEBHOOK_SECRET"
-
-  cleanup:
-    name: Prune old GHCR versions (${{ matrix.image }})
-    runs-on: ubuntu-latest
-    needs: deploy
-    permissions:
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - app-agent-auth-api
-          - app-agent-data-api
-          - app-domain-api
-          - app-agent-registry-api
-          - app-user-registration
-          - app-hermes
-          - app-hermes-worker
-    steps:
-      - uses: actions/delete-package-versions@v5
+      - name: Prune old GHCR versions
+        uses: actions/delete-package-versions@v5
         with:
           package-name: ${{ matrix.image }}
           package-type: container


### PR DESCRIPTION
## Summary

Deploy workflows no longer wait for every image build to finish before any deploy can start. Each changed service now runs build, push, deploy, and GHCR cleanup in one matrix job. Fail-fast stops the rest when one job fails, and path detection skips services that did not change.

## Related issues

Closes #535

## Important changes

- Replaced separate `publish` and `deploy` jobs with a single `publish-and-deploy` matrix job per service.
- Added `.github/scripts/detect-changed-services.sh` so app and agent workflows only run for touched services (shared package changes still rebuild all services in that workflow).
- Set `fail-fast: true` on the deploy matrix.
- Moved the VPN + webhook deploy step into `.github/actions/remote-deploy/`.

## Other changes

- Removed the old `max-parallel: 3` cap on deploy jobs; matrix jobs now run in full parallel after migrations.
- Per-service GHCR pruning runs at the end of each successful matrix job instead of a final cleanup job that waited on every deploy.

## Key files to review

- `.github/workflows/app-deploy.yml` — new change detection gate and combined publish/deploy matrix for app services.
- `.github/workflows/agent-deploy.yml` — same pattern for agent services.
- `.github/scripts/detect-changed-services.sh` — maps git diffs to service matrix entries for app vs agent workflows.
- `.github/actions/remote-deploy/action.yml` — shared deploy step extracted from the old inline shell blocks.

## How to test

1. Merge to main with a change scoped to one app (for example `apps/mediapulse/domain-api/**`) and confirm the app deploy workflow runs only that service's matrix job after migrations.
2. Confirm a failing Docker build cancels remaining matrix jobs instead of continuing through all services.
3. Push a docs-only commit and confirm app/agent deploy workflows skip the publish/deploy matrix (`any=false`).
