### PR TITLE
Add query-analysis LLM sampling and few-shot brainstorm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ graphify*.*
 .graphifyignore
 graph.*
 GRAPH_REPORT.md
+
+# Cursor
+.cursor/plans

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -77,3 +77,84 @@ describe("queryAnalysisConfigSchema prompts", () => {
     expect(parsed.prompts?.systemPrompt).toContain("allowedLanguages");
   });
 });
+
+describe("queryAnalysisConfigSchema sampling", () => {
+  it("defaults creativity sampling fields", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.temperature).toBe(0.9);
+    expect(parsed.topP).toBe(0.95);
+    expect(parsed.presencePenalty).toBe(0.4);
+    expect(parsed.frequencyPenalty).toBe(0.5);
+    expect(parsed.seed).toBeUndefined();
+  });
+
+  it("rejects temperature above 2", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      temperature: 2.1,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => issue.path.includes("temperature")),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects presencePenalty above 2", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      presencePenalty: 3,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.path.includes("presencePenalty"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects non-integer seed values", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      seed: 1.5,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) => issue.path.includes("seed")),
+      ).toBe(true);
+    }
+  });
+});
+
+describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
+  it("defaults useBrainstormPass to false and fewShotExemplarCount to 3", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.useBrainstormPass).toBe(false);
+    expect(parsed.fewShotExemplarCount).toBe(3);
+    expect(parsed.brainstormModel).toBeUndefined();
+  });
+
+  it("accepts brainstorm and few-shot overrides", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      useBrainstormPass: true,
+      brainstormModel: "gpt-4o",
+      fewShotExemplarCount: 0,
+    });
+    expect(parsed.useBrainstormPass).toBe(true);
+    expect(parsed.brainstormModel).toBe("gpt-4o");
+    expect(parsed.fewShotExemplarCount).toBe(0);
+  });
+
+  it("rejects fewShotExemplarCount above 6", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      fewShotExemplarCount: 7,
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -58,6 +58,38 @@ export const queryAnalysisConfigSchema = z
       .optional()
       .default(DEFAULT_DETERMINISTIC_PACK),
     /**
+     * LLM sampling temperature (higher = more varied phrasing).
+     */
+    temperature: z.number().min(0).max(2).optional().default(0.9),
+    /**
+     * Nucleus sampling top-p cutoff.
+     */
+    topP: z.number().min(0).max(1).optional().default(0.95),
+    /**
+     * Penalizes tokens already present in the output (encourages new topics).
+     */
+    presencePenalty: z.number().min(-2).max(2).optional().default(0.4),
+    /**
+     * Penalizes tokens by prior frequency in the output (reduces repetition).
+     */
+    frequencyPenalty: z.number().min(-2).max(2).optional().default(0.5),
+    /**
+     * Optional fixed seed for reproducible LLM output during regression hunts.
+     */
+    seed: z.number().int().optional(),
+    /**
+     * When true, runs a free-form brainstorm pass before structured query generation.
+     */
+    useBrainstormPass: z.boolean().optional().default(false),
+    /**
+     * Model id for the brainstorm pass (defaults to `openaiModel` in `run.ts` when omitted).
+     */
+    brainstormModel: z.string().min(1).optional(),
+    /**
+     * Number of curated few-shot exemplars to inject (0 disables exemplars).
+     */
+    fewShotExemplarCount: z.number().int().min(0).max(6).optional().default(3),
+    /**
      * Optional overrides for query-generation LLM system/user templates (Hermes).
      * When omitted, built-in defaults are used. Do not put API keys inside prompt text.
      */

--- a/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.test.ts
@@ -1,0 +1,30 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_QUERY_EXEMPLARS,
+  formatExemplarAssistantContent,
+  selectFewShotExemplars,
+} from "./default-exemplars";
+
+describe("selectFewShotExemplars", () => {
+  it("returns zero exemplars when count is 0", () => {
+    expect(selectFewShotExemplars(0)).toEqual([]);
+  });
+
+  it("caps at the library size", () => {
+    expect(selectFewShotExemplars(10)).toHaveLength(
+      DEFAULT_QUERY_EXEMPLARS.length,
+    );
+  });
+});
+
+describe("formatExemplarAssistantContent", () => {
+  it("formats query rows with intents", () => {
+    const text = formatExemplarAssistantContent([
+      { text: "ACME latest news", intent: "breaking" },
+    ]);
+    expect(text).toContain("ACME latest news");
+    expect(text).toContain("(breaking)");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts
+++ b/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts
@@ -1,0 +1,166 @@
+import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
+
+/** One curated few-shot query row with intent label. */
+export type QueryExemplarRow = {
+  text: string;
+  intent: QueryAnalysisIntent;
+};
+
+/** Hand-written (context → queries) pair for few-shot prompting. */
+export type QueryExemplar = {
+  /** Serialized ticker context block shown to the model. */
+  context: string;
+  /** Example queries demonstrating tone, granularity, and intent mix. */
+  queries: QueryExemplarRow[];
+};
+
+/** Large-cap consumer staples archetype. */
+const largeCapConsumerExemplar: QueryExemplar = {
+  context: [
+    "Ticker symbol: PG",
+    "Company name: Procter & Gamble Co",
+    "Top entities:",
+    "- Gillette (Brand) relevance=0.85",
+    "- Pampers (Brand) relevance=0.8",
+    "Recent themes:",
+    "- pricing power (articles: 4)",
+    "- organic growth (articles: 3)",
+    "Sector peers:",
+    "- KO (Coca-Cola Co) relevance=1",
+    "- CL (Colgate-Palmolive) relevance=0.9",
+  ].join("\n"),
+  queries: [
+    { text: "P&G pricing vs Unilever consumer staples", intent: "fundamental" },
+    { text: "Gillette market share erosion latest", intent: "breaking" },
+    { text: "Pampers diaper category volume trends", intent: "fundamental" },
+    { text: "Procter Gamble organic sales guidance", intent: "fundamental" },
+    { text: "PG relation changes brand portfolio", intent: "kg_change" },
+    { text: "why is PG stock moving today", intent: "breaking" },
+    { text: "P&G China demand slowdown impact", intent: "breaking" },
+    {
+      text: "Colgate-Palmolive vs PG margin comparison",
+      intent: "fundamental",
+    },
+  ],
+};
+
+/** Mid-cap industrial manufacturer archetype. */
+const midCapIndustrialExemplar: QueryExemplar = {
+  context: [
+    "Ticker symbol: ROK",
+    "Company name: Rockwell Automation Inc",
+    "Top entities:",
+    "- FactoryTalk (Product) relevance=0.75",
+    "- Allen-Bradley (Brand) relevance=0.9",
+    "Recent themes:",
+    "- automation backlog (articles: 5)",
+    "- semiconductor capex (articles: 2)",
+    "Sector peers:",
+    "- EMR (Emerson Electric) relevance=1",
+    "- HON (Honeywell) relevance=0.85",
+  ].join("\n"),
+  queries: [
+    { text: "Rockwell Automation order backlog trend", intent: "fundamental" },
+    { text: "ROK vs Emerson automation revenue mix", intent: "fundamental" },
+    { text: "Allen-Bradley supply chain lead times", intent: "breaking" },
+    {
+      text: "Rockwell FactoryTalk software attach rate",
+      intent: "fundamental",
+    },
+    { text: "ROK entity relation changes acquisitions", intent: "kg_change" },
+    { text: "industrial automation capex cycle 2026", intent: "breaking" },
+    { text: "Honeywell vs Rockwell margin outlook", intent: "fundamental" },
+  ],
+};
+
+/** Regulated financial institution archetype. */
+const regulatedFinancialExemplar: QueryExemplar = {
+  context: [
+    "Ticker symbol: JPM",
+    "Company name: JPMorgan Chase & Co",
+    "Top entities:",
+    "- Chase Bank (Subsidiary) relevance=0.95",
+    "- First Republic assets (Acquisition) relevance=0.6",
+    "Recent themes:",
+    "- net interest margin (articles: 6)",
+    "- Basel III endgame (articles: 4)",
+    "Calendar:",
+    "- Recent events: stress_test, dividend_increase",
+  ].join("\n"),
+  queries: [
+    { text: "JPMorgan net interest margin Q2 outlook", intent: "fundamental" },
+    {
+      text: "Basel III endgame impact JPM capital ratios",
+      intent: "fundamental",
+    },
+    { text: "JPM stress test results Fed response", intent: "breaking" },
+    {
+      text: "Chase consumer credit card delinquency trend",
+      intent: "fundamental",
+    },
+    { text: "JPMorgan relation changes subsidiary map", intent: "kg_change" },
+    { text: "why is JPM stock falling today", intent: "breaking" },
+    { text: "JPM dividend increase vs peers yield", intent: "fundamental" },
+    { text: "First Republic integration cost overrun", intent: "breaking" },
+  ],
+};
+
+/** High-growth technology platform archetype. */
+const techPlatformExemplar: QueryExemplar = {
+  context: [
+    "Ticker symbol: CRM",
+    "Company name: Salesforce Inc",
+    "Top entities:",
+    "- Slack (Subsidiary) relevance=0.8",
+    "- Data Cloud (Product) relevance=0.7",
+    "Recent themes:",
+    "- AI agents (articles: 8)",
+    "- seat compression (articles: 3)",
+    "Recent headlines:",
+    '- 2026-05-10 (reuters.com) — "Salesforce unveils Agentforce roadmap"',
+  ].join("\n"),
+  queries: [
+    {
+      text: "Salesforce Agentforce adoption enterprise pilots",
+      intent: "breaking",
+    },
+    { text: "CRM AI agents monetization model", intent: "fundamental" },
+    { text: "Slack integration Salesforce bundle attach", intent: "kg_change" },
+    { text: "Salesforce seat compression ARR impact", intent: "fundamental" },
+    { text: "CRM vs Microsoft Dynamics AI comparison", intent: "fundamental" },
+    { text: "Salesforce Data Cloud growth rate", intent: "fundamental" },
+    { text: "why is CRM moving after earnings", intent: "breaking" },
+  ],
+};
+
+/** Version-controlled few-shot library (order is stable for reproducibility). */
+export const DEFAULT_QUERY_EXEMPLARS: QueryExemplar[] = [
+  largeCapConsumerExemplar,
+  midCapIndustrialExemplar,
+  regulatedFinancialExemplar,
+  techPlatformExemplar,
+];
+
+/**
+ * Returns the first N curated exemplars for few-shot prompting.
+ *
+ * @param count - Number of exemplars to include (0 disables few-shot).
+ * @returns Slice of the default exemplar library.
+ */
+export const selectFewShotExemplars = (count: number): QueryExemplar[] =>
+  DEFAULT_QUERY_EXEMPLARS.slice(0, Math.max(0, count));
+
+/**
+ * Formats exemplar query rows as an assistant-style few-shot response.
+ *
+ * @param queries - Example query rows with intents.
+ * @returns Multi-line assistant content for chat history.
+ */
+export const formatExemplarAssistantContent = (
+  queries: QueryExemplarRow[],
+): string => {
+  const lines = queries.map(
+    (row, index) => `${String(index + 1)}. "${row.text}" (${row.intent})`,
+  );
+  return ["Here are search queries I would use:", ...lines].join("\n");
+};

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -2,9 +2,14 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
+  buildBrainstormPrompt,
   buildQueryAnalysisSystemContent,
   buildQueryAnalysisUserContent,
+  buildStructuredQueryMessages,
+  fetchBrainstormBullets,
   fetchLlmQueryCandidates,
+  fetchQueryAnalysisLlmCandidates,
+  parseBrainstormBullets,
   resolveQueryAnalysisSystemContent,
   resolveQueryAnalysisUserContent,
 } from "./llm-queries";
@@ -187,7 +192,192 @@ describe("buildQueryAnalysisUserContent", () => {
   });
 });
 
+describe("parseBrainstormBullets", () => {
+  it("strips list prefixes and empty lines", () => {
+    const bullets = parseBrainstormBullets(
+      "- first angle\n\n2. second angle\n* third angle",
+    );
+    expect(bullets).toEqual(["first angle", "second angle", "third angle"]);
+  });
+});
+
+describe("buildBrainstormPrompt", () => {
+  it("includes serialized context in the user message", () => {
+    const ctx = {
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "ACME",
+        name: "Acme Co",
+        metadata: null,
+      },
+      topEntities: [],
+      recentThemes: [],
+      ...emptyEnrichedContext,
+    };
+    const prompt = buildBrainstormPrompt(
+      {
+        queryCount: 10,
+        allowedLanguages: ["en"],
+        minDeterministicCount: 4,
+        weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+      },
+      ctx,
+    );
+    expect(prompt.system).toContain("12–20");
+    expect(prompt.user).toContain("ACME");
+  });
+});
+
+describe("buildStructuredQueryMessages", () => {
+  it("injects few-shot exemplar turns before the live user message", () => {
+    const messages = buildStructuredQueryMessages({
+      systemContent: "system",
+      userContent: "live context",
+      fewShotExemplarCount: 2,
+    });
+    expect(messages[0]?.role).toBe("system");
+    expect(messages.filter((m) => m.role === "user")).toHaveLength(3);
+    expect(messages.at(-1)).toEqual({ role: "user", content: "live context" });
+  });
+
+  it("appends brainstorm bullets to the final user message", () => {
+    const messages = buildStructuredQueryMessages({
+      systemContent: "system",
+      userContent: "live context",
+      fewShotExemplarCount: 0,
+      brainstormBullets: ["angle one", "angle two"],
+    });
+    const finalUser = messages.at(-1);
+    expect(finalUser?.content).toContain("previously brainstormed");
+    expect(finalUser?.content).toContain("angle one");
+  });
+});
+
+describe("fetchBrainstormBullets", () => {
+  it("parses generateText output into bullet strings", async () => {
+    const generateTextForBrainstorm = vi.fn().mockResolvedValue({
+      text: "- margin outlook\n- peer comparison",
+    });
+    const bullets = await fetchBrainstormBullets(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 200,
+        strategy: {
+          queryCount: 10,
+          allowedLanguages: ["en"],
+          minDeterministicCount: 4,
+          weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+        },
+        context: {
+          ticker: {
+            id: "11111111-1111-4111-a111-111111111111",
+            symbol: "ACME",
+            name: "Acme Co",
+            metadata: null,
+          },
+          topEntities: [],
+          recentThemes: [],
+          ...emptyEnrichedContext,
+        },
+        sampling: {
+          temperature: 0.9,
+          topP: 0.95,
+          presencePenalty: 0.4,
+          frequencyPenalty: 0.5,
+        },
+      },
+      { generateTextForBrainstorm },
+    );
+    expect(bullets).toEqual(["margin outlook", "peer comparison"]);
+  });
+});
+
+describe("fetchQueryAnalysisLlmCandidates", () => {
+  const baseParams = {
+    apiKey: "sk-test",
+    model: "gpt-4o-mini",
+    brainstormModel: "gpt-4o-mini",
+    maxOutputTokens: 100,
+    systemContent: "system",
+    userContent: "user context",
+    context: {
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "ACME",
+        name: "Acme Co",
+        metadata: null,
+      },
+      topEntities: [],
+      recentThemes: [],
+      ...emptyEnrichedContext,
+    },
+    strategy: {
+      queryCount: 10,
+      allowedLanguages: ["en"],
+      minDeterministicCount: 4,
+      weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+    },
+    sampling: {
+      temperature: 0.9,
+      topP: 0.95,
+      presencePenalty: 0.4,
+      frequencyPenalty: 0.5,
+    },
+    fewShotExemplarCount: 0,
+  };
+
+  it("calls brainstorm first when useBrainstormPass is true", async () => {
+    const fetchBrainstormBulletsSpy = vi
+      .fn()
+      .mockResolvedValue(["angle a", "angle b"]);
+    const fetchLlmQueryCandidatesSpy = vi
+      .fn()
+      .mockResolvedValue([{ text: "ok", intent: "breaking" as const }]);
+
+    await fetchQueryAnalysisLlmCandidates(
+      { ...baseParams, useBrainstormPass: true },
+      {
+        fetchBrainstormBullets: fetchBrainstormBulletsSpy,
+        fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy,
+      },
+    );
+
+    expect(fetchBrainstormBulletsSpy).toHaveBeenCalledTimes(1);
+    expect(fetchLlmQueryCandidatesSpy).toHaveBeenCalledTimes(1);
+    const messages = fetchLlmQueryCandidatesSpy.mock.calls[0]?.[0]?.messages as
+      | { role: string; content: string }[]
+      | undefined;
+    expect(messages?.at(-1)?.content).toContain("angle a");
+  });
+
+  it("skips brainstorm when useBrainstormPass is false", async () => {
+    const fetchBrainstormBulletsSpy = vi.fn();
+    const fetchLlmQueryCandidatesSpy = vi
+      .fn()
+      .mockResolvedValue([{ text: "ok", intent: "breaking" as const }]);
+
+    await fetchQueryAnalysisLlmCandidates(
+      { ...baseParams, useBrainstormPass: false },
+      {
+        fetchBrainstormBullets: fetchBrainstormBulletsSpy,
+        fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy,
+      },
+    );
+
+    expect(fetchBrainstormBulletsSpy).not.toHaveBeenCalled();
+    expect(fetchLlmQueryCandidatesSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("fetchLlmQueryCandidates", () => {
+  const defaultSampling = {
+    temperature: 0.9,
+    topP: 0.95,
+    presencePenalty: 0.4,
+    frequencyPenalty: 0.5,
+  };
+
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -210,6 +400,7 @@ describe("fetchLlmQueryCandidates", () => {
         model: "gpt-4o-mini",
         maxOutputTokens: 100,
         messages: [{ role: "user", content: "hi" }],
+        sampling: defaultSampling,
       },
       { generateObjectForQueries },
     );
@@ -217,6 +408,62 @@ describe("fetchLlmQueryCandidates", () => {
     // Assert
     expect(rows).toEqual([{ text: "ok", intent: "breaking" }]);
     expect(generateObjectForQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it("forwards default sampling fields to generateObject", async () => {
+    // Setup
+    const generateObjectForQueries = vi.fn().mockResolvedValue({
+      object: { queries: [] },
+    });
+
+    // Act
+    await fetchLlmQueryCandidates(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        messages: [{ role: "user", content: "hi" }],
+        sampling: defaultSampling,
+      },
+      { generateObjectForQueries },
+    );
+
+    // Assert
+    expect(generateObjectForQueries).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 0.9,
+        topP: 0.95,
+        presencePenalty: 0.4,
+        frequencyPenalty: 0.5,
+      }),
+    );
+    expect(generateObjectForQueries.mock.calls[0]?.[0]).not.toHaveProperty(
+      "seed",
+    );
+  });
+
+  it("forwards custom seed to generateObject when set", async () => {
+    // Setup
+    const generateObjectForQueries = vi.fn().mockResolvedValue({
+      object: { queries: [] },
+    });
+
+    // Act
+    await fetchLlmQueryCandidates(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        messages: [{ role: "user", content: "hi" }],
+        sampling: { ...defaultSampling, seed: 42 },
+      },
+      { generateObjectForQueries },
+    );
+
+    // Assert
+    expect(generateObjectForQueries).toHaveBeenCalledWith(
+      expect.objectContaining({ seed: 42 }),
+    );
   });
 
   it("propagates generateObject errors to the caller", async () => {
@@ -231,6 +478,7 @@ describe("fetchLlmQueryCandidates", () => {
           model: "gpt-4o-mini",
           maxOutputTokens: 100,
           messages: [{ role: "user", content: "hi" }],
+          sampling: defaultSampling,
         },
         { generateObjectForQueries },
       ),

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateObject } from "ai";
+import { generateObject, generateText } from "ai";
 import type { ModelMessage } from "ai";
 import {
   queryAnalysisIntentSchema,
@@ -13,6 +13,11 @@ import {
   QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
 } from "./query-analysis-prompt-defaults";
 import { substituteLlmPromptTemplate } from "@workspace/agent-llm-prompt-template";
+
+import {
+  formatExemplarAssistantContent,
+  selectFewShotExemplars,
+} from "./exemplars/default-exemplars";
 
 /** Zod schema for structured LLM output (validated by AI SDK). */
 export const llmQueriesOutputSchema = z.object({
@@ -181,18 +186,196 @@ export const buildQueryAnalysisUserContent = (
   return lines.join("\n");
 };
 
+/** System instruction for the free-form brainstorm pass. */
+const BRAINSTORM_SYSTEM_PROMPT = [
+  "You are a financial research analyst brainstorming search angles.",
+  "List 12–20 distinct angles a savvy analyst would search for about the company below.",
+  "Write free prose as plain bullet points — one angle per line.",
+  "Do not output JSON, intent labels, or numbered schema fields.",
+].join("\n");
+
+/**
+ * Builds the system and user messages for the brainstorm pass.
+ *
+ * @param strategy - Strategy knobs (languages inform phrasing expectations).
+ * @param context - Live GET /query-analysis payload.
+ * @returns System and user content for `generateText`.
+ */
+export const buildBrainstormPrompt = (
+  strategy: LlmQueryStrategyPrompt,
+  context: GetQueryAnalysisResponse,
+): { system: string; user: string } => ({
+  system: [
+    BRAINSTORM_SYSTEM_PROMPT,
+    `Write angles in these languages when natural: ${strategy.allowedLanguages.join(", ")}.`,
+  ].join("\n\n"),
+  user: buildQueryAnalysisUserContent(context),
+});
+
+/**
+ * Parses brainstorm model output into trimmed bullet strings.
+ *
+ * @param text - Raw `generateText` output.
+ * @returns Non-empty bullet lines with common list prefixes stripped.
+ */
+export const parseBrainstormBullets = (text: string): string[] => {
+  const bullets: string[] = [];
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine
+      .trim()
+      .replace(/^[-*•]\s*/, "")
+      .replace(/^\d+[.)]\s*/, "")
+      .trim();
+    if (line.length > 0) {
+      bullets.push(line);
+    }
+  }
+  return bullets;
+};
+
+/**
+ * Appends brainstorm refinement instructions to the structured-call user content.
+ *
+ * @param userContent - Serialized live context for the target ticker.
+ * @param brainstormBullets - Angles from the brainstorm pass.
+ * @returns User message content for the structured JSON call.
+ */
+export const buildStructuredUserContentWithBrainstorm = (
+  userContent: string,
+  brainstormBullets: string[],
+): string => {
+  const bulletBlock = brainstormBullets
+    .map((bullet) => `- ${bullet}`)
+    .join("\n");
+  return [
+    userContent,
+    "",
+    "Here are angles you previously brainstormed:",
+    bulletBlock,
+    "",
+    "Now refine, dedupe, and label each with an intent in the JSON response.",
+  ].join("\n");
+};
+
+/**
+ * Builds chat messages for the structured query-generation call.
+ *
+ * @param options - System/user content, optional few-shot exemplars, brainstorm bullets.
+ * @returns Message array for `generateObject`.
+ */
+export const buildStructuredQueryMessages = (options: {
+  systemContent: string;
+  userContent: string;
+  fewShotExemplarCount: number;
+  brainstormBullets?: string[];
+}): ModelMessage[] => {
+  const messages: ModelMessage[] = [
+    {
+      role: "system",
+      content: options.brainstormBullets?.length
+        ? `${options.systemContent}\n\nRefine the brainstormed angles into the final JSON query list. Dedupe near-duplicates before assigning intents.`
+        : options.systemContent,
+    },
+  ];
+
+  for (const exemplar of selectFewShotExemplars(options.fewShotExemplarCount)) {
+    messages.push({ role: "user", content: exemplar.context });
+    messages.push({
+      role: "assistant",
+      content: formatExemplarAssistantContent(exemplar.queries),
+    });
+  }
+
+  const finalUserContent =
+    options.brainstormBullets && options.brainstormBullets.length > 0
+      ? buildStructuredUserContentWithBrainstorm(
+          options.userContent,
+          options.brainstormBullets,
+        )
+      : options.userContent;
+
+  messages.push({ role: "user", content: finalUserContent });
+  return messages;
+};
+
+export type LlmQuerySampling = {
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+};
+
 export type GenerateObjectForQueries = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmQueriesOutputSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
 }) => Promise<{ object: z.infer<typeof llmQueriesOutputSchema> }>;
+
+export type GenerateTextForBrainstorm = (args: {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  messages: ModelMessage[];
+  maxOutputTokens: number;
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+}) => Promise<{ text: string }>;
+
+/**
+ * Runs the free-form brainstorm pass and returns parsed bullet angles.
+ *
+ * @param params - API key, model, token budget, strategy, context, and sampling.
+ * @param deps - Injectable `generateText` (default: production `generateText` from `ai`).
+ * @returns Trimmed bullet strings from model output.
+ */
+export const fetchBrainstormBullets = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    strategy: LlmQueryStrategyPrompt;
+    context: GetQueryAnalysisResponse;
+    sampling: LlmQuerySampling;
+  },
+  deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
+    generateTextForBrainstorm: generateText,
+  },
+): Promise<string[]> => {
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  const { system, user } = buildBrainstormPrompt(
+    params.strategy,
+    params.context,
+  );
+  const { sampling } = params;
+  const { text } = await deps.generateTextForBrainstorm({
+    model: openai(params.model),
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+    maxOutputTokens: params.maxOutputTokens,
+    temperature: sampling.temperature,
+    topP: sampling.topP,
+    presencePenalty: sampling.presencePenalty,
+    frequencyPenalty: sampling.frequencyPenalty,
+    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+  });
+  return parseBrainstormBullets(text);
+};
 
 /**
  * Calls the chat model with structured output; returns trimmed non-empty candidates with intents.
  * Throws on transport, API, or schema validation errors (caller handles fallback).
  *
- * @param params - API key, model id, token budget, and chat messages.
+ * @param params - API key, model id, token budget, chat messages, and sampling knobs.
  * @param deps - Injectable `generateObject` (default: production `generateObject` from `ai`).
  * @returns LLM candidate rows (may be empty if the model returns only empty strings).
  */
@@ -202,19 +385,86 @@ export const fetchLlmQueryCandidates = async (
     model: string;
     maxOutputTokens: number;
     messages: ModelMessage[];
+    sampling: LlmQuerySampling;
   },
   deps: { generateObjectForQueries: GenerateObjectForQueries } = {
     generateObjectForQueries: generateObject,
   },
 ): Promise<Array<{ text: string; intent: QueryAnalysisIntent }>> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
