### PR TITLE
Add query-analysis personas, intents, critique, semantic dedupe, and diversity gate

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -1,8 +1,12 @@
 /** @vitest-environment node */
-
 import { describe, expect, it } from "vitest";
 
-import { queryAnalysisConfigSchema } from "./config-schema";
+import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
+
+import {
+  queryAnalysisConfigSchema,
+  resolveIntentWeights,
+} from "./config-schema";
 import { QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH } from "./query-analysis-prompt-defaults";
 
 const minimal = { openaiApiKey: "sk-test" } satisfies Parameters<
@@ -23,12 +27,57 @@ describe("queryAnalysisConfigSchema templatePack", () => {
     expect(parsed.templatePack).toBe("rich-v2");
   });
 
+  it("accepts rich-v2-extended template pack", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      templatePack: "rich-v2-extended",
+    });
+    expect(parsed.templatePack).toBe("rich-v2-extended");
+  });
+
   it("rejects unknown template pack names", () => {
     const result = queryAnalysisConfigSchema.safeParse({
       ...minimal,
       templatePack: "unknown",
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("resolveIntentWeights", () => {
+  it("returns defaults when neither intentWeights nor legacy fields are overridden", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(resolveIntentWeights(parsed)).toEqual(
+      DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+    );
+  });
+
+  it("lifts legacy weightBreaking fields when intentWeights is absent", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      weightBreaking: 2,
+      weightKgChange: 1.5,
+      weightFundamental: 0.25,
+    });
+    expect(resolveIntentWeights(parsed)).toMatchObject({
+      breaking: 2,
+      kg_change: 1.5,
+      fundamental: 0.25,
+      esg: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.esg,
+    });
+  });
+
+  it("prefers intentWeights when explicitly provided", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      intentWeights: { esg: 0.9, technical: 0.2 },
+      weightBreaking: 99,
+    });
+    expect(resolveIntentWeights(parsed)).toMatchObject({
+      breaking: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.breaking,
+      esg: 0.9,
+      technical: 0.2,
+    });
   });
 });
 
@@ -66,15 +115,16 @@ describe("queryAnalysisConfigSchema prompts", () => {
     expect(result.success).toBe(false);
   });
 
-  it("accepts valid prompt placeholders", () => {
+  it("accepts valid prompt placeholders including expanded intent counts", () => {
     const parsed = queryAnalysisConfigSchema.parse({
       ...minimal,
       prompts: {
-        systemPrompt: "L: {{allowedLanguages}} B:{{targetBreakingCount}}",
+        systemPrompt:
+          "L: {{allowedLanguages}} B:{{targetBreakingCount}} E:{{targetEsgCount}}",
         userPromptTemplate: "CTX:\n{{queryContextBlock}}",
       },
     });
-    expect(parsed.prompts?.systemPrompt).toContain("allowedLanguages");
+    expect(parsed.prompts?.systemPrompt).toContain("targetEsgCount");
   });
 });
 
@@ -156,5 +206,123 @@ describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
       fewShotExemplarCount: 7,
     });
     expect(result.success).toBe(false);
