### PR TITLE
Add query-analysis template packs and enrich GET context

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -65,12 +65,16 @@ vi.mock("@mediapulse/database", () => ({
     },
     ticker: {
       findUniqueOrThrow: vi.fn(),
+      findMany: vi.fn(),
     },
     tickerEntity: {
       findMany: vi.fn(),
     },
     dataSource: {
       createMany: vi.fn(),
+      findMany: vi.fn(),
+    },
+    entityRelation: {
       findMany: vi.fn(),
     },
   },
@@ -572,7 +576,11 @@ describe("agent-data-api", () => {
         updatedAt: new Date("2026-03-19T00:00:00.000Z"),
       });
       vi.mocked(prisma.tickerEntity.findMany).mockResolvedValue([]);
-      vi.mocked(prisma.dataSource.findMany).mockResolvedValue([]);
+      vi.mocked(prisma.dataSource.findMany)
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([]);
+      vi.mocked(prisma.entityRelation.findMany).mockResolvedValue([]);
 
       // Act
       const { app } = await import("./index.js");
@@ -587,6 +595,10 @@ describe("agent-data-api", () => {
       expect(body.ticker.symbol).toBe("AAPL");
       expect(body.topEntities).toEqual([]);
       expect(body.recentThemes).toEqual([]);
+      expect(body.peers).toEqual([]);
+      expect(body.calendar).toEqual({ recentEventTypes: [] });
+      expect(body.headlineSamples).toEqual([]);
+      expect(body.kgNeighborhood).toEqual([]);
     });
   });
 