+  const { sampling } = params;
   const { object } = await deps.generateObjectForQueries({
     model: openai(params.model),
     schema: llmQueriesOutputSchema,
     maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
+    temperature: sampling.temperature,
+    topP: sampling.topP,
+    presencePenalty: sampling.presencePenalty,
+    frequencyPenalty: sampling.frequencyPenalty,
+    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
   });
   return (object.queries ?? [])
     .map((q) => ({ text: q.text.trim(), intent: q.intent }))
     .filter((q) => q.text.length > 0);
+};
+
+/** Parameters for the full query-analysis LLM path (optional brainstorm + structured call). */
+export type FetchQueryAnalysisLlmCandidatesParams = {
+  apiKey: string;
+  model: string;
+  brainstormModel: string;
+  maxOutputTokens: number;
+  systemContent: string;
+  userContent: string;
+  context: GetQueryAnalysisResponse;
+  strategy: LlmQueryStrategyPrompt;
+  sampling: LlmQuerySampling;
+  useBrainstormPass: boolean;
+  fewShotExemplarCount: number;
+};
+
+/**
+ * Fetches LLM query candidates, optionally running a brainstorm pass first.
+ *
+ * @param params - Full LLM path configuration from Hermes invoke config.
+ * @param deps - Injectable brainstorm and structured-output collaborators.
+ * @returns Trimmed LLM candidate rows with intents.
+ */
+export const fetchQueryAnalysisLlmCandidates = async (
+  params: FetchQueryAnalysisLlmCandidatesParams,
+  deps: {
+    fetchBrainstormBullets?: typeof fetchBrainstormBullets;
+    fetchLlmQueryCandidates?: typeof fetchLlmQueryCandidates;
+  } = {},
+): Promise<Array<{ text: string; intent: QueryAnalysisIntent }>> => {
+  const runBrainstorm = deps.fetchBrainstormBullets ?? fetchBrainstormBullets;
+  const runStructured = deps.fetchLlmQueryCandidates ?? fetchLlmQueryCandidates;
+
+  let brainstormBullets: string[] | undefined;
+  if (params.useBrainstormPass) {
+    brainstormBullets = await runBrainstorm({
+      apiKey: params.apiKey,
+      model: params.brainstormModel,
+      maxOutputTokens: params.maxOutputTokens,
+      strategy: params.strategy,
+      context: params.context,
+      sampling: params.sampling,
+    });
+  }
+
+  const messages = buildStructuredQueryMessages({
+    systemContent: params.systemContent,
+    userContent: params.userContent,
+    fewShotExemplarCount: params.fewShotExemplarCount,
+    brainstormBullets,
+  });
+
+  return runStructured({
+    apiKey: params.apiKey,
+    model: params.model,
+    maxOutputTokens: params.maxOutputTokens,
+    messages,
+    sampling: params.sampling,
+  });
 };

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { queryAnalysisConfigSchema } from "./config-schema";
 
