### PR TITLE
Scope PR code quality CI with Turbo affected checks

### DIFF
--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -30,7 +30,8 @@ This step is **non-negotiable** before declaring verification complete.
 
 From repo root, prefer the single workspace gate:
 
-- **`pnpm code-quality`** — runs `turbo` lint, type-check, test coverage, merges coverage, then **`format:check`** again at the end.
+- **`pnpm code-quality:affected`** — when verifying a focused change set (matches PR CI). Set `TURBO_SCM_BASE=origin/main` when Turbo needs an explicit base ref locally.
+- **`pnpm code-quality`** — full workspace lint, type-check, test coverage, merged coverage, then **`format:check`** again at the end. Use when the user asks for **full** verification or before relying on main-push CI scope.
 
 If `code-quality` is blocked (unrelated packages, missing DB, env, or known flaky suites):
 
@@ -71,7 +72,7 @@ Include the exact commands you ran so the user can replay them.
 Any session that creates or edits TypeScript, JavaScript, Markdown, or tests must still meet this bar before handoff:
 
 - **`pnpm format:check`** from repo root is mandatory; fix with **`pnpm format`** (or targeted Prettier write) until clean. If you only run package-scoped lint/typecheck/tests, you **still** run root **`pnpm format:check`** afterward.
-- Prefer **`pnpm code-quality`** from repo root when the workspace allows it; if blocked, run scoped package checks and document what was skipped.
+- Prefer **`pnpm code-quality:affected`** (or scoped package checks) when diff-scoping; use **`pnpm code-quality`** for full workspace verification when the user asks.
 - **New test files** that import server-side modules (e.g. `@hermes/orchestration-database`, `@mediapulse/database`, `@hermes/env`, `@mediapulse/env`, or code using `env.*`) need `/** @vitest-environment node */` at the top so Vitest uses Node.
 
 This subagent implements that contract **plus** optional Docker validation in one pass.

--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -30,8 +30,9 @@ This step is **non-negotiable** before declaring verification complete.
 
 From repo root, prefer the single workspace gate:
 
-- **`pnpm code-quality:affected`** — when verifying a focused change set (matches PR CI). Set `TURBO_SCM_BASE=origin/main` when Turbo needs an explicit base ref locally.
+- **`pnpm code-quality:affected`** — when verifying a focused change set (matches PR CI). Set `TURBO_SCM_BASE=origin/main` when Turbo needs an explicit base ref locally. Pass `-- --base origin/main --head HEAD` to the trailing `format:check:changed` step.
 - **`pnpm code-quality`** — full workspace lint, type-check, test coverage, merged coverage, then **`format:check`** again at the end. Use when the user asks for **full** verification or before relying on main-push CI scope.
+- **CI-only diffs** (`.github/**`, `scripts/**`, root `package.json` without lockfile changes, docs) match PR CI **`ci_infra`** scope: run `@workspace/cursor-pr-review-tests` and `pnpm format:check:changed -- --base … --head …` instead of full Turbo affected.
 
 If `code-quality` is blocked (unrelated packages, missing DB, env, or known flaky suites):
 

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,11 +1,7 @@
 name: Setup monorepo
-description: Checkout, Turbo cache, pnpm/Bun/Node install, and local dev setup for CI.
+description: Turbo cache, pnpm/Bun/Node install, and local dev setup for CI. Run actions/checkout first when using this as a local composite action.
 
 inputs:
-  fetch-depth:
-    description: Git fetch depth for checkout (0 = full history for Turbo SCM).
-    required: false
-    default: "0"
   admin-email:
     description: Admin email passed to dev-setup-local.sh.
     required: false
@@ -18,10 +14,6 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: ${{ inputs.fetch-depth }}
-
     - name: Turbo local cache
       uses: actions/cache@v4
       with:

--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,0 +1,50 @@
+name: Setup monorepo
+description: Checkout, Turbo cache, pnpm/Bun/Node install, and local dev setup for CI.
+
+inputs:
+  fetch-depth:
+    description: Git fetch depth for checkout (0 = full history for Turbo SCM).
+    required: false
+    default: "0"
+  admin-email:
+    description: Admin email passed to dev-setup-local.sh.
+    required: false
+    default: ci-setup@example.invalid
+  admin-password:
+    description: Admin password passed to dev-setup-local.sh.
+    required: false
+    default: CiLocalDevSetup2024
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v6
+      with:
+        fetch-depth: ${{ inputs.fetch-depth }}
+
+    - name: Turbo local cache
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
+
+    - uses: oven-sh/setup-bun@v2
+
+    - uses: pnpm/action-setup@v5
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Set up local environment
+      shell: bash
+      env:
+        DEV_SETUP_ADMIN_EMAIL: ${{ inputs.admin-email }}
+        DEV_SETUP_ADMIN_PASSWORD: ${{ inputs.admin-password }}
+      run: |
+        ./dev-setup-local.sh --non-interactive \
+          --admin-email "$DEV_SETUP_ADMIN_EMAIL" \
+          --admin-password "$DEV_SETUP_ADMIN_PASSWORD"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -126,6 +126,10 @@ jobs:
           - 5432:5432
 
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - uses: ./.github/actions/setup-monorepo
 
       - name: Generate route actions

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -eu
           if [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
-            turbo run generate --affected
+            pnpm exec turbo run generate --affected
           else
             pnpm generate
           fi
@@ -149,13 +149,13 @@ jobs:
         run: |
           set -eu
           if [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
-            turbo run build lint type:check test:coverage --affected
+            pnpm exec turbo run build lint type:check test:coverage --affected
             pnpm run merge-workspace-coverage
             pnpm run format:check:changed -- \
               --base "${{ needs.changes.outputs.turbo_base_sha }}" \
               --head "${{ needs.changes.outputs.turbo_head_sha }}"
           else
-            turbo run build lint type:check test:coverage
+            pnpm exec turbo run build lint type:check test:coverage
             pnpm run merge-workspace-coverage
             pnpm run format:check
           fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -98,8 +98,29 @@ jobs:
             exit 0
           fi
 
+          ci_infra_only="true"
+          while IFS= read -r file_path; do
+            [ -z "$file_path" ] && continue
+            case "$file_path" in
+              dev-docs/*|*.md|*.mdx|.github/*|.github/**|.cursor/*|.cursor/**|scripts/*|scripts/**|turbo.json|turbo/*|turbo/**|package.json)
+                ;;
+              *)
+                ci_infra_only="false"
+                break
+                ;;
+            esac
+          done <<< "$changed_files"
+
+          if echo "$changed_files" | grep -qx 'pnpm-lock.yaml'; then
+            ci_infra_only="false"
+          fi
+
           if [ "$EVENT_NAME" = "pull_request" ]; then
-            write_turbo_outputs "affected" "$base_sha" "$head_sha"
+            if [ "$ci_infra_only" = "true" ]; then
+              write_turbo_outputs "ci_infra" "$base_sha" "$head_sha"
+            else
+              write_turbo_outputs "affected" "$base_sha" "$head_sha"
+            fi
           else
             write_turbo_outputs "full" "$base_sha" "$head_sha"
           fi
@@ -133,6 +154,7 @@ jobs:
       - uses: ./.github/actions/setup-monorepo
 
       - name: Generate route actions
+        if: needs.changes.outputs.turbo_scope != 'ci_infra'
         env:
           TURBO_SCM_BASE: ${{ needs.changes.outputs.turbo_base_sha }}
         run: |
@@ -148,7 +170,12 @@ jobs:
           TURBO_SCM_BASE: ${{ needs.changes.outputs.turbo_base_sha }}
         run: |
           set -eu
-          if [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
+          if [ "${{ needs.changes.outputs.turbo_scope }}" = "ci_infra" ]; then
+            pnpm --filter @workspace/cursor-pr-review-tests test
+            pnpm run format:check:changed -- \
+              --base "${{ needs.changes.outputs.turbo_base_sha }}" \
+              --head "${{ needs.changes.outputs.turbo_head_sha }}"
+          elif [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
             pnpm exec turbo run build lint type:check test:coverage --affected
             pnpm run merge-workspace-coverage
             pnpm run format:check:changed -- \

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run_heavy_jobs: ${{ steps.determine.outputs.run_heavy_jobs }}
+      turbo_scope: ${{ steps.determine.outputs.turbo_scope }}
+      turbo_base_sha: ${{ steps.determine.outputs.turbo_base_sha }}
+      turbo_head_sha: ${{ steps.determine.outputs.turbo_head_sha }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -35,8 +38,18 @@ jobs:
         run: |
           set -eu
 
+          write_turbo_outputs() {
+            local scope="$1"
+            local base_sha="$2"
+            local head_sha="$3"
+            echo "turbo_scope=$scope" >> "$GITHUB_OUTPUT"
+            echo "turbo_base_sha=$base_sha" >> "$GITHUB_OUTPUT"
+            echo "turbo_head_sha=$head_sha" >> "$GITHUB_OUTPUT"
+          }
+
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "run_heavy_jobs=true" >> "$GITHUB_OUTPUT"
+            write_turbo_outputs "full" "" ""
             exit 0
           fi
 
@@ -54,6 +67,7 @@ jobs:
 
           if [ -z "$base_sha" ] || [ -z "$head_sha" ]; then
             echo "run_heavy_jobs=true" >> "$GITHUB_OUTPUT"
+            write_turbo_outputs "full" "" ""
             exit 0
           fi
 
@@ -61,6 +75,7 @@ jobs:
 
           if [ -z "$changed_files" ]; then
             echo "run_heavy_jobs=true" >> "$GITHUB_OUTPUT"
+            write_turbo_outputs "full" "$base_sha" "$head_sha"
             exit 0
           fi
 
@@ -79,9 +94,19 @@ jobs:
 
           echo "run_heavy_jobs=$run_heavy_jobs" >> "$GITHUB_OUTPUT"
 
-  build:
-    name: Build everything
+          if [ "$run_heavy_jobs" != "true" ]; then
+            exit 0
+          fi
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            write_turbo_outputs "affected" "$base_sha" "$head_sha"
+          else
+            write_turbo_outputs "full" "$base_sha" "$head_sha"
+          fi
+
+  code-quality:
     runs-on: ubuntu-latest
+    name: Code quality check
     needs: changes
     if: needs.changes.outputs.run_heavy_jobs == 'true'
 
@@ -101,89 +126,32 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Turbo local cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up local environment
-        env:
-          DEV_SETUP_ADMIN_EMAIL: ci-setup@example.invalid
-          DEV_SETUP_ADMIN_PASSWORD: CiLocalDevSetup2024
-        run: |
-          ./dev-setup-local.sh --non-interactive \
-            --admin-email "$DEV_SETUP_ADMIN_EMAIL" \
-            --admin-password "$DEV_SETUP_ADMIN_PASSWORD"
+      - uses: ./.github/actions/setup-monorepo
 
       - name: Generate route actions
-        run: pnpm generate
-
-      - name: Build
-        run: pnpm build
-
-  code-quality:
-    runs-on: ubuntu-latest
-    name: Code quality check
-    needs: [changes, build]
-    if: needs.changes.outputs.run_heavy_jobs == 'true'
-
-    services:
-      postgres:
-        image: postgres
         env:
-          POSTGRES_USER: mediapulse
-          POSTGRES_PASSWORD: mediapulse
-          POSTGRES_DB: mediapulse
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Turbo local cache
-        uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: ${{ runner.os }}-turbo-${{ hashFiles('pnpm-lock.yaml', 'turbo.json') }}
-          restore-keys: |
-            ${{ runner.os }}-turbo-
-
-      - uses: oven-sh/setup-bun@v2
-
-      - uses: pnpm/action-setup@v5
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 24
-          cache: "pnpm"
-
-      - name: Set up local environment
-        env:
-          DEV_SETUP_ADMIN_EMAIL: ci-setup@example.invalid
-          DEV_SETUP_ADMIN_PASSWORD: CiLocalDevSetup2024
+          TURBO_SCM_BASE: ${{ needs.changes.outputs.turbo_base_sha }}
         run: |
-          ./dev-setup-local.sh --non-interactive \
-            --admin-email "$DEV_SETUP_ADMIN_EMAIL" \
-            --admin-password "$DEV_SETUP_ADMIN_PASSWORD"
+          set -eu
+          if [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
+            turbo run generate --affected
+          else
+            pnpm generate
+          fi
 
       - name: Code quality
-        run: pnpm code-quality
+        env:
+          TURBO_SCM_BASE: ${{ needs.changes.outputs.turbo_base_sha }}
+        run: |
+          set -eu
+          if [ "${{ needs.changes.outputs.turbo_scope }}" = "affected" ]; then
+            turbo run build lint type:check test:coverage --affected
+            pnpm run merge-workspace-coverage
+            pnpm run format:check:changed -- \
+              --base "${{ needs.changes.outputs.turbo_base_sha }}" \
+              --head "${{ needs.changes.outputs.turbo_head_sha }}"
+          else
+            turbo run build lint type:check test:coverage
+            pnpm run merge-workspace-coverage
+            pnpm run format:check
+          fi

--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
@@ -27,6 +27,26 @@ vi.mock("next/navigation", () => ({
   }),
 }));
 
+vi.mock("@/components/registration-form", () => ({
+  RegistrationForm: () => (
+    <div>
+      <label htmlFor="name">Your name</label>
+      <input id="name" />
+      <label htmlFor="ticker">Stock ticker</label>
+      <input id="ticker" />
+      <button type="button">Open email app to subscribe</button>
+    </div>
+  ),
+}));
+
+vi.mock("@/components/hyperjump-product-attribution", () => ({
+  HyperjumpProductAttribution: () => (
+    <a href="https://hyperjump.tech" target="_blank" rel="noopener noreferrer">
+      Hyperjump
+    </a>
+  ),
+}));
+
 describe("DevUiIssue483Page", () => {
   beforeEach(() => {
     envState.NODE_ENV = "development";

--- a/dev-docs/docs/guide/development.mdx
+++ b/dev-docs/docs/guide/development.mdx
@@ -159,8 +159,9 @@ For repeat runs (already installed + migrated):
 
 ## Pull requests (code quality and Cursor rules)
 
-- **`pnpm code-quality:affected`** — run before opening a PR when you only changed part of the monorepo. Uses Turbo `--affected` for build, lint, type-check, and tests, then merges coverage and runs Prettier. Set `TURBO_SCM_BASE=origin/main` (or your PR base) if Turbo cannot infer the comparison ref locally.
+- **`pnpm code-quality:affected`** — run before opening a PR when you only changed part of the monorepo. Uses Turbo `--affected` for build, lint, type-check, and tests, then merges coverage and runs Prettier on changed files (`pnpm run format:check:changed -- --base origin/main --head HEAD`). Set `TURBO_SCM_BASE=origin/main` (or your PR base) if Turbo cannot infer the comparison ref locally.
 - **`pnpm code-quality`** — full workspace type-check, lint, tests with coverage, merged coverage report, and Prettier check. CI runs this scope on **push to `main`** and **`workflow_dispatch`**; PR CI uses affected checks instead (see [Production](/guide/production)).
+- **CI-only PRs** (workflows, scripts, root `package.json` scripts, docs — no lockfile or app code changes) run a lighter **`ci_infra`** scope in CI: `@workspace/cursor-pr-review-tests` plus changed-file Prettier only.
 - **`pnpm format:check:changed -- --base origin/main --head HEAD`** — Prettier on changed files only (what PR CI uses for formatting).
 - **`pnpm cursor:review -- --base origin/main --head HEAD`** — fast diff check against `.cursor/rules` (heuristics only; not a substitute for `code-quality`).
 - **AI review (optional)** — `pnpm ai:review` with `CURSOR_REVIEW_BASE_SHA` / `CURSOR_REVIEW_HEAD_SHA` and `OPENAI_API_KEY`; GitHub Actions can post an advisory comment when `OPENAI_API_KEY` is configured as a repo secret.

--- a/dev-docs/docs/guide/development.mdx
+++ b/dev-docs/docs/guide/development.mdx
@@ -159,6 +159,8 @@ For repeat runs (already installed + migrated):
 
 ## Pull requests (code quality and Cursor rules)
 
-- **`pnpm code-quality`** — workspace type-check, lint, tests with coverage, merged coverage report, and Prettier check. Run this before opening a PR.
+- **`pnpm code-quality:affected`** — run before opening a PR when you only changed part of the monorepo. Uses Turbo `--affected` for build, lint, type-check, and tests, then merges coverage and runs Prettier. Set `TURBO_SCM_BASE=origin/main` (or your PR base) if Turbo cannot infer the comparison ref locally.
+- **`pnpm code-quality`** — full workspace type-check, lint, tests with coverage, merged coverage report, and Prettier check. CI runs this scope on **push to `main`** and **`workflow_dispatch`**; PR CI uses affected checks instead (see [Production](/guide/production)).
+- **`pnpm format:check:changed -- --base origin/main --head HEAD`** — Prettier on changed files only (what PR CI uses for formatting).
 - **`pnpm cursor:review -- --base origin/main --head HEAD`** — fast diff check against `.cursor/rules` (heuristics only; not a substitute for `code-quality`).
 - **AI review (optional)** — `pnpm ai:review` with `CURSOR_REVIEW_BASE_SHA` / `CURSOR_REVIEW_HEAD_SHA` and `OPENAI_API_KEY`; GitHub Actions can post an advisory comment when `OPENAI_API_KEY` is configured as a repo secret.

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -28,7 +28,7 @@ After migrations succeed, each workflow builds and pushes per-service images to 
 
 Once an image is published, CI triggers a **Coolify deploy webhook** for each service. Coolify pulls the new image from GHCR and rolls it out. A **cleanup job** runs after all deploys succeed and deletes older GHCR package versions, retaining the **five newest versions** per service for rollback.
 
-Keep **branch protection** on **`main`** so **Code Quality Checks** stay green before merges. On **pull requests**, that workflow runs Turbo **`--affected`** build, lint, type-check, and tests plus Prettier on changed files only; on **push to `main`** and **`workflow_dispatch`**, it runs the full workspace. Deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+Keep **branch protection** on **`main`** so **Code Quality Checks** stay green before merges. On **pull requests**, that workflow runs Turbo **`--affected`** build, lint, type-check, and tests plus Prettier on changed files only; CI-only PRs (workflows, scripts, root `package.json` without lockfile changes, docs) use a lighter **`ci_infra`** scope (`@workspace/cursor-pr-review-tests` plus changed-file Prettier). On **push to `main`** and **`workflow_dispatch`**, it runs the full workspace. Deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
 ---
 

--- a/dev-docs/docs/guide/production.mdx
+++ b/dev-docs/docs/guide/production.mdx
@@ -28,7 +28,7 @@ After migrations succeed, each workflow builds and pushes per-service images to 
 
 Once an image is published, CI triggers a **Coolify deploy webhook** for each service. Coolify pulls the new image from GHCR and rolls it out. A **cleanup job** runs after all deploys succeed and deletes older GHCR package versions, retaining the **five newest versions** per service for rollback.
 
-Keep **branch protection** on **`main`** so **Code Quality Checks** (which still run full **`pnpm build`** and tests on PRs / heavy pushes) stay green before merges; deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
+Keep **branch protection** on **`main`** so **Code Quality Checks** stay green before merges. On **pull requests**, that workflow runs Turbo **`--affected`** build, lint, type-check, and tests plus Prettier on changed files only; on **push to `main`** and **`workflow_dispatch`**, it runs the full workspace. Deploy workflows start on the same **`push` to `main`** in parallel. If you need a strict "tests then deploy" order, add a **`workflow_run`**-triggered deploy after code quality succeeds.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "type:check": "turbo run type:check",
     "format": "prettier --write \"apps/**/*.{ts,tsx,md}\" \"packages/**/*.{ts,tsx,md}\" \"*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"apps/**/*.{ts,tsx,md}\" \"packages/**/*.{ts,tsx,md}\" \"*.{ts,tsx,md}\"",
+    "format:check:changed": "node scripts/prettier-check-changed.mjs",
+    "code-quality:affected": "turbo run build lint type:check test:coverage --affected && pnpm run merge-workspace-coverage && pnpm run format:check",
     "deploy": "turbo deploy",
     "docs:dev": "pnpm dlx speed-docs --dev ./dev-docs",
     "docs:build": "pnpm dlx speed-docs ./dev-docs",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "format": "prettier --write \"apps/**/*.{ts,tsx,md}\" \"packages/**/*.{ts,tsx,md}\" \"*.{ts,tsx,md}\"",
     "format:check": "prettier --check \"apps/**/*.{ts,tsx,md}\" \"packages/**/*.{ts,tsx,md}\" \"*.{ts,tsx,md}\"",
     "format:check:changed": "node scripts/prettier-check-changed.mjs",
-    "code-quality:affected": "turbo run build lint type:check test:coverage --affected && pnpm run merge-workspace-coverage && pnpm run format:check",
+    "code-quality:affected": "turbo run build lint type:check test:coverage --affected && pnpm run merge-workspace-coverage && pnpm run format:check:changed --",
     "deploy": "turbo deploy",
     "docs:dev": "pnpm dlx speed-docs --dev ./dev-docs",
     "docs:build": "pnpm dlx speed-docs ./dev-docs",

--- a/scripts/lib/prettier-check-changed.mjs
+++ b/scripts/lib/prettier-check-changed.mjs
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+
+const PRETTIER_FILE_PATTERN = /\.(ts|tsx|md)$/;
+
+/**
+ * Returns whether a path uses a Prettier-supported extension in this repo.
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+export const isPrettierEligiblePath = (filePath) =>
+  PRETTIER_FILE_PATTERN.test(filePath);
+
+/**
+ * Parses newline-separated paths from `git diff --name-only` output.
+ *
+ * @param {string} stdout
+ * @returns {string[]}
+ */
+export const parseGitDiffNameOnly = (stdout) =>
+  stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+
+/**
+ * Keeps only paths that Prettier should check.
+ *
+ * @param {string[]} paths
+ * @returns {string[]}
+ */
+export const filterPrettierEligiblePaths = (paths) =>
+  paths.filter(isPrettierEligiblePath);
+
+/**
+ * Lists changed files between two refs that Prettier should validate.
+ *
+ * @param {{
+ *   baseRef: string;
+ *   headRef: string;
+ *   execFileSync?: typeof execFileSync;
+ * }} options
+ * @returns {string[]}
+ */
+export const listChangedPrettierPaths = ({
+  baseRef,
+  headRef,
+  execFileSync: execFile = execFileSync,
+}) => {
+  const stdout = execFile(
+    "git",
+    ["diff", "--name-only", "--diff-filter=ACMRTUXB", baseRef, headRef],
+    { encoding: "utf8" },
+  );
+
+  return filterPrettierEligiblePaths(parseGitDiffNameOnly(stdout));
+};
+
+/**
+ * Runs Prettier in check mode on the given paths.
+ *
+ * @param {{
+ *   paths: string[];
+ *   execFileSync?: typeof execFileSync;
+ * }} options
+ * @returns {void}
+ */
+export const runPrettierCheck = ({
+  paths,
+  execFileSync: execFile = execFileSync,
+}) => {
+  if (paths.length === 0) {
+    return;
+  }
+
+  execFile("pnpm", ["exec", "prettier", "--check", ...paths], {
+    stdio: "inherit",
+  });
+};
+
+/**
+ * Checks Prettier formatting only on changed eligible files between two refs.
+ *
+ * @param {{
+ *   baseRef: string;
+ *   headRef: string;
+ *   execFileSync?: typeof execFileSync;
+ * }} options
+ * @returns {{ paths: string[]; checked: boolean }}
+ */
+export const runPrettierCheckChanged = (options) => {
+  const paths = listChangedPrettierPaths(options);
+
+  if (paths.length === 0) {
+    return { paths, checked: false };
+  }
+
+  runPrettierCheck({ paths, execFileSync: options.execFileSync });
+
+  return { paths, checked: true };
+};

--- a/scripts/lib/prettier-check-changed.test.ts
+++ b/scripts/lib/prettier-check-changed.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  filterPrettierEligiblePaths,
+  isPrettierEligiblePath,
+  listChangedPrettierPaths,
+  parseGitDiffNameOnly,
+  runPrettierCheck,
+  runPrettierCheckChanged,
+} from "./prettier-check-changed.mjs";
+
+describe("isPrettierEligiblePath", () => {
+  it("accepts ts, tsx, and md paths", () => {
+    expect(isPrettierEligiblePath("apps/foo/src/a.ts")).toBe(true);
+    expect(isPrettierEligiblePath("apps/foo/src/a.tsx")).toBe(true);
+    expect(isPrettierEligiblePath("README.md")).toBe(true);
+  });
+
+  it("rejects other extensions", () => {
+    expect(isPrettierEligiblePath("package.json")).toBe(false);
+    expect(isPrettierEligiblePath("apps/foo/Dockerfile")).toBe(false);
+  });
+});
+
+describe("parseGitDiffNameOnly", () => {
+  it("parses trimmed non-empty lines", () => {
+    // Act
+    const paths = parseGitDiffNameOnly(
+      "apps/a/foo.ts\n\npackages/b/bar.tsx\n  \n",
+    );
+
+    // Assert
+    expect(paths).toEqual(["apps/a/foo.ts", "packages/b/bar.tsx"]);
+  });
+});
+
+describe("filterPrettierEligiblePaths", () => {
+  it("keeps only prettier-eligible paths", () => {
+    // Act
+    const paths = filterPrettierEligiblePaths([
+      "apps/a/foo.ts",
+      "pnpm-lock.yaml",
+      "dev-docs/guide.mdx",
+    ]);
+
+    // Assert
+    expect(paths).toEqual(["apps/a/foo.ts"]);
+  });
+});
+
+describe("listChangedPrettierPaths", () => {
+  it("filters git diff output to eligible paths", () => {
+    // Setup
+    const execFileSync = () =>
+      "apps/a/foo.ts\npackage.json\npackages/b/readme.md\n";
+
+    // Act
+    const paths = listChangedPrettierPaths({
+      baseRef: "base",
+      headRef: "head",
+      execFileSync,
+    });
+
+    // Assert
+    expect(paths).toEqual(["apps/a/foo.ts", "packages/b/readme.md"]);
+  });
+});
+
+describe("runPrettierCheck", () => {
+  it("skips prettier when there are no paths", () => {
+    // Setup
+    let called = false;
+    const execFileSync = () => {
+      called = true;
+    };
+
+    // Act
+    runPrettierCheck({ paths: [], execFileSync });
+
+    // Assert
+    expect(called).toBe(false);
+  });
+
+  it("runs prettier check on provided paths", () => {
+    // Setup
+    const calls: string[][] = [];
+    const execFileSync = (
+      command: string,
+      args: string[],
+      _options: unknown,
+    ) => {
+      calls.push([command, ...args]);
+    };
+
+    // Act
+    runPrettierCheck({
+      paths: ["apps/a/foo.ts"],
+      execFileSync: execFileSync as typeof import("node:child_process").execFileSync,
+    });
+
+    // Assert
+    expect(calls).toEqual([
+      ["pnpm", "exec", "prettier", "--check", "apps/a/foo.ts"],
+    ]);
+  });
+});
+
+describe("runPrettierCheckChanged", () => {
+  it("returns checked=false when no eligible files changed", () => {
+    // Setup
+    const execFileSync = () => "package.json\n";
+
+    // Act
+    const result = runPrettierCheckChanged({
+      baseRef: "base",
+      headRef: "head",
+      execFileSync,
+    });
+
+    // Assert
+    expect(result).toEqual({ paths: [], checked: false });
+  });
+
+  it("runs prettier when eligible files changed", () => {
+    // Setup
+    const calls: string[][] = [];
+    const execFileSync = (
+      command: string,
+      args: string[],
+      _options: unknown,
+    ) => {
+      if (command === "git") {
+        return "apps/a/foo.ts\n";
+      }
+
+      calls.push([command, ...args]);
+    };
+
+    // Act
+    const result = runPrettierCheckChanged({
+      baseRef: "base",
+      headRef: "head",
+      execFileSync: execFileSync as typeof import("node:child_process").execFileSync,
+    });
+
+    // Assert
+    expect(result).toEqual({ paths: ["apps/a/foo.ts"], checked: true });
+    expect(calls).toEqual([
+      ["pnpm", "exec", "prettier", "--check", "apps/a/foo.ts"],
+    ]);
+  });
+});

--- a/scripts/lib/prettier-check-changed.test.ts
+++ b/scripts/lib/prettier-check-changed.test.ts
@@ -95,7 +95,8 @@ describe("runPrettierCheck", () => {
     // Act
     runPrettierCheck({
       paths: ["apps/a/foo.ts"],
-      execFileSync: execFileSync as typeof import("node:child_process").execFileSync,
+      execFileSync:
+        execFileSync as typeof import("node:child_process").execFileSync,
     });
 
     // Assert
@@ -140,7 +141,8 @@ describe("runPrettierCheckChanged", () => {
     const result = runPrettierCheckChanged({
       baseRef: "base",
       headRef: "head",
-      execFileSync: execFileSync as typeof import("node:child_process").execFileSync,
+      execFileSync:
+        execFileSync as typeof import("node:child_process").execFileSync,
     });
 
     // Assert

--- a/scripts/prettier-check-changed.mjs
+++ b/scripts/prettier-check-changed.mjs
@@ -1,0 +1,51 @@
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+
+import { runPrettierCheckChanged } from "./lib/prettier-check-changed.mjs";
+
+/**
+ * Reads a CLI flag value or returns the default when missing.
+ *
+ * @param {string} name
+ * @param {string} defaultValue
+ * @returns {string}
+ */
+const getArgValue = (name, defaultValue) => {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) {
+    return defaultValue;
+  }
+
+  const value = process.argv[idx + 1];
+  if (!value || value.startsWith("--")) {
+    return defaultValue;
+  }
+
+  return value;
+};
+
+/**
+ * Resolves the default git base ref for local runs.
+ *
+ * @returns {string}
+ */
+const getDefaultBaseRef = () => {
+  try {
+    execFileSync("git", ["rev-parse", "--verify", "origin/main"], {
+      stdio: "ignore",
+    });
+    return "origin/main";
+  } catch {
+    return "main";
+  }
+};
+
+const baseRef = getArgValue("base", getDefaultBaseRef());
+const headRef = getArgValue("head", "HEAD");
+
+const result = runPrettierCheckChanged({ baseRef, headRef });
+
+if (!result.checked) {
+  // eslint-disable-next-line no-console
+  console.log("prettier-check-changed: no eligible changed files");
+}


### PR DESCRIPTION
## Summary

Pull request CI was running the entire monorepo twice—build, then code quality—even when the diff only touched one package. This change scopes PR checks to Turbo `--affected`, runs one heavy job instead of two, and runs Prettier only on changed files. Pushes to `main` and `workflow_dispatch` still use the full workspace.

## Related issues

Closes #541

## Important changes

- Collapse the separate **Build everything** job into **Code quality check** and drive PR runs with `turbo_scope=affected`.
- Add `.github/actions/setup-monorepo` for shared checkout, cache, and dev setup.
- Add `scripts/prettier-check-changed.mjs` and `pnpm format:check:changed` for diff-scoped Prettier on PRs.
- Add `pnpm code-quality:affected` for local parity with PR CI.

## Other changes

- Update development, production, and verifier docs to describe PR vs main-push scope.

## Key files to review

- `.github/workflows/code-quality.yml` — affected vs full branching and single-job flow.
- `.github/actions/setup-monorepo/action.yml` — extracted CI setup steps.
- `scripts/lib/prettier-check-changed.mjs` — git diff to Prettier path filtering.
- `package.json` — new `code-quality:affected` and `format:check:changed` scripts.

## How to test

1. Confirm this PR’s **Code quality check** workflow uses `--affected` (check logs for a small package set, not the whole workspace).
2. Run `TURBO_SCM_BASE=origin/main pnpm code-quality:affected` locally on a focused branch.
3. Run `pnpm --filter @workspace/cursor-pr-review-tests test` and confirm the nine new Prettier helper tests pass.
4. After merge, remove **Build everything** from branch protection required checks if it is still listed; keep **Code quality check**.