--- a/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.test.ts
@@ -1,0 +1,149 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildKgNeighborhood,
+  buildPeerMetadataOrFilters,
+  collectRecentEventTypes,
+  extractMarketCap,
+  extractTickerSectorIndustry,
+  mapPeersWithRelevance,
+  pickMetadataString,
+  resolveHeadlinePublishedAt,
+  sortAndLimitPeers,
+  sourceNameFromUrl,
+} from "./query-analysis-context-helpers";
+
+describe("pickMetadataString", () => {
+  it("returns the first matching non-empty string key", () => {
+    expect(
+      pickMetadataString({ Sektor: "Finance", sector: "Ignored" }, [
+        "Sektor",
+        "sector",
+      ]),
+    ).toBe("Finance");
+  });
+});
+
+describe("extractTickerSectorIndustry", () => {
+  it("reads IDX and admin metadata keys", () => {
+    expect(
+      extractTickerSectorIndustry({ Sektor: "Energy", Industri: "Oil" }),
+    ).toEqual({ sector: "Energy", industry: "Oil" });
+  });
+});
+
+describe("extractMarketCap", () => {
+  it("parses numeric and string market cap values", () => {
+    expect(extractMarketCap({ marketCap: 1_000_000 })).toBe(1_000_000);
+    expect(extractMarketCap({ MarketCap: "2,500,000" })).toBe(2_500_000);
+  });
+});
+
+describe("buildPeerMetadataOrFilters", () => {
+  it("returns undefined when sector and industry are absent", () => {
+    expect(buildPeerMetadataOrFilters(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("sortAndLimitPeers", () => {
+  it("orders by market cap descending then id", () => {
+    const sorted = sortAndLimitPeers([
+      {
+        id: "b",
+        symbol: "B",
+        name: "B Co",
+        metadata: { marketCap: 100 },
+      },
+      {
+        id: "a",
+        symbol: "A",
+        name: "A Co",
+        metadata: { marketCap: 200 },
+      },
+    ]);
+
+    expect(sorted.map((peer) => peer.symbol)).toEqual(["A", "B"]);
+  });
+});
+
+describe("mapPeersWithRelevance", () => {
+  it("assigns descending relevance scores", () => {
+    expect(
+      mapPeersWithRelevance([
+        { symbol: "AAA", name: "Alpha" },
+        { symbol: "BBB", name: "Beta" },
+      ]),
+    ).toEqual([
+      { symbol: "AAA", name: "Alpha", relevance: 1 },
+      { symbol: "BBB", name: "Beta", relevance: 0.9 },
+    ]);
+  });
+});
+
+describe("sourceNameFromUrl", () => {
+  it("returns hostname without www prefix", () => {
+    expect(sourceNameFromUrl("https://www.reuters.com/article/1")).toBe(
+      "reuters.com",
+    );
+  });
+});
+
+describe("resolveHeadlinePublishedAt", () => {
+  it("prefers metadata publishedAt over createdAt", () => {
+    expect(
+      resolveHeadlinePublishedAt(
+        { publishedAt: "2026-05-18T08:00:00.000Z" },
+        new Date("2026-05-19T00:00:00.000Z"),
+      ),
+    ).toBe("2026-05-18T08:00:00.000Z");
+  });
+});
+
+describe("collectRecentEventTypes", () => {
+  it("deduplicates event types in first-seen order", () => {
+    expect(
+      collectRecentEventTypes([
+        { metadata: { eventType: "ratings_change" } },
+        { metadata: { eventType: "executive_departure" } },
+        { metadata: { eventType: "ratings_change" } },
+      ]),
+    ).toEqual(["ratings_change", "executive_departure"]);
+  });
+});
+
+describe("buildKgNeighborhood", () => {
+  it("caps per-entity and global relation counts with dedupe", () => {
+    const neighborhood = buildKgNeighborhood(
+      ["entity-a"],
+      [
+        {
+          fromEntityId: "entity-a",
+          toEntityId: "entity-b",
+          fromEntity: { canonicalName: "A" },
+          toEntity: { canonicalName: "B" },
+          relationType: { name: "owns" },
+        },
+        {
+          fromEntityId: "entity-a",
+          toEntityId: "entity-c",
+          fromEntity: { canonicalName: "A" },
+          toEntity: { canonicalName: "C" },
+          relationType: { name: "owns" },
+        },
+        {
+          fromEntityId: "entity-a",
+          toEntityId: "entity-b",
+          fromEntity: { canonicalName: "A" },
+          toEntity: { canonicalName: "B" },
+          relationType: { name: "owns" },
+        },
+      ],
+    );
+
+    expect(neighborhood).toEqual([
+      { fromEntity: "A", relationType: "owns", toEntity: "B" },
+      { fromEntity: "A", relationType: "owns", toEntity: "C" },
+    ]);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.ts
+++ b/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.ts
@@ -1,0 +1,282 @@
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+type KgNeighborhoodRow = {
+  fromEntity: string;
+  relationType: string;
+  toEntity: string;
+};
+
+/** Maximum sector/industry peers returned in GET context. */
+export const QUERY_ANALYSIS_PEER_LIMIT = 5;
+
+/** Maximum headline samples returned in GET context. */
+export const QUERY_ANALYSIS_HEADLINE_LIMIT = 5;
+
+/** Maximum KG neighborhood edges returned in GET context. */
+export const QUERY_ANALYSIS_KG_NEIGHBORHOOD_LIMIT = 30;
+
+/** Per-entity cap when sampling one-hop KG relations. */
+export const QUERY_ANALYSIS_KG_RELATIONS_PER_ENTITY = 3;
+
+/** Rolling window for calendar event-type sampling (days). */
+export const QUERY_ANALYSIS_CALENDAR_EVENT_DAYS = 30;
+
+type TickerMetadataRecord = Record<string, unknown>;
+
+/**
+ * Reads the first non-empty string from metadata for the given keys.
+ *
+ * @param metadata - Ticker or data-source JSON metadata.
+ * @param keys - Candidate field names in priority order.
+ * @returns Trimmed string value, or `undefined` when absent.
+ */
+export const pickMetadataString = (
+  metadata: unknown,
+  keys: string[],
+): string | undefined => {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return undefined;
+  }
+  const record = metadata as TickerMetadataRecord;
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+};
+
+/**
+ * Extracts sector and industry labels from ticker metadata (IDX or admin keys).
+ *
+ * @param metadata - Ticker JSON metadata.
+ * @returns Sector/industry strings when present.
+ */
+export const extractTickerSectorIndustry = (
+  metadata: unknown,
+): { sector?: string; industry?: string } => ({
+  sector: pickMetadataString(metadata, ["Sektor", "sector"]),
+  industry: pickMetadataString(metadata, ["Industri", "industry"]),
+});
+
+/**
+ * Parses market-cap style numeric metadata for peer ordering.
+ *
+ * @param metadata - Ticker JSON metadata.
+ * @returns Numeric market cap, or `null` when unavailable.
+ */
+export const extractMarketCap = (metadata: unknown): number | null => {
+  if (!metadata || typeof metadata !== "object" || Array.isArray(metadata)) {
+    return null;
+  }
+  const record = metadata as TickerMetadataRecord;
+  for (const key of ["marketCap", "MarketCap", "market_cap"]) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+    if (typeof value === "string") {
+      const parsed = Number(value.replace(/,/g, ""));
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Builds Prisma `OR` filters for sector/industry peer lookup on JSON metadata.
+ *
+ * @param sector - Sector label from the anchor ticker.
+ * @param industry - Industry label from the anchor ticker.
+ * @returns Prisma-compatible OR clauses, or `undefined` when both are absent.
+ */
+export const buildPeerMetadataOrFilters = (
+  sector: string | undefined,
+  industry: string | undefined,
+): Array<Record<string, unknown>> | undefined => {
+  const filters: Array<Record<string, unknown>> = [];
+  if (sector) {
+    filters.push({ metadata: { path: ["Sektor"], equals: sector } });
+    filters.push({ metadata: { path: ["sector"], equals: sector } });
+  }
+  if (industry) {
+    filters.push({ metadata: { path: ["Industri"], equals: industry } });
+    filters.push({ metadata: { path: ["industry"], equals: industry } });
+  }
+  return filters.length > 0 ? filters : undefined;
+};
+
+/**
+ * Sorts peer ticker rows by market cap descending, then id ascending.
+ *
+ * @param peers - Candidate peer rows with metadata.
+ * @returns Sorted peers capped at {@link QUERY_ANALYSIS_PEER_LIMIT}.
+ */
+export const sortAndLimitPeers = <
+  T extends { id: string; symbol: string; name: string; metadata: unknown },
+>(
+  peers: T[],
+): T[] =>
+  [...peers]
+    .sort((left, right) => {
+      const leftCap = extractMarketCap(left.metadata);
+      const rightCap = extractMarketCap(right.metadata);
+      if (leftCap !== null && rightCap !== null) {
+        return rightCap - leftCap;
+      }
+      if (leftCap !== null) {
+        return -1;
+      }
+      if (rightCap !== null) {
+        return 1;
+      }
+      return left.id.localeCompare(right.id);
+    })
+    .slice(0, QUERY_ANALYSIS_PEER_LIMIT);
+
+/**
+ * Assigns descending relevance weights for ordered peer rows.
+ *
+ * @param peers - Ordered peer rows.
+ * @returns Peer DTOs with relevance scores.
+ */
+export const mapPeersWithRelevance = (
+  peers: Array<{ symbol: string; name: string }>,
+): GetQueryAnalysisResponse["peers"] =>
+  peers.map((peer, index) => ({
+    symbol: peer.symbol,
+    name: peer.name,
+    relevance: Math.max(0.1, 1 - index * 0.1),
+  }));
+
+/**
+ * Derives a display source name from a data-source URL.
+ *
+ * @param url - Article URL.
+ * @returns Hostname without a leading `www.` segment.
+ */
+export const sourceNameFromUrl = (url: string): string => {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+};
+
+/**
+ * Resolves headline publish time from metadata or ingestion timestamp.
+ *
+ * @param metadata - Data-source JSON metadata.
+ * @param createdAt - Row creation timestamp.
+ * @returns ISO-8601 publish timestamp string.
+ */
+export const resolveHeadlinePublishedAt = (
+  metadata: unknown,
+  createdAt: Date,
+): string => {
+  const fromMetadata = pickMetadataString(metadata, [
+    "publishedAt",
+    "published_at",
+    "fetchedAt",
+  ]);
+  if (fromMetadata) {
+    const parsed = new Date(fromMetadata);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return createdAt.toISOString();
+};
+
+/**
+ * Extracts an event-type label from data-source metadata.
+ *
+ * @param metadata - Data-source JSON metadata.
+ * @returns Event type string, or `undefined` when absent.
+ */
+export const extractEventTypeFromMetadata = (
+  metadata: unknown,
+): string | undefined =>
+  pickMetadataString(metadata, ["eventType", "event_type", "type"]);
+
+/**
+ * Collects unique recent event types from data-source metadata rows.
+ *
+ * @param rows - Recent data sources within the calendar window.
+ * @returns De-duplicated event types in first-seen order.
+ */
+export const collectRecentEventTypes = (
+  rows: Array<{ metadata: unknown }>,
+): string[] => {
+  const seen = new Set<string>();
+  const eventTypes: string[] = [];
+  for (const row of rows) {
+    const eventType = extractEventTypeFromMetadata(row.metadata);
+    if (!eventType || seen.has(eventType)) {
+      continue;
+    }
+    seen.add(eventType);
+    eventTypes.push(eventType);
+  }
+  return eventTypes;
+};
+
+type EntityRelationRow = {
+  fromEntity: { canonicalName: string };
+  toEntity: { canonicalName: string };
+  relationType: { name: string };
+};
+
+/**
+ * Samples up to three one-hop relations per top entity, deduped and capped globally.
+ *
+ * @param entityIds - Top entity ids ordered by relevance.
+ * @param relations - Candidate one-hop relations including entity/type names.
+ * @returns Flattened neighborhood edges.
+ */
+export const buildKgNeighborhood = (
+  entityIds: string[],
+  relations: Array<
+    EntityRelationRow & { fromEntityId: string; toEntityId: string }
+  >,
+): KgNeighborhoodRow[] => {
+  const seen = new Set<string>();
+  const neighborhood: KgNeighborhoodRow[] = [];
+
+  for (const entityId of entityIds) {
+    let addedForEntity = 0;
+    for (const relation of relations) {
+      if (
+        relation.fromEntityId !== entityId &&
+        relation.toEntityId !== entityId
+      ) {
+        continue;
+      }
+      const tripleKey = `${relation.fromEntity.canonicalName}|${relation.relationType.name}|${relation.toEntity.canonicalName}`;
+      if (seen.has(tripleKey)) {
+        continue;
+      }
+      seen.add(tripleKey);
+      neighborhood.push({
+        fromEntity: relation.fromEntity.canonicalName,
+        relationType: relation.relationType.name,
+        toEntity: relation.toEntity.canonicalName,
+      });
+      addedForEntity += 1;
+      if (
+        neighborhood.length >= QUERY_ANALYSIS_KG_NEIGHBORHOOD_LIMIT ||
+        addedForEntity >= QUERY_ANALYSIS_KG_RELATIONS_PER_ENTITY
+      ) {
+        break;
+      }
+    }
+    if (neighborhood.length >= QUERY_ANALYSIS_KG_NEIGHBORHOOD_LIMIT) {
+      break;
+    }
+  }
+
+  return neighborhood;
+};

--- a/apps/mediapulse/agent-data-api/src/services/query-analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/query-analysis.test.ts
@@ -1,0 +1,222 @@
+/** @vitest-environment node */
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mediapulse/database", () => ({
+  prisma: {},
+}));
+
+const TICKER_ID = "11111111-1111-4111-a111-111111111111";
+const PEER_ONE_ID = "22222222-2222-4222-a222-222222222222";
+const PEER_TWO_ID = "33333333-3333-4333-a333-333333333333";
+const ENTITY_A_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ENTITY_B_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+let getQueryAnalysisContext: typeof import("./query-analysis.js").getQueryAnalysisContext;
+
+beforeAll(async () => {
+  ({ getQueryAnalysisContext } = await import("./query-analysis.js"));
+});
+
+describe("getQueryAnalysisContext", () => {
+  it("returns enriched context with peers, headlines, calendar, and KG neighborhood", async () => {
+    const findUniqueOrThrow = vi.fn().mockResolvedValue({
+      id: TICKER_ID,
+      symbol: "ACME",
+      name: "Acme Co",
+      metadata: { Sektor: "Technology", Industri: "Software" },
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    });
+    const tickerEntityFindMany = vi.fn().mockResolvedValue([
+      {
+        entityId: ENTITY_A_ID,
+        relevanceWeight: 0.9,
+        entity: {
+          canonicalName: "Alpha Subsidiary",
+          type: { name: "Organization" },
+        },
+      },
+      {
+        entityId: ENTITY_B_ID,
+        relevanceWeight: 0.7,
+        entity: {
+          canonicalName: "Beta Partner",
+          type: { name: "Organization" },
+        },
+      },
+    ]);
+    const dataSourceFindMany = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { title: "AI momentum" },
+        { title: "Cloud growth" },
+        { title: "Margin watch" },
+        { title: "Supply chain" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          title: "Acme beats estimates",
+          url: "https://www.reuters.com/markets/acme",
+          createdAt: new Date("2026-05-18T10:00:00.000Z"),
+          metadata: { publishedAt: "2026-05-18T08:00:00.000Z" },
+        },
+        {
+          title: "Acme expands cloud unit",
+          url: "https://news.example.com/acme-cloud",
+          createdAt: new Date("2026-05-17T10:00:00.000Z"),
+          metadata: null,
+        },
+        {
+          title: "Analyst upgrade for Acme",
+          url: "https://finance.example.com/acme-upgrade",
+          createdAt: new Date("2026-05-16T10:00:00.000Z"),
+          metadata: { eventType: "ratings_change" },
+        },
+        {
+          title: "CFO transition at Acme",
+          url: "https://finance.example.com/acme-cfo",
+          createdAt: new Date("2026-05-15T10:00:00.000Z"),
+          metadata: { eventType: "executive_departure" },
+        },
+      ])
+      .mockResolvedValueOnce([
+        { metadata: { eventType: "ratings_change" } },
+        { metadata: { eventType: "executive_departure" } },
+      ]);
+    const tickerFindMany = vi.fn().mockResolvedValue([
+      {
+        id: PEER_ONE_ID,
+        symbol: "PEER1",
+        name: "Peer One",
+        metadata: { Sektor: "Technology", marketCap: 500 },
+      },
+      {
+        id: PEER_TWO_ID,
+        symbol: "PEER2",
+        name: "Peer Two",
+        metadata: { Sektor: "Technology", marketCap: 900 },
+      },
+    ]);
+    const entityRelationFindMany = vi.fn().mockResolvedValue([
+      {
+        fromEntityId: ENTITY_A_ID,
+        toEntityId: ENTITY_B_ID,
+        fromEntity: { canonicalName: "Alpha Subsidiary" },
+        toEntity: { canonicalName: "Beta Partner" },
+        relationType: { name: "PARTNER_OF" },
+      },
+      {
+        fromEntityId: ENTITY_B_ID,
+        toEntityId: ENTITY_A_ID,
+        fromEntity: { canonicalName: "Beta Partner" },
+        toEntity: { canonicalName: "Alpha Subsidiary" },
+        relationType: { name: "COMPETITOR" },
+      },
+      {
+        fromEntityId: ENTITY_A_ID,
+        toEntityId: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+        fromEntity: { canonicalName: "Alpha Subsidiary" },
+        toEntity: { canonicalName: "Gamma Vendor" },
+        relationType: { name: "SUPPLIER_OF" },
+      },
+    ]);
+
+    const db = {
+      ticker: { findUniqueOrThrow, findMany: tickerFindMany },
+      tickerEntity: { findMany: tickerEntityFindMany },
+      dataSource: { findMany: dataSourceFindMany },
+      entityRelation: { findMany: entityRelationFindMany },
+      searchQuerySet: {
+        updateMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        findUnique: vi.fn(),
+        delete: vi.fn(),
+      },
+      searchQuery: { deleteMany: vi.fn(), createMany: vi.fn() },
+    };
+
+    const payload = await getQueryAnalysisContext({ tickerId: TICKER_ID }, db);
+
+    expect(payload.peers).toEqual([
+      { symbol: "PEER2", name: "Peer Two", relevance: 1 },
+      { symbol: "PEER1", name: "Peer One", relevance: 0.9 },
+    ]);
+    expect(payload.headlineSamples).toHaveLength(4);
+    expect(payload.headlineSamples[0]).toEqual({
+      title: "Acme beats estimates",
+      publishedAt: "2026-05-18T08:00:00.000Z",
+      sourceName: "reuters.com",
+    });
+    expect(payload.calendar.recentEventTypes).toEqual([
+      "ratings_change",
+      "executive_departure",
+    ]);
+    expect(payload.kgNeighborhood).toEqual([
+      {
+        fromEntity: "Alpha Subsidiary",
+        relationType: "PARTNER_OF",
+        toEntity: "Beta Partner",
+      },
+      {
+        fromEntity: "Beta Partner",
+        relationType: "COMPETITOR",
+        toEntity: "Alpha Subsidiary",
+      },
+      {
+        fromEntity: "Alpha Subsidiary",
+        relationType: "SUPPLIER_OF",
+        toEntity: "Gamma Vendor",
+      },
+    ]);
+    expect(tickerFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          id: { not: TICKER_ID },
+        }),
+      }),
+    );
+  });
+
+  it("returns empty enriched collections for sparse fixtures", async () => {
+    const db = {
+      ticker: {
+        findUniqueOrThrow: vi.fn().mockResolvedValue({
+          id: TICKER_ID,
+          symbol: "ACME",
+          name: "Acme Co",
+          metadata: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        }),
+        findMany: vi.fn(),
+      },
+      tickerEntity: { findMany: vi.fn().mockResolvedValue([]) },
+      dataSource: {
+        findMany: vi
+          .fn()
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([])
+          .mockResolvedValueOnce([]),
+      },
+      entityRelation: { findMany: vi.fn() },
+      searchQuerySet: {
+        updateMany: vi.fn(),
+        create: vi.fn(),
+        update: vi.fn(),
+        findUnique: vi.fn(),
+        delete: vi.fn(),
+      },
+      searchQuery: { deleteMany: vi.fn(), createMany: vi.fn() },
+    };
+
+    const payload = await getQueryAnalysisContext({ tickerId: TICKER_ID }, db);
+
+    expect(payload.peers).toEqual([]);
+    expect(payload.calendar).toEqual({ recentEventTypes: [] });
+    expect(payload.headlineSamples).toEqual([]);
+    expect(payload.kgNeighborhood).toEqual([]);
+    expect(db.ticker.findMany).not.toHaveBeenCalled();
+    expect(db.entityRelation.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/query-analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/query-analysis.ts
@@ -5,10 +5,25 @@ import type {
   PostQueryAnalysisBody,
 } from "@workspace/agent-data-api-contract";
 
+import {
+  buildKgNeighborhood,
+  buildPeerMetadataOrFilters,
+  collectRecentEventTypes,
+  extractTickerSectorIndustry,
+  mapPeersWithRelevance,
+  QUERY_ANALYSIS_CALENDAR_EVENT_DAYS,
+  QUERY_ANALYSIS_HEADLINE_LIMIT,
+  QUERY_ANALYSIS_PEER_LIMIT,
+  resolveHeadlinePublishedAt,
+  sortAndLimitPeers,
+  sourceNameFromUrl,
+} from "./query-analysis-context-helpers";
+
 type QueryAnalysisDb = {
-  ticker: Pick<typeof prisma.ticker, "findUniqueOrThrow">;
+  ticker: Pick<typeof prisma.ticker, "findUniqueOrThrow" | "findMany">;
   tickerEntity: Pick<typeof prisma.tickerEntity, "findMany">;
   dataSource: Pick<typeof prisma.dataSource, "findMany">;
+  entityRelation: Pick<typeof prisma.entityRelation, "findMany">;
   searchQuerySet: Pick<
     typeof prisma.searchQuerySet,
     "updateMany" | "create" | "update" | "findUnique" | "delete"
@@ -20,16 +35,23 @@ const defaultDb: QueryAnalysisDb = {
   ticker: prisma.ticker,
   tickerEntity: prisma.tickerEntity,
   dataSource: prisma.dataSource,
+  entityRelation: prisma.entityRelation,
   searchQuerySet: prisma.searchQuerySet,
   searchQuery: prisma.searchQuery,
 };
+
+const entityRelationInclude = {
+  fromEntity: { select: { canonicalName: true } },
+  toEntity: { select: { canonicalName: true } },
+  relationType: { select: { name: true } },
+} satisfies Prisma.EntityRelationInclude;
 
 /**
  * Builds query-analysis GET response data for one ticker.
  *
  * @param query - Validated query payload containing `tickerId`.
  * @param db - Optional injected DB delegates for testing.
- * @returns Ticker metadata, top entities, and recent themes.
+ * @returns Ticker metadata, KG context, peers, calendar, headlines, and neighborhood.
  */
 export const getQueryAnalysisContext = async (
   query: GetQueryAnalysisQuery,
@@ -39,19 +61,101 @@ export const getQueryAnalysisContext = async (
     where: { id: query.tickerId },
   } satisfies Prisma.TickerFindUniqueOrThrowArgs);
 
-  const topEntities = await db.tickerEntity.findMany({
+  const topEntityRows = await db.tickerEntity.findMany({
     where: { tickerId: query.tickerId },
     include: { entity: { include: { type: true } } },
     take: 10,
     orderBy: { relevanceWeight: "desc" },
   } satisfies Prisma.TickerEntityFindManyArgs);
 
-  const recentSources = await db.dataSource.findMany({
+  const themeSourceArgs = {
     where: { tickerId: query.tickerId },
     select: { title: true },
-    orderBy: { createdAt: "desc" },
+    orderBy: { createdAt: "desc" as const },
     take: 20,
-  } satisfies Prisma.DataSourceFindManyArgs);
+  } satisfies Prisma.DataSourceFindManyArgs;
+
+  const headlineSourceArgs = {
+    where: { tickerId: query.tickerId },
+    select: {
+      title: true,
+      url: true,
+      createdAt: true,
+      metadata: true,
+    },
+    orderBy: { createdAt: "desc" as const },
+    take: QUERY_ANALYSIS_HEADLINE_LIMIT,
+  } satisfies Prisma.DataSourceFindManyArgs;
+
+  const calendarWindowStart = new Date();
+  calendarWindowStart.setDate(
+    calendarWindowStart.getDate() - QUERY_ANALYSIS_CALENDAR_EVENT_DAYS,
+  );
+  const calendarSourceArgs = {
+    where: {
+      tickerId: query.tickerId,
+      createdAt: { gte: calendarWindowStart },
+    },
+    select: { metadata: true },
+    orderBy: { createdAt: "desc" as const },
+  } satisfies Prisma.DataSourceFindManyArgs;
+
+  const { sector, industry } = extractTickerSectorIndustry(ticker.metadata);
+  const peerMetadataFilters = buildPeerMetadataOrFilters(sector, industry);
+  const peerArgs =
+    peerMetadataFilters === undefined
+      ? null
+      : ({
+          where: {
+            id: { not: query.tickerId },
+            OR: peerMetadataFilters,
+          },
+          select: {
+            id: true,
+            symbol: true,
+            name: true,
+            metadata: true,
+          },
+          take: QUERY_ANALYSIS_PEER_LIMIT * 4,
+        } satisfies Prisma.TickerFindManyArgs);
+
+  const entityIds = topEntityRows.map((row) => row.entityId);
+  const kgNeighborhoodArgs =
+    entityIds.length === 0
+      ? null
+      : ({
+          where: {
+            OR: [
+              { fromEntityId: { in: entityIds } },
+              { toEntityId: { in: entityIds } },
+            ],
+          },
+          include: entityRelationInclude,
+          orderBy: { weight: "desc" as const },
+        } satisfies Prisma.EntityRelationFindManyArgs);
+
+  const [
+    recentSources,
+    headlineSources,
+    calendarSources,
+    peerCandidates,
+    kgRelations,
+  ] = await Promise.all([
+    db.dataSource.findMany(themeSourceArgs),
+    db.dataSource.findMany(headlineSourceArgs),
+    db.dataSource.findMany(calendarSourceArgs),
+    peerArgs ? db.ticker.findMany(peerArgs) : Promise.resolve([]),
+    kgNeighborhoodArgs
+      ? db.entityRelation.findMany(kgNeighborhoodArgs)
+      : Promise.resolve([]),
+  ]);
+
+  const peers = mapPeersWithRelevance(
+    sortAndLimitPeers(peerCandidates).map((peer) => ({
+      symbol: peer.symbol,
+      name: peer.name,
+    })),
+  );
 
   return {
     ticker: {
@@ -60,7 +164,7 @@ export const getQueryAnalysisContext = async (
       name: ticker.name,
       metadata: ticker.metadata,
     },
-    topEntities: topEntities.map((row) => ({
+    topEntities: topEntityRows.map((row) => ({
       canonicalName: row.entity.canonicalName,
       typeName: row.entity.type.name,
       relevanceWeight: row.relevanceWeight,
@@ -69,6 +173,16 @@ export const getQueryAnalysisContext = async (
       theme: row.title,
       articleCount: 1,
     })),
+    peers,
+    calendar: {
+      recentEventTypes: collectRecentEventTypes(calendarSources),
+    },
+    headlineSamples: headlineSources.map((row) => ({
+      title: row.title,
+      publishedAt: resolveHeadlinePublishedAt(row.metadata, row.createdAt),
+      sourceName: sourceNameFromUrl(row.url),
+    })),
+    kgNeighborhood: buildKgNeighborhood(entityIds, kgRelations),
   };
 };
 

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -9,6 +9,29 @@ const minimal = { openaiApiKey: "sk-test" } satisfies Parameters<
   typeof queryAnalysisConfigSchema.parse
 >[0];
 
+describe("queryAnalysisConfigSchema templatePack", () => {
+  it("defaults templatePack to default-v1", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.templatePack).toBe("default-v1");
+  });
+
+  it("accepts rich-v2 template pack", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      templatePack: "rich-v2",
+    });
+    expect(parsed.templatePack).toBe("rich-v2");
+  });
+
+  it("rejects unknown template pack names", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      templatePack: "unknown",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
 describe("queryAnalysisConfigSchema prompts", () => {
   it("rejects unknown placeholder in systemPrompt", () => {
     const result = queryAnalysisConfigSchema.safeParse({

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -2,6 +2,10 @@ import { z } from "zod";
 
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import {
+  DEFAULT_DETERMINISTIC_PACK,
+  DETERMINISTIC_PACK_NAMES,
+} from "./templates/deterministic-packs";
+import {
   QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH,
   QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS,
   QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS,
@@ -45,6 +49,14 @@ export const queryAnalysisConfigSchema = z
      * LLM output token budget for generating structured query candidates.
      */
     maxTokens: z.number().int().positive().optional().default(800),
+    /**
+     * Named deterministic template pack used for the query floor.
+     * Switch via Hermes invoke config without redeploying the agent.
+     */
+    templatePack: z
+      .enum(DETERMINISTIC_PACK_NAMES)
+      .optional()
+      .default(DEFAULT_DETERMINISTIC_PACK),
     /**
      * Optional overrides for query-generation LLM system/user templates (Hermes).
      * When omitted, built-in defaults are used. Do not put API keys inside prompt text.

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -25,6 +25,13 @@ describe("resolveQueryAnalysisSystemContent", () => {
   });
 });
 
+const emptyEnrichedContext = {
+  peers: [] as [],
+  calendar: { recentEventTypes: [] as string[] },
+  headlineSamples: [] as [],
+  kgNeighborhood: [] as [],
+};
+
 describe("resolveQueryAnalysisUserContent", () => {
   it("matches buildQueryAnalysisUserContent when Hermes omits override", () => {
     const ctx = {
@@ -46,6 +53,7 @@ describe("resolveQueryAnalysisUserContent", () => {
         relationType: string;
         change: "added";
       }[],
+      ...emptyEnrichedContext,
     };
 
     const resolved = resolveQueryAnalysisUserContent(undefined, ctx);
@@ -64,6 +72,7 @@ describe("resolveQueryAnalysisUserContent", () => {
       topEntities: [],
       recentThemes: [],
       recentRelationDeltas: [],
+      ...emptyEnrichedContext,
     };
     const text = resolveQueryAnalysisUserContent(
       "START\n{{queryContextBlock}}\nEND",
@@ -119,6 +128,25 @@ describe("buildQueryAnalysisUserContent", () => {
           change: "added" as const,
         },
       ],
+      peers: [{ symbol: "PEER1", name: "Peer One", relevance: 0.9 }],
+      calendar: {
+        nextEarningsAt: "2026-07-22T00:00:00.000Z",
+        recentEventTypes: ["ratings_change"],
+      },
+      headlineSamples: [
+        {
+          title: "Acme beats estimates",
+          publishedAt: "2026-05-18T08:00:00.000Z",
+          sourceName: "reuters.com",
+        },
+      ],
+      kgNeighborhood: [
+        {
+          fromEntity: "Subsidiary",
+          relationType: "PARTNER_OF",
+          toEntity: "Vendor",
+        },
+      ],
     };
 
     // Act
@@ -130,6 +158,32 @@ describe("buildQueryAnalysisUserContent", () => {
     expect(text).toContain("Subsidiary");
     expect(text).toContain("AI");
     expect(text).toContain("owns");
+    expect(text).toContain("Sector peers:");
+    expect(text).toContain("PEER1");
+    expect(text).toContain("Next earnings: 2026-07-22T00:00:00.000Z");
+    expect(text).toContain("Recent headlines:");
+    expect(text).toContain("reuters.com");
+    expect(text).toContain("KG neighborhood:");
+    expect(text).toContain("PARTNER_OF");
+  });
+
+  it("omits empty enriched blocks from the user prompt", () => {
+    const text = buildQueryAnalysisUserContent({
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "ACME",
+        name: "Acme Co",
+        metadata: null,
+      },
+      topEntities: [],
+      recentThemes: [],
+      ...emptyEnrichedContext,
+    });
+
+    expect(text).not.toContain("Sector peers:");
+    expect(text).not.toContain("Calendar:");
+    expect(text).not.toContain("Recent headlines:");
+    expect(text).not.toContain("KG neighborhood:");
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -145,6 +145,39 @@ export const buildQueryAnalysisUserContent = (
       );
     }
   }
+  if (context.peers.length > 0) {
+    lines.push("Sector peers:");
+    for (const peer of context.peers) {
+      lines.push(`- ${peer.symbol} (${peer.name}) relevance=${peer.relevance}`);
+    }
+  }
+  const calendar = context.calendar;
+  if (calendar.nextEarningsAt || calendar.recentEventTypes.length > 0) {
+    lines.push("Calendar:");
+    if (calendar.nextEarningsAt) {
+      lines.push(`- Next earnings: ${calendar.nextEarningsAt}`);
+    }
+    if (calendar.recentEventTypes.length > 0) {
+      lines.push(`- Recent events: ${calendar.recentEventTypes.join(", ")}`);
+    }
+  }
+  if (context.headlineSamples.length > 0) {
+    lines.push("Recent headlines:");
+    for (const headline of context.headlineSamples) {
+      const publishedDate = headline.publishedAt.slice(0, 10);
+      lines.push(
+        `- ${publishedDate} (${headline.sourceName}) — "${headline.title}"`,
+      );
+    }
+  }
+  if (context.kgNeighborhood.length > 0) {
+    lines.push("KG neighborhood:");
+    for (const edge of context.kgNeighborhood) {
+      lines.push(
+        `- ${edge.fromEntity} --${edge.relationType}--> ${edge.toEntity}`,
+      );
+    }
+  }
   return lines.join("\n");
 };
 

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -40,7 +40,8 @@ vi.mock("@workspace/logger", () => ({
   },
 }));
 
-import { buildDeterministicQueries, runQueryAnalysis } from "./run";
+import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
+import { runQueryAnalysis } from "./run";
 
 const ctxResponse = {
   ticker: {
@@ -51,6 +52,10 @@ const ctxResponse = {
   },
   topEntities: [] as [],
   recentThemes: [] as [],
+  peers: [] as [],
+  calendar: { recentEventTypes: [] as string[] },
+  headlineSamples: [] as [],
+  kgNeighborhood: [] as [],
 };
 
 const baseConfig = queryAnalysisConfigSchema.parse({ openaiApiKey: "sk" });
@@ -77,13 +82,15 @@ describe("query-analysis run", () => {
   });
 
   describe("buildDeterministicQueries", () => {
-    it("creates deterministic baseline queries", () => {
+    it("creates deterministic baseline queries from default-v1 pack", () => {
       // Act
-      const queries = buildDeterministicQueries("AAPL", "Apple Inc.");
+      const queries = buildDeterministicQueries(ctxResponse, {
+        pack: "default-v1",
+      });
 
       // Assert
-      expect(queries.length).toBeGreaterThan(0);
-      expect(queries[0]?.text).toContain("AAPL");
+      expect(queries.length).toBe(5);
+      expect(queries[0]?.text).toContain("ABC");
       expect(queries.some((query) => query.intent === "fundamental")).toBe(
         true,
       );

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -10,29 +10,11 @@ import {
   fetchLlmQueryCandidates,
 } from "./llm-queries";
 import { mergeQueryCandidates } from "./merge-query-candidates";
+import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
+
+export { buildDeterministicQueries } from "./templates/build-deterministic-queries";
 
 type QueryAnalysisInput = { tickerId: string };
-
-/**
- * Builds deterministic baseline query candidates.
- *
- * @param symbol - Ticker symbol.
- * @param name - Ticker display name.
- * @returns Deterministic query texts with intent labels.
- */
-export const buildDeterministicQueries = (
-  symbol: string,
-  name: string,
-): Array<{
-  text: string;
-  intent: "breaking" | "kg_change" | "fundamental";
-}> => [
-  { text: `${symbol} latest news`, intent: "breaking" },
-  { text: `${name} breaking news`, intent: "breaking" },
-  { text: `${name} relation changes`, intent: "kg_change" },
-  { text: `${name} earnings guidance`, intent: "fundamental" },
-  { text: `${name} regulatory update`, intent: "fundamental" },
-];
 
 /**
  * Runs the query-analysis agent for one ticker and persists an active query set.
@@ -53,10 +35,11 @@ export const runQueryAnalysis = async (
   const queryContext = await client.queryAnalysis.get({
     tickerId: input.tickerId,
   });
-  const deterministic = buildDeterministicQueries(
-    queryContext.ticker.symbol,
-    queryContext.ticker.name,
-  );
+  const templatePack = config.templatePack!;
+
+  const deterministic = buildDeterministicQueries(queryContext, {
+    pack: templatePack,
+  });
 
   // Zod applies defaults in `createAgentApp` before calling `run`.
   const queryCount = config.queryCount!;

--- a/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
@@ -1,0 +1,45 @@
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+import type { DeterministicCandidate } from "../merge-query-candidates";
+import {
+  type DeterministicPackName,
+  getDeterministicPack,
+} from "./deterministic-packs";
+import {
+  type SlotResolverClock,
+  resolveTemplatePattern,
+  resolveSlots,
+} from "./slot-resolver";
+
+/** Options for building deterministic query candidates from a template pack. */
+export type BuildDeterministicQueriesOptions = {
+  pack?: DeterministicPackName;
+  clock?: SlotResolverClock;
+};
+
+/**
+ * Builds deterministic baseline query candidates from context and a named pack.
+ *
+ * @param context - GET /query-analysis response (ticker, entities, themes).
+ * @param options - Pack name and clock for time slots (defaults: `default-v1`, now).
+ * @returns Rendered candidates; templates with unresolved slots are omitted.
+ */
+export const buildDeterministicQueries = (
+  context: GetQueryAnalysisResponse,
+  options: BuildDeterministicQueriesOptions = {},
+): DeterministicCandidate[] => {
+  const packName = options.pack ?? "default-v1";
+  const clock = options.clock ?? (() => new Date());
+  const pack = getDeterministicPack(packName);
+  const slots = resolveSlots(context, clock);
+  const candidates: DeterministicCandidate[] = [];
+
+  for (const row of pack.templates) {
+    const text = resolveTemplatePattern(row.template, slots);
+    if (text) {
+      candidates.push({ text, intent: row.intent });
+    }
+  }
+
+  return candidates;
+};

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
@@ -1,0 +1,123 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+import { buildDeterministicQueries } from "./build-deterministic-queries";
+import {
+  DETERMINISTIC_PACKS,
+  getDeterministicPack,
+  MAX_TEMPLATES_PER_PACK,
+} from "./deterministic-packs";
+
+const FIXED_CLOCK = (): Date => new Date("2026-05-21T12:00:00.000Z");
+
+const emptyEnrichedContext = {
+  peers: [] as [],
+  calendar: { recentEventTypes: [] as string[] },
+  headlineSamples: [] as [],
+  kgNeighborhood: [] as [],
+};
+
+const fullContext: GetQueryAnalysisResponse = {
+  ticker: {
+    id: "11111111-1111-4111-a111-111111111111",
+    symbol: "ACME",
+    name: "Acme Co",
+    metadata: null,
+  },
+  topEntities: [
+    {
+      canonicalName: "Subsidiary Inc",
+      typeName: "Organization",
+      relevanceWeight: 0.9,
+    },
+  ],
+  recentThemes: [{ theme: "AI", articleCount: 3 }],
+  ...emptyEnrichedContext,
+};
+
+describe("getDeterministicPack", () => {
+  it("returns default-v1 for unknown pack names", () => {
+    // Act
+    const pack = getDeterministicPack("unknown-pack");
+
+    // Assert
+    expect(pack.name).toBe("default-v1");
+  });
+});
+
+describe("default-v1 pack", () => {
+  it("reproduces the original five baseline queries", () => {
+    // Act
+    const queries = buildDeterministicQueries(fullContext, {
+      pack: "default-v1",
+      clock: FIXED_CLOCK,
+    });
+
+    // Assert
+    expect(queries).toEqual([
+      { text: "ACME latest news", intent: "breaking" },
+      { text: "Acme Co breaking news", intent: "breaking" },
+      { text: "Acme Co relation changes", intent: "kg_change" },
+      { text: "Acme Co earnings guidance", intent: "fundamental" },
+      { text: "Acme Co regulatory update", intent: "fundamental" },
+    ]);
+  });
+});
+
+describe("rich-v2 pack", () => {
+  it("yields at least fifteen distinct rows for a fully populated context", () => {
+    // Act
+    const queries = buildDeterministicQueries(fullContext, {
+      pack: "rich-v2",
+      clock: FIXED_CLOCK,
+    });
+    const distinctTexts = new Set(queries.map((row) => row.text));
+
+    // Assert
+    expect(queries.length).toBeGreaterThanOrEqual(15);
+    expect(distinctTexts.size).toBe(queries.length);
+  });
+
+  it("covers all three intent categories", () => {
+    // Act
+    const queries = buildDeterministicQueries(fullContext, {
+      pack: "rich-v2",
+      clock: FIXED_CLOCK,
+    });
+    const intents = new Set(queries.map((row) => row.intent));
+
+    // Assert
+    expect(intents.has("breaking")).toBe(true);
+    expect(intents.has("kg_change")).toBe(true);
+    expect(intents.has("fundamental")).toBe(true);
+  });
+
+  it("drops theme-coupled templates when recent themes are absent", () => {
+    // Setup
+    const sparseContext: GetQueryAnalysisResponse = {
+      ...fullContext,
+      recentThemes: [],
+    };
+
+    // Act
+    const queries = buildDeterministicQueries(sparseContext, {
+      pack: "rich-v2",
+      clock: FIXED_CLOCK,
+    });
+
+    // Assert
+    expect(queries.every((row) => !row.text.includes("{recentTheme}"))).toBe(
+      true,
+    );
+    expect(queries.every((row) => !row.text.includes("AI"))).toBe(true);
+  });
+
+  it("stays within the pack template cap", () => {
+    // Assert
+    expect(DETERMINISTIC_PACKS["rich-v2"].templates.length).toBeLessThanOrEqual(
+      MAX_TEMPLATES_PER_PACK,
+    );
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -1,0 +1,99 @@
+import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
+
+/** Named deterministic template pack identifiers. */
+export const DETERMINISTIC_PACK_NAMES = ["default-v1", "rich-v2"] as const;
+
+/** Valid `templatePack` config value. */
+export type DeterministicPackName = (typeof DETERMINISTIC_PACK_NAMES)[number];
+
+/** Default pack when Hermes omits `templatePack` or passes an unknown value. */
+export const DEFAULT_DETERMINISTIC_PACK: DeterministicPackName = "default-v1";
+
+/** Maximum templates evaluated per pack to avoid dominating merge/dedup work. */
+export const MAX_TEMPLATES_PER_PACK = 25;
+
+/** One row in a deterministic template pack before slot resolution. */
+export type DeterministicTemplate = {
+  template: string;
+  intent: QueryAnalysisIntent;
+};
+
+/** A named collection of deterministic query templates. */
+export type DeterministicPack = {
+  name: DeterministicPackName;
+  templates: DeterministicTemplate[];
+};
+
+/** Original five-template baseline (symbol/name only). */
+const defaultV1Pack: DeterministicPack = {
+  name: "default-v1",
+  templates: [
+    { template: "{symbol} latest news", intent: "breaking" },
+    { template: "{name} breaking news", intent: "breaking" },
+    { template: "{name} relation changes", intent: "kg_change" },
+    { template: "{name} earnings guidance", intent: "fundamental" },
+    { template: "{name} regulatory update", intent: "fundamental" },
+  ],
+};
+
+/** Expanded pack with comparative, time-anchored, theme-, entity-, and question-form angles. */
+const richV2Pack: DeterministicPack = {
+  name: "rich-v2",
+  templates: [
+    { template: "{symbol} latest news", intent: "breaking" },
+    { template: "{name} breaking news", intent: "breaking" },
+    { template: "why is {symbol} moving today", intent: "breaking" },
+    { template: "why is {symbol} falling", intent: "breaking" },
+    { template: "{name} {recentTheme} reaction", intent: "breaking" },
+    { template: "{name} relation changes", intent: "kg_change" },
+    { template: "{topEntity} impact on {name}", intent: "kg_change" },
+    { template: "{name} {topEntity} risk", intent: "kg_change" },
+    { template: "{name} earnings guidance", intent: "fundamental" },
+    { template: "{name} regulatory update", intent: "fundamental" },
+    { template: "{name} {currentQuarter} earnings", intent: "fundamental" },
+    {
+      template: "{symbol} guidance update {currentYear}",
+      intent: "fundamental",
+    },
+    { template: "{name} vs sector peers", intent: "fundamental" },
+    { template: "{name} vs peers {currentQuarter}", intent: "fundamental" },
+    { template: "{name} market share {currentYear}", intent: "fundamental" },
+    { template: "{name} {currentQuarter} guidance", intent: "fundamental" },
+    { template: "{name} {recentTheme} analyst view", intent: "fundamental" },
+    { template: "{name} {recentTheme} impact", intent: "fundamental" },
+    { template: "is {name} a buy {currentMonth}", intent: "fundamental" },
+    { template: "is {name} a buy now", intent: "fundamental" },
+    { template: "{name} long-term thesis", intent: "fundamental" },
+    { template: "{name} bear case", intent: "fundamental" },
+    { template: "{name} bull case", intent: "fundamental" },
+  ],
+};
+
+/** All registered deterministic template packs keyed by name. */
+export const DETERMINISTIC_PACKS: Record<
+  DeterministicPackName,
+  DeterministicPack
+> = {
+  "default-v1": defaultV1Pack,
+  "rich-v2": richV2Pack,
+};
+
+/**
+ * Returns the template pack for a configured pack name.
+ *
+ * @param packName - Hermes `templatePack` value.
+ * @returns Pack definition capped at {@link MAX_TEMPLATES_PER_PACK} templates.
+ */
+export const getDeterministicPack = (
+  packName: DeterministicPackName | string,
+): DeterministicPack => {
+  const resolvedName =
+    packName in DETERMINISTIC_PACKS
+      ? (packName as DeterministicPackName)
+      : DEFAULT_DETERMINISTIC_PACK;
+  const pack = DETERMINISTIC_PACKS[resolvedName];
+  return {
+    ...pack,
+    templates: pack.templates.slice(0, MAX_TEMPLATES_PER_PACK),
+  };
+};

--- a/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.test.ts
@@ -1,0 +1,138 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+import {
+  extractSlotsFromPattern,
+  formatCurrentQuarter,
+  resolveSlots,
+  resolveTemplatePattern,
+} from "./slot-resolver";
+
+const FIXED_CLOCK = (): Date => new Date("2026-05-21T12:00:00.000Z");
+
+const emptyEnrichedContext = {
+  peers: [] as [],
+  calendar: { recentEventTypes: [] as string[] },
+  headlineSamples: [] as [],
+  kgNeighborhood: [] as [],
+};
+
+const fullContext: GetQueryAnalysisResponse = {
+  ticker: {
+    id: "11111111-1111-4111-a111-111111111111",
+    symbol: "ACME",
+    name: "Acme Co",
+    metadata: null,
+  },
+  topEntities: [
+    {
+      canonicalName: "Subsidiary Inc",
+      typeName: "Organization",
+      relevanceWeight: 0.9,
+    },
+  ],
+  recentThemes: [{ theme: "AI", articleCount: 3 }],
+  ...emptyEnrichedContext,
+};
+
+const sparseContext: GetQueryAnalysisResponse = {
+  ticker: {
+    id: "22222222-2222-4222-a222-222222222222",
+    symbol: "ABC",
+    name: "ABC Ltd",
+    metadata: null,
+  },
+  topEntities: [],
+  recentThemes: [],
+  ...emptyEnrichedContext,
+};
+
+describe("formatCurrentQuarter", () => {
+  it("formats May as Q2 of the calendar year", () => {
+    // Act
+    const label = formatCurrentQuarter(new Date("2026-05-21T00:00:00.000Z"));
+
+    // Assert
+    expect(label).toBe("Q2 2026");
+  });
+});
+
+describe("extractSlotsFromPattern", () => {
+  it("returns unique slot names in order of first appearance", () => {
+    // Act
+    const slots = extractSlotsFromPattern(
+      "{name} {recentTheme} and {name} again",
+    );
+
+    // Assert
+    expect(slots).toEqual(["name", "recentTheme"]);
+  });
+});
+
+describe("resolveSlots", () => {
+  it("resolves calendar slots from a fixed clock", () => {
+    // Act
+    const slots = resolveSlots(sparseContext, FIXED_CLOCK);
+
+    // Assert
+    expect(slots.currentQuarter).toBe("Q2 2026");
+    expect(slots.currentYear).toBe("2026");
+    expect(slots.currentMonth).toBe("May");
+  });
+
+  it("includes context-dependent slots when data is present", () => {
+    // Act
+    const slots = resolveSlots(fullContext, FIXED_CLOCK);
+
+    // Assert
+    expect(slots.topEntity).toBe("Subsidiary Inc");
+    expect(slots.recentTheme).toBe("AI");
+  });
+
+  it("omits context-dependent slots when arrays are empty", () => {
+    // Act
+    const slots = resolveSlots(sparseContext, FIXED_CLOCK);
+
+    // Assert
+    expect(slots.topEntity).toBeUndefined();
+    expect(slots.recentTheme).toBeUndefined();
+  });
+});
+
+describe("resolveTemplatePattern", () => {
+  it("fills all slots in a fully populated pattern", () => {
+    // Setup
+    const slots = resolveSlots(fullContext, FIXED_CLOCK);
+
+    // Act
+    const text = resolveTemplatePattern("{name} {recentTheme} impact", slots);
+
+    // Assert
+    expect(text).toBe("Acme Co AI impact");
+  });
+
+  it("returns null when a required slot is unresolved", () => {
+    // Setup
+    const slots = resolveSlots(sparseContext, FIXED_CLOCK);
+
+    // Act
+    const text = resolveTemplatePattern("{name} {recentTheme} impact", slots);
+
+    // Assert
+    expect(text).toBeNull();
+  });
+
+  it("never emits literal brace tokens for resolved patterns", () => {
+    // Setup
+    const slots = resolveSlots(sparseContext, FIXED_CLOCK);
+
+    // Act
+    const text = resolveTemplatePattern("{symbol} latest news", slots);
+
+    // Assert
+    expect(text).toBe("ABC latest news");
+    expect(text).not.toContain("{");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.ts
@@ -1,0 +1,119 @@
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+/** Clock dependency for time-anchored template slots. */
+export type SlotResolverClock = () => Date;
+
+/** Slot values available to deterministic template packs. */
+export type ResolvedTemplateSlots = {
+  symbol: string;
+  name: string;
+  topEntity?: string;
+  recentTheme?: string;
+  currentQuarter: string;
+  currentYear: string;
+  currentMonth: string;
+};
+
+const TEMPLATE_SLOT_PATTERN = /\{([a-zA-Z]+)\}/g;
+
+/**
+ * Extracts unique slot names referenced in a template string (e.g. `{name}` → `name`).
+ *
+ * @param pattern - Template text with `{slot}` placeholders.
+ * @returns Ordered unique slot names.
+ */
+export const extractSlotsFromPattern = (pattern: string): string[] => {
+  const names = new Set<string>();
+  for (const match of pattern.matchAll(TEMPLATE_SLOT_PATTERN)) {
+    const slot = match[1];
+    if (slot) {
+      names.add(slot);
+    }
+  }
+  return [...names];
+};
+
+/**
+ * Formats the calendar quarter for a date (e.g. May 2026 → `Q2 2026`).
+ *
+ * @param date - Reference instant.
+ * @returns Quarter label including year.
+ */
+export const formatCurrentQuarter = (date: Date): string => {
+  const quarter = Math.floor(date.getMonth() / 3) + 1;
+  return `Q${String(quarter)} ${String(date.getFullYear())}`;
+};
+
+/**
+ * Formats the calendar month name for a date (e.g. May 2026 → `May`).
+ *
+ * @param date - Reference instant.
+ * @returns English long month name.
+ */
+export const formatCurrentMonth = (date: Date): string =>
+  date.toLocaleString("en-US", { month: "long" });
+
+/**
+ * Resolves slot values from query-analysis context and an injectable clock.
+ *
+ * @param context - GET /query-analysis response.
+ * @param clock - Returns the reference instant (default: now).
+ * @returns Slot map; optional slots are `undefined` when context lacks data.
+ */
+export const resolveSlots = (
+  context: GetQueryAnalysisResponse,
+  clock: SlotResolverClock = () => new Date(),
+): ResolvedTemplateSlots => {
+  const now = clock();
+  const topEntity =
+    context.topEntities.length > 0
+      ? [...context.topEntities].sort(
+          (a, b) => b.relevanceWeight - a.relevanceWeight,
+        )[0]?.canonicalName
+      : undefined;
+
+  return {
+    symbol: context.ticker.symbol,
+    name: context.ticker.name,
+    topEntity,
+    recentTheme: context.recentThemes[0]?.theme,
+    currentQuarter: formatCurrentQuarter(now),
+    currentYear: String(now.getFullYear()),
+    currentMonth: formatCurrentMonth(now),
+  };
+};
+
+/**
+ * Renders a template when every referenced slot resolves to a non-empty string.
+ *
+ * @param pattern - Template text with `{slot}` placeholders.
+ * @param slots - Resolved slot values from {@link resolveSlots}.
+ * @returns Rendered query text, or `null` when a required slot is missing.
+ */
+export const resolveTemplatePattern = (
+  pattern: string,
+  slots: ResolvedTemplateSlots,
+): string | null => {
+  const required = extractSlotsFromPattern(pattern);
+  const slotRecord: Record<string, string | undefined> = {
+    symbol: slots.symbol,
+    name: slots.name,
+    topEntity: slots.topEntity,
+    recentTheme: slots.recentTheme,
+    currentQuarter: slots.currentQuarter,
+    currentYear: slots.currentYear,
+    currentMonth: slots.currentMonth,
+  };
+
+  for (const name of required) {
+    const value = slotRecord[name];
+    if (!value?.trim()) {
+      return null;
+    }
+  }
+
+  return pattern.replace(TEMPLATE_SLOT_PATTERN, (_match, key: string) => {
+    const value = slotRecord[key];
+    return value?.trim() ?? "";
+  });
+};

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -20,6 +20,40 @@ It uses:
 - **Reads:** `GET /api/query-analysis?tickerId=...`
 - **Writes:** `POST /api/query-analysis` (upsert search queries)
 
+### GET response fields
+
+| Field | Shape | Notes |
+| ----- | ----- | ----- |
+| `ticker` | `{ id, symbol, name, metadata }` | Anchor company |
+| `topEntities` | `{ canonicalName, typeName, relevanceWeight }[]` | Up to 10 KG entities |
+| `recentThemes` | `{ theme, articleCount }[]` | Recent article-title themes |
+| `recentRelationDeltas` | optional relation delta rows | When present from upstream |
+| `peers` | `{ symbol, name, relevance }[]` | Up to 5 sector/industry siblings from ticker metadata |
+| `calendar` | `{ nextEarningsAt?, recentEventTypes[] }` | `nextEarningsAt` is omitted until a calendar table exists; event types come from recent data-source metadata |
+| `headlineSamples` | `{ title, publishedAt, sourceName }[]` | Up to 5 recent headlines (`publishedAt` uses ingestion time or metadata) |
+| `kgNeighborhood` | `{ fromEntity, relationType, toEntity }[]` | One-hop KG edges for top entities (deduped, capped at 30) |
+
+Empty fixtures still return the four enriched collections as empty arrays (never omitted keys).
+
+### Sample user-prompt block
+
+When the LLM user prompt is built, non-empty enriched sections appear beneath themes and relation deltas:
+
+```
+Sector peers:
+- PEER1 (Peer One Corp) relevance=1
+- PEER2 (Peer Two Inc) relevance=0.9
+
+Calendar:
+- Recent events: ratings_change, executive_departure
+
+Recent headlines:
+- 2026-05-18 (reuters.com) — "Acme beats estimates"
+
+KG neighborhood:
+- Alpha Subsidiary --PARTNER_OF--> Beta Partner
+```
+
 ## Environment variables
 
 | Variable                     | Required | Notes                                                          |
@@ -45,6 +79,7 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | `allowedLanguages`                                        | No       | Target languages as BCP-47 codes (default `["en"]`).                                                                                                                                                                                         |
 | `weightBreaking` / `weightKgChange` / `weightFundamental` | No       | Intent mix weights (default `1`, `0.8`, `0.6`).                                                                                                                                                                                              |
 | `maxTokens`                                               | No       | LLM output token budget (default `800`).                                                                                                                                                                                                     |
+| `templatePack`                                            | No       | Deterministic template pack name (default `default-v1`). Set to `rich-v2` for the expanded ~20-template pack. Operators can switch packs via Hermes invoke config without redeploying the agent.                                              |
 | `prompts.systemPrompt`                                    | No       | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
 | `prompts.userPromptTemplate`                              | No       | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context).                                                                                                                         |
 
@@ -56,6 +91,25 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | **`prompts.systemPrompt` set**       | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{minDeterministicCount}}`** are still filled from the same strategy fields so you can reference numeric targets without redeploying.                 |
 | **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data.                                                                                                                                                                                             |
 | **Merge / persistence**              | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math.                                                                                                                               |
+
+## Deterministic template packs
+
+Deterministic queries are built from a named **template pack** before the LLM complement is merged. Set **`templatePack`** in Hermes invoke config to switch packs without redeploying the agent.
+
+| Pack | Templates | Slots used | Example row |
+| ---- | --------- | ------------ | ----------- |
+| **`default-v1`** | 5 | `{symbol}`, `{name}` | `ACME latest news` |
+| **`rich-v2`** | ~20 | `{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, `{currentQuarter}`, `{currentYear}`, `{currentMonth}` | `Acme Co AI impact` |
+
+Templates whose required slots cannot be filled from live GET /query-analysis context are **skipped** (never persisted with literal `{slot}` tokens). For example, `{recentTheme}` templates are omitted when the ticker has no recent themes.
+
+Slot resolution uses the agent clock at run time:
+
+- **`{currentQuarter}`** — e.g. `Q2 2026` for May 2026
+- **`{currentYear}`** — calendar year, e.g. `2026`
+- **`{currentMonth}`** — full English month name, e.g. `May`
+- **`{topEntity}`** — highest-weight entity from `topEntities`
+- **`{recentTheme}`** — first entry from `recentThemes`
 
 ## Hermes run payload
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -381,6 +381,10 @@ describe("createAgentDataApiClient", () => {
         },
         topEntities: [],
         recentThemes: [],
+        peers: [],
+        calendar: { recentEventTypes: [] },
+        headlineSamples: [],
+        kgNeighborhood: [],
       }),
       statusCode: 200,
     });

--- a/packages/shared/agent-data-api-contract/src/query-analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.ts
@@ -67,12 +67,39 @@ export const queryAnalysisRecentThemeSchema = z.object({
   articleCount: z.number().int().nonnegative(),
 });
 
+export const queryAnalysisPeerSchema = z.object({
+  symbol: z.string(),
+  name: z.string(),
+  relevance: z.number(),
+});
+
+export const queryAnalysisCalendarSchema = z.object({
+  nextEarningsAt: z.string().datetime().optional(),
+  recentEventTypes: z.array(z.string()),
+});
+
+export const queryAnalysisHeadlineSampleSchema = z.object({
+  title: z.string(),
+  publishedAt: z.string(),
+  sourceName: z.string(),
+});
+
+export const queryAnalysisKgNeighborhoodSchema = z.object({
+  fromEntity: z.string(),
+  relationType: z.string(),
+  toEntity: z.string(),
+});
+
 export const getQueryAnalysisResponseSchema = z.object({
   ticker: queryAnalysisTickerSchema,
   topEntities: z.array(queryAnalysisTopEntitySchema),
   recentThemes: z.array(queryAnalysisRecentThemeSchema),
   recentRelationDeltas: z.array(queryAnalysisRelationDeltaSchema).optional(),
   configSnapshot: queryAnalysisConfigSnapshotSchema.optional(),
+  peers: z.array(queryAnalysisPeerSchema).default([]),
+  calendar: queryAnalysisCalendarSchema.default({ recentEventTypes: [] }),
+  headlineSamples: z.array(queryAnalysisHeadlineSampleSchema).default([]),
+  kgNeighborhood: z.array(queryAnalysisKgNeighborhoodSchema).default([]),
 });
 
 export const postQueryAnalysisResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Query-analysis now supports named deterministic template packs and a richer GET context. Operators can switch between the original five-query floor and a ~20-template `rich-v2` pack via Hermes `templatePack`, while the LLM prompt can draw on sector peers, recent headline phrasing, calendar event types, and one-hop KG relations.

## Related issues

Closes #537

## Important changes

- Added `default-v1` and `rich-v2` deterministic template packs with slot resolution (`{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, calendar slots); unresolved slots drop the template instead of persisting literal placeholders.
- Exposed `templatePack` in query-analysis Hermes config (defaults to `default-v1`).
- Extended `GET /query-analysis` with `peers`, `calendar`, `headlineSamples`, and `kgNeighborhood`; empty fixtures return empty arrays, not missing keys.
- Updated `buildQueryAnalysisUserContent` to render the four new blocks only when data is present.

## Other changes

- Added service helpers and unit tests for context enrichment and template resolution.
- Updated dev-docs for template packs and the expanded I/O contract.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/templates/` — pack definitions, slot resolver, deterministic builder
- `apps/mediapulse/agent-data-api/src/services/query-analysis.ts` — enriched GET context fetches
- `packages/shared/agent-data-api-contract/src/query-analysis.ts` — response schema additions
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — prompt serialization for new blocks

## How to test

1. Run `pnpm --filter @mediapulse/query-analysis test` and `pnpm --filter @mediapulse/agent-data-api test -- src/services/query-analysis.test.ts src/services/query-analysis-context-helpers.test.ts`.
2. Rebuild the contract package: `pnpm --filter @workspace/agent-data-api-contract build`.
3. Invoke query-analysis with `templatePack: "rich-v2"` and confirm persisted queries include varied deterministic rows when ticker context has themes/entities.
4. Call `GET /api/v1/query-analysis?tickerId=...` and confirm `peers`, `calendar`, `headlineSamples`, and `kgNeighborhood` are present (empty arrays when data is sparse).