-const { mockGet, mockCreate, mockFetchLlm } = vi.hoisted(() => ({
+const { mockGet, mockCreate, mockFetchQueryLlm } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockCreate: vi.fn(),
-  mockFetchLlm: vi.fn(),
+  mockFetchQueryLlm: vi.fn(),
 }));
 
 vi.mock("@mediapulse/env/agents-query-analysis", () => ({
@@ -28,7 +28,7 @@ vi.mock("./llm-queries", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./llm-queries")>();
   return {
     ...actual,
-    fetchLlmQueryCandidates: mockFetchLlm,
+    fetchQueryAnalysisLlmCandidates: mockFetchQueryLlm,
   };
 });
 
@@ -64,7 +64,7 @@ describe("query-analysis run", () => {
   beforeEach(() => {
     mockGet.mockReset();
     mockCreate.mockReset();
-    mockFetchLlm.mockReset();
+    mockFetchQueryLlm.mockReset();
 
     mockGet.mockResolvedValue(ctxResponse);
     mockCreate.mockResolvedValue({
@@ -72,7 +72,7 @@ describe("query-analysis run", () => {
       createdSetId: "33333333-3333-4333-a333-333333333333",
       activeSetId: "44444444-4444-4444-a444-444444444444",
     });
-    mockFetchLlm.mockResolvedValue([
+    mockFetchQueryLlm.mockResolvedValue([
       { text: "LLM extra", intent: "kg_change" as const },
     ]);
   });
@@ -153,7 +153,7 @@ describe("query-analysis run", () => {
 
   it("continues with deterministic merge when LLM throws", async () => {
     // Setup
-    mockFetchLlm.mockRejectedValue(new Error("LLM down"));
+    mockFetchQueryLlm.mockRejectedValue(new Error("LLM down"));
 
     // Act
     const result = await runQueryAnalysis({
@@ -172,5 +172,44 @@ describe("query-analysis run", () => {
       }
     ).queries;
     expect(queries.every((q) => q.source === "deterministic")).toBe(true);
+  });
+
+  it("passes useBrainstormPass through to the LLM orchestrator", async () => {
+    // Act
+    const result = await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: queryAnalysisConfigSchema.parse({
+        openaiApiKey: "sk",
+        useBrainstormPass: true,
+      }),
+      token: "Bearer t",
+    });
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(mockFetchQueryLlm).toHaveBeenCalledWith(
+      expect.objectContaining({ useBrainstormPass: true }),
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queries: expect.arrayContaining([
+          expect.objectContaining({ text: "LLM extra", intent: "kg_change" }),
+        ]),
+      }),
+    );
+  });
+
+  it("defaults useBrainstormPass to false in the LLM orchestrator", async () => {
+    // Act
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: baseConfig,
+      token: "Bearer t",
+    });
+
+    // Assert
+    expect(mockFetchQueryLlm).toHaveBeenCalledWith(
+      expect.objectContaining({ useBrainstormPass: false }),
+    );
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -7,7 +7,7 @@ import type { QueryAnalysisConfig } from "./config-schema";
 import {
   resolveQueryAnalysisSystemContent,
   resolveQueryAnalysisUserContent,
-  fetchLlmQueryCandidates,
+  fetchQueryAnalysisLlmCandidates,
 } from "./llm-queries";
 import { mergeQueryCandidates } from "./merge-query-candidates";
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
@@ -50,19 +50,29 @@ export const runQueryAnalysis = async (
   const weightFundamental = config.weightFundamental!;
   const openaiModel = config.openaiModel!;
   const maxTokens = config.maxTokens!;
+  const temperature = config.temperature!;
+  const topP = config.topP!;
+  const presencePenalty = config.presencePenalty!;
+  const frequencyPenalty = config.frequencyPenalty!;
+  const seed = config.seed;
+  const useBrainstormPass = config.useBrainstormPass!;
+  const fewShotExemplarCount = config.fewShotExemplarCount!;
+  const brainstormModel = config.brainstormModel ?? openaiModel;
+
+  const strategyPrompt = {
+    queryCount,
+    allowedLanguages,
+    minDeterministicCount,
+    weights: {
+      breaking: weightBreaking,
+      kgChange: weightKgChange,
+      fundamental: weightFundamental,
+    },
+  };
 
   const systemContent = resolveQueryAnalysisSystemContent(
     config.prompts?.systemPrompt,
-    {
-      queryCount,
-      allowedLanguages,
-      minDeterministicCount,
-      weights: {
-        breaking: weightBreaking,
-        kgChange: weightKgChange,
-        fundamental: weightFundamental,
-      },
-    },
+    strategyPrompt,
   );
   const userContent = resolveQueryAnalysisUserContent(
     config.prompts?.userPromptTemplate,
@@ -74,16 +84,28 @@ export const runQueryAnalysis = async (
     userContent,
   );
 
-  let llmCandidates: Awaited<ReturnType<typeof fetchLlmQueryCandidates>> = [];
+  let llmCandidates: Awaited<
+    ReturnType<typeof fetchQueryAnalysisLlmCandidates>
+  > = [];
   try {
-    llmCandidates = await fetchLlmQueryCandidates({
+    llmCandidates = await fetchQueryAnalysisLlmCandidates({
       apiKey: config.openaiApiKey,
       model: openaiModel,
+      brainstormModel,
       maxOutputTokens: maxTokens,
-      messages: [
-        { role: "system", content: systemContent },
-        { role: "user", content: userContent },
-      ],
+      systemContent,
+      userContent,
+      context: queryContext,
+      strategy: strategyPrompt,
+      useBrainstormPass,
+      fewShotExemplarCount,
+      sampling: {
+        temperature,
+        topP,
+        presencePenalty,
+        frequencyPenalty,
+        ...(seed !== undefined ? { seed } : {}),
+      },
     });
   } catch (error) {
     logger.warn(
@@ -115,6 +137,14 @@ export const runQueryAnalysis = async (
     },
     model: openaiModel,
     maxTokens,
+    temperature,
+    topP,
+    presencePenalty,
+    frequencyPenalty,
+    useBrainstormPass,
+    fewShotExemplarCount,
+    ...(useBrainstormPass ? { brainstormModel } : {}),
+    ...(seed !== undefined ? { seed } : {}),
   };
 
   const response = await client.queryAnalysis.create({

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -22,16 +22,16 @@ It uses:
 
 ### GET response fields
 
-| Field | Shape | Notes |
-| ----- | ----- | ----- |
-| `ticker` | `{ id, symbol, name, metadata }` | Anchor company |
-| `topEntities` | `{ canonicalName, typeName, relevanceWeight }[]` | Up to 10 KG entities |
-| `recentThemes` | `{ theme, articleCount }[]` | Recent article-title themes |
-| `recentRelationDeltas` | optional relation delta rows | When present from upstream |
-| `peers` | `{ symbol, name, relevance }[]` | Up to 5 sector/industry siblings from ticker metadata |
-| `calendar` | `{ nextEarningsAt?, recentEventTypes[] }` | `nextEarningsAt` is omitted until a calendar table exists; event types come from recent data-source metadata |
-| `headlineSamples` | `{ title, publishedAt, sourceName }[]` | Up to 5 recent headlines (`publishedAt` uses ingestion time or metadata) |
-| `kgNeighborhood` | `{ fromEntity, relationType, toEntity }[]` | One-hop KG edges for top entities (deduped, capped at 30) |
+| Field                  | Shape                                            | Notes                                                                                                        |
+| ---------------------- | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `ticker`               | `{ id, symbol, name, metadata }`                 | Anchor company                                                                                               |
+| `topEntities`          | `{ canonicalName, typeName, relevanceWeight }[]` | Up to 10 KG entities                                                                                         |
+| `recentThemes`         | `{ theme, articleCount }[]`                      | Recent article-title themes                                                                                  |
+| `recentRelationDeltas` | optional relation delta rows                     | When present from upstream                                                                                   |
+| `peers`                | `{ symbol, name, relevance }[]`                  | Up to 5 sector/industry siblings from ticker metadata                                                        |
+| `calendar`             | `{ nextEarningsAt?, recentEventTypes[] }`        | `nextEarningsAt` is omitted until a calendar table exists; event types come from recent data-source metadata |
+| `headlineSamples`      | `{ title, publishedAt, sourceName }[]`           | Up to 5 recent headlines (`publishedAt` uses ingestion time or metadata)                                     |
+| `kgNeighborhood`       | `{ fromEntity, relationType, toEntity }[]`       | One-hop KG edges for top entities (deduped, capped at 30)                                                    |
 
 Empty fixtures still return the four enriched collections as empty arrays (never omitted keys).
 
@@ -79,9 +79,23 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | `allowedLanguages`                                        | No       | Target languages as BCP-47 codes (default `["en"]`).                                                                                                                                                                                         |
 | `weightBreaking` / `weightKgChange` / `weightFundamental` | No       | Intent mix weights (default `1`, `0.8`, `0.6`).                                                                                                                                                                                              |
 | `maxTokens`                                               | No       | LLM output token budget (default `800`).                                                                                                                                                                                                     |
-| `templatePack`                                            | No       | Deterministic template pack name (default `default-v1`). Set to `rich-v2` for the expanded ~20-template pack. Operators can switch packs via Hermes invoke config without redeploying the agent.                                              |
+| `templatePack`                                            | No       | Deterministic template pack name (default `default-v1`). Set to `rich-v2` for the expanded ~20-template pack. Operators can switch packs via Hermes invoke config without redeploying the agent.                                             |
 | `prompts.systemPrompt`                                    | No       | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
 | `prompts.userPromptTemplate`                              | No       | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context).                                                                                                                         |
+
+### Creativity sampling
+
+LLM query generation uses higher-variance defaults than the AI SDK baseline so operators get lateral phrasing without redeploying. All fields are persisted in the run **`strategySnapshot`** for audit and reproduction.
+
+| Field              | Range    | Default     | Notes                                                                                                       |
+| ------------------ | -------- | ----------- | ----------------------------------------------------------------------------------------------------------- |
+| `temperature`      | `0`–`2`  | `0.9`       | Overall randomness. Raise for more varied phrasing; lower if outputs drift off-topic.                       |
+| `topP`             | `0`–`1`  | `0.95`      | Nucleus sampling cutoff. Usually leave near default unless you are tuning alongside `temperature`.          |
+| `presencePenalty`  | `-2`–`2` | `0.4`       | Pushes the model toward new topics. **Tune this first** when duplicate query angles dominate the LLM pool.  |
+| `frequencyPenalty` | `-2`–`2` | `0.5`       | Reduces repeated tokens. Raise slightly if the model keeps reusing the same words across rows.              |
+| `seed`             | integer  | _(omitted)_ | Fixed seed for reproducible output during regression hunts. Leave unset in production for genuine variance. |
+
+**Tune-up recipe:** If persisted queries feel repetitive, bump `presencePenalty` by `0.1`–`0.2` before touching `temperature`. If phrasing is too wild, lower `temperature` toward `0.7` and keep penalties steady. Set `seed` only when you need bit-for-bit comparison across prompt edits.
 
 ### Weights vs prompt overrides (REQ-010)
 
@@ -96,10 +110,10 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 
 Deterministic queries are built from a named **template pack** before the LLM complement is merged. Set **`templatePack`** in Hermes invoke config to switch packs without redeploying the agent.
 
-| Pack | Templates | Slots used | Example row |
-| ---- | --------- | ------------ | ----------- |
-| **`default-v1`** | 5 | `{symbol}`, `{name}` | `ACME latest news` |
-| **`rich-v2`** | ~20 | `{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, `{currentQuarter}`, `{currentYear}`, `{currentMonth}` | `Acme Co AI impact` |
+| Pack             | Templates | Slots used                                                                                                  | Example row         |
+| ---------------- | --------- | ----------------------------------------------------------------------------------------------------------- | ------------------- |
+| **`default-v1`** | 5         | `{symbol}`, `{name}`                                                                                        | `ACME latest news`  |
+| **`rich-v2`**    | ~20       | `{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, `{currentQuarter}`, `{currentYear}`, `{currentMonth}` | `Acme Co AI impact` |
 
 Templates whose required slots cannot be filled from live GET /query-analysis context are **skipped** (never persisted with literal `{slot}` tokens). For example, `{recentTheme}` templates are omitted when the ticker has no recent themes.
 


### PR DESCRIPTION
## Summary

Adds Hermes-configurable LLM sampling and an optional brainstorm + few-shot path to the query-analysis agent. Sampling fields (temperature, topP, penalties, seed) flow into structured query generation and show up in `strategySnapshot`. Few-shot sector exemplars and a second brainstorm pass are off by default so existing runs behave the same unless you turn them on.

## Related issues

Closes #539

## Important changes

- Config schema: `temperature`, `topP`, `presencePenalty`, `frequencyPenalty`, optional `seed`; defaults tuned for creative query variety
- `fetchQueryAnalysisLlmCandidates` orchestrates optional brainstorm (`generateText`) then structured queries (`generateObject`) with sampling
- `default-exemplars.ts`: four sector archetypes with 6–8 example queries each; `fewShotExemplarCount` caps how many pairs are injected
- `useBrainstormPass` and optional `brainstormModel` for the two-pass flow
- `strategySnapshot` records sampling and brainstorm/few-shot settings

## Other changes

- `.gitignore`: ignore `.cursor/plans`
- Docs: creativity sampling and brainstorm/few-shot sections in query-analysis.mdx

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — new fields, defaults, bounds
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — brainstorm prompt, orchestrator, sampling passthrough
- `apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts` — sector exemplar library
- `apps/mediapulse/agents/query-analysis/src/run.ts` — wires orchestrator and snapshot
- `apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts` — two-pass vs single-pass, sampling assertions

## How to test

1. `pnpm --filter @mediapulse/query-analysis test` — expect 66 passing tests
2. `pnpm --filter @mediapulse/query-analysis type:check`
3. With defaults unchanged, confirm a run still uses single-pass structured generation
4. Set `useBrainstormPass: true` in agent config and verify brainstorm bullets appear in the structured prompt path (see `llm-queries.test.ts` for mock patterns)