+  });
+});
+
+describe("queryAnalysisConfigSchema personas", () => {
+  it("defaults personas and perPersonaQuotaCount", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.personas).toEqual(["analyst", "retail", "regulator"]);
+    expect(parsed.perPersonaQuotaCount).toBe(3);
+  });
+
+  it("accepts persona overrides", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      personas: ["esg", "short_seller"],
+      perPersonaQuotaCount: 2,
+    });
+    expect(parsed.personas).toEqual(["esg", "short_seller"]);
+    expect(parsed.perPersonaQuotaCount).toBe(2);
+  });
+});
+
+describe("queryAnalysisConfigSchema self-critique", () => {
+  it("defaults useSelfCritique to false and critiqueDropFraction to 0.25", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.useSelfCritique).toBe(false);
+    expect(parsed.critiqueDropFraction).toBe(0.25);
+    expect(parsed.critiqueModel).toBeUndefined();
+  });
+
+  it("accepts self-critique overrides", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      useSelfCritique: true,
+      critiqueDropFraction: 0.2,
+      critiqueModel: "gpt-4o",
+    });
+    expect(parsed.useSelfCritique).toBe(true);
+    expect(parsed.critiqueDropFraction).toBe(0.2);
+    expect(parsed.critiqueModel).toBe("gpt-4o");
+  });
+
+  it("rejects critiqueDropFraction above 0.5", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      critiqueDropFraction: 0.6,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("queryAnalysisConfigSchema semanticDedupe", () => {
+  it("defaults semantic dedupe to disabled when omitted", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.semanticDedupe).toBeUndefined();
+  });
+
+  it("accepts semantic dedupe overrides", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      semanticDedupe: {
+        enabled: true,
+        threshold: 0.9,
+        embeddingModel: "text-embedding-3-large",
+      },
+    });
+    expect(parsed.semanticDedupe?.enabled).toBe(true);
+    expect(parsed.semanticDedupe?.threshold).toBe(0.9);
+    expect(parsed.semanticDedupe?.embeddingModel).toBe(
+      "text-embedding-3-large",
+    );
+  });
+
+  it("rejects semantic dedupe threshold above 1", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      semanticDedupe: { enabled: true, threshold: 1.1 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("queryAnalysisConfigSchema diversityGate", () => {
+  it("defaults diversity gate to disabled when omitted", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.diversityGate).toBeUndefined();
+  });
+
+  it("accepts diversity gate overrides", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      diversityGate: {
+        enabled: true,
+        threshold: 0.75,
+        weights: { lexical: 0.5, intent: 0.25, semantic: 0.25 },
+      },
+    });
+    expect(parsed.diversityGate?.enabled).toBe(true);
+    expect(parsed.diversityGate?.threshold).toBe(0.75);
+    expect(parsed.diversityGate?.weights?.lexical).toBe(0.5);
+  });
+
+  it("rejects diversity gate threshold above 1", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      diversityGate: { enabled: true, threshold: 1.2 },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("resolveDiversityGateConfig", () => {
+  it("returns schema defaults when diversityGate is omitted", async () => {
+    const { resolveDiversityGateConfig } = await import("./config-schema");
+    expect(resolveDiversityGateConfig({})).toEqual({
+      enabled: false,
+      threshold: 0.6,
+      weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
+    });
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+import {
+  DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+  queryAnalysisIntentSchema,
+  type QueryAnalysisIntent,
+  type QueryAnalysisIntentWeights,
+} from "@workspace/agent-data-api-contract";
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import {
   DEFAULT_DETERMINISTIC_PACK,
@@ -10,6 +16,77 @@ import {
   QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS,
   QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS,
 } from "./query-analysis-prompt-defaults";
+
+/**
+ * Resolves intent weights from Hermes config, lifting legacy `weight*` fields when
+ * `intentWeights` is absent.
+ *
+ * @param config - Parsed invoke config fields related to intent weighting.
+ * @returns Full intent weight record with defaults for any omitted intents.
+ */
+export const resolveIntentWeights = (config: {
+  intentWeights?: Partial<QueryAnalysisIntentWeights>;
+  weightBreaking?: number;
+  weightKgChange?: number;
+  weightFundamental?: number;
+}): QueryAnalysisIntentWeights => {
+  if (config.intentWeights !== undefined) {
+    return {
+      ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+      ...config.intentWeights,
+    };
+  }
+  return {
+    ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+    breaking:
+      config.weightBreaking ?? DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.breaking,
+    kg_change:
+      config.weightKgChange ?? DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.kg_change,
+    fundamental:
+      config.weightFundamental ??
+      DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.fundamental,
+  };
+};
+
+/** Resolved diversity gate settings with defaults applied. */
+export type ResolvedDiversityGateConfig = {
+  enabled: boolean;
+  threshold: number;
+  weights: {
+    lexical: number;
+    intent: number;
+    semantic: number;
+  };
+};
+
+/**
+ * Resolves diversity gate config with schema defaults when fields are omitted.
+ *
+ * @param config - Parsed or raw Hermes invoke config.
+ * @returns Effective gate settings for scoring and regenerate decisions.
+ */
+export const resolveDiversityGateConfig = (config: {
+  diversityGate?: {
+    enabled?: boolean;
+    threshold?: number;
+    weights?: {
+      lexical?: number;
+      intent?: number;
+      semantic?: number;
+    };
+  };
+}): ResolvedDiversityGateConfig => {
+  const gate = config.diversityGate;
+  return {
+    enabled: gate?.enabled ?? false,
+    threshold: gate?.threshold ?? 0.6,
+    weights: {
+      lexical: gate?.weights?.lexical ?? 0.4,
+      intent: gate?.weights?.intent ?? 0.3,
+      semantic: gate?.weights?.semantic ?? 0.3,
+    },
+  };
+};
 
 /**
  * Runtime configuration from Hermes invoke `config` (variable substitution).
@@ -40,10 +117,22 @@ export const queryAnalysisConfigSchema = z
      */
     allowedLanguages: z.array(z.string().min(1)).optional().default(["en"]),
     /**
-     * Relative weights used to shape ordering / selection of the non-deterministic pool.
+     * Relative weights keyed by intent for merge ordering and LLM target counts.
+     */
+    intentWeights: z
+      .record(queryAnalysisIntentSchema, z.number().nonnegative())
+      .optional(),
+    /**
+     * @deprecated Use `intentWeights.breaking`. Lifted when `intentWeights` is absent.
      */
     weightBreaking: z.number().nonnegative().optional().default(1),
+    /**
+     * @deprecated Use `intentWeights.kg_change`. Lifted when `intentWeights` is absent.
+     */
     weightKgChange: z.number().nonnegative().optional().default(0.8),
+    /**
+     * @deprecated Use `intentWeights.fundamental`. Lifted when `intentWeights` is absent.
+     */
     weightFundamental: z.number().nonnegative().optional().default(0.6),
     /**
      * LLM output token budget for generating structured query candidates.
@@ -90,6 +179,55 @@ export const queryAnalysisConfigSchema = z
      */
     fewShotExemplarCount: z.number().int().min(0).max(6).optional().default(3),
     /**
+     * Persona ids from the in-process library to fan out parallel LLM calls.
+     */
+    personas: z
+      .array(z.string().min(1))
+      .optional()
+      .default(["analyst", "retail", "regulator"]),
+    /**
+     * Maximum structured query rows requested from each persona call.
+     */
+    perPersonaQuotaCount: z.number().int().positive().optional().default(3),
+    /**
+     * When true, runs a self-critique pass after LLM generation to replace the weakest rows.
+     */
+    useSelfCritique: z.boolean().optional().default(false),
+    /**
+     * Maximum fraction of LLM candidates the critique pass may replace (one-for-one).
+     */
+    critiqueDropFraction: z.number().min(0).max(0.5).optional().default(0.25),
+    /**
+     * Model id for the critique pass (defaults to `openaiModel` in `run.ts` when omitted).
+     */
+    critiqueModel: z.string().min(1).optional(),
+    /**
+     * Optional semantic deduplication of LLM candidates via embedding cosine similarity.
+     */
+    semanticDedupe: z
+      .object({
+        enabled: z.boolean().default(false),
+        threshold: z.number().min(0).max(1).default(0.85),
+        embeddingModel: z.string().default("text-embedding-3-small"),
+      })
+      .optional(),
+    /**
+     * Optional diversity score gate: one broaden regenerate pass when composite is below threshold.
+     */
+    diversityGate: z
+      .object({
+        enabled: z.boolean().default(false),
+        threshold: z.number().min(0).max(1).default(0.6),
+        weights: z
+          .object({
+            lexical: z.number().nonnegative().default(0.4),
+            intent: z.number().nonnegative().default(0.3),
+            semantic: z.number().nonnegative().default(0.3),
+          })
+          .default({ lexical: 0.4, intent: 0.3, semantic: 0.3 }),
+      })
+      .optional(),
+    /**
      * Optional overrides for query-generation LLM system/user templates (Hermes).
      * When omitted, built-in defaults are used. Do not put API keys inside prompt text.
      */
@@ -101,7 +239,7 @@ export const queryAnalysisConfigSchema = z
             message: `prompts.systemPrompt must be at most ${String(QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
           })
           .describe(
-            "Optional system prompt template. Placeholders: {{allowedLanguages}}, {{targetBreakingCount}}, {{targetKgCount}}, {{targetFundamentalCount}}, {{minDeterministicCount}} (derived from queryCount, allowedLanguages, minDeterministicCount, and weight* fields when overrides are absent).",
+            "Optional system prompt template. Placeholders: {{allowedLanguages}}, {{targetBreakingCount}}, {{targetKgCount}}, {{targetFundamentalCount}}, {{targetSentimentCount}}, {{targetCompetitorCount}}, {{targetSupplyChainCount}}, {{targetEsgCount}}, {{targetMacroCount}}, {{targetTechnicalCount}}, {{minDeterministicCount}} (derived from queryCount, allowedLanguages, minDeterministicCount, and intentWeights when overrides are absent).",
           )
           .optional(),
         userPromptTemplate: z

--- a/apps/mediapulse/agents/query-analysis/src/diversity/score.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/diversity/score.test.ts
@@ -1,0 +1,128 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  buildDiversityBroadenSystemNudge,
+  computeCompositeDiversityScore,
+  computeDiversityScore,
+  computeLexicalDiversity,
+  computeNormalizedEntropy,
+  computeSemanticSpread,
+  DEFAULT_DIVERSITY_SCORE_WEIGHTS,
+  tokenizeQueryText,
+} from "./score";
+
+describe("tokenizeQueryText", () => {
+  it("lowercases and splits on whitespace", () => {
+    expect(tokenizeQueryText("  ABC Latest  News ")).toEqual([
+      "abc",
+      "latest",
+      "news",
+    ]);
+  });
+});
+
+describe("computeLexicalDiversity", () => {
+  it("returns a low ratio for many identical texts", () => {
+    const rows = Array.from({ length: 10 }, () => ({
+      text: "abc latest news",
+      intent: "breaking" as const,
+    }));
+    expect(computeLexicalDiversity(rows)).toBeCloseTo(0.1, 5);
+  });
+
+  it("returns 1 when every token is unique within a row and rows differ", () => {
+    const rows = [
+      { text: "alpha", intent: "breaking" as const },
+      { text: "beta", intent: "kg_change" as const },
+    ];
+    expect(computeLexicalDiversity(rows)).toBe(1);
+  });
+});
+
+describe("computeNormalizedEntropy", () => {
+  it("returns 0 for a single intent", () => {
+    expect(computeNormalizedEntropy(["breaking", "breaking"])).toBe(0);
+  });
+
+  it("returns 1 for a balanced two-intent split", () => {
+    expect(computeNormalizedEntropy(["breaking", "fundamental"])).toBeCloseTo(
+      1,
+      5,
+    );
+  });
+});
+
+describe("computeSemanticSpread", () => {
+  it("returns 0 for fewer than two embeddings", () => {
+    expect(computeSemanticSpread([[1, 0]])).toBe(0);
+  });
+
+  it("returns higher spread for orthogonal unit vectors", () => {
+    const spread = computeSemanticSpread([
+      [1, 0],
+      [0, 1],
+    ]);
+    expect(spread).toBeCloseTo(1, 5);
+  });
+});
+
+describe("computeCompositeDiversityScore", () => {
+  it("renormalizes weights when semantic axis is omitted", () => {
+    const composite = computeCompositeDiversityScore(
+      { lexicalDiversity: 1, intentCoverage: 0 },
+      DEFAULT_DIVERSITY_SCORE_WEIGHTS,
+    );
+    expect(composite).toBeCloseTo(0.4 / 0.7, 5);
+  });
+});
+
+describe("computeDiversityScore", () => {
+  it("scores identical texts with low lexical and intent coverage", () => {
+    const rows = Array.from({ length: 10 }, () => ({
+      text: "ABC latest news",
+      intent: "breaking" as const,
+    }));
+    const score = computeDiversityScore(rows);
+    expect(score.lexicalDiversity).toBeCloseTo(0.1, 5);
+    expect(score.intentCoverage).toBe(0);
+    expect(score.composite).toBeLessThan(0.2);
+  });
+
+  it("scores a varied set at or above 0.8", () => {
+    const intents = [
+      "breaking",
+      "kg_change",
+      "fundamental",
+      "sentiment",
+      "competitor",
+      "supply_chain",
+      "esg",
+      "macro",
+      "technical",
+      "breaking",
+    ] as const;
+    const personas = ["analyst", "retail", "regulator"] as const;
+    const rows = intents.map((intent, index) => ({
+      text: `token${String(index)}a token${String(index)}b token${String(index)}c`,
+      intent,
+      persona: personas[index % personas.length]!,
+    }));
+    const score = computeDiversityScore(rows);
+    expect(score.composite).toBeGreaterThanOrEqual(0.8);
+    expect(score.personaCoverage).toBeGreaterThan(0);
+  });
+});
+
+describe("buildDiversityBroadenSystemNudge", () => {
+  it("includes composite breakdown and broaden instruction", () => {
+    const nudge = buildDiversityBroadenSystemNudge({
+      lexicalDiversity: 0.1,
+      intentCoverage: 0,
+      composite: 0.04,
+    });
+    expect(nudge).toContain("low on diversity");
+    expect(nudge).toContain("lexical=0.10");
+    expect(nudge).toContain("Vary phrasing");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/diversity/score.ts
+++ b/apps/mediapulse/agents/query-analysis/src/diversity/score.ts
@@ -1,0 +1,224 @@
+import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
+
+import { cosineSimilarity } from "../embeddings";
+
+/** Default composite weights for diversity scoring axes. */
+export const DEFAULT_DIVERSITY_SCORE_WEIGHTS = {
+  lexical: 0.4,
+  intent: 0.3,
+  semantic: 0.3,
+} as const;
+
+export type DiversityScoreWeights = {
+  lexical: number;
+  intent: number;
+  semantic: number;
+};
+
+/** One candidate row scored for diversity before merge. */
+export type DiversityScoreRow = {
+  text: string;
+  intent: QueryAnalysisIntent;
+  persona?: string;
+};
+
+/** Per-axis and composite diversity metrics for a candidate batch. */
+export type DiversityScoreResult = {
+  lexicalDiversity: number;
+  intentCoverage: number;
+  personaCoverage?: number;
+  semanticSpread?: number;
+  composite: number;
+};
+
+/** Maximum rows used for O(n²) semantic spread (pairwise distance). */
+export const MAX_SEMANTIC_SPREAD_ROWS = 50;
+
+/**
+ * Tokenizes query text for lexical diversity (lowercase whitespace tokens).
+ *
+ * @param text - Raw query string.
+ * @returns Non-empty tokens.
+ */
+export const tokenizeQueryText = (text: string): string[] =>
+  text
+    .toLowerCase()
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+
+/**
+ * Computes distinct-token ratio across all query texts (0–1).
+ *
+ * @param rows - Candidate rows to score.
+ * @returns Lexical diversity; 0 when there are no tokens.
+ */
+export const computeLexicalDiversity = (rows: DiversityScoreRow[]): number => {
+  const tokens: string[] = [];
+  for (const row of rows) {
+    tokens.push(...tokenizeQueryText(row.text));
+  }
+  if (tokens.length === 0) {
+    return 0;
+  }
+  return new Set(tokens).size / tokens.length;
+};
+
+/**
+ * Computes Shannon entropy of categorical values, normalized to [0, 1].
+ *
+ * @param values - Category labels (e.g. intents or persona ids).
+ * @returns Normalized entropy; 0 when fewer than two distinct categories appear.
+ */
+export const computeNormalizedEntropy = (values: string[]): number => {
+  if (values.length === 0) {
+    return 0;
+  }
+  const counts = new Map<string, number>();
+  for (const value of values) {
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+  const distinct = counts.size;
+  if (distinct <= 1) {
+    return 0;
+  }
+  let entropy = 0;
+  const total = values.length;
+  for (const count of counts.values()) {
+    const probability = count / total;
+    entropy -= probability * Math.log(probability);
+  }
+  return entropy / Math.log(distinct);
+};
+
+/**
+ * Computes mean pairwise cosine distance (1 − similarity) for embedding vectors.
+ *
+ * @param embeddings - Row-aligned embedding vectors.
+ * @returns Mean distance in [0, 1] when at least two vectors exist; otherwise 0.
+ */
+export const computeSemanticSpread = (embeddings: number[][]): number => {
+  const subset = embeddings.slice(0, MAX_SEMANTIC_SPREAD_ROWS);
+  if (subset.length < 2) {
+    return 0;
+  }
+  let pairCount = 0;
+  let distanceSum = 0;
+  for (let i = 0; i < subset.length; i++) {
+    for (let j = i + 1; j < subset.length; j++) {
+      const similarity = cosineSimilarity(subset[i]!, subset[j]!);
+      distanceSum += 1 - similarity;
+      pairCount += 1;
+    }
+  }
+  return pairCount > 0 ? distanceSum / pairCount : 0;
+};
+
+/**
+ * Builds the weighted composite diversity score from axis metrics.
+ *
+ * @param axes - Per-axis scores in [0, 1].
+ * @param weights - Axis weights (renormalized when semantic is omitted).
+ * @returns Composite score in [0, 1].
+ */
+export const computeCompositeDiversityScore = (
+  axes: {
+    lexicalDiversity: number;
+    intentCoverage: number;
+    semanticSpread?: number;
+  },
+  weights: DiversityScoreWeights,
+): number => {
+  const terms: Array<{ weight: number; value: number }> = [
+    { weight: weights.lexical, value: axes.lexicalDiversity },
+    { weight: weights.intent, value: axes.intentCoverage },
+  ];
+  if (axes.semanticSpread !== undefined) {
+    terms.push({ weight: weights.semantic, value: axes.semanticSpread });
+  }
+  const weightSum = terms.reduce((sum, term) => sum + term.weight, 0);
+  if (weightSum <= 0) {
+    return 0;
+  }
+  return (
+    terms.reduce((sum, term) => sum + term.weight * term.value, 0) / weightSum
+  );
+};
+
+/**
+ * Computes diversity metrics over LLM candidate rows (pure, no I/O).
+ *
+ * @param rows - Candidate batch to score.
+ * @param opts - Optional axis weights and precomputed embeddings keyed by trimmed text.
+ * @returns Per-axis metrics and weighted composite score.
+ */
+export const computeDiversityScore = (
+  rows: DiversityScoreRow[],
+  opts: {
+    weights?: DiversityScoreWeights;
+    embeddingsByText?: ReadonlyMap<string, number[]>;
+  } = {},
+): DiversityScoreResult => {
+  const weights = opts.weights ?? DEFAULT_DIVERSITY_SCORE_WEIGHTS;
+  const lexicalDiversity = computeLexicalDiversity(rows);
+  const intentCoverage = computeNormalizedEntropy(
+    rows.map((row) => row.intent),
+  );
+
+  const personaValues = rows
+    .map((row) => row.persona)
+    .filter((persona): persona is string => persona !== undefined);
+  const personaCoverage =
+    personaValues.length > 0
+      ? computeNormalizedEntropy(personaValues)
+      : undefined;
+
+  let semanticSpread: number | undefined;
+  if (opts.embeddingsByText && rows.length >= 2) {
+    const embeddings = rows
+      .map((row) => opts.embeddingsByText?.get(row.text.trim()))
+      .filter((vector): vector is number[] => vector !== undefined);
+    if (embeddings.length >= 2) {
+      semanticSpread = computeSemanticSpread(embeddings);
+    }
+  }
+
+  const composite = computeCompositeDiversityScore(
+    { lexicalDiversity, intentCoverage, semanticSpread },
+    weights,
+  );
+
+  return {
+    lexicalDiversity,
+    intentCoverage,
+    ...(personaCoverage !== undefined ? { personaCoverage } : {}),
+    ...(semanticSpread !== undefined ? { semanticSpread } : {}),
+    composite,
+  };
+};
+
+/**
+ * Builds a system-prompt nudge asking the model to broaden a low-diversity batch.
+ *
+ * @param score - Diversity score breakdown from the prior attempt.
+ * @returns Text appended to the generation system prompt for the regenerate pass.
+ */
+export const buildDiversityBroadenSystemNudge = (
+  score: DiversityScoreResult,
+): string => {
+  const parts = [
+    `lexical=${score.lexicalDiversity.toFixed(2)}`,
+    `intent=${score.intentCoverage.toFixed(2)}`,
+  ];
+  if (score.semanticSpread !== undefined) {
+    parts.push(`semantic=${score.semanticSpread.toFixed(2)}`);
+  }
+  if (score.personaCoverage !== undefined) {
+    parts.push(`persona=${score.personaCoverage.toFixed(2)}`);
+  }
+  return [
+    `Your last attempt scored low on diversity (composite ${score.composite.toFixed(2)}).`,
+    `Breakdown: ${parts.join(", ")}.`,
+    "Vary phrasing, intents, and angles.",
+  ].join(" ");
+};

--- a/apps/mediapulse/agents/query-analysis/src/embeddings.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/embeddings.test.ts
@@ -1,0 +1,182 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  buildEmbeddingByText,
+  buildQuerySemanticEmbedder,
+  collectQueryTextsForEmbedding,
+  cosineSimilarity,
+  dedupeBySimilarity,
+  embedQueries,
+  maxCosineSimilarity,
+} from "./embeddings";
+import {
+  dedupeLlmBySimilarity,
+  mergeQueryCandidates,
+} from "./merge-query-candidates";
+
+const vecA = [1, 0, 0];
+/** Unit vector with ~0.92 cosine similarity to `vecA` (survives 0.95, drops at 0.85). */
+const vecNearA = [0.92, 0.39, 0];
+const vecDistinct = [0, 1, 0];
+
+const fakeEmbeddingMap = new Map<string, number[]>([
+  ["AAPL latest news", vecA],
+  ["Apple latest news", vecNearA],
+  ["AAPL supply chain risk", vecDistinct],
+  ["ACME earnings guidance", vecA],
+  ["Apple Inc earnings call", vecNearA],
+]);
+
+const fakeEmbedder = (threshold: number) => ({
+  threshold,
+  embeddingByText: fakeEmbeddingMap,
+});
+
+describe("cosineSimilarity", () => {
+  it("returns 1 for identical unit vectors", () => {
+    expect(cosineSimilarity(vecA, vecA)).toBeCloseTo(1);
+  });
+
+  it("returns high similarity for near-duplicate unit vectors", () => {
+    const sim = cosineSimilarity(vecA, vecNearA);
+    expect(sim).toBeGreaterThan(0.85);
+    expect(sim).toBeLessThan(0.95);
+  });
+});
+
+describe("dedupeBySimilarity", () => {
+  const rows = [
+    { text: "AAPL latest news" },
+    { text: "Apple latest news" },
+    { text: "AAPL supply chain risk" },
+  ];
+  const embeddings = [vecA, vecNearA, vecDistinct];
+
+  it("collapses near-duplicates at threshold 0.85", () => {
+    const deduped = dedupeBySimilarity(rows, embeddings, 0.85, 1);
+    expect(deduped.map((row) => row.text)).toEqual([
+      "AAPL latest news",
+      "AAPL supply chain risk",
+    ]);
+  });
+
+  it("keeps near-duplicates at threshold 0.95", () => {
+    const deduped = dedupeBySimilarity(rows, embeddings, 0.95, 1);
+    expect(deduped.map((row) => row.text)).toEqual([
+      "AAPL latest news",
+      "Apple latest news",
+      "AAPL supply chain risk",
+    ]);
+  });
+});
+
+describe("dedupeLlmBySimilarity", () => {
+  it("drops a semantically similar LLM row when a deterministic anchor exists", () => {
+    const llm = dedupeLlmBySimilarity(
+      [
+        { text: "Apple Inc earnings call", intent: "fundamental" },
+        { text: "AAPL supply chain risk", intent: "supply_chain" },
+      ],
+      [{ text: "ACME earnings guidance", intent: "fundamental" }],
+      fakeEmbedder(0.85),
+    );
+
+    expect(llm).toEqual([
+      {
+        text: "AAPL supply chain risk",
+        intent: "supply_chain",
+        source: "llm",
+      },
+    ]);
+  });
+});
+
+describe("mergeQueryCandidates with semantic embedder", () => {
+  it("prefers deterministic anchors over semantically similar LLM rows", () => {
+    const merged = mergeQueryCandidates({
+      deterministic: [
+        { text: "ACME earnings guidance", intent: "fundamental" },
+      ],
+      llm: [
+        { text: "Apple Inc earnings call", intent: "fundamental" },
+        { text: "AAPL supply chain risk", intent: "supply_chain" },
+      ],
+      queryCount: 3,
+      minDeterministicCount: 1,
+      weights: {
+        breaking: 1,
+        kg_change: 0.8,
+        fundamental: 0.6,
+        sentiment: 0.5,
+        competitor: 0.5,
+        supply_chain: 0.4,
+        esg: 0.3,
+        macro: 0.4,
+        technical: 0.3,
+      },
+      embedder: fakeEmbedder(0.85),
+    });
+
+    expect(merged.map((row) => row.text)).toEqual([
+      "ACME earnings guidance",
+      "AAPL supply chain risk",
+    ]);
+    expect(merged.every((row) => row.text !== "Apple Inc earnings call")).toBe(
+      true,
+    );
+  });
+});
+
+describe("collectQueryTextsForEmbedding", () => {
+  it("dedupes texts and preserves deterministic-first order", () => {
+    const texts = collectQueryTextsForEmbedding(
+      [{ text: "  AAPL news  " }, { text: "AAPL news" }],
+      [{ text: "Apple news" }],
+    );
+    expect(texts).toEqual(["AAPL news", "Apple news"]);
+  });
+});
+
+describe("embedQueries", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty array without calling the API when texts is empty", async () => {
+    const embedManyFn = vi.fn();
+    const vectors = await embedQueries(
+      [],
+      { apiKey: "sk-test" },
+      { embedManyFn },
+    );
+    expect(vectors).toEqual([]);
+    expect(embedManyFn).not.toHaveBeenCalled();
+  });
+
+  it("batches all texts in a single embedMany call", async () => {
+    const embedManyFn = vi.fn().mockResolvedValue({
+      embeddings: [vecA, vecDistinct],
+    });
+    const vectors = await embedQueries(
+      ["AAPL news", "supply chain"],
+      { apiKey: "sk-test", model: "text-embedding-3-small" },
+      { embedManyFn },
+    );
+    expect(embedManyFn).toHaveBeenCalledTimes(1);
+    expect(vectors).toHaveLength(2);
+  });
+});
+
+describe("buildQuerySemanticEmbedder", () => {
+  it("maps trimmed texts to embedding vectors", () => {
+    const embedder = buildQuerySemanticEmbedder(
+      ["AAPL news", "supply chain"],
+      [vecA, vecDistinct],
+      0.85,
+    );
+    expect(embedder.embeddingByText.get("AAPL news")).toEqual(vecA);
+    expect(maxCosineSimilarity(vecNearA, [vecA])).toBeGreaterThan(0.85);
+    expect(buildEmbeddingByText(["x"], [vecA]).get("x")).toEqual(vecA);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/embeddings.ts
+++ b/apps/mediapulse/agents/query-analysis/src/embeddings.ts
@@ -1,0 +1,190 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { embedMany } from "ai";
+
+/** Default OpenAI embedding model for semantic query deduplication. */
+export const DEFAULT_QUERY_EMBEDDING_MODEL = "text-embedding-3-small";
+
+export type EmbedManyFn = typeof embedMany;
+
+/**
+ * Computes cosine similarity between two embedding vectors.
+ *
+ * @param a - First embedding vector.
+ * @param b - Second embedding vector (same dimension as `a`).
+ * @returns Cosine similarity in [-1, 1], or 0 when either vector has zero magnitude.
+ */
+export const cosineSimilarity = (a: number[], b: number[]): number => {
+  if (a.length !== b.length || a.length === 0) {
+    return 0;
+  }
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < a.length; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    normA += av * av;
+    normB += bv * bv;
+  }
+  if (normA === 0 || normB === 0) {
+    return 0;
+  }
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+};
+
+/**
+ * Returns the maximum cosine similarity between `vector` and any vector in `accepted`.
+ *
+ * @param vector - Candidate embedding.
+ * @param accepted - Embeddings already accepted as anchors or prior rows.
+ * @returns Highest similarity score, or 0 when `accepted` is empty.
+ */
+export const maxCosineSimilarity = (
+  vector: number[],
+  accepted: number[][],
+): number => {
+  let max = 0;
+  for (const anchor of accepted) {
+    const similarity = cosineSimilarity(vector, anchor);
+    if (similarity > max) {
+      max = similarity;
+    }
+  }
+  return max;
+};
+
+/**
+ * Embeds query strings in a single batched OpenAI request.
+ *
+ * @param texts - Non-empty query strings to embed (deduped by caller when batching a run).
+ * @param params - API key and optional embedding model id.
+ * @param deps - Injectable `embedMany` (default: production `embedMany` from `ai`).
+ * @returns Parallel embedding vectors (empty when `texts` is empty; no API call).
+ */
+export const embedQueries = async (
+  texts: string[],
+  params: { apiKey: string; model?: string },
+  deps: { embedManyFn?: EmbedManyFn } = {},
+): Promise<number[][]> => {
+  if (texts.length === 0) {
+    return [];
+  }
+  const embedManyFn = deps.embedManyFn ?? embedMany;
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  const { embeddings } = await embedManyFn({
+    model: openai.embedding(params.model ?? DEFAULT_QUERY_EMBEDDING_MODEL),
+    values: texts,
+  });
+  return embeddings;
+};
+
+/**
+ * Walks rows in input order, dropping any row whose embedding exceeds `threshold`
+ * cosine similarity to an already-accepted row. The first `anchorCount` rows are
+ * anchors: they are always accepted and never dropped.
+ *
+ * @param rows - Candidate rows aligned with `embeddings`.
+ * @param embeddings - Parallel embedding vectors (same length as `rows`).
+ * @param threshold - Maximum allowed cosine similarity vs accepted rows.
+ * @param anchorCount - Prefix length treated as anchors (never dropped).
+ * @returns Filtered rows preserving input order among survivors.
+ */
+export const dedupeBySimilarity = <T extends { text: string }>(
+  rows: T[],
+  embeddings: number[][],
+  threshold: number,
+  anchorCount: number,
+): T[] => {
+  const accepted: T[] = [];
+  const acceptedEmbeddings: number[][] = [];
+  const effectiveAnchors = Math.min(anchorCount, rows.length);
+
+  for (let index = 0; index < rows.length; index++) {
+    const row = rows[index]!;
+    const embedding = embeddings[index] ?? [];
+    if (index < effectiveAnchors) {
+      accepted.push(row);
+      acceptedEmbeddings.push(embedding);
+      continue;
+    }
+    if (maxCosineSimilarity(embedding, acceptedEmbeddings) > threshold) {
+      continue;
+    }
+    accepted.push(row);
+    acceptedEmbeddings.push(embedding);
+  }
+
+  return accepted;
+};
+
+/**
+ * Collects unique trimmed query texts for a single batched embedding call per run.
+ *
+ * @param deterministic - Deterministic template rows.
+ * @param llm - LLM candidate rows.
+ * @returns De-duplicated trimmed texts in deterministic-first order.
+ */
+export const collectQueryTextsForEmbedding = (
+  deterministic: Array<{ text: string }>,
+  llm: Array<{ text: string }>,
+): string[] => {
+  const seen = new Set<string>();
+  const texts: string[] = [];
+  const add = (raw: string): void => {
+    const text = raw.trim();
+    if (text.length === 0 || seen.has(text)) {
+      return;
+    }
+    seen.add(text);
+    texts.push(text);
+  };
+  for (const row of deterministic) {
+    add(row.text);
+  }
+  for (const row of llm) {
+    add(row.text);
+  }
+  return texts;
+};
+
+/**
+ * Builds a trimmed-text → embedding lookup from parallel arrays.
+ *
+ * @param texts - Query strings passed to {@link embedQueries}.
+ * @param embeddings - Vectors returned in the same order as `texts`.
+ * @returns Map keyed by trimmed query text.
+ */
+export const buildEmbeddingByText = (
+  texts: string[],
+  embeddings: number[][],
+): Map<string, number[]> => {
+  const map = new Map<string, number[]>();
+  for (let index = 0; index < texts.length; index++) {
+    map.set(texts[index]!, embeddings[index] ?? []);
+  }
+  return map;
+};
+
+/** Precomputed embeddings injected into merge for semantic LLM deduplication. */
+export type QuerySemanticEmbedder = {
+  threshold: number;
+  embeddingByText: ReadonlyMap<string, number[]>;
+};
+
+/**
+ * Builds the embedder dependency from one batched embedding response.
+ *
+ * @param texts - Texts embedded in the batched call.
+ * @param embeddings - Vectors from {@link embedQueries}.
+ * @param threshold - Cosine similarity cutoff.
+ * @returns Embedder for {@link mergeQueryCandidates}.
+ */
+export const buildQuerySemanticEmbedder = (
+  texts: string[],
+  embeddings: number[][],
+  threshold: number,
+): QuerySemanticEmbedder => ({
+  threshold,
+  embeddingByText: buildEmbeddingByText(texts, embeddings),
+});

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -1,18 +1,26 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
+
 import {
   buildBrainstormPrompt,
   buildQueryAnalysisSystemContent,
   buildQueryAnalysisUserContent,
   buildStructuredQueryMessages,
+  applySelfCritiqueToCandidateBatch,
   fetchBrainstormBullets,
   fetchLlmQueryCandidates,
+  fetchLlmQueryCandidatesByPersona,
   fetchQueryAnalysisLlmCandidates,
+  mergeCritiqueReplacements,
   parseBrainstormBullets,
+  regenerateDroppedQueries,
   resolveQueryAnalysisSystemContent,
   resolveQueryAnalysisUserContent,
+  selectCandidatesToDropFromCritique,
 } from "./llm-queries";
+import { DEFAULT_QUERY_PERSONAS } from "./personas/default-personas";
 
 describe("resolveQueryAnalysisSystemContent", () => {
   it("matches buildQueryAnalysisSystemContent when Hermes omits override", () => {
@@ -20,7 +28,7 @@ describe("resolveQueryAnalysisSystemContent", () => {
       queryCount: 10,
       allowedLanguages: ["en", "de"],
       minDeterministicCount: 3,
-      weights: { breaking: 1, kgChange: 1, fundamental: 1 } as const,
+      intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
     };
 
     const resolved = resolveQueryAnalysisSystemContent(undefined, strategy);
@@ -96,7 +104,7 @@ describe("buildQueryAnalysisSystemContent", () => {
       queryCount: 10,
       allowedLanguages: ["en", "de"],
       minDeterministicCount: 3,
-      weights: { breaking: 1, kgChange: 1, fundamental: 1 },
+      intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
     });
 
     // Assert
@@ -219,7 +227,12 @@ describe("buildBrainstormPrompt", () => {
         queryCount: 10,
         allowedLanguages: ["en"],
         minDeterministicCount: 4,
-        weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+        intentWeights: {
+          ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+          breaking: 1,
+          kg_change: 0.8,
+          fundamental: 0.6,
+        },
       },
       ctx,
     );
@@ -267,7 +280,12 @@ describe("fetchBrainstormBullets", () => {
           queryCount: 10,
           allowedLanguages: ["en"],
           minDeterministicCount: 4,
-          weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+          intentWeights: {
+            ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+            breaking: 1,
+            kg_change: 0.8,
+            fundamental: 0.6,
+          },
         },
         context: {
           ticker: {
@@ -316,7 +334,12 @@ describe("fetchQueryAnalysisLlmCandidates", () => {
       queryCount: 10,
       allowedLanguages: ["en"],
       minDeterministicCount: 4,
-      weights: { breaking: 1, kgChange: 0.8, fundamental: 0.6 },
+      intentWeights: {
+        ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+        breaking: 1,
+        kg_change: 0.8,
+        fundamental: 0.6,
+      },
     },
     sampling: {
       temperature: 0.9,
@@ -367,6 +390,296 @@ describe("fetchQueryAnalysisLlmCandidates", () => {
 
     expect(fetchBrainstormBulletsSpy).not.toHaveBeenCalled();
     expect(fetchLlmQueryCandidatesSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("selectCandidatesToDropFromCritique", () => {
+  const candidates = Array.from({ length: 10 }, (_, index) => ({
+    text: `query-${String(index + 1)}`,
+    intent: "breaking" as const,
+  }));
+
+  it("returns at most floor(n * dropFraction) flagged rows, worst first", () => {
+    const toDrop = selectCandidatesToDropFromCritique(
+      candidates,
+      [
+        { text: "query-1", relevance: 2, novelty: 1, drop: true },
+        { text: "query-5", relevance: 1, novelty: 2, drop: true },
+        { text: "query-9", relevance: 3, novelty: 1, drop: true },
+        { text: "query-2", relevance: 5, novelty: 5, drop: false },
+      ],
+      0.3,
+    );
+    expect(toDrop).toHaveLength(3);
+    expect(toDrop.map((row) => row.text)).toEqual([
+      "query-1",
+      "query-5",
+      "query-9",
+    ]);
+  });
+
+  it("returns an empty list when no rows are flagged drop", () => {
+    const toDrop = selectCandidatesToDropFromCritique(
+      candidates,
+      candidates.map((row) => ({
+        text: row.text,
+        relevance: 4,
+        novelty: 4,
+        drop: false,
+      })),
+      0.25,
+    );
+    expect(toDrop).toEqual([]);
+  });
+});
+
+describe("applySelfCritiqueToCandidateBatch", () => {
+  const baseParams = {
+    apiKey: "sk-test",
+    critiqueModel: "gpt-4o-mini",
+    generationModel: "gpt-4o-mini",
+    maxOutputTokens: 200,
+    systemContent: "system",
+    userContent: "user context",
+    context: {
+      ticker: {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "ACME",
+        name: "Acme Co",
+        metadata: null,
+      },
+      topEntities: [],
+      recentThemes: [],
+      ...emptyEnrichedContext,
+    },
+    dropFraction: 0.3,
+    fewShotExemplarCount: 0,
+    sampling: {
+      temperature: 0.9,
+      topP: 0.95,
+      presencePenalty: 0.4,
+      frequencyPenalty: 0.5,
+    },
+  };
+
+  const tenCandidates = Array.from({ length: 10 }, (_, index) => ({
+    text: `query-${String(index + 1)}`,
+    intent: "breaking" as const,
+  }));
+
+  it("calls the regenerator with dropCount matching flagged rows and preserves total count", async () => {
+    const critiqueQueryCandidatesSpy = vi.fn().mockResolvedValue([
+      { text: "query-1", relevance: 1, novelty: 1, drop: true },
+      { text: "query-4", relevance: 2, novelty: 1, drop: true },
+      { text: "query-7", relevance: 1, novelty: 2, drop: true },
+      ...tenCandidates
+        .filter((row) => !["query-1", "query-4", "query-7"].includes(row.text))
+        .map((row) => ({
+          text: row.text,
+          relevance: 5,
+          novelty: 5,
+          drop: false,
+        })),
+    ]);
+    const regenerateDroppedQueriesSpy = vi.fn().mockResolvedValue([
+      { text: "replacement-1", intent: "fundamental" as const },
+      { text: "replacement-2", intent: "fundamental" as const },
+      { text: "replacement-3", intent: "fundamental" as const },
+    ]);
+
+    const result = await applySelfCritiqueToCandidateBatch(
+      tenCandidates,
+      baseParams,
+      {
+        critiqueQueryCandidates: critiqueQueryCandidatesSpy,
+        regenerateDroppedQueries: regenerateDroppedQueriesSpy,
+      },
+    );
+
+    expect(regenerateDroppedQueriesSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ dropCount: 3 }),
+    );
+    expect(result.replacedCount).toBe(3);
+    expect(result.candidates).toHaveLength(10);
+    expect(result.candidates.map((row) => row.text)).toEqual([
+      "query-2",
+      "query-3",
+      "query-5",
+      "query-6",
+      "query-8",
+      "query-9",
+      "query-10",
+      "replacement-1",
+      "replacement-2",
+      "replacement-3",
+    ]);
+  });
+
+  it("does not call the regenerator when zero rows are flagged drop", async () => {
+    const critiqueQueryCandidatesSpy = vi.fn().mockResolvedValue(
+      tenCandidates.map((row) => ({
+        text: row.text,
+        relevance: 5,
+        novelty: 5,
+        drop: false,
+      })),
+    );
+    const regenerateDroppedQueriesSpy = vi.fn();
+
+    const result = await applySelfCritiqueToCandidateBatch(
+      tenCandidates,
+      baseParams,
+      {
+        critiqueQueryCandidates: critiqueQueryCandidatesSpy,
+        regenerateDroppedQueries: regenerateDroppedQueriesSpy,
+      },
+    );
+
+    expect(regenerateDroppedQueriesSpy).not.toHaveBeenCalled();
+    expect(result.candidates).toEqual(tenCandidates);
+    expect(result.replacedCount).toBe(0);
+  });
+});
+
+describe("mergeCritiqueReplacements", () => {
+  it("preserves persona tags on replacement rows", () => {
+    const merged = mergeCritiqueReplacements(
+      [
+        { text: "keep", intent: "breaking", persona: "analyst" },
+        { text: "drop me", intent: "breaking", persona: "analyst" },
+      ],
+      [{ text: "drop me", intent: "breaking", persona: "analyst" }],
+      [{ text: "new query", intent: "fundamental" }],
+    );
+    expect(merged).toEqual([
+      { text: "keep", intent: "breaking", persona: "analyst" },
+      { text: "new query", intent: "fundamental", persona: "analyst" },
+    ]);
+  });
+});
+
+describe("regenerateDroppedQueries", () => {
+  it("returns an empty array when dropCount is zero", async () => {
+    const fetchLlmQueryCandidatesSpy = vi.fn();
+    const rows = await regenerateDroppedQueries(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        systemContent: "system",
+        userContent: "user",
+        keptCandidates: [],
+        dropCount: 0,
+        fewShotExemplarCount: 0,
+        sampling: {
+          temperature: 0.9,
+          topP: 0.95,
+          presencePenalty: 0.4,
+          frequencyPenalty: 0.5,
+        },
+      },
+      { fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy },
+    );
+    expect(rows).toEqual([]);
+    expect(fetchLlmQueryCandidatesSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchLlmQueryCandidatesByPersona", () => {
+  const personas = DEFAULT_QUERY_PERSONAS.slice(0, 3);
+  const baseParams = {
+    apiKey: "sk-test",
+    model: "gpt-4o-mini",
+    maxOutputTokens: 100,
+    systemContent: "system",
+    userContent: "user context",
+    personas,
+    perPersonaQuota: 3,
+    fewShotExemplarCount: 0,
+    sampling: {
+      temperature: 0.9,
+      topP: 0.95,
+      presencePenalty: 0.4,
+      frequencyPenalty: 0.5,
+    },
+  };
+
+  it("calls generateObject once per persona and tags results", async () => {
+    const fetchLlmQueryCandidatesSpy = vi
+      .fn()
+      .mockImplementation(async (_params, _deps) => {
+        const callIndex = fetchLlmQueryCandidatesSpy.mock.calls.length - 1;
+        const persona = personas[callIndex];
+        return [
+          {
+            text: `${persona?.id}-q1`,
+            intent: "breaking" as const,
+          },
+        ];
+      });
+
+    const rows = await fetchLlmQueryCandidatesByPersona(baseParams, {
+      fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy,
+    });
+
+    expect(fetchLlmQueryCandidatesSpy).toHaveBeenCalledTimes(3);
+    expect(rows).toEqual([
+      { text: "analyst-q1", intent: "breaking", persona: "analyst" },
+      { text: "retail-q1", intent: "breaking", persona: "retail" },
+      { text: "regulator-q1", intent: "breaking", persona: "regulator" },
+    ]);
+  });
+
+  it("continues when one persona call fails", async () => {
+    const fetchLlmQueryCandidatesSpy = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("rate limit"))
+      .mockResolvedValueOnce([
+        { text: "retail ok", intent: "breaking" as const },
+      ])
+      .mockResolvedValueOnce([
+        { text: "regulator ok", intent: "fundamental" as const },
+      ]);
+    const warn = vi.fn();
+
+    const rows = await fetchLlmQueryCandidatesByPersona(baseParams, {
+      fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy,
+      warn,
+    });
+
+    expect(fetchLlmQueryCandidatesSpy).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(rows).toEqual([
+      { text: "retail ok", intent: "breaking", persona: "retail" },
+      { text: "regulator ok", intent: "fundamental", persona: "regulator" },
+    ]);
+  });
+
+  it("caps each persona at perPersonaQuota", async () => {
+    const fetchLlmQueryCandidatesSpy = vi.fn().mockResolvedValue([
+      { text: "one", intent: "breaking" as const },
+      { text: "two", intent: "breaking" as const },
+      { text: "three", intent: "breaking" as const },
+      { text: "four", intent: "breaking" as const },
+    ]);
+
+    const rows = await fetchLlmQueryCandidatesByPersona(
+      { ...baseParams, perPersonaQuota: 2 },
+      { fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy },
+    );
+
+    expect(rows.filter((row) => row.persona === "analyst")).toHaveLength(2);
+  });
+
+  it("appends persona system nudge to the structured system prompt", async () => {
+    const fetchLlmQueryCandidatesSpy = vi.fn().mockResolvedValue([]);
+    await fetchLlmQueryCandidatesByPersona(baseParams, {
+      fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy,
+    });
+    const firstMessages = fetchLlmQueryCandidatesSpy.mock.calls[0]?.[0]
+      ?.messages as { role: string; content: string }[] | undefined;
+    expect(firstMessages?.[0]?.content).toContain("system");
+    expect(firstMessages?.[0]?.content).toContain(personas[0]!.systemNudge);
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -2,13 +2,16 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject, generateText } from "ai";
 import type { ModelMessage } from "ai";
 import {
+  QUERY_ANALYSIS_INTENTS,
   queryAnalysisIntentSchema,
   type GetQueryAnalysisResponse,
   type QueryAnalysisIntent,
+  type QueryAnalysisIntentWeights,
 } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
 import {
+  QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS,
   QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
   QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
 } from "./query-analysis-prompt-defaults";
@@ -18,6 +21,9 @@ import {
   formatExemplarAssistantContent,
   selectFewShotExemplars,
 } from "./exemplars/default-exemplars";
+import type { QueryPersona } from "./personas/default-personas";
+import type { LlmCandidate } from "./merge-query-candidates";
+import { normalizeQueryKey } from "./merge-query-candidates";
 
 /** Zod schema for structured LLM output (validated by AI SDK). */
 export const llmQueriesOutputSchema = z.object({
@@ -29,15 +35,27 @@ export const llmQueriesOutputSchema = z.object({
   ),
 });
 
+/** Zod schema for the self-critique structured-output pass. */
+export const llmCritiqueOutputSchema = z.object({
+  ratings: z.array(
+    z.object({
+      text: z.string(),
+      relevance: z.number().min(1).max(5),
+      novelty: z.number().min(1).max(5),
+      drop: z.boolean(),
+    }),
+  ),
+});
+
+export type CritiqueRating = z.infer<
+  typeof llmCritiqueOutputSchema
+>["ratings"][number];
+
 export type LlmQueryStrategyPrompt = {
   queryCount: number;
   allowedLanguages: string[];
   minDeterministicCount: number;
-  weights: {
-    breaking: number;
-    kgChange: number;
-    fundamental: number;
-  };
+  intentWeights: QueryAnalysisIntentWeights;
 };
 
 /**
@@ -49,22 +67,24 @@ export type LlmQueryStrategyPrompt = {
 export const buildQueryAnalysisSystemTemplateReplacements = (
   strategy: LlmQueryStrategyPrompt,
 ): Record<string, string> => {
-  const sum =
-    strategy.weights.breaking +
-    strategy.weights.kgChange +
-    strategy.weights.fundamental;
-  const ratioBreaking = sum > 0 ? strategy.weights.breaking / sum : 1 / 3;
-  const ratioKg = sum > 0 ? strategy.weights.kgChange / sum : 1 / 3;
-  const ratioFund = sum > 0 ? strategy.weights.fundamental / sum : 1 / 3;
-  return {
+  const sum = QUERY_ANALYSIS_INTENTS.reduce(
+    (total, intent) => total + strategy.intentWeights[intent],
+    0,
+  );
+  const replacements: Record<string, string> = {
     allowedLanguages: strategy.allowedLanguages.join(", "),
-    targetBreakingCount: String(
-      Math.round(ratioBreaking * strategy.queryCount),
-    ),
-    targetKgCount: String(Math.round(ratioKg * strategy.queryCount)),
-    targetFundamentalCount: String(Math.round(ratioFund * strategy.queryCount)),
     minDeterministicCount: String(strategy.minDeterministicCount),
   };
+  for (const intent of QUERY_ANALYSIS_INTENTS) {
+    const ratio =
+      sum > 0
+        ? strategy.intentWeights[intent] / sum
+        : 1 / QUERY_ANALYSIS_INTENTS.length;
+    replacements[QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS[intent]] = String(
+      Math.round(ratio * strategy.queryCount),
+    );
+  }
+  return replacements;
 };
 
 /**
@@ -318,6 +338,18 @@ export type GenerateObjectForQueries = (args: {
   seed?: number;
 }) => Promise<{ object: z.infer<typeof llmQueriesOutputSchema> }>;
 
+export type GenerateObjectForCritique = (args: {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  schema: typeof llmCritiqueOutputSchema;
+  maxOutputTokens: number;
+  messages: ModelMessage[];
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+}) => Promise<{ object: z.infer<typeof llmCritiqueOutputSchema> }>;
+
 export type GenerateTextForBrainstorm = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   messages: ModelMessage[];
@@ -467,4 +499,460 @@ export const fetchQueryAnalysisLlmCandidates = async (
     messages,
     sampling: params.sampling,
   });
+};
+
+export type FetchLlmQueryCandidatesByPersonaParams = {
+  apiKey: string;
+  model: string;
+  maxOutputTokens: number;
+  systemContent: string;
+  userContent: string;
+  personas: QueryPersona[];
+  perPersonaQuota: number;
+  fewShotExemplarCount: number;
+  brainstormBullets?: string[];
+  /** Optional extra system instruction (e.g. diversity-gate broaden nudge). */
+  broadenSystemNudge?: string;
+  sampling: LlmQuerySampling;
+};
+
+/**
+ * Runs one structured LLM call per persona in parallel and tags each row with its persona id.
+ * A failing persona is logged and skipped; surviving personas still contribute candidates.
+ *
+ * @param params - Shared prompt content, persona list, per-persona cap, and sampling knobs.
+ * @param deps - Injectable structured-output runner and optional warn logger.
+ * @returns Flattened LLM candidates tagged with `persona` ids.
+ */
+export const fetchLlmQueryCandidatesByPersona = async (
+  params: FetchLlmQueryCandidatesByPersonaParams,
+  deps: {
+    fetchLlmQueryCandidates?: typeof fetchLlmQueryCandidates;
+    warn?: (
+      message: string,
+      meta: { personaId: string; error: unknown },
+    ) => void;
+  } = {},
+): Promise<LlmCandidate[]> => {
+  const runStructured = deps.fetchLlmQueryCandidates ?? fetchLlmQueryCandidates;
+  const warn =
+    deps.warn ??
+    (() => {
+      /* no-op default for tests */
+    });
+
+  const results = await Promise.all(
+    params.personas.map(async (persona) => {
+      try {
+        const systemContent = [
+          params.systemContent,
+          params.broadenSystemNudge,
+          persona.systemNudge,
+        ]
+          .filter((part) => part !== undefined && part.length > 0)
+          .join("\n\n");
+        const messages = buildStructuredQueryMessages({
+          systemContent,
+          userContent: params.userContent,
+          fewShotExemplarCount: params.fewShotExemplarCount,
+          brainstormBullets: params.brainstormBullets,
+        });
+        const rows = await runStructured({
+          apiKey: params.apiKey,
+          model: params.model,
+          maxOutputTokens: params.maxOutputTokens,
+          messages,
+          sampling: params.sampling,
+        });
+        return rows.slice(0, params.perPersonaQuota).map((row) => ({
+          ...row,
+          persona: persona.id,
+        }));
+      } catch (error) {
+        warn("query-analysis persona LLM call failed; skipping persona", {
+          personaId: persona.id,
+          error,
+        });
+        return [];
+      }
+    }),
+  );
+
+  return results.flat();
+};
+
+/** Default wall-clock budget for the self-critique pass before shipping original candidates. */
+export const DEFAULT_CRITIC_PASS_DEADLINE_MS = 30_000;
+
+/**
+ * Builds the critique system prompt instructing the model to score and flag weak rows.
+ *
+ * @param dropFraction - Configured fraction of candidates eligible for replacement.
+ * @returns System message content for the critique call.
+ */
+export const buildCritiqueSystemContent = (dropFraction: number): string => {
+  const pct = Math.round(dropFraction * 100);
+  return [
+    "You are reviewing finance search queries another model generated for a ticker.",
+    "Rate each query's relevance to the company context (1=off-topic, 5=highly relevant) and novelty (1=generic duplicate, 5=fresh angle).",
+    `Mark roughly the worst ${String(pct)}% as drop: true — only queries that should be replaced.`,
+    'Return ONLY JSON: { "ratings": [ { "text": string, "relevance": number, "novelty": number, "drop": boolean } ] }.',
+    "Include one rating object per input query using the exact query text.",
+  ].join("\n");
+};
+
+/**
+ * Serializes candidate rows for the critique user message.
+ *
+ * @param candidates - LLM rows to score.
+ * @returns Numbered bullet list for the critique call.
+ */
+export const formatCandidatesForCritique = (
+  candidates: LlmCandidate[],
+): string =>
+  candidates
+    .map((row, index) => `${String(index + 1)}. "${row.text}" (${row.intent})`)
+    .join("\n");
+
+/**
+ * Selects which candidates to drop after critique, capped by `dropFraction`.
+ *
+ * @param candidates - Original candidate rows.
+ * @param ratings - Model critique output aligned by query text.
+ * @param dropFraction - Maximum fraction of rows that may be replaced.
+ * @returns Rows to remove (worst among those flagged `drop`, up to the cap).
+ */
+export const selectCandidatesToDropFromCritique = (
+  candidates: LlmCandidate[],
+  ratings: CritiqueRating[],
+  dropFraction: number,
+): LlmCandidate[] => {
+  if (candidates.length === 0 || dropFraction <= 0) {
+    return [];
+  }
+  const maxDrop = Math.floor(candidates.length * dropFraction);
+  if (maxDrop === 0) {
+    return [];
+  }
+
+  const ratingByKey = new Map(
+    ratings.map((rating) => [normalizeQueryKey(rating.text), rating]),
+  );
+
+  const flagged = candidates
+    .filter((candidate) => {
+      const rating = ratingByKey.get(normalizeQueryKey(candidate.text));
+      return rating?.drop === true;
+    })
+    .sort((a, b) => {
+      const ratingA = ratingByKey.get(normalizeQueryKey(a.text));
+      const ratingB = ratingByKey.get(normalizeQueryKey(b.text));
+      const scoreA = (ratingA?.relevance ?? 0) + (ratingA?.novelty ?? 0);
+      const scoreB = (ratingB?.relevance ?? 0) + (ratingB?.novelty ?? 0);
+      return scoreA - scoreB;
+    });
+
+  return flagged.slice(0, maxDrop);
+};
+
+/**
+ * Merges kept candidates with replacement rows, preserving optional persona tags.
+ *
+ * @param candidates - Full original candidate list.
+ * @param toDrop - Rows removed by critique.
+ * @param replacements - New rows from the regenerator (length should match `toDrop`).
+ * @returns Candidate list with the same length as the input when replacements fill the gap.
+ */
+export const mergeCritiqueReplacements = (
+  candidates: LlmCandidate[],
+  toDrop: LlmCandidate[],
+  replacements: LlmCandidate[],
+): LlmCandidate[] => {
+  const dropKeys = new Set(toDrop.map((row) => normalizeQueryKey(row.text)));
+  const kept = candidates.filter(
+    (row) => !dropKeys.has(normalizeQueryKey(row.text)),
+  );
+  const persona = toDrop[0]?.persona;
+  const taggedReplacements = replacements.map((row) => ({
+    ...row,
+    ...(persona !== undefined ? { persona } : {}),
+  }));
+  return [...kept, ...taggedReplacements];
+};
+
+/**
+ * Calls the critique model to score each candidate against live ticker context.
+ *
+ * @param params - API key, model, token budget, context, candidates, and sampling knobs.
+ * @param deps - Injectable `generateObject` for the critique schema.
+ * @returns Parsed critique ratings (may be empty on model output gaps).
+ */
+export const critiqueQueryCandidates = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    context: GetQueryAnalysisResponse;
+    candidates: LlmCandidate[];
+    dropFraction: number;
+    sampling: LlmQuerySampling;
+  },
+  deps: { generateObjectForCritique: GenerateObjectForCritique } = {
+    generateObjectForCritique: generateObject,
+  },
+): Promise<CritiqueRating[]> => {
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  const userContent = [
+    buildQueryAnalysisUserContent(params.context),
+    "",
+    "Queries to critique:",
+    formatCandidatesForCritique(params.candidates),
+  ].join("\n");
+  const { sampling } = params;
+  const { object } = await deps.generateObjectForCritique({
+    model: openai(params.model),
+    schema: llmCritiqueOutputSchema,
+    maxOutputTokens: params.maxOutputTokens,
+    messages: [
+      {
+        role: "system",
+        content: buildCritiqueSystemContent(params.dropFraction),
+      },
+      { role: "user", content: userContent },
+    ],
+    temperature: sampling.temperature,
+    topP: sampling.topP,
+    presencePenalty: sampling.presencePenalty,
+    frequencyPenalty: sampling.frequencyPenalty,
+    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+  });
+  return object.ratings ?? [];
+};
+
+/**
+ * Regenerates replacement queries for rows dropped by critique.
+ *
+ * @param params - Generation prompt, kept anti-examples, and replacement count.
+ * @param deps - Injectable structured-output runner.
+ * @returns Up to `dropCount` new candidate rows.
+ */
+export const regenerateDroppedQueries = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    systemContent: string;
+    userContent: string;
+    keptCandidates: LlmCandidate[];
+    dropCount: number;
+    fewShotExemplarCount: number;
+    sampling: LlmQuerySampling;
+  },
+  deps: { fetchLlmQueryCandidates?: typeof fetchLlmQueryCandidates } = {},
+): Promise<LlmCandidate[]> => {
+  const runStructured = deps.fetchLlmQueryCandidates ?? fetchLlmQueryCandidates;
+  if (params.dropCount <= 0) {
+    return [];
+  }
+
+  const keptBlock = params.keptCandidates
+    .map((row) => `- "${row.text}"`)
+    .join("\n");
+  const replacementSystem = [
+    params.systemContent,
+    "",
+    "You already produced these queries — do NOT restate or lightly rephrase them:",
+    keptBlock.length > 0 ? keptBlock : "(none)",
+    "",
+    `Generate exactly ${String(params.dropCount)} new, distinct search queries in the JSON response.`,
+  ].join("\n");
+
+  const messages = buildStructuredQueryMessages({
+    systemContent: replacementSystem,
+    userContent: params.userContent,
+    fewShotExemplarCount: params.fewShotExemplarCount,
+  });
+
+  const rows = await runStructured({
+    apiKey: params.apiKey,
+    model: params.model,
+    maxOutputTokens: params.maxOutputTokens,
+    messages,
+    sampling: params.sampling,
+  });
+
+  return rows.slice(0, params.dropCount);
+};
+
+/**
+ * Runs critique → drop → regenerate for one homogeneous candidate batch (same persona or untagged).
+ *
+ * @param candidates - LLM rows to refine (non-empty).
+ * @param params - Shared critique/regeneration configuration.
+ * @param deps - Injectable critique and regeneration collaborators.
+ * @returns Refined candidates and how many rows were replaced.
+ */
+export const applySelfCritiqueToCandidateBatch = async (
+  candidates: LlmCandidate[],
+  params: {
+    apiKey: string;
+    critiqueModel: string;
+    generationModel: string;
+    maxOutputTokens: number;
+    systemContent: string;
+    userContent: string;
+    context: GetQueryAnalysisResponse;
+    dropFraction: number;
+    fewShotExemplarCount: number;
+    sampling: LlmQuerySampling;
+  },
+  deps: {
+    critiqueQueryCandidates?: typeof critiqueQueryCandidates;
+    regenerateDroppedQueries?: typeof regenerateDroppedQueries;
+  } = {},
+): Promise<{ candidates: LlmCandidate[]; replacedCount: number }> => {
+  const runCritique = deps.critiqueQueryCandidates ?? critiqueQueryCandidates;
+  const runRegenerate =
+    deps.regenerateDroppedQueries ?? regenerateDroppedQueries;
+
+  const ratings = await runCritique({
+    apiKey: params.apiKey,
+    model: params.critiqueModel,
+    maxOutputTokens: params.maxOutputTokens,
+    context: params.context,
+    candidates,
+    dropFraction: params.dropFraction,
+    sampling: params.sampling,
+  });
+
+  const toDrop = selectCandidatesToDropFromCritique(
+    candidates,
+    ratings,
+    params.dropFraction,
+  );
+  if (toDrop.length === 0) {
+    return { candidates, replacedCount: 0 };
+  }
+
+  const dropKeys = new Set(toDrop.map((row) => normalizeQueryKey(row.text)));
+  const keptCandidates = candidates.filter(
+    (row) => !dropKeys.has(normalizeQueryKey(row.text)),
+  );
+
+  const replacements = await runRegenerate({
+    apiKey: params.apiKey,
+    model: params.generationModel,
+    maxOutputTokens: params.maxOutputTokens,
+    systemContent: params.systemContent,
+    userContent: params.userContent,
+    keptCandidates,
+    dropCount: toDrop.length,
+    fewShotExemplarCount: params.fewShotExemplarCount,
+    sampling: params.sampling,
+  });
+
+  return {
+    candidates: mergeCritiqueReplacements(candidates, toDrop, replacements),
+    replacedCount: toDrop.length,
+  };
+};
+
+/**
+ * Applies self-critique per persona group (when tagged) or once for the full LLM pool.
+ *
+ * @param params - Candidates, timing budget, and critique/regeneration configuration.
+ * @param deps - Injectable batch critique runner and clock for deadline checks.
+ * @returns Refined candidates plus observability metadata for the strategy snapshot.
+ */
+export const applySelfCritiquePass = async (
+  params: {
+    apiKey: string;
+    critiqueModel: string;
+    generationModel: string;
+    maxOutputTokens: number;
+    systemContent: string;
+    userContent: string;
+    context: GetQueryAnalysisResponse;
+    candidates: LlmCandidate[];
+    dropFraction: number;
+    fewShotExemplarCount: number;
+    sampling: LlmQuerySampling;
+    runStartMs: number;
+    deadlineMs: number;
+  },
+  deps: {
+    applySelfCritiqueToCandidateBatch?: typeof applySelfCritiqueToCandidateBatch;
+    critiqueQueryCandidates?: typeof critiqueQueryCandidates;
+    regenerateDroppedQueries?: typeof regenerateDroppedQueries;
+    now?: () => number;
+  } = {},
+): Promise<{
+  candidates: LlmCandidate[];
+  replacedCount: number;
+  skippedDueToDeadline: boolean;
+}> => {
+  const runBatch =
+    deps.applySelfCritiqueToCandidateBatch ?? applySelfCritiqueToCandidateBatch;
+  const now = deps.now ?? (() => Date.now());
+
+  if (params.candidates.length === 0) {
+    return { candidates: [], replacedCount: 0, skippedDueToDeadline: false };
+  }
+
+  if (now() - params.runStartMs > params.deadlineMs) {
+    return {
+      candidates: params.candidates,
+      replacedCount: 0,
+      skippedDueToDeadline: true,
+    };
+  }
+
+  const hasPersonaTags = params.candidates.some(
+    (row) => row.persona !== undefined,
+  );
+  const batches: LlmCandidate[][] = hasPersonaTags
+    ? [...groupCandidatesByPersona(params.candidates).values()]
+    : [params.candidates];
+
+  let replacedCount = 0;
+  const refined: LlmCandidate[] = [];
+
+  for (const batch of batches) {
+    if (now() - params.runStartMs > params.deadlineMs) {
+      refined.push(...batch);
+      continue;
+    }
+    const batchDeps = {
+      critiqueQueryCandidates: deps.critiqueQueryCandidates,
+      regenerateDroppedQueries: deps.regenerateDroppedQueries,
+    };
+    const result = await runBatch(batch, params, batchDeps);
+    replacedCount += result.replacedCount;
+    refined.push(...result.candidates);
+  }
+
+  return {
+    candidates: refined,
+    replacedCount,
+    skippedDueToDeadline: false,
+  };
+};
+
+/**
+ * Groups persona-tagged candidates by persona id, preserving first-seen persona order.
+ *
+ * @param candidates - LLM rows that may carry persona tags.
+ * @returns Map of persona id → candidate rows in original order within each bucket.
+ */
+export const groupCandidatesByPersona = (
+  candidates: LlmCandidate[],
+): Map<string, LlmCandidate[]> => {
+  const groups = new Map<string, LlmCandidate[]>();
+  for (const row of candidates) {
+    const personaId = row.persona ?? "__default__";
+    const bucket = groups.get(personaId) ?? [];
+    bucket.push(row);
+    groups.set(personaId, bucket);
+  }
+  return groups;
 };

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
@@ -1,13 +1,19 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it } from "vitest";
 
+import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
+
 import {
   dedupeDeterministic,
   dedupeLlmAgainstKeys,
   intentMergeWeight,
   mergeQueryCandidates,
   normalizeQueryKey,
+  orderLlmRowsByPersonaRoundRobin,
+  sortPoolByIntentWeight,
 } from "./merge-query-candidates";
+
+const baseWeights = DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS;
 
 describe("normalizeQueryKey", () => {
   it("trims, collapses whitespace, and lowercases", () => {
@@ -21,10 +27,20 @@ describe("normalizeQueryKey", () => {
 
 describe("intentMergeWeight", () => {
   it("returns the configured weight for each intent", () => {
-    const w = { breaking: 1, kgChange: 0.5, fundamental: 0.25 };
+    const w = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.5,
+      fundamental: 0.25,
+    };
     expect(intentMergeWeight("breaking", w)).toBe(1);
     expect(intentMergeWeight("kg_change", w)).toBe(0.5);
     expect(intentMergeWeight("fundamental", w)).toBe(0.25);
+    expect(intentMergeWeight("esg", w)).toBe(baseWeights.esg);
+  });
+
+  it("returns 0 for intents missing from the weight record", () => {
+    expect(intentMergeWeight("esg", {} as typeof baseWeights)).toBe(0);
   });
 });
 
@@ -74,7 +90,12 @@ describe("mergeQueryCandidates", () => {
   });
 
   it("assigns contiguous ranks and respects queryCount", () => {
-    const weights = { breaking: 1, kgChange: 0.8, fundamental: 0.6 };
+    const weights = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.8,
+      fundamental: 0.6,
+    };
     const det = [
       { text: "a", intent: "breaking" as const },
       { text: "b", intent: "kg_change" as const },
@@ -92,7 +113,12 @@ describe("mergeQueryCandidates", () => {
   });
 
   it("keeps a deterministic floor up to queryCount", () => {
-    const weights = { breaking: 1, kgChange: 0.8, fundamental: 0.6 };
+    const weights = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.8,
+      fundamental: 0.6,
+    };
     const det = [
       { text: "d1", intent: "breaking" as const },
       { text: "d2", intent: "breaking" as const },
@@ -111,7 +137,12 @@ describe("mergeQueryCandidates", () => {
   });
 
   it("orders the tail by higher intent weight first when trimming pool", () => {
-    const weights = { breaking: 1, kgChange: 0.8, fundamental: 0.6 };
+    const weights = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.8,
+      fundamental: 0.6,
+    };
     const det = [
       { text: "d1", intent: "fundamental" as const },
       { text: "d2", intent: "kg_change" as const },
@@ -131,5 +162,89 @@ describe("mergeQueryCandidates", () => {
     expect(merged[0]?.source).toBe("deterministic");
     expect(merged[1]?.text).toBe("l2");
     expect(merged[2]?.text).toBe("d2");
+  });
+
+  it("round-robins persona-tagged LLM rows after the deterministic floor", () => {
+    const weights = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.8,
+      fundamental: 0.6,
+    };
+    const det = [
+      { text: "d1", intent: "breaking" as const },
+      { text: "d2", intent: "breaking" as const },
+    ];
+    const llm = [
+      { text: "a1", intent: "breaking" as const, persona: "persona-a" },
+      { text: "a2", intent: "breaking" as const, persona: "persona-a" },
+      { text: "a3", intent: "breaking" as const, persona: "persona-a" },
+      { text: "b1", intent: "breaking" as const, persona: "persona-b" },
+      { text: "b2", intent: "breaking" as const, persona: "persona-b" },
+      { text: "b3", intent: "breaking" as const, persona: "persona-b" },
+      { text: "c1", intent: "breaking" as const, persona: "persona-c" },
+      { text: "c2", intent: "breaking" as const, persona: "persona-c" },
+      { text: "c3", intent: "breaking" as const, persona: "persona-c" },
+    ];
+    const merged = mergeQueryCandidates({
+      deterministic: det,
+      llm,
+      queryCount: 11,
+      minDeterministicCount: 2,
+      weights,
+    });
+
+    expect(merged).toHaveLength(11);
+    expect(
+      merged.slice(0, 2).every((row) => row.source === "deterministic"),
+    ).toBe(true);
+    expect(merged.slice(2).map((row) => row.persona)).toEqual([
+      "persona-a",
+      "persona-b",
+      "persona-c",
+      "persona-a",
+      "persona-b",
+      "persona-c",
+      "persona-a",
+      "persona-b",
+      "persona-c",
+    ]);
+  });
+});
+
+describe("orderLlmRowsByPersonaRoundRobin", () => {
+  it("interleaves rows by first-seen persona order", () => {
+    const ordered = orderLlmRowsByPersonaRoundRobin([
+      { text: "a1", intent: "breaking", source: "llm", persona: "a" },
+      { text: "b1", intent: "breaking", source: "llm", persona: "b" },
+      { text: "a2", intent: "breaking", source: "llm", persona: "a" },
+      { text: "b2", intent: "breaking", source: "llm", persona: "b" },
+    ]);
+    expect(ordered.map((row) => row.text)).toEqual(["a1", "b1", "a2", "b2"]);
+  });
+});
+
+describe("sortPoolByIntentWeight", () => {
+  it("orders rows by descending intent weight", () => {
+    const weights = {
+      ...baseWeights,
+      breaking: 1,
+      kg_change: 0.5,
+      fundamental: 0.25,
+    };
+    const sorted = sortPoolByIntentWeight(
+      [
+        {
+          row: { text: "fund", intent: "fundamental", source: "deterministic" },
+          index: 0,
+        },
+        {
+          row: { text: "break", intent: "breaking", source: "deterministic" },
+          index: 1,
+        },
+      ],
+      weights,
+    );
+    expect(sorted.map((row) => row.text)).toEqual(["break", "fund"]);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
@@ -1,5 +1,8 @@
 import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
 
+import type { QuerySemanticEmbedder } from "./embeddings";
+import { maxCosineSimilarity } from "./embeddings";
+
 /** One deterministic template row before merge. */
 export type DeterministicCandidate = {
   text: string;
@@ -10,6 +13,8 @@ export type DeterministicCandidate = {
 export type LlmCandidate = {
   text: string;
   intent: QueryAnalysisIntent;
+  /** Persona id when produced by multi-persona fan-out (observability only). */
+  persona?: string;
 };
 
 /** Row persisted via agent-data-api `queryAnalysis.create`. */
@@ -18,14 +23,14 @@ export type MergedQueryRow = {
   source: "deterministic" | "llm";
   intent: QueryAnalysisIntent;
   rank: number;
+  /** Persona id for LLM rows from multi-persona fan-out (observability only). */
+  persona?: string;
 };
 
-/** Relative emphasis for ordering the non-floor pool (same shape as strategy snapshot weights). */
-export type QueryMergeWeights = {
-  breaking: number;
-  kgChange: number;
-  fundamental: number;
-};
+import type { QueryAnalysisIntentWeights } from "@workspace/agent-data-api-contract";
+
+/** Relative emphasis for ordering the non-floor pool keyed by intent label. */
+export type QueryMergeWeights = QueryAnalysisIntentWeights;
 
 /**
  * Normalizes query text for case-insensitive deduplication: trim, collapse internal whitespace, lowercase.
@@ -40,21 +45,13 @@ export const normalizeQueryKey = (text: string): string =>
  * Returns the merge weight for an intent using the configured snapshot weights.
  *
  * @param intent - Query intent label.
- * @param weights - Relative weights (breaking / KG / fundamental).
- * @returns Numeric weight for sorting (higher = kept earlier when capacity is limited).
+ * @param weights - Relative weights keyed by intent.
+ * @returns Numeric weight for sorting (unknown intents default to 0).
  */
 export const intentMergeWeight = (
   intent: QueryAnalysisIntent,
   weights: QueryMergeWeights,
-): number => {
-  if (intent === "breaking") {
-    return weights.breaking;
-  }
-  if (intent === "kg_change") {
-    return weights.kgChange;
-  }
-  return weights.fundamental;
-};
+): number => weights[intent] ?? 0;
 
 /**
  * Dedupes deterministic rows by {@link normalizeQueryKey}, preserving first occurrence order.
@@ -92,11 +89,17 @@ export const dedupeDeterministic = (
 export const dedupeLlmAgainstKeys = (
   llm: LlmCandidate[],
   seenKeys: Set<string>,
-): Array<{ text: string; intent: QueryAnalysisIntent; source: "llm" }> => {
+): Array<{
+  text: string;
+  intent: QueryAnalysisIntent;
+  source: "llm";
+  persona?: string;
+}> => {
   const out: Array<{
     text: string;
     intent: QueryAnalysisIntent;
     source: "llm";
+    persona?: string;
   }> = [];
   for (const row of llm) {
     const text = row.text.trim();
@@ -108,16 +111,170 @@ export const dedupeLlmAgainstKeys = (
       continue;
     }
     seenKeys.add(key);
-    out.push({ text, intent: row.intent, source: "llm" });
+    out.push({
+      text,
+      intent: row.intent,
+      source: "llm",
+      ...(row.persona !== undefined ? { persona: row.persona } : {}),
+    });
   }
   return out;
+};
+
+/**
+ * Dedupes LLM rows by cosine similarity against deterministic anchors and prior accepts.
+ * Deterministic anchors are never dropped; they only constrain later LLM rows.
+ *
+ * @param llm - LLM candidate rows from the model.
+ * @param anchorRows - String-deduped deterministic rows used as similarity anchors.
+ * @param embedder - Precomputed embeddings for the run.
+ * @returns Rows tagged as `source: "llm"`.
+ */
+export const dedupeLlmBySimilarity = (
+  llm: LlmCandidate[],
+  anchorRows: DeterministicCandidate[],
+  embedder: QuerySemanticEmbedder,
+): Array<{
+  text: string;
+  intent: QueryAnalysisIntent;
+  source: "llm";
+  persona?: string;
+}> => {
+  const acceptedEmbeddings: number[][] = [];
+  for (const anchor of anchorRows) {
+    const text = anchor.text.trim();
+    if (text.length === 0) {
+      continue;
+    }
+    const embedding = embedder.embeddingByText.get(text);
+    if (embedding) {
+      acceptedEmbeddings.push(embedding);
+    }
+  }
+
+  const out: Array<{
+    text: string;
+    intent: QueryAnalysisIntent;
+    source: "llm";
+    persona?: string;
+  }> = [];
+
+  for (const row of llm) {
+    const text = row.text.trim();
+    if (text.length === 0) {
+      continue;
+    }
+    const embedding = embedder.embeddingByText.get(text);
+    if (
+      embedding &&
+      maxCosineSimilarity(embedding, acceptedEmbeddings) > embedder.threshold
+    ) {
+      continue;
+    }
+    if (embedding) {
+      acceptedEmbeddings.push(embedding);
+    }
+    out.push({
+      text,
+      intent: row.intent,
+      source: "llm",
+      ...(row.persona !== undefined ? { persona: row.persona } : {}),
+    });
+  }
+
+  return out;
+};
+
+type PoolRow = {
+  text: string;
+  intent: QueryAnalysisIntent;
+  source: "deterministic" | "llm";
+  persona?: string;
+};
+
+/**
+ * Sorts pool rows by intent merge weight with stable tie-breaking on input index.
+ *
+ * @param rows - Candidate rows with original indices.
+ * @param weights - Relative intent weights from strategy snapshot.
+ * @returns Rows ordered by descending weight.
+ */
+export const sortPoolByIntentWeight = (
+  rows: Array<{ row: PoolRow; index: number }>,
+  weights: QueryMergeWeights,
+): PoolRow[] => {
+  const pool = rows.map((entry) => ({
+    ...entry,
+    weight: intentMergeWeight(entry.row.intent, weights),
+  }));
+  pool.sort((a, b) => {
+    if (b.weight !== a.weight) {
+      return b.weight - a.weight;
+    }
+    return a.index - b.index;
+  });
+  return pool.map((entry) => entry.row);
+};
+
+/**
+ * Orders persona-tagged LLM rows in round-robin across persona ids, preserving
+ * first-seen persona order. Within each persona, rows keep input order.
+ *
+ * @param llmRows - Deduped LLM rows that may carry persona tags.
+ * @returns LLM rows interleaved A, B, C, A, … when personas are present.
+ */
+export const orderLlmRowsByPersonaRoundRobin = (
+  llmRows: Array<PoolRow & { persona?: string }>,
+): PoolRow[] => {
+  const personaOrder: string[] = [];
+  const buckets = new Map<string, PoolRow[]>();
+  const withoutPersona: PoolRow[] = [];
+
+  for (const row of llmRows) {
+    if (row.persona === undefined) {
+      withoutPersona.push(row);
+      continue;
+    }
+    if (!buckets.has(row.persona)) {
+      personaOrder.push(row.persona);
+      buckets.set(row.persona, []);
+    }
+    buckets.get(row.persona)?.push(row);
+  }
+
+  if (personaOrder.length === 0) {
+    return llmRows;
+  }
+
+  const indices = new Map(personaOrder.map((id) => [id, 0]));
+  const ordered: PoolRow[] = [];
+  let remaining = llmRows.length - withoutPersona.length;
+
+  while (remaining > 0) {
+    let progressed = false;
+    for (const personaId of personaOrder) {
+      const bucket = buckets.get(personaId) ?? [];
+      const index = indices.get(personaId) ?? 0;
+      if (index < bucket.length) {
+        ordered.push(bucket[index]!);
+        indices.set(personaId, index + 1);
+        remaining -= 1;
+        progressed = true;
+      }
+    }
+    if (!progressed) {
+      break;
+    }
+  }
+
+  return [...ordered, ...withoutPersona];
 };
 
 /**
  * Merges deterministic and LLM candidates: dedupes, enforces a deterministic floor within `queryCount`,
  * orders the extension pool by intent weights (stable), assigns contiguous ranks.
  *
- * @param params - Deterministic templates, LLM rows, caps, and weights.
+ * @param params - Deterministic templates, LLM rows, caps, weights, and optional embedder.
  * @returns Final query rows ready for persistence (length ≤ `queryCount`, ≥ 1 if inputs allow).
  */
 export const mergeQueryCandidates = (params: {
@@ -126,6 +283,7 @@ export const mergeQueryCandidates = (params: {
   queryCount: number;
   minDeterministicCount: number;
   weights: QueryMergeWeights;
+  embedder?: QuerySemanticEmbedder;
 }): MergedQueryRow[] => {
   const { queryCount, minDeterministicCount, weights } = params;
   const dedupedDet = dedupeDeterministic(params.deterministic);
@@ -134,12 +292,12 @@ export const mergeQueryCandidates = (params: {
     queryCount,
     dedupedDet.length,
   );
-  const detFloor = dedupedDet.slice(0, effectiveMin).map((row) => ({
+  const detFloor: PoolRow[] = dedupedDet.slice(0, effectiveMin).map((row) => ({
     text: row.text,
     intent: row.intent,
     source: "deterministic" as const,
   }));
-  const detExtra = dedupedDet.slice(effectiveMin).map((row) => ({
+  const detExtra: PoolRow[] = dedupedDet.slice(effectiveMin).map((row) => ({
     text: row.text,
     intent: row.intent,
     source: "deterministic" as const,
@@ -147,25 +305,46 @@ export const mergeQueryCandidates = (params: {
   const seenKeys = new Set(
     dedupedDet.map((row) => normalizeQueryKey(row.text)),
   );
-  const llmRows = dedupeLlmAgainstKeys(params.llm, seenKeys);
-  const pool = [...detExtra, ...llmRows].map((row, index) => ({
+  const llmRows = params.embedder
+    ? dedupeLlmBySimilarity(params.llm, dedupedDet, params.embedder)
+    : dedupeLlmAgainstKeys(params.llm, seenKeys);
+  const hasPersonaTaggedLlm = llmRows.some((row) => row.persona !== undefined);
+
+  const detExtraIndexed = detExtra.map((row, index) => ({ row, index }));
+  const llmIndexed = llmRows.map((row, index) => ({
     row,
-    index,
-    weight: intentMergeWeight(row.intent, weights),
+    index: detExtra.length + index,
   }));
-  pool.sort((a, b) => {
-    if (b.weight !== a.weight) {
-      return b.weight - a.weight;
-    }
-    return a.index - b.index;
-  });
+
+  let tail: PoolRow[];
+  if (hasPersonaTaggedLlm) {
+    const detExtraOrdered = sortPoolByIntentWeight(detExtraIndexed, weights);
+    const llmOrdered = orderLlmRowsByPersonaRoundRobin(
+      llmIndexed.map((entry) => entry.row),
+    );
+    tail = [...detExtraOrdered, ...llmOrdered];
+  } else {
+    const pool = [...detExtraIndexed, ...llmIndexed].map((entry) => ({
+      row: entry.row,
+      index: entry.index,
+      weight: intentMergeWeight(entry.row.intent, weights),
+    }));
+    pool.sort((a, b) => {
+      if (b.weight !== a.weight) {
+        return b.weight - a.weight;
+      }
+      return a.index - b.index;
+    });
+    tail = pool.map((entry) => entry.row);
+  }
+
   const maxPool = Math.max(0, queryCount - detFloor.length);
-  const tail = pool.slice(0, maxPool).map((p) => p.row);
-  const combined = [...detFloor, ...tail];
+  const combined = [...detFloor, ...tail.slice(0, maxPool)];
   return combined.map((row, i) => ({
     text: row.text,
     source: row.source,
     intent: row.intent,
     rank: i + 1,
+    ...(row.persona !== undefined ? { persona: row.persona } : {}),
   }));
 };

--- a/apps/mediapulse/agents/query-analysis/src/personas/default-personas.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/personas/default-personas.test.ts
@@ -1,0 +1,55 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
+
+import {
+  DEFAULT_QUERY_PERSONAS,
+  personaIntentMergeWeight,
+  resolveQueryPersonas,
+} from "./default-personas";
+
+describe("DEFAULT_QUERY_PERSONAS", () => {
+  it("defines five personas with unique ids", () => {
+    const ids = DEFAULT_QUERY_PERSONAS.map((p) => p.id);
+    expect(ids).toEqual([
+      "analyst",
+      "retail",
+      "regulator",
+      "esg",
+      "short_seller",
+    ]);
+    expect(new Set(ids).size).toBe(5);
+  });
+});
+
+describe("resolveQueryPersonas", () => {
+  it("returns personas in config order and skips unknown ids", () => {
+    const warn = vi.fn();
+    const resolved = resolveQueryPersonas(["retail", "nope", "analyst"], {
+      warn,
+    });
+    expect(resolved.map((p) => p.id)).toEqual(["retail", "analyst"]);
+    expect(warn).toHaveBeenCalledWith(
+      "unknown query-analysis persona id; skipping",
+      { unknownId: "nope" },
+    );
+  });
+
+  it("returns an empty array when every id is unknown", () => {
+    const resolved = resolveQueryPersonas(["missing"]);
+    expect(resolved).toEqual([]);
+  });
+});
+
+describe("personaIntentMergeWeight", () => {
+  it("multiplies base strategy weight by persona intent bias", () => {
+    const regulator = DEFAULT_QUERY_PERSONAS.find((p) => p.id === "regulator");
+    expect(regulator).toBeDefined();
+    const weight = personaIntentMergeWeight("fundamental", regulator!, {
+      ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+      fundamental: 0.6,
+    });
+    expect(weight).toBeCloseTo(0.6 * 1.5);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/personas/default-personas.ts
+++ b/apps/mediapulse/agents/query-analysis/src/personas/default-personas.ts
@@ -1,0 +1,128 @@
+import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
+
+/** Per-intent sampling multiplier applied when merging persona-scoped candidates. */
+export type PersonaIntentBias = {
+  breaking: number;
+  kg_change: number;
+  fundamental: number;
+};
+
+/** Static query-generation persona resolved from Hermes config ids. */
+export type QueryPersona = {
+  id: string;
+  displayName: string;
+  /** One–two sentences appended to the base system prompt for this voice. */
+  systemNudge: string;
+  intentBias: PersonaIntentBias;
+};
+
+/** Sell-side equity research voice. */
+const analystPersona: QueryPersona = {
+  id: "analyst",
+  displayName: "Sell-side analyst",
+  systemNudge:
+    "Write like a sell-side equity analyst: earnings drivers, segment trends, and peer comps. Prefer institutional phrasing.",
+  intentBias: { breaking: 1.0, kg_change: 0.9, fundamental: 1.2 },
+};
+
+/** Retail trader / momentum-focused voice. */
+const retailPersona: QueryPersona = {
+  id: "retail",
+  displayName: "Retail trader",
+  systemNudge:
+    "Write like an active retail trader: catalysts, price action, social buzz, and near-term setups. Keep queries short and searchable.",
+  intentBias: { breaking: 1.5, kg_change: 0.7, fundamental: 0.6 },
+};
+
+/** Regulatory and disclosure-focused voice. */
+const regulatorPersona: QueryPersona = {
+  id: "regulator",
+  displayName: "Regulator",
+  systemNudge:
+    "Focus on compliance, disclosure, and rulemaking angles. Skip price action and trading slang.",
+  intentBias: { breaking: 0.5, kg_change: 1.0, fundamental: 1.5 },
+};
+
+/** ESG and sustainability research voice. */
+const esgPersona: QueryPersona = {
+  id: "esg",
+  displayName: "ESG researcher",
+  systemNudge:
+    "Emphasize environmental, social, and governance risks, controversies, and stewardship angles. Avoid pure technical chart queries.",
+  intentBias: { breaking: 0.8, kg_change: 1.1, fundamental: 1.3 },
+};
+
+/** Contrarian / short-thesis voice. */
+const shortSellerPersona: QueryPersona = {
+  id: "short_seller",
+  displayName: "Short seller",
+  systemNudge:
+    "Surface bearish and forensic angles: accounting red flags, supply-chain weakness, auditor concerns, and downside catalysts others ignore.",
+  intentBias: { breaking: 1.2, kg_change: 1.0, fundamental: 1.4 },
+};
+
+/** In-process persona library keyed by stable id. */
+export const DEFAULT_QUERY_PERSONAS: QueryPersona[] = [
+  analystPersona,
+  retailPersona,
+  regulatorPersona,
+  esgPersona,
+  shortSellerPersona,
+];
+
+const personaById = new Map(
+  DEFAULT_QUERY_PERSONAS.map((persona) => [persona.id, persona]),
+);
+
+/**
+ * Resolves Hermes persona id strings against the in-process library.
+ * Unknown ids are omitted with a warning via the optional logger.
+ *
+ * @param ids - Persona ids from invoke config (order preserved).
+ * @param deps - Optional warn logger for unknown ids.
+ * @returns Matching persona definitions in config order.
+ */
+export const resolveQueryPersonas = (
+  ids: string[],
+  deps: {
+    warn?: (message: string, meta: { unknownId: string }) => void;
+  } = {},
+): QueryPersona[] => {
+  const resolved: QueryPersona[] = [];
+  for (const id of ids) {
+    const persona = personaById.get(id);
+    if (persona) {
+      resolved.push(persona);
+    } else {
+      deps.warn?.("unknown query-analysis persona id; skipping", {
+        unknownId: id,
+      });
+    }
+  }
+  return resolved;
+};
+
+/**
+ * Returns the persona-scoped merge weight for a candidate intent.
+ *
+ * @param intent - Query intent label.
+ * @param persona - Persona whose bias multipliers apply.
+ * @param baseWeights - Global strategy weights from the snapshot.
+ * @returns Combined weight for ordering within a persona group.
+ */
+export const personaIntentMergeWeight = (
+  intent: QueryAnalysisIntent,
+  persona: QueryPersona,
+  baseWeights: Record<QueryAnalysisIntent, number>,
+): number => {
+  const base = baseWeights[intent] ?? 0;
+  const bias =
+    intent === "breaking"
+      ? persona.intentBias.breaking
+      : intent === "kg_change"
+        ? persona.intentBias.kg_change
+        : intent === "fundamental"
+          ? persona.intentBias.fundamental
+          : 1;
+  return base * bias;
+};

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS,
   QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
   QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
 } from "./query-analysis-prompt-defaults";
@@ -22,7 +23,23 @@ describe("query-analysis default prompt templates", () => {
       "{{targetFundamentalCount}}",
     );
     expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{targetEsgCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{targetTechnicalCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
       "{{minDeterministicCount}}",
+    );
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain("esg");
+    expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "supply_chain",
+    );
+  });
+
+  it("maps every intent to a target-count placeholder", () => {
+    expect(Object.keys(QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS)).toHaveLength(
+      9,
     );
   });
 

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
@@ -1,13 +1,34 @@
+import {
+  QUERY_ANALYSIS_INTENTS,
+  type QueryAnalysisIntent,
+} from "@workspace/agent-data-api-contract";
+
 /** Maximum characters allowed for each Hermes `prompts.*` string on query-analysis. */
 export const QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
+
+/** System prompt placeholder for each intent's approximate target count. */
+export const QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS: Record<
+  QueryAnalysisIntent,
+  string
+> = {
+  breaking: "targetBreakingCount",
+  kg_change: "targetKgCount",
+  fundamental: "targetFundamentalCount",
+  sentiment: "targetSentimentCount",
+  competitor: "targetCompetitorCount",
+  supply_chain: "targetSupplyChainCount",
+  esg: "targetEsgCount",
+  macro: "targetMacroCount",
+  technical: "targetTechnicalCount",
+};
 
 /** Allowed `{{...}}` names in `prompts.systemPrompt`. */
 export const QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS = [
   "allowedLanguages",
-  "targetBreakingCount",
-  "targetKgCount",
-  "targetFundamentalCount",
   "minDeterministicCount",
+  ...QUERY_ANALYSIS_INTENTS.map(
+    (intent) => QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS[intent],
+  ),
 ] as const;
 
 /** Allowed `{{...}}` names in `prompts.userPromptTemplate`. */
@@ -15,18 +36,44 @@ export const QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS = [
   "queryContextBlock",
 ] as const;
 
+const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_INTENTS.map(
+  (intent) => `"${intent}"`,
+).join(" | ");
+
 /**
  * Default system prompt template when Hermes omits `prompts.systemPrompt`.
  * Substitutes strategy-derived counts and the configured language list.
  */
 export const QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
   "You generate finance search queries for news and data retrieval.",
-  'Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": "breaking" | "kg_change" | "fundamental" } ] }.',
+  `Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": ${QUERY_ANALYSIS_INTENT_JSON_UNION} } ] }.`,
   "Each query must be concise web-search style text.",
   "Write queries in these languages (BCP-47 codes as configured): {{allowedLanguages}}. If multiple, you may mix languages across queries.",
-  "Target roughly {{targetBreakingCount}} breaking, {{targetKgCount}} kg_change, {{targetFundamentalCount}} fundamental queries (approximate; total queries should not exceed the remaining budget after the deterministic baseline).",
+  [
+    "Target approximate intent counts (total queries should not exceed the remaining budget after the deterministic baseline):",
+    `- breaking: {{targetBreakingCount}}`,
+    `- kg_change: {{targetKgCount}}`,
+    `- fundamental: {{targetFundamentalCount}}`,
+    `- sentiment: {{targetSentimentCount}}`,
+    `- competitor: {{targetCompetitorCount}}`,
+    `- supply_chain: {{targetSupplyChainCount}}`,
+    `- esg: {{targetEsgCount}}`,
+    `- macro: {{targetMacroCount}}`,
+    `- technical: {{targetTechnicalCount}}`,
+  ].join("\n"),
   "At least {{minDeterministicCount}} high-quality queries will be added deterministically by the system; your queries complement that set (avoid duplicating obvious symbol+news patterns).",
-  "Intent meanings: breaking = timely news/events; kg_change = knowledge-graph style relation or entity changes; fundamental = earnings, guidance, regulatory, balance-sheet style.",
+  [
+    "Intent meanings:",
+    "- breaking: timely news, catalysts, and price-moving events",
+    "- kg_change: knowledge-graph relation or entity changes",
+    "- fundamental: earnings, guidance, regulatory filings, balance-sheet style",
+    "- sentiment: social buzz, analyst tone, retail chatter, reputation swings",
+    "- competitor: peer positioning, share shifts, competitive threats",
+    "- supply_chain: suppliers, logistics, input costs, production bottlenecks",
+    "- esg: environmental, social, governance risks and controversies",
+    "- macro: rates, FX, commodity, geopolitical, and sector-wide drivers",
+    "- technical: chart patterns, momentum, support/resistance, volume signals",
+  ].join("\n"),
 ].join("\n\n");
 
 /** Default user prompt template: full serialized GET context. */

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -28,7 +28,8 @@ vi.mock("./llm-queries", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./llm-queries")>();
   return {
     ...actual,
-    fetchQueryAnalysisLlmCandidates: mockFetchQueryLlm,
+    fetchLlmQueryCandidatesByPersona: mockFetchQueryLlm,
+    fetchBrainstormBullets: vi.fn(),
   };
 });
 
@@ -41,7 +42,7 @@ vi.mock("@workspace/logger", () => ({
 }));
 
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
-import { runQueryAnalysis } from "./run";
+import { clampPerPersonaQuotaCount, runQueryAnalysis } from "./run";
 
 const ctxResponse = {
   ticker: {
@@ -61,10 +62,13 @@ const ctxResponse = {
 const baseConfig = queryAnalysisConfigSchema.parse({ openaiApiKey: "sk" });
 
 describe("query-analysis run", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     mockGet.mockReset();
     mockCreate.mockReset();
     mockFetchQueryLlm.mockReset();
+
+    const { fetchBrainstormBullets } = await import("./llm-queries");
+    vi.mocked(fetchBrainstormBullets).mockReset();
 
     mockGet.mockResolvedValue(ctxResponse);
     mockCreate.mockResolvedValue({
@@ -73,7 +77,7 @@ describe("query-analysis run", () => {
       activeSetId: "44444444-4444-4444-a444-444444444444",
     });
     mockFetchQueryLlm.mockResolvedValue([
-      { text: "LLM extra", intent: "kg_change" as const },
+      { text: "LLM extra", intent: "kg_change" as const, persona: "analyst" },
     ]);
   });
 
@@ -175,6 +179,10 @@ describe("query-analysis run", () => {
   });
 
   it("passes useBrainstormPass through to the LLM orchestrator", async () => {
+    const { fetchBrainstormBullets } = await import("./llm-queries");
+    const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
+    fetchBrainstormBulletsMock.mockResolvedValue(["angle"]);
+
     // Act
     const result = await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
@@ -187,8 +195,10 @@ describe("query-analysis run", () => {
 
     // Assert
     expect(result.success).toBe(true);
+    expect(fetchBrainstormBulletsMock).toHaveBeenCalledTimes(1);
     expect(mockFetchQueryLlm).toHaveBeenCalledWith(
-      expect.objectContaining({ useBrainstormPass: true }),
+      expect.objectContaining({ brainstormBullets: ["angle"] }),
+      expect.anything(),
     );
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -200,6 +210,9 @@ describe("query-analysis run", () => {
   });
 
   it("defaults useBrainstormPass to false in the LLM orchestrator", async () => {
+    const { fetchBrainstormBullets } = await import("./llm-queries");
+    const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
+
     // Act
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
@@ -208,8 +221,64 @@ describe("query-analysis run", () => {
     });
 
     // Assert
+    expect(fetchBrainstormBulletsMock).not.toHaveBeenCalled();
     expect(mockFetchQueryLlm).toHaveBeenCalledWith(
-      expect.objectContaining({ useBrainstormPass: false }),
+      expect.objectContaining({ brainstormBullets: undefined }),
+      expect.anything(),
     );
+  });
+
+  it("fires one diversity-gate broaden regenerate when the first batch is near-identical", async () => {
+    const lowDiversityBatch = Array.from({ length: 10 }, () => ({
+      text: "ABC latest news",
+      intent: "breaking" as const,
+      persona: "analyst",
+    }));
+    mockFetchQueryLlm
+      .mockResolvedValueOnce(lowDiversityBatch)
+      .mockResolvedValueOnce([
+        {
+          text: "ABC supply chain risk Q2",
+          intent: "supply_chain" as const,
+          persona: "retail",
+        },
+      ]);
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: queryAnalysisConfigSchema.parse({
+        openaiApiKey: "sk",
+        diversityGate: { enabled: true, threshold: 0.6 },
+      }),
+      token: "Bearer t",
+    });
+
+    expect(mockFetchQueryLlm).toHaveBeenCalledTimes(2);
+    const secondCall = mockFetchQueryLlm.mock.calls[1]?.[0] as {
+      broadenSystemNudge?: string;
+    };
+    expect(secondCall.broadenSystemNudge).toContain("diversity");
+    expect(secondCall.broadenSystemNudge).toContain("Vary phrasing");
+
+    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+      strategySnapshot: {
+        diversityScore?: { composite: number };
+        diversityGate?: { diversityRegenerateFired: boolean };
+      };
+    };
+    expect(createPayload.strategySnapshot.diversityScore).toBeDefined();
+    expect(
+      createPayload.strategySnapshot.diversityGate?.diversityRegenerateFired,
+    ).toBe(true);
+  });
+});
+
+describe("clampPerPersonaQuotaCount", () => {
+  it("returns configured quota when fan-out is within the guard", () => {
+    expect(clampPerPersonaQuotaCount(3, 3, 10)).toBe(3);
+  });
+
+  it("clamps quota when fan-out exceeds queryCount * 3", () => {
+    expect(clampPerPersonaQuotaCount(3, 10, 5)).toBe(5);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -5,16 +5,250 @@ import { logger } from "@workspace/logger";
 import { env } from "@mediapulse/env/agents-query-analysis";
 import type { QueryAnalysisConfig } from "./config-schema";
 import {
+  resolveDiversityGateConfig,
+  resolveIntentWeights,
+} from "./config-schema";
+import {
   resolveQueryAnalysisSystemContent,
   resolveQueryAnalysisUserContent,
-  fetchQueryAnalysisLlmCandidates,
+  fetchBrainstormBullets,
+  fetchLlmQueryCandidatesByPersona,
+  applySelfCritiquePass,
+  DEFAULT_CRITIC_PASS_DEADLINE_MS,
 } from "./llm-queries";
+import type { LlmCandidate } from "./merge-query-candidates";
 import { mergeQueryCandidates } from "./merge-query-candidates";
+import {
+  buildQuerySemanticEmbedder,
+  buildEmbeddingByText,
+  collectQueryTextsForEmbedding,
+  embedQueries,
+} from "./embeddings";
+import type { DeterministicCandidate } from "./merge-query-candidates";
+import { resolveQueryPersonas } from "./personas/default-personas";
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
+import {
+  buildDiversityBroadenSystemNudge,
+  computeDiversityScore,
+  type DiversityScoreResult,
+  type DiversityScoreRow,
+} from "./diversity/score";
 
 export { buildDeterministicQueries } from "./templates/build-deterministic-queries";
 
+export { DEFAULT_CRITIC_PASS_DEADLINE_MS } from "./llm-queries";
+
+type PersonaFetchParams = Parameters<
+  typeof fetchLlmQueryCandidatesByPersona
+>[0];
+type PersonaFetchDeps = Parameters<typeof fetchLlmQueryCandidatesByPersona>[1];
+
+/**
+ * Maps LLM candidate rows to diversity score inputs.
+ *
+ * @param llmCandidates - Post-critique LLM batch.
+ * @returns Rows for {@link computeDiversityScore}.
+ */
+export const toDiversityScoreRows = (
+  llmCandidates: LlmCandidate[],
+): DiversityScoreRow[] =>
+  llmCandidates.map((candidate) => ({
+    text: candidate.text,
+    intent: candidate.intent,
+    ...(candidate.persona !== undefined ? { persona: candidate.persona } : {}),
+  }));
+
+/**
+ * Embeds LLM candidate texts for the semantic diversity axis (llm rows only).
+ *
+ * @param llmCandidates - Candidate batch to embed.
+ * @param params - OpenAI credentials and embedding model.
+ * @param deps - Injectable embed collaborator.
+ * @returns Text-to-vector map when embedding succeeds; `undefined` on failure or empty input.
+ */
+export const buildLlmEmbeddingsForDiversity = async (
+  llmCandidates: LlmCandidate[],
+  params: { apiKey: string; embeddingModel: string; tickerId: string },
+  deps: {
+    embedQueries?: typeof embedQueries;
+    logWarn?: (message: string, meta: Record<string, unknown>) => void;
+  } = {},
+): Promise<Map<string, number[]> | undefined> => {
+  const runEmbed = deps.embedQueries ?? embedQueries;
+  const warn =
+    deps.logWarn ??
+    ((message, meta) => {
+      logger.warn(meta, message);
+    });
+
+  const texts = collectQueryTextsForEmbedding([], llmCandidates);
+  if (texts.length < 2) {
+    return undefined;
+  }
+
+  try {
+    const embeddings = await runEmbed(texts, {
+      apiKey: params.apiKey,
+      model: params.embeddingModel,
+    });
+    return buildEmbeddingByText(texts, embeddings);
+  } catch (error) {
+    warn(
+      "query-analysis diversity semantic embedding failed; omitting semantic axis",
+      { error, tickerId: params.tickerId },
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Runs at most one diversity-gate broaden regenerate pass when composite is below threshold.
+ *
+ * @param params - Current LLM batch, gate settings, optional embeddings, and broaden fetcher.
+ * @returns Merged candidates, scores, and whether a regenerate pass ran.
+ */
+export const applyDiversityGatePass = async (params: {
+  llmCandidates: LlmCandidate[];
+  diversityGate: ReturnType<typeof resolveDiversityGateConfig>;
+  embeddingsByText?: ReadonlyMap<string, number[]>;
+  allowRegenerate?: boolean;
+  fetchBroadenBatch: (broadenSystemNudge: string) => Promise<LlmCandidate[]>;
+  logWarn?: (message: string, meta: Record<string, unknown>) => void;
+}): Promise<{
+  candidates: LlmCandidate[];
+  diversityScore: DiversityScoreResult;
+  diversityRegenerateFired: boolean;
+}> => {
+  const warn =
+    params.logWarn ??
+    ((message, meta) => {
+      logger.warn(meta, message);
+    });
+
+  const scoreRows = toDiversityScoreRows(params.llmCandidates);
+  const scoreBeforeGate = computeDiversityScore(scoreRows, {
+    weights: params.diversityGate.weights,
+    embeddingsByText: params.embeddingsByText,
+  });
+
+  if (
+    !params.diversityGate.enabled ||
+    scoreBeforeGate.composite >= params.diversityGate.threshold ||
+    params.llmCandidates.length === 0 ||
+    params.allowRegenerate === false
+  ) {
+    return {
+      candidates: params.llmCandidates,
+      diversityScore: scoreBeforeGate,
+      diversityRegenerateFired: false,
+    };
+  }
+
+  const broadenNudge = buildDiversityBroadenSystemNudge(scoreBeforeGate);
+  let broadened: LlmCandidate[] = [];
+  try {
+    broadened = await params.fetchBroadenBatch(broadenNudge);
+  } catch (error) {
+    warn(
+      "query-analysis diversity gate regenerate failed; shipping first batch",
+      {
+        error,
+      },
+    );
+  }
+
+  const mergedCandidates = [...params.llmCandidates, ...broadened];
+  const diversityScore = computeDiversityScore(
+    toDiversityScoreRows(mergedCandidates),
+    {
+      weights: params.diversityGate.weights,
+      embeddingsByText: params.embeddingsByText,
+    },
+  );
+
+  return {
+    candidates: mergedCandidates,
+    diversityScore,
+    diversityRegenerateFired: true,
+  };
+};
+
 type QueryAnalysisInput = { tickerId: string };
+
+/**
+ * Builds the semantic embedder for merge, falling back to string dedupe on API failure.
+ *
+ * @param params - OpenAI credentials, candidate rows, threshold, and logging context.
+ * @param deps - Injectable embedding collaborator and logger.
+ * @returns Embedder when embedding succeeds; `undefined` to fall back to string-key dedupe.
+ */
+export const buildSemanticEmbedderForMerge = async (
+  params: {
+    apiKey: string;
+    deterministic: DeterministicCandidate[];
+    llmCandidates: LlmCandidate[];
+    threshold: number;
+    embeddingModel: string;
+    tickerId: string;
+  },
+  deps: {
+    embedQueries?: typeof embedQueries;
+    logWarn?: (message: string, meta: Record<string, unknown>) => void;
+  } = {},
+): Promise<ReturnType<typeof buildQuerySemanticEmbedder> | undefined> => {
+  const runEmbed = deps.embedQueries ?? embedQueries;
+  const warn =
+    deps.logWarn ??
+    ((message, meta) => {
+      logger.warn(meta, message);
+    });
+
+  const texts = collectQueryTextsForEmbedding(
+    params.deterministic,
+    params.llmCandidates,
+  );
+  if (texts.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const embeddings = await runEmbed(texts, {
+      apiKey: params.apiKey,
+      model: params.embeddingModel,
+    });
+    return buildQuerySemanticEmbedder(texts, embeddings, params.threshold);
+  } catch (error) {
+    warn(
+      "query-analysis semantic dedupe embedding failed; falling back to string-key dedupe",
+      { error, tickerId: params.tickerId },
+    );
+    return undefined;
+  }
+};
+
+/**
+ * Clamps per-persona quota when fan-out would exceed three times the target set size.
+ *
+ * @param personasLength - Number of personas that will run in parallel.
+ * @param perPersonaQuotaCount - Configured quota per persona.
+ * @param queryCount - Total rows to persist in the active query set.
+ * @returns Effective per-persona quota (≥ 1 when personasLength > 0).
+ */
+export const clampPerPersonaQuotaCount = (
+  personasLength: number,
+  perPersonaQuotaCount: number,
+  queryCount: number,
+): number => {
+  if (personasLength <= 0) {
+    return perPersonaQuotaCount;
+  }
+  const maxTotal = queryCount * 3;
+  const product = personasLength * perPersonaQuotaCount;
+  if (product <= maxTotal) {
+    return perPersonaQuotaCount;
+  }
+  return Math.max(1, Math.floor(maxTotal / personasLength));
+};
 
 /**
  * Runs the query-analysis agent for one ticker and persists an active query set.
@@ -26,6 +260,7 @@ export const runQueryAnalysis = async (
   context: AgentRunContext<QueryAnalysisInput, QueryAnalysisConfig>,
 ): Promise<AgentRunResult> => {
   const { input, config, token, hermesCorrelation } = context;
+  const runStartMs = Date.now();
   const client = createAgentDataApiClient({
     baseUrl: env.AGENT_DATA_API_URL,
     version: "v1",
@@ -45,9 +280,7 @@ export const runQueryAnalysis = async (
   const queryCount = config.queryCount!;
   const allowedLanguages = config.allowedLanguages!;
   const minDeterministicCount = config.minDeterministicCount!;
-  const weightBreaking = config.weightBreaking!;
-  const weightKgChange = config.weightKgChange!;
-  const weightFundamental = config.weightFundamental!;
+  const intentWeights = resolveIntentWeights(config);
   const openaiModel = config.openaiModel!;
   const maxTokens = config.maxTokens!;
   const temperature = config.temperature!;
@@ -58,16 +291,47 @@ export const runQueryAnalysis = async (
   const useBrainstormPass = config.useBrainstormPass!;
   const fewShotExemplarCount = config.fewShotExemplarCount!;
   const brainstormModel = config.brainstormModel ?? openaiModel;
+  const useSelfCritique = config.useSelfCritique!;
+  const critiqueDropFraction = config.critiqueDropFraction!;
+  const critiqueModel = config.critiqueModel ?? openaiModel;
+  const personaIds = config.personas!;
+  let perPersonaQuotaCount = config.perPersonaQuotaCount!;
+  const resolvedPersonas = resolveQueryPersonas(personaIds, {
+    warn: (_message, meta) => {
+      logger.warn(
+        { unknownPersonaId: meta.unknownId, tickerId: input.tickerId },
+        "unknown query-analysis persona id; skipping",
+      );
+    },
+  });
+
+  if (
+    resolvedPersonas.length > 0 &&
+    resolvedPersonas.length * perPersonaQuotaCount > queryCount * 3
+  ) {
+    const clamped = clampPerPersonaQuotaCount(
+      resolvedPersonas.length,
+      perPersonaQuotaCount,
+      queryCount,
+    );
+    logger.warn(
+      {
+        tickerId: input.tickerId,
+        personas: resolvedPersonas.length,
+        configuredPerPersonaQuotaCount: perPersonaQuotaCount,
+        clampedPerPersonaQuotaCount: clamped,
+        queryCount,
+      },
+      "query-analysis persona fan-out exceeds cost guard; clamping perPersonaQuotaCount",
+    );
+    perPersonaQuotaCount = clamped;
+  }
 
   const strategyPrompt = {
     queryCount,
     allowedLanguages,
     minDeterministicCount,
-    weights: {
-      breaking: weightBreaking,
-      kgChange: weightKgChange,
-      fundamental: weightFundamental,
-    },
+    intentWeights,
   };
 
   const systemContent = resolveQueryAnalysisSystemContent(
@@ -84,29 +348,60 @@ export const runQueryAnalysis = async (
     userContent,
   );
 
-  let llmCandidates: Awaited<
-    ReturnType<typeof fetchQueryAnalysisLlmCandidates>
-  > = [];
+  let llmCandidates: LlmCandidate[] = [];
+  let brainstormBullets: string[] | undefined;
   try {
-    llmCandidates = await fetchQueryAnalysisLlmCandidates({
-      apiKey: config.openaiApiKey,
-      model: openaiModel,
-      brainstormModel,
-      maxOutputTokens: maxTokens,
-      systemContent,
-      userContent,
-      context: queryContext,
-      strategy: strategyPrompt,
-      useBrainstormPass,
-      fewShotExemplarCount,
-      sampling: {
-        temperature,
-        topP,
-        presencePenalty,
-        frequencyPenalty,
-        ...(seed !== undefined ? { seed } : {}),
-      },
-    });
+    if (useBrainstormPass) {
+      brainstormBullets = await fetchBrainstormBullets({
+        apiKey: config.openaiApiKey,
+        model: brainstormModel,
+        maxOutputTokens: maxTokens,
+        strategy: strategyPrompt,
+        context: queryContext,
+        sampling: {
+          temperature,
+          topP,
+          presencePenalty,
+          frequencyPenalty,
+          ...(seed !== undefined ? { seed } : {}),
+        },
+      });
+    }
+
+    if (resolvedPersonas.length > 0) {
+      llmCandidates = await fetchLlmQueryCandidatesByPersona(
+        {
+          apiKey: config.openaiApiKey,
+          model: openaiModel,
+          maxOutputTokens: maxTokens,
+          systemContent,
+          userContent,
+          personas: resolvedPersonas,
+          perPersonaQuota: perPersonaQuotaCount,
+          fewShotExemplarCount,
+          brainstormBullets,
+          sampling: {
+            temperature,
+            topP,
+            presencePenalty,
+            frequencyPenalty,
+            ...(seed !== undefined ? { seed } : {}),
+          },
+        },
+        {
+          warn: (_message, meta) => {
+            logger.warn(
+              {
+                error: meta.error,
+                personaId: meta.personaId,
+                tickerId: input.tickerId,
+              },
+              "query-analysis persona LLM call failed; skipping persona",
+            );
+          },
+        },
+      );
+    }
   } catch (error) {
     logger.warn(
       { error, tickerId: input.tickerId },
@@ -114,27 +409,190 @@ export const runQueryAnalysis = async (
     );
   }
 
+  let selfCritiqueReplacedCount = 0;
+  let selfCritiqueSkippedDueToDeadline = false;
+  if (useSelfCritique && llmCandidates.length > 0) {
+    if (Date.now() - runStartMs > DEFAULT_CRITIC_PASS_DEADLINE_MS) {
+      selfCritiqueSkippedDueToDeadline = true;
+      logger.warn(
+        {
+          tickerId: input.tickerId,
+          elapsedMs: Date.now() - runStartMs,
+          deadlineMs: DEFAULT_CRITIC_PASS_DEADLINE_MS,
+        },
+        "query-analysis self-critique skipped due to deadline; shipping original LLM candidates",
+      );
+    } else {
+      try {
+        const critiqueResult = await applySelfCritiquePass({
+          apiKey: config.openaiApiKey,
+          critiqueModel,
+          generationModel: openaiModel,
+          maxOutputTokens: maxTokens,
+          systemContent,
+          userContent,
+          context: queryContext,
+          candidates: llmCandidates,
+          dropFraction: critiqueDropFraction,
+          fewShotExemplarCount,
+          sampling: {
+            temperature,
+            topP,
+            presencePenalty,
+            frequencyPenalty,
+            ...(seed !== undefined ? { seed } : {}),
+          },
+          runStartMs,
+          deadlineMs: DEFAULT_CRITIC_PASS_DEADLINE_MS,
+        });
+        llmCandidates = critiqueResult.candidates;
+        selfCritiqueReplacedCount = critiqueResult.replacedCount;
+        selfCritiqueSkippedDueToDeadline = critiqueResult.skippedDueToDeadline;
+        if (critiqueResult.skippedDueToDeadline) {
+          logger.warn(
+            { tickerId: input.tickerId },
+            "query-analysis self-critique aborted mid-pass due to deadline",
+          );
+        }
+      } catch (error) {
+        logger.warn(
+          { error, tickerId: input.tickerId },
+          "query-analysis self-critique failed; using pre-critique LLM candidates",
+        );
+      }
+    }
+  }
+
+  const diversityGate = resolveDiversityGateConfig(config);
+  const semanticDedupeConfig = config.semanticDedupe;
+  const embeddingModel =
+    semanticDedupeConfig?.embeddingModel ?? "text-embedding-3-small";
+
+  const personaFetchSampling = {
+    temperature,
+    topP,
+    presencePenalty,
+    frequencyPenalty,
+    ...(seed !== undefined ? { seed } : {}),
+  };
+  const personaFetchDeps: PersonaFetchDeps = {
+    warn: (_message, meta) => {
+      logger.warn(
+        {
+          error: meta.error,
+          personaId: meta.personaId,
+          tickerId: input.tickerId,
+        },
+        "query-analysis persona LLM call failed; skipping persona",
+      );
+    },
+  };
+  const buildPersonaFetchParams = (
+    broadenSystemNudge?: string,
+  ): PersonaFetchParams => ({
+    apiKey: config.openaiApiKey,
+    model: openaiModel,
+    maxOutputTokens: maxTokens,
+    systemContent,
+    userContent,
+    personas: resolvedPersonas,
+    perPersonaQuota: perPersonaQuotaCount,
+    fewShotExemplarCount,
+    brainstormBullets,
+    sampling: personaFetchSampling,
+    ...(broadenSystemNudge !== undefined ? { broadenSystemNudge } : {}),
+  });
+
+  let diversityEmbeddingsByText: Map<string, number[]> | undefined;
+  if (semanticDedupeConfig?.enabled && llmCandidates.length >= 2) {
+    diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
+      llmCandidates,
+      {
+        apiKey: config.openaiApiKey,
+        embeddingModel,
+        tickerId: input.tickerId,
+      },
+    );
+  }
+
+  let diversityScore: DiversityScoreResult | undefined;
+  let diversityRegenerateFired = false;
+  if (llmCandidates.length > 0) {
+    const gateResult = await applyDiversityGatePass({
+      llmCandidates,
+      diversityGate,
+      embeddingsByText: diversityEmbeddingsByText,
+      allowRegenerate: resolvedPersonas.length > 0,
+      fetchBroadenBatch: (broadenSystemNudge) =>
+        fetchLlmQueryCandidatesByPersona(
+          buildPersonaFetchParams(broadenSystemNudge),
+          personaFetchDeps,
+        ),
+      logWarn: (message, meta) => {
+        logger.warn({ ...meta, tickerId: input.tickerId }, message);
+      },
+    });
+    llmCandidates = gateResult.candidates;
+    diversityScore = gateResult.diversityScore;
+    diversityRegenerateFired = gateResult.diversityRegenerateFired;
+
+    if (diversityRegenerateFired && semanticDedupeConfig?.enabled) {
+      diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
+        llmCandidates,
+        {
+          apiKey: config.openaiApiKey,
+          embeddingModel,
+          tickerId: input.tickerId,
+        },
+      );
+      diversityScore = computeDiversityScore(
+        toDiversityScoreRows(llmCandidates),
+        {
+          weights: diversityGate.weights,
+          embeddingsByText: diversityEmbeddingsByText,
+        },
+      );
+    }
+
+    logger.info(
+      {
+        tickerId: input.tickerId,
+        diversityScore,
+        diversityRegenerateFired,
+        diversityGateEnabled: diversityGate.enabled,
+      },
+      "query-analysis diversity score computed",
+    );
+  }
+
+  let semanticEmbedder: Awaited<
+    ReturnType<typeof buildSemanticEmbedderForMerge>
+  > = undefined;
+  if (semanticDedupeConfig?.enabled) {
+    semanticEmbedder = await buildSemanticEmbedderForMerge({
+      apiKey: config.openaiApiKey,
+      deterministic,
+      llmCandidates,
+      threshold: semanticDedupeConfig.threshold ?? 0.85,
+      embeddingModel,
+      tickerId: input.tickerId,
+    });
+  }
+
   const merged = mergeQueryCandidates({
     deterministic,
     llm: llmCandidates,
     queryCount,
     minDeterministicCount,
-    weights: {
-      breaking: weightBreaking,
-      kgChange: weightKgChange,
-      fundamental: weightFundamental,
-    },
+    weights: intentWeights,
+    ...(semanticEmbedder ? { embedder: semanticEmbedder } : {}),
   });
 
   const strategySnapshot = {
     queryCount,
     allowedLanguages,
     minDeterministicCount,
-    weights: {
-      breaking: weightBreaking,
-      kgChange: weightKgChange,
-      fundamental: weightFundamental,
-    },
+    intentWeights,
     model: openaiModel,
     maxTokens,
     temperature,
@@ -143,8 +601,43 @@ export const runQueryAnalysis = async (
     frequencyPenalty,
     useBrainstormPass,
     fewShotExemplarCount,
+    personas: personaIds,
+    perPersonaQuotaCount,
+    useSelfCritique,
+    ...(useSelfCritique
+      ? {
+          critiqueDropFraction,
+          critiqueModel,
+          selfCritiqueReplacedCount,
+          selfCritiqueSkippedDueToDeadline,
+        }
+      : {}),
     ...(useBrainstormPass ? { brainstormModel } : {}),
     ...(seed !== undefined ? { seed } : {}),
+    ...(semanticDedupeConfig?.enabled
+      ? {
+          semanticDedupe: {
+            enabled: true,
+            threshold: semanticDedupeConfig.threshold ?? 0.85,
+            embeddingModel,
+          },
+        }
+      : {}),
+    ...(diversityScore !== undefined
+      ? {
+          diversityScore,
+          ...(diversityGate.enabled
+            ? {
+                diversityGate: {
+                  enabled: true,
+                  threshold: diversityGate.threshold,
+                  weights: diversityGate.weights,
+                  diversityRegenerateFired,
+                },
+              }
+            : {}),
+        }
+      : {}),
   };
 
   const response = await client.queryAnalysis.create({
@@ -152,7 +645,12 @@ export const runQueryAnalysis = async (
     generationSource: "hybrid_v1",
     strategySnapshot,
     activate: true,
-    queries: merged,
+    queries: merged.map(({ text, source, intent, rank }) => ({
+      text,
+      source,
+      intent,
+      rank,
+    })),
     ...(hermesCorrelation?.jobId !== undefined
       ? { agentJobId: hermesCorrelation.jobId }
       : {}),

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
@@ -121,3 +121,28 @@ describe("rich-v2 pack", () => {
     );
   });
 });
+
+describe("rich-v2-extended pack", () => {
+  it("covers every intent in the expanded taxonomy", () => {
+    const queries = buildDeterministicQueries(fullContext, {
+      pack: "rich-v2-extended",
+      clock: FIXED_CLOCK,
+    });
+    const intents = new Set(queries.map((row) => row.intent));
+    expect(intents.has("breaking")).toBe(true);
+    expect(intents.has("kg_change")).toBe(true);
+    expect(intents.has("fundamental")).toBe(true);
+    expect(intents.has("sentiment")).toBe(true);
+    expect(intents.has("competitor")).toBe(true);
+    expect(intents.has("supply_chain")).toBe(true);
+    expect(intents.has("esg")).toBe(true);
+    expect(intents.has("macro")).toBe(true);
+    expect(intents.has("technical")).toBe(true);
+  });
+
+  it("stays within the pack template cap", () => {
+    expect(
+      DETERMINISTIC_PACKS["rich-v2-extended"].templates.length,
+    ).toBeLessThanOrEqual(MAX_TEMPLATES_PER_PACK);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -1,7 +1,11 @@
 import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
 
 /** Named deterministic template pack identifiers. */
-export const DETERMINISTIC_PACK_NAMES = ["default-v1", "rich-v2"] as const;
+export const DETERMINISTIC_PACK_NAMES = [
+  "default-v1",
+  "rich-v2",
+  "rich-v2-extended",
+] as const;
 
 /** Valid `templatePack` config value. */
 export type DeterministicPackName = (typeof DETERMINISTIC_PACK_NAMES)[number];
@@ -69,6 +73,39 @@ const richV2Pack: DeterministicPack = {
   ],
 };
 
+/** Opt-in pack extending rich-v2 with coverage for the expanded intent taxonomy. */
+const richV2ExtendedPack: DeterministicPack = {
+  name: "rich-v2-extended",
+  templates: [
+    { template: "{symbol} latest news", intent: "breaking" },
+    { template: "why is {symbol} moving today", intent: "breaking" },
+    { template: "{name} {recentTheme} reaction", intent: "breaking" },
+    { template: "{name} relation changes", intent: "kg_change" },
+    { template: "{topEntity} impact on {name}", intent: "kg_change" },
+    { template: "{name} earnings guidance", intent: "fundamental" },
+    { template: "{name} vs sector peers", intent: "fundamental" },
+    { template: "{name} {currentQuarter} guidance", intent: "fundamental" },
+    { template: "{name} social media sentiment", intent: "sentiment" },
+    { template: "{name} analyst sentiment shift", intent: "sentiment" },
+    {
+      template: "{name} vs {topEntity} competitive threat",
+      intent: "competitor",
+    },
+    {
+      template: "{name} market share vs peers {currentYear}",
+      intent: "competitor",
+    },
+    { template: "{name} supplier risk", intent: "supply_chain" },
+    { template: "{name} supply chain disruption", intent: "supply_chain" },
+    { template: "{name} ESG controversies", intent: "esg" },
+    { template: "{name} sustainability disclosure", intent: "esg" },
+    { template: "{name} interest rate sensitivity", intent: "macro" },
+    { template: "{name} FX headwind {currentQuarter}", intent: "macro" },
+    { template: "{name} chart pattern {currentMonth}", intent: "technical" },
+    { template: "{symbol} support resistance levels", intent: "technical" },
+  ],
+};
+
 /** All registered deterministic template packs keyed by name. */
 export const DETERMINISTIC_PACKS: Record<
   DeterministicPackName,
@@ -76,6 +113,7 @@ export const DETERMINISTIC_PACKS: Record<
 > = {
   "default-v1": defaultV1Pack,
   "rich-v2": richV2Pack,
+  "rich-v2-extended": richV2ExtendedPack,
 };
 
 /**

--- a/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/query-analysis.mdx
@@ -77,10 +77,11 @@ This agent is configured per pipeline step via the Hermes invoke request body `c
 | `queryCount`                                              | No       | Total queries to persist (default `10`).                                                                                                                                                                                                     |
 | `minDeterministicCount`                                   | No       | Deterministic “floor” before LLM complement (default `4`).                                                                                                                                                                                   |
 | `allowedLanguages`                                        | No       | Target languages as BCP-47 codes (default `["en"]`).                                                                                                                                                                                         |
-| `weightBreaking` / `weightKgChange` / `weightFundamental` | No       | Intent mix weights (default `1`, `0.8`, `0.6`).                                                                                                                                                                                              |
+| `intentWeights`                                           | No       | Per-intent merge and LLM target-count weights (default favors `breaking` / `kg_change` / `fundamental`; new intents default ≤ `0.5`). Keys: `breaking`, `kg_change`, `fundamental`, `sentiment`, `competitor`, `supply_chain`, `esg`, `macro`, `technical`. |
+| `weightBreaking` / `weightKgChange` / `weightFundamental` | No       | **Deprecated.** Lifted into `intentWeights` when `intentWeights` is absent (default `1`, `0.8`, `0.6`).                                                                                                                                      |
 | `maxTokens`                                               | No       | LLM output token budget (default `800`).                                                                                                                                                                                                     |
-| `templatePack`                                            | No       | Deterministic template pack name (default `default-v1`). Set to `rich-v2` for the expanded ~20-template pack. Operators can switch packs via Hermes invoke config without redeploying the agent.                                             |
-| `prompts.systemPrompt`                                    | No       | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and the `weight*` fields (see below). |
+| `templatePack`                                            | No       | Deterministic template pack name (default `default-v1`). Set to `rich-v2` for the expanded ~20-template pack, or `rich-v2-extended` for all nine intents. Operators can switch packs via Hermes invoke config without redeploying the agent. |
+| `prompts.systemPrompt`                                    | No       | Optional full system prompt template. When set, it replaces the built-in default wording; placeholders inject languages and **intent-count hints** derived from `queryCount`, `minDeterministicCount`, and `intentWeights` (see below). |
 | `prompts.userPromptTemplate`                              | No       | Optional user prompt template. Default is a single `{{queryContextBlock}}` (serialized GET /query-analysis context).                                                                                                                         |
 
 ### Creativity sampling
@@ -101,19 +102,38 @@ LLM query generation uses higher-variance defaults than the AI SDK baseline so o
 
 | Situation                            | What still affects the LLM                                                                                                                                                                                                                                                                                                       |
 | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **No `prompts` fields**              | Package defaults: system text includes approximate breaking / kg_change / fundamental counts computed from **`queryCount`** and **`weightBreaking`** / **`weightKgChange`** / **`weightFundamental`**; user text is the GET context. **`allowedLanguages`** and **`minDeterministicCount`** appear in the default system prompt. |
-| **`prompts.systemPrompt` set**       | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{minDeterministicCount}}`** are still filled from the same strategy fields so you can reference numeric targets without redeploying.                 |
+| **No `prompts` fields**              | Package defaults: system text includes approximate counts for all nine intents computed from **`queryCount`** and **`intentWeights`**; user text is the GET context. **`allowedLanguages`** and **`minDeterministicCount`** appear in the default system prompt. |
+| **`prompts.systemPrompt` set**       | You replace the system instructions. Placeholders **`{{allowedLanguages}}`**, **`{{targetBreakingCount}}`**, **`{{targetKgCount}}`**, **`{{targetFundamentalCount}}`**, **`{{targetSentimentCount}}`**, **`{{targetCompetitorCount}}`**, **`{{targetSupplyChainCount}}`**, **`{{targetEsgCount}}`**, **`{{targetMacroCount}}`**, **`{{targetTechnicalCount}}`**, and **`{{minDeterministicCount}}`** are still filled from the same strategy fields. |
 | **`prompts.userPromptTemplate` set** | You control layout around **`{{queryContextBlock}}`** (or use only that token). The serialized context still reflects live GET data.                                                                                                                                                                                             |
-| **Merge / persistence**              | **`mergeQueryCandidates`** still uses **`weight*`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math.                                                                                                                               |
+| **Merge / persistence**              | **`mergeQueryCandidates`** still uses **`intentWeights`** and **`queryCount`** / **`minDeterministicCount`** for ordering and filling the persisted query set—prompt overrides do not change merge math.                                                                                                                         |
+
+## Query intents
+
+Each persisted query row carries an **`intent`** label. Legacy rows use the original trio; new runs may emit any value below.
+
+| Intent         | Meaning                                              | Example query                         | Default weight |
+| -------------- | ---------------------------------------------------- | ------------------------------------- | -------------- |
+| `breaking`     | Timely news, catalysts, price-moving events           | `why is ACME moving today`            | `1.0`          |
+| `kg_change`    | Knowledge-graph relation or entity changes           | `Acme Co relation changes`            | `0.8`          |
+| `fundamental`  | Earnings, guidance, regulatory, balance-sheet angles | `Acme Co Q2 2026 guidance`            | `0.6`          |
+| `sentiment`    | Social buzz, analyst tone, reputation swings         | `Acme Co social media sentiment`      | `0.5`          |
+| `competitor`   | Peer positioning, share shifts, competitive threats  | `Acme Co vs peers market share`       | `0.5`          |
+| `supply_chain` | Suppliers, logistics, input costs, bottlenecks       | `Acme Co supplier risk`               | `0.4`          |
+| `esg`          | Environmental, social, governance controversies    | `Acme Co ESG controversies`           | `0.3`          |
+| `macro`        | Rates, FX, commodity, geopolitical drivers           | `Acme Co interest rate sensitivity`   | `0.4`          |
+| `technical`    | Chart patterns, momentum, support/resistance         | `ACME chart pattern May`              | `0.3`          |
+
+New intents default to lower weights so enabling the taxonomy without re-tuning does not crowd out breaking news in the persisted set.
 
 ## Deterministic template packs
 
 Deterministic queries are built from a named **template pack** before the LLM complement is merged. Set **`templatePack`** in Hermes invoke config to switch packs without redeploying the agent.
 
-| Pack             | Templates | Slots used                                                                                                  | Example row         |
-| ---------------- | --------- | ----------------------------------------------------------------------------------------------------------- | ------------------- |
-| **`default-v1`** | 5         | `{symbol}`, `{name}`                                                                                        | `ACME latest news`  |
-| **`rich-v2`**    | ~20       | `{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, `{currentQuarter}`, `{currentYear}`, `{currentMonth}` | `Acme Co AI impact` |
+| Pack                  | Templates | Slots used                                                                                                  | Example row                    |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------------------- | ------------------------------ |
+| **`default-v1`**      | 5         | `{symbol}`, `{name}`                                                                                        | `ACME latest news`             |
+| **`rich-v2`**         | ~20       | `{symbol}`, `{name}`, `{topEntity}`, `{recentTheme}`, `{currentQuarter}`, `{currentYear}`, `{currentMonth}` | `Acme Co AI impact`            |
+| **`rich-v2-extended`**| ~20       | Same as `rich-v2` plus templates for sentiment, competitor, supply chain, ESG, macro, and technical intents | `Acme Co ESG controversies`    |
 
 Templates whose required slots cannot be filled from live GET /query-analysis context are **skipped** (never persisted with literal `{slot}` tokens). For example, `{recentTheme}` templates are omitted when the ticker has no recent themes.
 
@@ -124,6 +144,32 @@ Slot resolution uses the agent clock at run time:
 - **`{currentMonth}`** — full English month name, e.g. `May`
 - **`{topEntity}`** — highest-weight entity from `topEntities`
 - **`{recentTheme}`** — first entry from `recentThemes`
+
+## Diversity score and regenerate gate
+
+Before merge, the agent scores the LLM candidate batch on three axes and persists the breakdown in **`strategySnapshot.diversityScore`** (always, even when the gate is off). That lets operators collect telemetry before turning enforcement on.
+
+| Axis | What it measures | Penalizes |
+| ---- | ---------------- | --------- |
+| **Lexical** | Distinct-token ratio across all query texts | Repeated wording and copy-paste phrasing |
+| **Intent coverage** | Normalized entropy of intent labels (`÷ log(n_distinct_intents)`) | Collapse to one or two intents |
+| **Semantic spread** | Mean pairwise cosine distance from embeddings (when semantic dedupe is enabled) | Paraphrases that mean the same thing |
+
+**Persona coverage** (normalized entropy of persona tags) is recorded when rows carry `persona`; it does not enter the composite unless you extend weights in a future change.
+
+The **composite** is a weighted sum of lexical, intent, and semantic terms (defaults `0.4` / `0.3` / `0.3`). When semantic dedupe is off, the semantic term is omitted and the remaining weights are renormalized.
+
+| Config field | Default | Notes |
+| ------------ | ------- | ----- |
+| `diversityGate.enabled` | `false` | When `true` and composite &lt; threshold, one extra persona fan-out runs with a broaden nudge |
+| `diversityGate.threshold` | `0.6` | Scores below this trigger regenerate (max **one** pass per run) |
+| `diversityGate.weights.lexical` | `0.4` | Lexical axis weight |
+| `diversityGate.weights.intent` | `0.3` | Intent entropy weight |
+| `diversityGate.weights.semantic` | `0.3` | Semantic spread weight (ignored when semantic dedupe is off) |
+
+**When to enable:** Turn the gate on after you have a week of `diversityScore` snapshots and a sense of typical composite ranges for your tickers. Start with the default threshold; lower it if you still see narrow batches slipping through, raise it if regenerate passes add cost without improving persisted sets.
+
+The regenerate pass **appends** a second LLM batch; it does not discard the first. Semantic or string dedupe during merge collapses overlap. Even if the second batch is still low-diversity, the run ships after that single retry.
 
 ## Hermes run payload
 

--- a/packages/mediapulse/database/prisma/migrations/20260521120000_extend_search_query_intent/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260521120000_extend_search_query_intent/migration.sql
@@ -1,0 +1,7 @@
+-- AlterEnum
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'sentiment';
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'competitor';
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'supply_chain';
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'esg';
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'macro';
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'technical';

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -28,6 +28,12 @@ enum SearchQueryIntent {
   breaking
   kg_change
   fundamental
+  sentiment
+  competitor
+  supply_chain
+  esg
+  macro
+  technical
 }
 
 model DataSource {

--- a/packages/shared/agent-data-api-contract/package.json
+++ b/packages/shared/agent-data-api-contract/package.json
@@ -13,13 +13,15 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
-    "type:check": "tsc --noEmit"
+    "type:check": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "zod": "catalog:"
   },
   "devDependencies": {
     "@workspace/typescript-config": "workspace:*",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -96,6 +96,8 @@ export {
   postQueryAnalysisResponseSchema,
   queryAnalysisConfigSnapshotSchema,
   queryAnalysisIntentSchema,
+  QUERY_ANALYSIS_INTENTS,
+  DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
   queryAnalysisRecentThemeSchema,
   queryAnalysisRelationDeltaSchema,
   queryAnalysisSourceSchema,
@@ -107,6 +109,7 @@ export {
   type PostQueryAnalysisBody,
   type PostQueryAnalysisResponse,
   type QueryAnalysisIntent,
+  type QueryAnalysisIntentWeights,
   type QueryAnalysisSource,
 } from "./query-analysis.js";
 export {

--- a/packages/shared/agent-data-api-contract/src/query-analysis.test.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.test.ts
@@ -1,0 +1,34 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  queryAnalysisIntentSchema,
+  queryAnalysisPostQuerySchema,
+} from "./query-analysis.js";
+
+describe("queryAnalysisIntentSchema", () => {
+  it("accepts legacy breaking intent rows", () => {
+    const parsed = queryAnalysisPostQuerySchema.parse({
+      text: "ACME latest news",
+      source: "deterministic",
+      intent: "breaking",
+      rank: 1,
+    });
+    expect(parsed.intent).toBe("breaking");
+  });
+
+  it("accepts new esg intent rows", () => {
+    const parsed = queryAnalysisPostQuerySchema.parse({
+      text: "Acme Co ESG controversies",
+      source: "llm",
+      intent: "esg",
+      rank: 3,
+    });
+    expect(parsed.intent).toBe("esg");
+  });
+
+  it("rejects unknown intent labels", () => {
+    const result = queryAnalysisIntentSchema.safeParse("unknown_intent");
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/shared/agent-data-api-contract/src/query-analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.ts
@@ -1,10 +1,37 @@
 import { z } from "zod";
 
-export const queryAnalysisIntentSchema = z.enum([
+/** All supported query-analysis intent labels (contract source of truth). */
+export const QUERY_ANALYSIS_INTENTS = [
   "breaking",
   "kg_change",
   "fundamental",
-]);
+  "sentiment",
+  "competitor",
+  "supply_chain",
+  "esg",
+  "macro",
+  "technical",
+] as const;
+
+export const queryAnalysisIntentSchema = z.enum(QUERY_ANALYSIS_INTENTS);
+
+export type QueryAnalysisIntent = z.infer<typeof queryAnalysisIntentSchema>;
+
+/** Default merge / sampling weights keyed by intent (new intents intentionally ≤ 0.5). */
+export const DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS: Record<
+  QueryAnalysisIntent,
+  number
+> = {
+  breaking: 1,
+  kg_change: 0.8,
+  fundamental: 0.6,
+  sentiment: 0.5,
+  competitor: 0.5,
+  supply_chain: 0.4,
+  esg: 0.3,
+  macro: 0.4,
+  technical: 0.3,
+};
 
 export const queryAnalysisSourceSchema = z.enum(["deterministic", "llm"]);
 
@@ -16,11 +43,17 @@ export const queryAnalysisConfigSnapshotSchema = z.object({
   queryCount: z.number().int().positive(),
   allowedLanguages: z.array(z.string().trim().min(1)),
   minDeterministicCount: z.number().int().nonnegative(),
-  weights: z.object({
-    breaking: z.number().nonnegative(),
-    kgChange: z.number().nonnegative(),
-    fundamental: z.number().nonnegative(),
-  }),
+  /** @deprecated Prefer `intentWeights`; legacy snapshots may only include the original trio. */
+  weights: z
+    .object({
+      breaking: z.number().nonnegative(),
+      kgChange: z.number().nonnegative(),
+      fundamental: z.number().nonnegative(),
+    })
+    .optional(),
+  intentWeights: z
+    .record(queryAnalysisIntentSchema, z.number().nonnegative())
+    .optional(),
   model: z.string().trim().min(1).optional(),
   maxTokens: z.number().int().positive().optional(),
 });
@@ -116,5 +149,5 @@ export type GetQueryAnalysisResponse = z.infer<
 export type PostQueryAnalysisResponse = z.infer<
   typeof postQueryAnalysisResponseSchema
 >;
-export type QueryAnalysisIntent = z.infer<typeof queryAnalysisIntentSchema>;
 export type QueryAnalysisSource = z.infer<typeof queryAnalysisSourceSchema>;
+export type QueryAnalysisIntentWeights = Record<QueryAnalysisIntent, number>;

--- a/packages/shared/agent-data-api-contract/vitest.config.ts
+++ b/packages/shared/agent-data-api-contract/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1525,6 +1525,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.2.3)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/shared/agent-llm-prompt-template:
     devDependencies:


### PR DESCRIPTION
## Summary

Query-analysis runs were still too homogeneous: one synthetic analyst voice, three intent buckets, and string dedupe that let paraphrases through. This PR adds persona fan-out, nine intents, an optional self-critique pass, embedding-based dedupe, and a diversity score with an optional one-shot broaden regenerate. Scores land in `strategySnapshot` so operators can watch batch quality before turning the gate on.

## Related issues

Closes #543

## Important changes

- **Multi-persona prompting** — parallel fan-out per persona with round-robin merge and a cost guard on `perPersonaQuotaCount`.
- **Expanded intent taxonomy** — contract + Prisma enum migration; `intentWeights` replaces flat `weight*` fields with legacy lift.
- **Self-critique pass** — optional drop-and-replace on LLM rows only; skipped under a 30s deadline.
- **Semantic dedupe** — one batched embed call per run; deterministic rows stay as anchors; API failure falls back to string dedupe.
- **Diversity gate** — lexical, intent, and optional semantic axes; at most one broaden regenerate when `diversityGate.enabled` and composite is below threshold.

## Other changes

- `rich-v2-extended` deterministic template pack covering all nine intents.
- Dev-docs section on diversity scoring and gate configuration.
- Contract round-trip tests for new intent values.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/run.ts` — pipeline wiring (critique → diversity gate → semantic embedder → merge).
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — persona fan-out, critique, broaden nudge.
- `apps/mediapulse/agents/query-analysis/src/diversity/score.ts` — pure diversity metrics and composite.
- `apps/mediapulse/agents/query-analysis/src/embeddings.ts` — batched embed + cosine dedupe.
- `packages/shared/agent-data-api-contract/src/query-analysis.ts` — nine-intent schema.
- `packages/mediapulse/database/prisma/migrations/20260521120000_extend_search_query_intent/` — Postgres enum extension.

## How to test

1. From repo root: `corepack pnpm code-quality` (already green locally).
2. Scoped: `corepack pnpm --filter @mediapulse/agents-query-analysis test`.
3. Invoke query-analysis with default config — confirm persona-tagged LLM rows merge and `strategySnapshot` includes personas.
4. Enable `useSelfCritique: true` — confirm replaced count appears in snapshot; deterministic floor unchanged.
5. Enable `semanticDedupe.enabled: true` — confirm near-duplicate paraphrases collapse before merge.
6. Enable `diversityGate.enabled: true` with a low threshold on a ticker that produces narrow batches — confirm exactly one broaden fetch and `diversityScore` in snapshot.
