### PR TITLE
Add query-analysis wildcard, event bias, KG templates, and multilingual quotas

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -35,12 +35,25 @@ describe("queryAnalysisConfigSchema templatePack", () => {
     expect(parsed.templatePack).toBe("rich-v2-extended");
   });
 
+  it("accepts kg-aware-v1 template pack", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      templatePack: "kg-aware-v1",
+    });
+    expect(parsed.templatePack).toBe("kg-aware-v1");
+  });
+
   it("rejects unknown template pack names", () => {
     const result = queryAnalysisConfigSchema.safeParse({
       ...minimal,
       templatePack: "unknown",
     });
     expect(result.success).toBe(false);
+  });
+
+  it("defaults kgTemplateCap to 6", () => {
+    const parsed = queryAnalysisConfigSchema.parse(minimal);
+    expect(parsed.kgTemplateCap).toBe(6);
   });
 });
 
@@ -324,5 +337,81 @@ describe("resolveDiversityGateConfig", () => {
       threshold: 0.6,
       weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
     });
+  });
+});
+
+describe("resolveTemporalBiasConfig", () => {
+  it("defaults temporal bias to enabled", async () => {
+    const { resolveTemporalBiasConfig } = await import("./config-schema");
+    expect(resolveTemporalBiasConfig({})).toEqual({ enabled: true });
+  });
+
+  it("honors temporalBias.enabled=false", async () => {
+    const { resolveTemporalBiasConfig } = await import("./config-schema");
+    expect(
+      resolveTemporalBiasConfig({ temporalBias: { enabled: false } }),
+    ).toEqual({ enabled: false });
+  });
+});
+
+describe("queryAnalysisConfigSchema temporalBias", () => {
+  it("defaults temporalBias.enabled to true when the object is present", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      temporalBias: {},
+    });
+    expect(parsed.temporalBias?.enabled).toBe(true);
+  });
+});
+
+describe("queryAnalysisConfigSchema languageQuotas", () => {
+  it("accepts valid languageQuotas whose shares sum to 1.0", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      ...minimal,
+      languageQuotas: [
+        { language: "en", share: 0.6 },
+        { language: "id", share: 0.4 },
+      ],
+    });
+    expect(parsed.languageQuotas).toEqual([
+      { language: "en", share: 0.6 },
+      { language: "id", share: 0.4 },
+    ]);
+  });
+
+  it("rejects languageQuotas shares summing to 0.99", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      languageQuotas: [
+        { language: "en", share: 0.59 },
+        { language: "id", share: 0.4 },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("languageQuotas shares must sum to 1.0"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects languageQuotas shares summing to 1.01", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      ...minimal,
+      languageQuotas: [
+        { language: "en", share: 0.61 },
+        { language: "id", share: 0.4 },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("languageQuotas shares must sum to 1.0"),
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -59,6 +59,25 @@ export type ResolvedDiversityGateConfig = {
   };
 };
 
+/** Resolved temporal event-bias settings with defaults applied. */
+export type ResolvedTemporalBiasConfig = {
+  enabled: boolean;
+};
+
+/**
+ * Resolves temporal event-bias config with schema defaults when fields are omitted.
+ *
+ * @param config - Parsed or raw Hermes invoke config.
+ * @returns Effective temporal bias toggle for the run loop.
+ */
+export const resolveTemporalBiasConfig = (config: {
+  temporalBias?: {
+    enabled?: boolean;
+  };
+}): ResolvedTemporalBiasConfig => ({
+  enabled: config.temporalBias?.enabled ?? true,
+});
+
 /**
  * Resolves diversity gate config with schema defaults when fields are omitted.
  *
@@ -113,9 +132,21 @@ export const queryAnalysisConfigSchema = z
      */
     minDeterministicCount: z.number().int().nonnegative().optional().default(4),
     /**
-     * Target languages (BCP-47 codes) for LLM-generated query text.
+     * Per-language query budget shares and optional template pack overrides.
      */
-    allowedLanguages: z.array(z.string().min(1)).optional().default(["en"]),
+    languageQuotas: z
+      .array(
+        z.object({
+          language: z.string().min(1),
+          share: z.number().min(0).max(1),
+          templatePack: z.string().min(1).optional(),
+        }),
+      )
+      .optional(),
+    /**
+     * @deprecated Use `languageQuotas`. Lifted to equal shares when `languageQuotas` is absent.
+     */
+    allowedLanguages: z.array(z.string().min(1)).optional(),
     /**
      * Relative weights keyed by intent for merge ordering and LLM target counts.
      */
@@ -147,6 +178,11 @@ export const queryAnalysisConfigSchema = z
       .optional()
       .default(DEFAULT_DETERMINISTIC_PACK),
     /**
+     * Maximum KG relation rows expanded into deterministic templates per run.
+     * `0` disables KG-template expansion without changing the pack.
+     */
+    kgTemplateCap: z.number().int().nonnegative().optional().default(6),
+    /**
      * LLM sampling temperature (higher = more varied phrasing).
      */
     temperature: z.number().min(0).max(2).optional().default(0.9),
@@ -166,6 +202,14 @@ export const queryAnalysisConfigSchema = z
      * Optional fixed seed for reproducible LLM output during regression hunts.
      */
     seed: z.number().int().optional(),
+    /**
+     * Fraction of each query set reserved for stochastic wildcard (lateral) queries.
+     */
+    wildcardFraction: z.number().min(0).max(0.5).optional().default(0.1),
+    /**
+     * Sampling temperature for wildcard generation (defaults higher than `temperature`).
+     */
+    wildcardTemperature: z.number().min(0).max(2).optional().default(1.2),
     /**
      * When true, runs a free-form brainstorm pass before structured query generation.
      */
@@ -228,6 +272,14 @@ export const queryAnalysisConfigSchema = z
       })
       .optional(),
     /**
+     * Optional calendar-driven intent weight boosts (default on; conservative multipliers).
+     */
+    temporalBias: z
+      .object({
+        enabled: z.boolean().default(true),
+      })
+      .optional(),
+    /**
      * Optional overrides for query-generation LLM system/user templates (Hermes).
      * When omitted, built-in defaults are used. Do not put API keys inside prompt text.
      */
@@ -256,6 +308,20 @@ export const queryAnalysisConfigSchema = z
       .optional(),
   })
   .superRefine((data, ctx) => {
+    if (data.languageQuotas !== undefined && data.languageQuotas.length > 0) {
+      const sum = data.languageQuotas.reduce(
+        (total, quota) => total + quota.share,
+        0,
+      );
+      if (Math.abs(sum - 1) > 0.001) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `languageQuotas shares must sum to 1.0 (received ${String(sum)})`,
+          path: ["languageQuotas"],
+        });
+      }
+    }
+
     const prompts = data.prompts;
     if (!prompts) {
       return;

--- a/apps/mediapulse/agents/query-analysis/src/embeddings.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/embeddings.test.ts
@@ -114,6 +114,7 @@ describe("mergeQueryCandidates with semantic embedder", () => {
         esg: 0.3,
         macro: 0.4,
         technical: 0.3,
+        wildcard: 0,
       },
       embedder: fakeEmbedder(0.85),
     });

--- a/apps/mediapulse/agents/query-analysis/src/i18n/entity-aliases.ts
+++ b/apps/mediapulse/agents/query-analysis/src/i18n/entity-aliases.ts
@@ -1,0 +1,44 @@
+/** Static entity alias map: symbol → language → display name. */
+export const ENTITY_ALIASES_BY_SYMBOL: Record<
+  string,
+  Record<string, string>
+> = {
+  BBCA: {
+    en: "Bank Central Asia",
+    id: "Bank Central Asia",
+  },
+  BCA: {
+    en: "Bank Central Asia",
+    id: "Bank Central Asia",
+  },
+};
+
+/**
+ * Returns the primary BCP-47 language subtag (e.g. `id-ID` → `id`).
+ *
+ * @param language - BCP-47 language tag.
+ * @returns Lowercase primary subtag.
+ */
+export const primaryLanguageSubtag = (language: string): string =>
+  language.trim().split("-")[0]?.toLowerCase() ?? language.toLowerCase();
+
+/**
+ * Resolves the language-appropriate display name for a ticker, when aliased.
+ *
+ * @param symbol - Ticker symbol.
+ * @param canonicalName - Default company name from GET context.
+ * @param language - Target query language (BCP-47).
+ * @returns Alias when registered; otherwise the canonical name.
+ */
+export const resolveEntityDisplayName = (
+  symbol: string,
+  canonicalName: string,
+  language: string,
+): string => {
+  const aliases = ENTITY_ALIASES_BY_SYMBOL[symbol.trim().toUpperCase()];
+  if (!aliases) {
+    return canonicalName;
+  }
+  const primary = primaryLanguageSubtag(language);
+  return aliases[primary] ?? aliases[language] ?? canonicalName;
+};

--- a/apps/mediapulse/agents/query-analysis/src/language-quotas.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/language-quotas.test.ts
@@ -69,9 +69,9 @@ describe("distributeQueryCountAcrossLanguages", () => {
 
 describe("resolveLanguageTemplatePack", () => {
   it("prefers per-quota templatePack override", () => {
-    expect(
-      resolveLanguageTemplatePack("id", "kg-aware-v1", "default-v1"),
-    ).toBe("kg-aware-v1");
+    expect(resolveLanguageTemplatePack("id", "kg-aware-v1", "default-v1")).toBe(
+      "kg-aware-v1",
+    );
   });
 
   it("selects localized default pack by primary language subtag", () => {

--- a/apps/mediapulse/agents/query-analysis/src/language-quotas.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/language-quotas.test.ts
@@ -1,0 +1,91 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  distributeQueryCountAcrossLanguages,
+  languageQuotaSharesAreValid,
+  resolveLanguageQuotas,
+  resolveLanguageTemplatePack,
+} from "./language-quotas";
+
+describe("languageQuotaSharesAreValid", () => {
+  it("returns true when shares sum to 1.0", () => {
+    expect(
+      languageQuotaSharesAreValid([
+        { language: "en", share: 0.6 },
+        { language: "id", share: 0.4 },
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when shares sum away from 1.0", () => {
+    expect(
+      languageQuotaSharesAreValid([
+        { language: "en", share: 0.59 },
+        { language: "id", share: 0.4 },
+      ]),
+    ).toBe(false);
+  });
+});
+
+describe("resolveLanguageQuotas", () => {
+  it("returns explicit languageQuotas when provided", () => {
+    const quotas = [
+      { language: "en", share: 0.6 },
+      { language: "id", share: 0.4 },
+    ];
+    expect(resolveLanguageQuotas({ languageQuotas: quotas })).toEqual(quotas);
+  });
+
+  it("lifts legacy allowedLanguages to equal shares", () => {
+    expect(
+      resolveLanguageQuotas({ allowedLanguages: ["en", "id", "de"] }),
+    ).toEqual([
+      { language: "en", share: 1 / 3 },
+      { language: "id", share: 1 / 3 },
+      { language: "de", share: 1 / 3 },
+    ]);
+  });
+
+  it("defaults to English-only when neither field is set", () => {
+    expect(resolveLanguageQuotas({})).toEqual([{ language: "en", share: 1 }]);
+  });
+});
+
+describe("distributeQueryCountAcrossLanguages", () => {
+  it("assigns 6 English and 4 Indonesian rows for 60/40 split over 10", () => {
+    const distributed = distributeQueryCountAcrossLanguages(10, [
+      { language: "en", share: 0.6 },
+      { language: "id", share: 0.4 },
+    ]);
+
+    expect(distributed).toEqual([
+      { language: "en", share: 0.6, queryCount: 6 },
+      { language: "id", share: 0.4, queryCount: 4 },
+    ]);
+    expect(distributed.reduce((sum, row) => sum + row.queryCount, 0)).toBe(10);
+  });
+});
+
+describe("resolveLanguageTemplatePack", () => {
+  it("prefers per-quota templatePack override", () => {
+    expect(
+      resolveLanguageTemplatePack("id", "kg-aware-v1", "default-v1"),
+    ).toBe("kg-aware-v1");
+  });
+
+  it("selects localized default pack by primary language subtag", () => {
+    expect(resolveLanguageTemplatePack("id-ID", undefined, "default-v1")).toBe(
+      "default-id-v1",
+    );
+    expect(resolveLanguageTemplatePack("en", undefined, "default-v1")).toBe(
+      "default-en-v1",
+    );
+  });
+
+  it("falls back to global templatePack when no localized pack exists", () => {
+    expect(resolveLanguageTemplatePack("de", undefined, "rich-v2")).toBe(
+      "rich-v2",
+    );
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
+++ b/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
@@ -25,7 +25,9 @@ const SHARE_SUM_TOLERANCE = 0.001;
  * @param quotas - Parsed language quota rows.
  * @returns `true` when shares sum to approximately 1.0.
  */
-export const languageQuotaSharesAreValid = (quotas: LanguageQuota[]): boolean => {
+export const languageQuotaSharesAreValid = (
+  quotas: LanguageQuota[],
+): boolean => {
   if (quotas.length === 0) {
     return false;
   }
@@ -78,7 +80,8 @@ export const distributeQueryCountAcrossLanguages = (
     };
   });
 
-  let remainder = totalCount - entries.reduce((sum, row) => sum + row.queryCount, 0);
+  let remainder =
+    totalCount - entries.reduce((sum, row) => sum + row.queryCount, 0);
   const byRemainder = [...entries].sort(
     (left, right) =>
       right.exact - right.queryCount - (left.exact - left.queryCount),

--- a/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
+++ b/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
@@ -1,0 +1,117 @@
+import {
+  DEFAULT_DETERMINISTIC_PACK,
+  DEFAULT_TEMPLATE_PACK_BY_LANGUAGE,
+  type DeterministicPackName,
+} from "./templates/deterministic-packs";
+import { primaryLanguageSubtag } from "./i18n/entity-aliases";
+
+/** One language slice of the query budget with optional pack override. */
+export type LanguageQuota = {
+  language: string;
+  share: number;
+  templatePack?: string;
+};
+
+/** Language quota with an assigned integer row count. */
+export type DistributedLanguageQuota = LanguageQuota & {
+  queryCount: number;
+};
+
+const SHARE_SUM_TOLERANCE = 0.001;
+
+/**
+ * Validates that language quota shares sum to 1.0 within tolerance.
+ *
+ * @param quotas - Parsed language quota rows.
+ * @returns `true` when shares sum to approximately 1.0.
+ */
+export const languageQuotaSharesAreValid = (quotas: LanguageQuota[]): boolean => {
+  if (quotas.length === 0) {
+    return false;
+  }
+  const sum = quotas.reduce((total, quota) => total + quota.share, 0);
+  return Math.abs(sum - 1) <= SHARE_SUM_TOLERANCE;
+};
+
+/**
+ * Resolves effective language quotas from Hermes config, lifting legacy `allowedLanguages`.
+ *
+ * @param config - Parsed or raw invoke config language fields.
+ * @returns Normalized quota list whose shares sum to 1.0.
+ */
+export const resolveLanguageQuotas = (config: {
+  languageQuotas?: LanguageQuota[];
+  allowedLanguages?: string[];
+}): LanguageQuota[] => {
+  if (config.languageQuotas !== undefined && config.languageQuotas.length > 0) {
+    return config.languageQuotas;
+  }
+  const languages = config.allowedLanguages ?? ["en"];
+  if (languages.length === 0) {
+    return [{ language: "en", share: 1 }];
+  }
+  const share = 1 / languages.length;
+  return languages.map((language) => ({ language, share }));
+};
+
+/**
+ * Distributes an integer query budget across language quotas (largest-remainder method).
+ *
+ * @param totalCount - Total rows to allocate across languages.
+ * @param quotas - Language shares that sum to 1.0.
+ * @returns Quotas with `queryCount` assigned; sum equals `totalCount`.
+ */
+export const distributeQueryCountAcrossLanguages = (
+  totalCount: number,
+  quotas: LanguageQuota[],
+): DistributedLanguageQuota[] => {
+  if (quotas.length === 0 || totalCount <= 0) {
+    return [];
+  }
+
+  const entries = quotas.map((quota) => {
+    const exact = totalCount * quota.share;
+    return {
+      ...quota,
+      exact,
+      queryCount: Math.floor(exact),
+    };
+  });
+
+  let remainder = totalCount - entries.reduce((sum, row) => sum + row.queryCount, 0);
+  const byRemainder = [...entries].sort(
+    (left, right) =>
+      right.exact - right.queryCount - (left.exact - left.queryCount),
+  );
+
+  for (let index = 0; remainder > 0; index += 1) {
+    byRemainder[index % byRemainder.length]!.queryCount += 1;
+    remainder -= 1;
+  }
+
+  return entries.map(({ exact: _exact, ...quota }) => quota);
+};
+
+/**
+ * Resolves the deterministic template pack for a language slice.
+ *
+ * @param language - BCP-47 language tag for the slice.
+ * @param quotaTemplatePack - Optional per-quota pack override.
+ * @param globalTemplatePack - Hermes `templatePack` default for the run.
+ * @returns Pack name to pass to {@link buildDeterministicQueries}.
+ */
+export const resolveLanguageTemplatePack = (
+  language: string,
+  quotaTemplatePack: string | undefined,
+  globalTemplatePack: DeterministicPackName | string,
+): string => {
+  if (quotaTemplatePack !== undefined && quotaTemplatePack.length > 0) {
+    return quotaTemplatePack;
+  }
+  const primary = primaryLanguageSubtag(language);
+  const localized = DEFAULT_TEMPLATE_PACK_BY_LANGUAGE[primary];
+  if (localized !== undefined) {
+    return localized;
+  }
+  return globalTemplatePack || DEFAULT_DETERMINISTIC_PACK;
+};

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -13,6 +13,7 @@ import {
   fetchLlmQueryCandidates,
   fetchLlmQueryCandidatesByPersona,
   fetchQueryAnalysisLlmCandidates,
+  fetchWildcardCandidates,
   mergeCritiqueReplacements,
   parseBrainstormBullets,
   regenerateDroppedQueries,
@@ -26,6 +27,7 @@ describe("resolveQueryAnalysisSystemContent", () => {
   it("matches buildQueryAnalysisSystemContent when Hermes omits override", () => {
     const strategy = {
       queryCount: 10,
+      language: "en",
       allowedLanguages: ["en", "de"],
       minDeterministicCount: 3,
       intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
@@ -98,17 +100,17 @@ describe("resolveQueryAnalysisUserContent", () => {
 });
 
 describe("buildQueryAnalysisSystemContent", () => {
-  it("includes languages, intent mix hints, and schema instructions", () => {
+  it("includes language lock, intent mix hints, and schema instructions", () => {
     // Act
     const text = buildQueryAnalysisSystemContent({
       queryCount: 10,
-      allowedLanguages: ["en", "de"],
+      language: "id",
       minDeterministicCount: 3,
       intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
     });
 
     // Assert
-    expect(text).toContain("en, de");
+    expect(text).toContain("All queries must be in id");
     expect(text).toContain("kg_change");
     expect(text).toContain("3");
     expect(text).toContain('"queries"');
@@ -225,6 +227,7 @@ describe("buildBrainstormPrompt", () => {
     const prompt = buildBrainstormPrompt(
       {
         queryCount: 10,
+        language: "en",
         allowedLanguages: ["en"],
         minDeterministicCount: 4,
         intentWeights: {
@@ -278,6 +281,7 @@ describe("fetchBrainstormBullets", () => {
         maxOutputTokens: 200,
         strategy: {
           queryCount: 10,
+          language: "en",
           allowedLanguages: ["en"],
           minDeterministicCount: 4,
           intentWeights: {
@@ -332,6 +336,7 @@ describe("fetchQueryAnalysisLlmCandidates", () => {
     },
     strategy: {
       queryCount: 10,
+      language: "en",
       allowedLanguages: ["en"],
       minDeterministicCount: 4,
       intentWeights: {
@@ -796,5 +801,94 @@ describe("fetchLlmQueryCandidates", () => {
         { generateObjectForQueries },
       ),
     ).rejects.toThrow("api down");
+  });
+});
+
+describe("fetchWildcardCandidates", () => {
+  const defaultSampling = {
+    temperature: 0.9,
+    topP: 0.95,
+    presencePenalty: 0.4,
+    frequencyPenalty: 0.5,
+  };
+
+  const baseContext = {
+    ticker: {
+      id: "11111111-1111-4111-a111-111111111111",
+      symbol: "ACME",
+      name: "Acme Co",
+      metadata: null,
+    },
+    topEntities: [] as [],
+    recentThemes: [] as [],
+    recentRelationDeltas: [] as [],
+    ...emptyEnrichedContext,
+  };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes wildcardTemperature instead of global temperature to generateObject", async () => {
+    const generateObjectForWildcards = vi.fn().mockResolvedValue({
+      object: {
+        queries: [{ text: "Oblique supply rumor" }],
+      },
+    });
+
+    await fetchWildcardCandidates(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        count: 2,
+        context: baseContext,
+        allowedLanguages: ["en"],
+        sampling: defaultSampling,
+        wildcardTemperature: 1.2,
+      },
+      { generateObjectForWildcards },
+    );
+
+    expect(generateObjectForWildcards).toHaveBeenCalledWith(
+      expect.objectContaining({
+        temperature: 1.2,
+        topP: 0.95,
+      }),
+    );
+    expect(generateObjectForWildcards.mock.calls[0]?.[0].temperature).not.toBe(
+      defaultSampling.temperature,
+    );
+  });
+
+  it("tags rows with wildcard intent and respects count cap", async () => {
+    const generateObjectForWildcards = vi.fn().mockResolvedValue({
+      object: {
+        queries: [
+          { text: "First odd angle" },
+          { text: "Second odd angle" },
+          { text: "Third odd angle" },
+        ],
+      },
+    });
+
+    const rows = await fetchWildcardCandidates(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        count: 2,
+        context: baseContext,
+        allowedLanguages: ["en"],
+        sampling: defaultSampling,
+        wildcardTemperature: 1.2,
+      },
+      { generateObjectForWildcards },
+    );
+
+    expect(rows).toEqual([
+      { text: "First odd angle", intent: "wildcard" },
+      { text: "Second odd angle", intent: "wildcard" },
+    ]);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -2,7 +2,7 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject, generateText } from "ai";
 import type { ModelMessage } from "ai";
 import {
-  QUERY_ANALYSIS_INTENTS,
+  QUERY_ANALYSIS_STANDARD_INTENTS,
   queryAnalysisIntentSchema,
   type GetQueryAnalysisResponse,
   type QueryAnalysisIntent,
@@ -14,6 +14,8 @@ import {
   QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS,
   QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
   QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
+  WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
+  WILDCARD_USER_PROMPT_TEMPLATE_DEFAULT,
 } from "./query-analysis-prompt-defaults";
 import { substituteLlmPromptTemplate } from "@workspace/agent-llm-prompt-template";
 
@@ -24,6 +26,7 @@ import {
 import type { QueryPersona } from "./personas/default-personas";
 import type { LlmCandidate } from "./merge-query-candidates";
 import { normalizeQueryKey } from "./merge-query-candidates";
+import { resolveEntityDisplayName } from "./i18n/entity-aliases";
 
 /** Zod schema for structured LLM output (validated by AI SDK). */
 export const llmQueriesOutputSchema = z.object({
@@ -31,6 +34,15 @@ export const llmQueriesOutputSchema = z.object({
     z.object({
       text: z.string(),
       intent: queryAnalysisIntentSchema,
+    }),
+  ),
+});
+
+/** Zod schema for structured wildcard LLM output (no intent field). */
+export const llmWildcardOutputSchema = z.object({
+  queries: z.array(
+    z.object({
+      text: z.string(),
     }),
   ),
 });
@@ -53,7 +65,10 @@ export type CritiqueRating = z.infer<
 
 export type LlmQueryStrategyPrompt = {
   queryCount: number;
-  allowedLanguages: string[];
+  /** Single target language for this generation pass (BCP-47). */
+  language: string;
+  /** @deprecated Legacy list placeholder for Hermes custom templates. */
+  allowedLanguages?: string[];
   minDeterministicCount: number;
   intentWeights: QueryAnalysisIntentWeights;
 };
@@ -67,19 +82,22 @@ export type LlmQueryStrategyPrompt = {
 export const buildQueryAnalysisSystemTemplateReplacements = (
   strategy: LlmQueryStrategyPrompt,
 ): Record<string, string> => {
-  const sum = QUERY_ANALYSIS_INTENTS.reduce(
+  const sum = QUERY_ANALYSIS_STANDARD_INTENTS.reduce(
     (total, intent) => total + strategy.intentWeights[intent],
     0,
   );
   const replacements: Record<string, string> = {
-    allowedLanguages: strategy.allowedLanguages.join(", "),
+    language: strategy.language,
+    allowedLanguages: (strategy.allowedLanguages ?? [strategy.language]).join(
+      ", ",
+    ),
     minDeterministicCount: String(strategy.minDeterministicCount),
   };
-  for (const intent of QUERY_ANALYSIS_INTENTS) {
+  for (const intent of QUERY_ANALYSIS_STANDARD_INTENTS) {
     const ratio =
       sum > 0
         ? strategy.intentWeights[intent] / sum
-        : 1 / QUERY_ANALYSIS_INTENTS.length;
+        : 1 / QUERY_ANALYSIS_STANDARD_INTENTS.length;
     replacements[QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS[intent]] = String(
       Math.round(ratio * strategy.queryCount),
     );
@@ -116,11 +134,12 @@ export const resolveQueryAnalysisSystemContent = (
 export const resolveQueryAnalysisUserContent = (
   configuredUserPromptTemplate: string | undefined,
   context: GetQueryAnalysisResponse,
+  language?: string,
 ): string => {
   const template =
     configuredUserPromptTemplate ?? QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT;
   return substituteLlmPromptTemplate(template, {
-    queryContextBlock: buildQueryAnalysisUserContent(context),
+    queryContextBlock: buildQueryAnalysisUserContent(context, language),
   });
 };
 
@@ -142,10 +161,19 @@ export const buildQueryAnalysisSystemContent = (
  */
 export const buildQueryAnalysisUserContent = (
   context: GetQueryAnalysisResponse,
+  language?: string,
 ): string => {
+  const companyName =
+    language !== undefined
+      ? resolveEntityDisplayName(
+          context.ticker.symbol,
+          context.ticker.name,
+          language,
+        )
+      : context.ticker.name;
   const lines: string[] = [
     `Ticker symbol: ${context.ticker.symbol}`,
-    `Company name: ${context.ticker.name}`,
+    `Company name: ${companyName}`,
   ];
   if (context.topEntities.length > 0) {
     lines.push("Top entities:");
@@ -227,9 +255,9 @@ export const buildBrainstormPrompt = (
 ): { system: string; user: string } => ({
   system: [
     BRAINSTORM_SYSTEM_PROMPT,
-    `Write angles in these languages when natural: ${strategy.allowedLanguages.join(", ")}.`,
+    `Write angles in ${strategy.language}. Do not translate ticker symbols or proper nouns.`,
   ].join("\n\n"),
-  user: buildQueryAnalysisUserContent(context),
+  user: buildQueryAnalysisUserContent(context, strategy.language),
 });
 
 /**
@@ -325,6 +353,18 @@ export type LlmQuerySampling = {
   frequencyPenalty: number;
   seed?: number;
 };
+
+export type GenerateObjectForWildcards = (args: {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  schema: typeof llmWildcardOutputSchema;
+  maxOutputTokens: number;
+  messages: ModelMessage[];
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+}) => Promise<{ object: z.infer<typeof llmWildcardOutputSchema> }>;
 
 export type GenerateObjectForQueries = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
@@ -439,6 +479,113 @@ export const fetchLlmQueryCandidates = async (
   return (object.queries ?? [])
     .map((q) => ({ text: q.text.trim(), intent: q.intent }))
     .filter((q) => q.text.length > 0);
+};
+
+/**
+ * Resolves the wildcard system prompt from the built-in template and slot count.
+ *
+ * @param wildcardCount - Reserved wildcard slots for this run.
+ * @param allowedLanguages - BCP-47 language codes for phrasing hints.
+ * @returns System message content for the wildcard structured-output call.
+ */
+export const resolveWildcardSystemContent = (
+  wildcardCount: number,
+  allowedLanguages: string[],
+): string =>
+  substituteLlmPromptTemplate(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT, {
+    wildcardCount: String(wildcardCount),
+    allowedLanguages: allowedLanguages.join(", "),
+  });
+
+/**
+ * Resolves the wildcard user prompt (built-in template with serialized context).
+ *
+ * @param context - Serialized GET /query-analysis context for `{{queryContextBlock}}`.
+ * @returns User message content for the wildcard call.
+ */
+export const resolveWildcardUserContent = (
+  context: GetQueryAnalysisResponse,
+): string =>
+  substituteLlmPromptTemplate(WILDCARD_USER_PROMPT_TEMPLATE_DEFAULT, {
+    queryContextBlock: buildQueryAnalysisUserContent(context),
+  });
+
+/**
+ * Appends a dedupe nudge when regenerating wildcards after collision with existing rows.
+ *
+ * @param userContent - Base wildcard user message.
+ * @param avoidTexts - Query texts the model must not repeat.
+ * @returns User message with optional anti-duplication block.
+ */
+export const buildWildcardUserContentWithAvoidNudge = (
+  userContent: string,
+  avoidTexts: string[],
+): string => {
+  if (avoidTexts.length === 0) {
+    return userContent;
+  }
+  const block = avoidTexts.map((text) => `- "${text}"`).join("\n");
+  return [
+    userContent,
+    "",
+    "Do NOT repeat or lightly rephrase these queries:",
+    block,
+    "",
+    "Generate distinctly different lateral angles.",
+  ].join("\n");
+};
+
+/**
+ * Calls the chat model with minimal structured output for wildcard query slots.
+ *
+ * @param params - API key, model, token budget, count, context, sampling, and wildcard temperature.
+ * @param deps - Injectable `generateObject` (default: production `generateObject` from `ai`).
+ * @returns Trimmed wildcard candidate rows tagged with `intent: "wildcard"`.
+ */
+export const fetchWildcardCandidates = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    count: number;
+    context: GetQueryAnalysisResponse;
+    allowedLanguages: string[];
+    sampling: LlmQuerySampling;
+    wildcardTemperature: number;
+    avoidTexts?: string[];
+  },
+  deps: { generateObjectForWildcards: GenerateObjectForWildcards } = {
+    generateObjectForWildcards: generateObject,
+  },
+): Promise<Array<{ text: string; intent: "wildcard" }>> => {
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  const { sampling } = params;
+  const systemContent = resolveWildcardSystemContent(
+    params.count,
+    params.allowedLanguages,
+  );
+  const userContent = buildWildcardUserContentWithAvoidNudge(
+    resolveWildcardUserContent(params.context),
+    params.avoidTexts ?? [],
+  );
+  const { object } = await deps.generateObjectForWildcards({
+    model: openai(params.model),
+    schema: llmWildcardOutputSchema,
+    maxOutputTokens: params.maxOutputTokens,
+    messages: [
+      { role: "system", content: systemContent },
+      { role: "user", content: userContent },
+    ],
+    temperature: params.wildcardTemperature,
+    topP: sampling.topP,
+    presencePenalty: sampling.presencePenalty,
+    frequencyPenalty: sampling.frequencyPenalty,
+    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+  });
+  return (object.queries ?? [])
+    .map((q) => ({ text: q.text.trim(), intent: "wildcard" as const }))
+    .filter((q) => q.text.length > 0)
+    .slice(0, params.count);
 };
 
 /** Parameters for the full query-analysis LLM path (optional brainstorm + structured call). */

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
@@ -1,11 +1,13 @@
 /** @vitest-environment node */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
 
 import {
+  appendWildcardRowsToMerged,
   dedupeDeterministic,
   dedupeLlmAgainstKeys,
+  finalizeWildcardCandidates,
   intentMergeWeight,
   mergeQueryCandidates,
   normalizeQueryKey,
@@ -246,5 +248,70 @@ describe("sortPoolByIntentWeight", () => {
       weights,
     );
     expect(sorted.map((row) => row.text)).toEqual(["break", "fund"]);
+  });
+});
+
+describe("finalizeWildcardCandidates", () => {
+  it("retries once when dedupe drops wildcard rows", async () => {
+    const seenKeys = new Set<string>(["duplicate query"]);
+    const retryFetch = vi
+      .fn()
+      .mockResolvedValue([
+        { text: "Fresh lateral angle", intent: "wildcard" as const },
+      ]);
+
+    const accepted = await finalizeWildcardCandidates({
+      wildcards: [
+        { text: "Duplicate query", intent: "wildcard" },
+        { text: "Unique wildcard", intent: "wildcard" },
+      ],
+      seenKeys,
+      wildcardCount: 2,
+      retryFetch,
+    });
+
+    expect(accepted).toEqual([
+      { text: "Unique wildcard", intent: "wildcard", source: "llm" },
+      { text: "Fresh lateral angle", intent: "wildcard", source: "llm" },
+    ]);
+    expect(retryFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("appendWildcardRowsToMerged", () => {
+  it("appends wildcard rows and reassigns ranks up to queryCount", () => {
+    const merged = appendWildcardRowsToMerged(
+      [
+        {
+          text: "standard",
+          source: "llm",
+          intent: "breaking",
+          rank: 1,
+        },
+      ],
+      [
+        {
+          text: "wildcard one",
+          intent: "wildcard",
+          source: "llm",
+        },
+      ],
+      2,
+    );
+
+    expect(merged).toEqual([
+      {
+        text: "standard",
+        source: "llm",
+        intent: "breaking",
+        rank: 1,
+      },
+      {
+        text: "wildcard one",
+        source: "llm",
+        intent: "wildcard",
+        rank: 2,
+      },
+    ]);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
@@ -7,6 +7,8 @@ import { maxCosineSimilarity } from "./embeddings";
 export type DeterministicCandidate = {
   text: string;
   intent: QueryAnalysisIntent;
+  /** BCP-47 language tag when produced by a language slice (observability). */
+  language?: string;
 };
 
 /** One LLM row after validation (trimmed text, intent per model output). */
@@ -15,6 +17,8 @@ export type LlmCandidate = {
   intent: QueryAnalysisIntent;
   /** Persona id when produced by multi-persona fan-out (observability only). */
   persona?: string;
+  /** BCP-47 language tag when produced by a language slice (observability). */
+  language?: string;
 };
 
 /** Row persisted via agent-data-api `queryAnalysis.create`. */
@@ -25,6 +29,8 @@ export type MergedQueryRow = {
   rank: number;
   /** Persona id for LLM rows from multi-persona fan-out (observability only). */
   persona?: string;
+  /** BCP-47 language tag for multilingual quota observability. */
+  language?: string;
 };
 
 import type { QueryAnalysisIntentWeights } from "@workspace/agent-data-api-contract";
@@ -74,7 +80,11 @@ export const dedupeDeterministic = (
       continue;
     }
     seen.add(key);
-    out.push({ text, intent: row.intent });
+    out.push({
+      text,
+      intent: row.intent,
+      ...(row.language !== undefined ? { language: row.language } : {}),
+    });
   }
   return out;
 };
@@ -116,9 +126,117 @@ export const dedupeLlmAgainstKeys = (
       intent: row.intent,
       source: "llm",
       ...(row.persona !== undefined ? { persona: row.persona } : {}),
+      ...(row.language !== undefined ? { language: row.language } : {}),
     });
   }
   return out;
+};
+
+/**
+ * Dedupes wildcard rows against existing keys while preserving reserved slot count.
+ * When collisions drop rows, optionally retries once via `retryFetch`.
+ *
+ * @param params - Wildcard batch, occupied keys, slot budget, and optional retry fetcher.
+ * @returns Accepted wildcard rows (length ≤ `wildcardCount`) tagged as `source: "llm"`.
+ */
+export const finalizeWildcardCandidates = async (params: {
+  wildcards: LlmCandidate[];
+  seenKeys: Set<string>;
+  wildcardCount: number;
+  retryFetch?: (avoidTexts: string[]) => Promise<LlmCandidate[]>;
+}): Promise<
+  Array<{
+    text: string;
+    intent: QueryAnalysisIntent;
+    source: "llm";
+  }>
+> => {
+  const acceptFromBatch = (
+    batch: LlmCandidate[],
+    accepted: Array<{
+      text: string;
+      intent: QueryAnalysisIntent;
+      source: "llm";
+    }>,
+  ): number => {
+    let dropped = 0;
+    for (const row of batch) {
+      if (accepted.length >= params.wildcardCount) {
+        break;
+      }
+      const text = row.text.trim();
+      if (text.length === 0) {
+        continue;
+      }
+      const key = normalizeQueryKey(text);
+      if (params.seenKeys.has(key)) {
+        dropped += 1;
+        continue;
+      }
+      params.seenKeys.add(key);
+      accepted.push({
+        text,
+        intent: row.intent,
+        source: "llm",
+      });
+    }
+    return dropped;
+  };
+
+  const accepted: Array<{
+    text: string;
+    intent: QueryAnalysisIntent;
+    source: "llm";
+  }> = [];
+  const dropped = acceptFromBatch(params.wildcards, accepted);
+
+  if (
+    params.retryFetch !== undefined &&
+    accepted.length < params.wildcardCount &&
+    (dropped > 0 || params.wildcards.length < params.wildcardCount)
+  ) {
+    const avoidTexts = [
+      ...params.wildcards.map((row) => row.text.trim()).filter(Boolean),
+      ...accepted.map((row) => row.text),
+    ];
+    const retryCount = params.wildcardCount - accepted.length;
+    const replacements = await params.retryFetch(avoidTexts);
+    acceptFromBatch(replacements.slice(0, retryCount), accepted);
+  }
+
+  return accepted;
+};
+
+/**
+ * Appends wildcard rows to a merged set and reassigns contiguous ranks up to `queryCount`.
+ *
+ * @param merged - Standard pipeline rows from {@link mergeQueryCandidates}.
+ * @param wildcardRows - Reserved-slot wildcard rows.
+ * @param queryCount - Total rows to persist in the active query set.
+ * @returns Combined rows with updated ranks (length ≤ `queryCount`).
+ */
+export const appendWildcardRowsToMerged = (
+  merged: MergedQueryRow[],
+  wildcardRows: Array<{
+    text: string;
+    intent: QueryAnalysisIntent;
+    source: "llm";
+  }>,
+  queryCount: number,
+): MergedQueryRow[] => {
+  const combined = [...merged];
+  for (const row of wildcardRows) {
+    if (combined.length >= queryCount) {
+      break;
+    }
+    combined.push({
+      text: row.text,
+      source: row.source,
+      intent: row.intent,
+      rank: combined.length + 1,
+    });
+  }
+  return combined.map((row, index) => ({ ...row, rank: index + 1 }));
 };
 
 /**
@@ -179,6 +297,7 @@ export const dedupeLlmBySimilarity = (
       intent: row.intent,
       source: "llm",
       ...(row.persona !== undefined ? { persona: row.persona } : {}),
+      ...(row.language !== undefined ? { language: row.language } : {}),
     });
   }
 
@@ -190,6 +309,7 @@ type PoolRow = {
   intent: QueryAnalysisIntent;
   source: "deterministic" | "llm";
   persona?: string;
+  language?: string;
 };
 
 /**
@@ -296,11 +416,13 @@ export const mergeQueryCandidates = (params: {
     text: row.text,
     intent: row.intent,
     source: "deterministic" as const,
+    ...(row.language !== undefined ? { language: row.language } : {}),
   }));
   const detExtra: PoolRow[] = dedupedDet.slice(effectiveMin).map((row) => ({
     text: row.text,
     intent: row.intent,
     source: "deterministic" as const,
+    ...(row.language !== undefined ? { language: row.language } : {}),
   }));
   const seenKeys = new Set(
     dedupedDet.map((row) => normalizeQueryKey(row.text)),
@@ -346,5 +468,6 @@ export const mergeQueryCandidates = (params: {
     intent: row.intent,
     rank: i + 1,
     ...(row.persona !== undefined ? { persona: row.persona } : {}),
+    ...(row.language !== undefined ? { language: row.language } : {}),
   }));
 };

--- a/apps/mediapulse/agents/query-analysis/src/personas/default-personas.ts
+++ b/apps/mediapulse/agents/query-analysis/src/personas/default-personas.ts
@@ -1,5 +1,7 @@
 import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
 
+import { primaryLanguageSubtag } from "../i18n/entity-aliases";
+
 /** Per-intent sampling multiplier applied when merging persona-scoped candidates. */
 export type PersonaIntentBias = {
   breaking: number;
@@ -14,6 +16,8 @@ export type QueryPersona = {
   /** One–two sentences appended to the base system prompt for this voice. */
   systemNudge: string;
   intentBias: PersonaIntentBias;
+  /** BCP-47 primary subtags this persona supports; omitted means all languages. */
+  preferredLanguages?: string[];
 };
 
 /** Sell-side equity research voice. */
@@ -23,6 +27,7 @@ const analystPersona: QueryPersona = {
   systemNudge:
     "Write like a sell-side equity analyst: earnings drivers, segment trends, and peer comps. Prefer institutional phrasing.",
   intentBias: { breaking: 1.0, kg_change: 0.9, fundamental: 1.2 },
+  preferredLanguages: ["en"],
 };
 
 /** Retail trader / momentum-focused voice. */
@@ -32,6 +37,7 @@ const retailPersona: QueryPersona = {
   systemNudge:
     "Write like an active retail trader: catalysts, price action, social buzz, and near-term setups. Keep queries short and searchable.",
   intentBias: { breaking: 1.5, kg_change: 0.7, fundamental: 0.6 },
+  preferredLanguages: ["en", "id"],
 };
 
 /** Regulatory and disclosure-focused voice. */
@@ -41,6 +47,7 @@ const regulatorPersona: QueryPersona = {
   systemNudge:
     "Focus on compliance, disclosure, and rulemaking angles. Skip price action and trading slang.",
   intentBias: { breaking: 0.5, kg_change: 1.0, fundamental: 1.5 },
+  preferredLanguages: ["en"],
 };
 
 /** ESG and sustainability research voice. */
@@ -50,6 +57,7 @@ const esgPersona: QueryPersona = {
   systemNudge:
     "Emphasize environmental, social, and governance risks, controversies, and stewardship angles. Avoid pure technical chart queries.",
   intentBias: { breaking: 0.8, kg_change: 1.1, fundamental: 1.3 },
+  preferredLanguages: ["en"],
 };
 
 /** Contrarian / short-thesis voice. */
@@ -59,6 +67,7 @@ const shortSellerPersona: QueryPersona = {
   systemNudge:
     "Surface bearish and forensic angles: accounting red flags, supply-chain weakness, auditor concerns, and downside catalysts others ignore.",
   intentBias: { breaking: 1.2, kg_change: 1.0, fundamental: 1.4 },
+  preferredLanguages: ["en"],
 };
 
 /** In-process persona library keyed by stable id. */
@@ -101,6 +110,42 @@ export const resolveQueryPersonas = (
   }
   return resolved;
 };
+
+/**
+ * Returns whether a persona should run for the given query language.
+ *
+ * @param persona - Persona definition from the in-process library.
+ * @param language - Target BCP-47 language for the generation pass.
+ * @returns `true` when the persona supports the language or has no preference list.
+ */
+export const personaSupportsLanguage = (
+  persona: QueryPersona,
+  language: string,
+): boolean => {
+  if (
+    persona.preferredLanguages === undefined ||
+    persona.preferredLanguages.length === 0
+  ) {
+    return true;
+  }
+  const primary = primaryLanguageSubtag(language);
+  return persona.preferredLanguages.some(
+    (preferred) => primaryLanguageSubtag(preferred) === primary,
+  );
+};
+
+/**
+ * Filters personas to those compatible with a language slice.
+ *
+ * @param personas - Resolved persona list for the run.
+ * @param language - Target BCP-47 language for the generation pass.
+ * @returns Personas whose `preferredLanguages` include the language primary subtag.
+ */
+export const filterPersonasForLanguage = (
+  personas: QueryPersona[],
+  language: string,
+): QueryPersona[] =>
+  personas.filter((persona) => personaSupportsLanguage(persona, language));
 
 /**
  * Returns the persona-scoped merge weight for a candidate intent.

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.test.ts
@@ -6,12 +6,14 @@ import {
   QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS,
   QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
   QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT,
+  WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
+  WILDCARD_USER_PROMPT_TEMPLATE_DEFAULT,
 } from "./query-analysis-prompt-defaults";
 
 describe("query-analysis default prompt templates", () => {
   it("system default lists all system placeholders", () => {
     expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
-      "{{allowedLanguages}}",
+      "{{language}}",
     );
     expect(QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
       "{{targetBreakingCount}}",
@@ -47,5 +49,25 @@ describe("query-analysis default prompt templates", () => {
     expect(QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT).toBe(
       "{{queryContextBlock}}",
     );
+  });
+
+  it("wildcard system default omits intent taxonomy and includes slot count", () => {
+    expect(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{wildcardCount}}",
+    );
+    expect(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT).toContain(
+      "{{allowedLanguages}}",
+    );
+    expect(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT.toLowerCase()).toContain(
+      "lateral",
+    );
+    expect(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT).not.toContain(
+      "targetBreakingCount",
+    );
+    expect(WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT).not.toContain("breaking:");
+  });
+
+  it("wildcard user default is queryContextBlock only", () => {
+    expect(WILDCARD_USER_PROMPT_TEMPLATE_DEFAULT).toBe("{{queryContextBlock}}");
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
+++ b/apps/mediapulse/agents/query-analysis/src/query-analysis-prompt-defaults.ts
@@ -1,14 +1,16 @@
 import {
-  QUERY_ANALYSIS_INTENTS,
+  QUERY_ANALYSIS_STANDARD_INTENTS,
   type QueryAnalysisIntent,
 } from "@workspace/agent-data-api-contract";
 
 /** Maximum characters allowed for each Hermes `prompts.*` string on query-analysis. */
 export const QUERY_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
 
-/** System prompt placeholder for each intent's approximate target count. */
+type StandardQueryAnalysisIntent = Exclude<QueryAnalysisIntent, "wildcard">;
+
+/** System prompt placeholder for each standard intent's approximate target count. */
 export const QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS: Record<
-  QueryAnalysisIntent,
+  StandardQueryAnalysisIntent,
   string
 > = {
   breaking: "targetBreakingCount",
@@ -25,8 +27,9 @@ export const QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS: Record<
 /** Allowed `{{...}}` names in `prompts.systemPrompt`. */
 export const QUERY_ANALYSIS_SYSTEM_PROMPT_PLACEHOLDERS = [
   "allowedLanguages",
+  "language",
   "minDeterministicCount",
-  ...QUERY_ANALYSIS_INTENTS.map(
+  ...QUERY_ANALYSIS_STANDARD_INTENTS.map(
     (intent) => QUERY_ANALYSIS_INTENT_TARGET_PLACEHOLDERS[intent],
   ),
 ] as const;
@@ -36,7 +39,16 @@ export const QUERY_ANALYSIS_USER_PROMPT_PLACEHOLDERS = [
   "queryContextBlock",
 ] as const;
 
-const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_INTENTS.map(
+/** Allowed `{{...}}` names in the wildcard system prompt template. */
+export const WILDCARD_SYSTEM_PROMPT_PLACEHOLDERS = [
+  "wildcardCount",
+  "allowedLanguages",
+] as const;
+
+/** Allowed `{{...}}` names in the wildcard user prompt template. */
+export const WILDCARD_USER_PROMPT_PLACEHOLDERS = ["queryContextBlock"] as const;
+
+const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_STANDARD_INTENTS.map(
   (intent) => `"${intent}"`,
 ).join(" | ");
 
@@ -48,7 +60,8 @@ export const QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
   "You generate finance search queries for news and data retrieval.",
   `Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": ${QUERY_ANALYSIS_INTENT_JSON_UNION} } ] }.`,
   "Each query must be concise web-search style text.",
-  "Write queries in these languages (BCP-47 codes as configured): {{allowedLanguages}}. If multiple, you may mix languages across queries.",
+  "All queries must be in {{language}} (BCP-47). Do not code-mix or translate ticker symbols and proper nouns.",
+  "Do not translate ticker symbols or proper nouns into other languages.",
   [
     "Target approximate intent counts (total queries should not exceed the remaining budget after the deterministic baseline):",
     `- breaking: {{targetBreakingCount}}`,
@@ -79,3 +92,19 @@ export const QUERY_ANALYSIS_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
 /** Default user prompt template: full serialized GET context. */
 export const QUERY_ANALYSIS_USER_PROMPT_TEMPLATE_DEFAULT =
   "{{queryContextBlock}}";
+
+/**
+ * Default wildcard system prompt: lateral angles without intent taxonomy.
+ * Substitutes reserved slot count and configured languages.
+ */
+export const WILDCARD_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
+  "Generate {{wildcardCount}} short search queries unlike anything an institutional analyst would typically search for.",
+  "Lateral, surprising, second-order, contrarian, narrative, or culturally-grounded angles welcome.",
+  "Do not use the standard intent taxonomy — these queries are deliberately unconventional.",
+  "Reward odd framings, long-tail questions, and angles a typical analyst would not search for.",
+  'Return ONLY a JSON object: { "queries": [ { "text": string } ] }.',
+  "Write in these languages when natural (BCP-47 codes): {{allowedLanguages}}.",
+].join("\n\n");
+
+/** Default wildcard user prompt template: full serialized GET context. */
+export const WILDCARD_USER_PROMPT_TEMPLATE_DEFAULT = "{{queryContextBlock}}";

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -1,12 +1,16 @@
 /** @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
+
 import { queryAnalysisConfigSchema } from "./config-schema";
 
-const { mockGet, mockCreate, mockFetchQueryLlm } = vi.hoisted(() => ({
-  mockGet: vi.fn(),
-  mockCreate: vi.fn(),
-  mockFetchQueryLlm: vi.fn(),
-}));
+const { mockGet, mockCreate, mockFetchQueryLlm, mockFetchWildcard } =
+  vi.hoisted(() => ({
+    mockGet: vi.fn(),
+    mockCreate: vi.fn(),
+    mockFetchQueryLlm: vi.fn(),
+    mockFetchWildcard: vi.fn(),
+  }));
 
 vi.mock("@mediapulse/env/agents-query-analysis", () => ({
   env: {
@@ -29,6 +33,7 @@ vi.mock("./llm-queries", async (importOriginal) => {
   return {
     ...actual,
     fetchLlmQueryCandidatesByPersona: mockFetchQueryLlm,
+    fetchWildcardCandidates: mockFetchWildcard,
     fetchBrainstormBullets: vi.fn(),
   };
 });
@@ -42,7 +47,11 @@ vi.mock("@workspace/logger", () => ({
 }));
 
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
-import { clampPerPersonaQuotaCount, runQueryAnalysis } from "./run";
+import {
+  clampPerPersonaQuotaCount,
+  computeWildcardCount,
+  runQueryAnalysis,
+} from "./run";
 
 const ctxResponse = {
   ticker: {
@@ -66,6 +75,9 @@ describe("query-analysis run", () => {
     mockGet.mockReset();
     mockCreate.mockReset();
     mockFetchQueryLlm.mockReset();
+    mockFetchWildcard.mockReset();
+
+    mockFetchWildcard.mockResolvedValue([]);
 
     const { fetchBrainstormBullets } = await import("./llm-queries");
     vi.mocked(fetchBrainstormBullets).mockReset();
@@ -271,6 +283,126 @@ describe("query-analysis run", () => {
       createPayload.strategySnapshot.diversityGate?.diversityRegenerateFired,
     ).toBe(true);
   });
+
+  it("persists wildcardFraction budget as wildcard intent rows", async () => {
+    mockFetchQueryLlm.mockResolvedValue(
+      Array.from({ length: 8 }, (_, index) => ({
+        text: `Standard LLM ${String(index + 1)}`,
+        intent: "breaking" as const,
+        persona: "analyst",
+      })),
+    );
+    mockFetchWildcard.mockResolvedValue([
+      { text: "Wildcard lateral angle A", intent: "wildcard" as const },
+      { text: "Wildcard lateral angle B", intent: "wildcard" as const },
+    ]);
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: queryAnalysisConfigSchema.parse({
+        openaiApiKey: "sk",
+        queryCount: 10,
+        wildcardFraction: 0.2,
+        minDeterministicCount: 0,
+      }),
+      token: "Bearer t",
+    });
+
+    expect(mockFetchWildcard).toHaveBeenCalledTimes(1);
+    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+      queries: Array<{ intent: string }>;
+    };
+    const wildcardRows = createPayload.queries.filter(
+      (row) => row.intent === "wildcard",
+    );
+    expect(wildcardRows).toHaveLength(2);
+    expect(createPayload.queries).toHaveLength(10);
+  });
+
+  it("distributes queryCount across language quotas into locale-specific rows", async () => {
+    mockFetchQueryLlm.mockResolvedValue([]);
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: queryAnalysisConfigSchema.parse({
+        openaiApiKey: "sk",
+        queryCount: 10,
+        wildcardFraction: 0,
+        personas: [],
+        languageQuotas: [
+          { language: "en", share: 0.6 },
+          { language: "id", share: 0.4 },
+        ],
+      }),
+      token: "Bearer t",
+    });
+
+    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+      queries: Array<{ text: string }>;
+      strategySnapshot: {
+        languageQuotas: Array<{ language: string; share: number }>;
+      };
+    };
+
+    expect(createPayload.queries).toHaveLength(10);
+    expect(createPayload.strategySnapshot.languageQuotas).toEqual([
+      { language: "en", share: 0.6 },
+      { language: "id", share: 0.4 },
+    ]);
+
+    const indonesianPattern = /berita terbaru|laporan keuangan|prospek saham|perubahan relasi|update regulasi/i;
+
+    const englishSlice = createPayload.queries.slice(0, 6);
+    const indonesianSlice = createPayload.queries.slice(6);
+
+    expect(englishSlice).toHaveLength(6);
+    expect(indonesianSlice).toHaveLength(4);
+    expect(
+      englishSlice.every((row) => !indonesianPattern.test(row.text)),
+    ).toBe(true);
+    expect(
+      indonesianSlice.every((row) => indonesianPattern.test(row.text)),
+    ).toBe(true);
+  });
+
+  it("boosts fundamental intent weight in snapshot when earnings are within 14 days", async () => {
+    const fiveDaysFromNow = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000);
+    mockGet.mockResolvedValue({
+      ...ctxResponse,
+      calendar: {
+        recentEventTypes: [],
+        nextEarningsAt: fiveDaysFromNow.toISOString(),
+      },
+    });
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: queryAnalysisConfigSchema.parse({
+        openaiApiKey: "sk",
+        wildcardFraction: 0,
+      }),
+      token: "Bearer t",
+    });
+
+    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+      strategySnapshot: {
+        intentWeights: { fundamental: number };
+        appliedEventBias?: {
+          firedRuleIds: string[];
+          multipliers: { fundamental?: number };
+        };
+      };
+    };
+    expect(createPayload.strategySnapshot.intentWeights.fundamental).toBe(
+      DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS.fundamental * 2,
+    );
+    expect(
+      createPayload.strategySnapshot.appliedEventBias?.firedRuleIds,
+    ).toContain("near-earnings");
+    expect(
+      createPayload.strategySnapshot.appliedEventBias?.multipliers.fundamental,
+    ).toBe(2);
+  });
 });
 
 describe("clampPerPersonaQuotaCount", () => {
@@ -280,5 +412,13 @@ describe("clampPerPersonaQuotaCount", () => {
 
   it("clamps quota when fan-out exceeds queryCount * 3", () => {
     expect(clampPerPersonaQuotaCount(3, 10, 5)).toBe(5);
+  });
+});
+
+describe("computeWildcardCount", () => {
+  it("rounds queryCount times wildcardFraction", () => {
+    expect(computeWildcardCount(10, 0.2)).toBe(2);
+    expect(computeWildcardCount(10, 0.1)).toBe(1);
+    expect(computeWildcardCount(10, 0)).toBe(0);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -350,16 +350,17 @@ describe("query-analysis run", () => {
       { language: "id", share: 0.4 },
     ]);
 
-    const indonesianPattern = /berita terbaru|laporan keuangan|prospek saham|perubahan relasi|update regulasi/i;
+    const indonesianPattern =
+      /berita terbaru|laporan keuangan|prospek saham|perubahan relasi|update regulasi/i;
 
     const englishSlice = createPayload.queries.slice(0, 6);
     const indonesianSlice = createPayload.queries.slice(6);
 
     expect(englishSlice).toHaveLength(6);
     expect(indonesianSlice).toHaveLength(4);
-    expect(
-      englishSlice.every((row) => !indonesianPattern.test(row.text)),
-    ).toBe(true);
+    expect(englishSlice.every((row) => !indonesianPattern.test(row.text))).toBe(
+      true,
+    );
     expect(
       indonesianSlice.every((row) => indonesianPattern.test(row.text)),
     ).toBe(true);

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -33,8 +33,15 @@ import {
   collectQueryTextsForEmbedding,
   embedQueries,
 } from "./embeddings";
-import type { DeterministicCandidate, MergedQueryRow } from "./merge-query-candidates";
-import { resolveQueryPersonas, filterPersonasForLanguage, type QueryPersona } from "./personas/default-personas";
+import type {
+  DeterministicCandidate,
+  MergedQueryRow,
+} from "./merge-query-candidates";
+import {
+  resolveQueryPersonas,
+  filterPersonasForLanguage,
+  type QueryPersona,
+} from "./personas/default-personas";
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
 import {
   distributeQueryCountAcrossLanguages,
@@ -698,7 +705,10 @@ export const runQueryAnalysis = async (
 
   const languageCount = languageQuotas.length;
   const personaCellCount = resolvedPersonas.length * languageCount;
-  if (personaCellCount > 0 && personaCellCount * perPersonaQuotaCount > standardQueryCount * 3) {
+  if (
+    personaCellCount > 0 &&
+    personaCellCount * perPersonaQuotaCount > standardQueryCount * 3
+  ) {
     const clamped = clampPerPersonaQuotaCount(
       personaCellCount,
       perPersonaQuotaCount,
@@ -802,7 +812,8 @@ export const runQueryAnalysis = async (
   for (const slice of sliceResults) {
     selfCritiqueReplacedCount += slice.selfCritiqueReplacedCount;
     selfCritiqueSkippedDueToDeadline =
-      selfCritiqueSkippedDueToDeadline || slice.selfCritiqueSkippedDueToDeadline;
+      selfCritiqueSkippedDueToDeadline ||
+      slice.selfCritiqueSkippedDueToDeadline;
     diversityRegenerateFired =
       diversityRegenerateFired || slice.diversityRegenerateFired;
     if (slice.diversityScore !== undefined) {

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -1,4 +1,5 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import { logger } from "@workspace/logger";
@@ -7,36 +8,138 @@ import type { QueryAnalysisConfig } from "./config-schema";
 import {
   resolveDiversityGateConfig,
   resolveIntentWeights,
+  resolveTemporalBiasConfig,
 } from "./config-schema";
 import {
   resolveQueryAnalysisSystemContent,
   resolveQueryAnalysisUserContent,
   fetchBrainstormBullets,
   fetchLlmQueryCandidatesByPersona,
+  fetchWildcardCandidates,
   applySelfCritiquePass,
   DEFAULT_CRITIC_PASS_DEADLINE_MS,
+  type LlmQueryStrategyPrompt,
 } from "./llm-queries";
 import type { LlmCandidate } from "./merge-query-candidates";
-import { mergeQueryCandidates } from "./merge-query-candidates";
+import {
+  appendWildcardRowsToMerged,
+  finalizeWildcardCandidates,
+  mergeQueryCandidates,
+  normalizeQueryKey,
+} from "./merge-query-candidates";
 import {
   buildQuerySemanticEmbedder,
   buildEmbeddingByText,
   collectQueryTextsForEmbedding,
   embedQueries,
 } from "./embeddings";
-import type { DeterministicCandidate } from "./merge-query-candidates";
-import { resolveQueryPersonas } from "./personas/default-personas";
+import type { DeterministicCandidate, MergedQueryRow } from "./merge-query-candidates";
+import { resolveQueryPersonas, filterPersonasForLanguage, type QueryPersona } from "./personas/default-personas";
 import { buildDeterministicQueries } from "./templates/build-deterministic-queries";
+import {
+  distributeQueryCountAcrossLanguages,
+  resolveLanguageQuotas,
+  resolveLanguageTemplatePack,
+  type DistributedLanguageQuota,
+} from "./language-quotas";
 import {
   buildDiversityBroadenSystemNudge,
   computeDiversityScore,
   type DiversityScoreResult,
   type DiversityScoreRow,
 } from "./diversity/score";
+import { DEFAULT_EVENT_BIAS_RULES } from "./temporal/default-rules";
+import {
+  applyEventBiasToIntentWeights,
+  computeEventBias,
+  type EventBiasResult,
+} from "./temporal/event-bias";
 
 export { buildDeterministicQueries } from "./templates/build-deterministic-queries";
 
 export { DEFAULT_CRITIC_PASS_DEADLINE_MS } from "./llm-queries";
+
+/**
+ * Computes the reserved wildcard slot count from total set size and configured fraction.
+ *
+ * @param queryCount - Total rows to persist in the active query set.
+ * @param wildcardFraction - Fraction of `queryCount` reserved for wildcard queries.
+ * @returns Non-negative integer wildcard slot count.
+ */
+export const computeWildcardCount = (
+  queryCount: number,
+  wildcardFraction: number,
+): number => Math.round(queryCount * wildcardFraction);
+
+/**
+ * Builds the sampling object shared by standard and wildcard LLM calls.
+ *
+ * @param config - Parsed invoke config with sampling fields.
+ * @returns Sampling knobs for LLM calls.
+ */
+export const buildLlmSamplingFromConfig = (config: {
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+}): {
+  temperature: number;
+  topP: number;
+  presencePenalty: number;
+  frequencyPenalty: number;
+  seed?: number;
+} => ({
+  temperature: config.temperature,
+  topP: config.topP,
+  presencePenalty: config.presencePenalty,
+  frequencyPenalty: config.frequencyPenalty,
+  ...(config.seed !== undefined ? { seed: config.seed } : {}),
+});
+
+/**
+ * Applies optional calendar-driven event bias to configured intent weights.
+ *
+ * @param baseIntentWeights - Weights from Hermes config after legacy lifting.
+ * @param queryContext - Live GET /query-analysis payload.
+ * @param temporalBias - Resolved temporal bias toggle.
+ * @param deps - Injectable clock and rule library for tests.
+ * @returns Adjusted weights plus snapshot metadata when rules fire.
+ */
+export const resolveIntentWeightsWithEventBias = (
+  baseIntentWeights: ReturnType<typeof resolveIntentWeights>,
+  queryContext: GetQueryAnalysisResponse,
+  temporalBias: ReturnType<typeof resolveTemporalBiasConfig>,
+  deps: {
+    clock?: () => Date;
+    rules?: typeof DEFAULT_EVENT_BIAS_RULES;
+  } = {},
+): {
+  intentWeights: ReturnType<typeof resolveIntentWeights>;
+  appliedEventBias?: EventBiasResult;
+} => {
+  if (!temporalBias.enabled) {
+    return { intentWeights: baseIntentWeights };
+  }
+
+  const eventBias = computeEventBias(
+    queryContext,
+    deps.clock ?? (() => new Date()),
+    deps.rules ?? DEFAULT_EVENT_BIAS_RULES,
+  );
+
+  if (eventBias.firedRuleIds.length === 0) {
+    return { intentWeights: baseIntentWeights };
+  }
+
+  return {
+    intentWeights: applyEventBiasToIntentWeights(
+      baseIntentWeights,
+      eventBias.multipliers,
+    ),
+    appliedEventBias: eventBias,
+  };
+};
 
 type PersonaFetchParams = Parameters<
   typeof fetchLlmQueryCandidatesByPersona
@@ -250,6 +353,277 @@ export const clampPerPersonaQuotaCount = (
   return Math.max(1, Math.floor(maxTotal / personasLength));
 };
 
+/** Shared LLM configuration passed into each language slice. */
+type LanguageSliceSharedConfig = {
+  openaiApiKey: string;
+  openaiModel: string;
+  maxTokens: number;
+  globalTemplatePack: string;
+  kgTemplateCap: number;
+  intentWeights: LlmQueryStrategyPrompt["intentWeights"];
+  llmSampling: ReturnType<typeof buildLlmSamplingFromConfig>;
+  useBrainstormPass: boolean;
+  brainstormModel: string;
+  fewShotExemplarCount: number;
+  useSelfCritique: boolean;
+  critiqueDropFraction: number;
+  critiqueModel: string;
+  perPersonaQuotaCount: number;
+  diversityGate: ReturnType<typeof resolveDiversityGateConfig>;
+  semanticDedupeEnabled: boolean;
+  embeddingModel: string;
+  configuredSystemPrompt?: string;
+  configuredUserPromptTemplate?: string;
+  runStartMs: number;
+  tickerId: string;
+};
+
+/**
+ * Generates and merges deterministic + LLM candidates for one language quota slice.
+ *
+ * @param params - Language quota row, context, personas, and shared run config.
+ * @returns Merged rows for the slice plus observability counters.
+ */
+export const runLanguageQuerySlice = async (params: {
+  languageQuota: DistributedLanguageQuota;
+  minDeterministicCount: number;
+  queryContext: GetQueryAnalysisResponse;
+  personas: QueryPersona[];
+  shared: LanguageSliceSharedConfig;
+}): Promise<{
+  merged: MergedQueryRow[];
+  diversityScore?: DiversityScoreResult;
+  diversityRegenerateFired: boolean;
+  selfCritiqueReplacedCount: number;
+  selfCritiqueSkippedDueToDeadline: boolean;
+}> => {
+  const { languageQuota, shared } = params;
+  const language = languageQuota.language;
+  const langPersonas = filterPersonasForLanguage(params.personas, language);
+  const templatePack = resolveLanguageTemplatePack(
+    language,
+    languageQuota.templatePack,
+    shared.globalTemplatePack,
+  );
+
+  const deterministic = buildDeterministicQueries(params.queryContext, {
+    pack: templatePack,
+    kgTemplateCap: shared.kgTemplateCap,
+    language,
+  });
+
+  const strategyPrompt: LlmQueryStrategyPrompt = {
+    queryCount: languageQuota.queryCount,
+    language,
+    minDeterministicCount: params.minDeterministicCount,
+    intentWeights: shared.intentWeights,
+  };
+
+  const systemContent = resolveQueryAnalysisSystemContent(
+    shared.configuredSystemPrompt,
+    strategyPrompt,
+  );
+  const userContent = resolveQueryAnalysisUserContent(
+    shared.configuredUserPromptTemplate,
+    params.queryContext,
+    language,
+  );
+
+  let llmCandidates: LlmCandidate[] = [];
+  let brainstormBullets: string[] | undefined;
+  try {
+    if (shared.useBrainstormPass) {
+      brainstormBullets = await fetchBrainstormBullets({
+        apiKey: shared.openaiApiKey,
+        model: shared.brainstormModel,
+        maxOutputTokens: shared.maxTokens,
+        strategy: strategyPrompt,
+        context: params.queryContext,
+        sampling: shared.llmSampling,
+      });
+    }
+
+    if (langPersonas.length > 0) {
+      const rows = await fetchLlmQueryCandidatesByPersona(
+        {
+          apiKey: shared.openaiApiKey,
+          model: shared.openaiModel,
+          maxOutputTokens: shared.maxTokens,
+          systemContent,
+          userContent,
+          personas: langPersonas,
+          perPersonaQuota: shared.perPersonaQuotaCount,
+          fewShotExemplarCount: shared.fewShotExemplarCount,
+          brainstormBullets,
+          sampling: shared.llmSampling,
+        },
+        {
+          warn: (_message, meta) => {
+            logger.warn(
+              {
+                error: meta.error,
+                personaId: meta.personaId,
+                tickerId: shared.tickerId,
+                language,
+              },
+              "query-analysis persona LLM call failed; skipping persona",
+            );
+          },
+        },
+      );
+      llmCandidates = rows.map((row) => ({ ...row, language }));
+    }
+  } catch (error) {
+    logger.warn(
+      { error, tickerId: shared.tickerId, language },
+      "query-analysis LLM failed for language slice; using deterministic only",
+    );
+  }
+
+  let selfCritiqueReplacedCount = 0;
+  let selfCritiqueSkippedDueToDeadline = false;
+  if (shared.useSelfCritique && llmCandidates.length > 0) {
+    if (Date.now() - shared.runStartMs > DEFAULT_CRITIC_PASS_DEADLINE_MS) {
+      selfCritiqueSkippedDueToDeadline = true;
+    } else {
+      try {
+        const critiqueResult = await applySelfCritiquePass({
+          apiKey: shared.openaiApiKey,
+          critiqueModel: shared.critiqueModel,
+          generationModel: shared.openaiModel,
+          maxOutputTokens: shared.maxTokens,
+          systemContent,
+          userContent,
+          context: params.queryContext,
+          candidates: llmCandidates,
+          dropFraction: shared.critiqueDropFraction,
+          fewShotExemplarCount: shared.fewShotExemplarCount,
+          sampling: shared.llmSampling,
+          runStartMs: shared.runStartMs,
+          deadlineMs: DEFAULT_CRITIC_PASS_DEADLINE_MS,
+        });
+        llmCandidates = critiqueResult.candidates.map((row) => ({
+          ...row,
+          language,
+        }));
+        selfCritiqueReplacedCount = critiqueResult.replacedCount;
+        selfCritiqueSkippedDueToDeadline = critiqueResult.skippedDueToDeadline;
+      } catch (error) {
+        logger.warn(
+          { error, tickerId: shared.tickerId, language },
+          "query-analysis self-critique failed for language slice",
+        );
+      }
+    }
+  }
+
+  const diversityGate = shared.diversityGate;
+  let diversityEmbeddingsByText: Map<string, number[]> | undefined;
+  if (shared.semanticDedupeEnabled && llmCandidates.length >= 2) {
+    diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
+      llmCandidates,
+      {
+        apiKey: shared.openaiApiKey,
+        embeddingModel: shared.embeddingModel,
+        tickerId: shared.tickerId,
+      },
+    );
+  }
+
+  let diversityScore: DiversityScoreResult | undefined;
+  let diversityRegenerateFired = false;
+  if (llmCandidates.length > 0) {
+    const gateResult = await applyDiversityGatePass({
+      llmCandidates,
+      diversityGate,
+      embeddingsByText: diversityEmbeddingsByText,
+      allowRegenerate: langPersonas.length > 0,
+      fetchBroadenBatch: (broadenSystemNudge) =>
+        fetchLlmQueryCandidatesByPersona(
+          {
+            apiKey: shared.openaiApiKey,
+            model: shared.openaiModel,
+            maxOutputTokens: shared.maxTokens,
+            systemContent,
+            userContent,
+            personas: langPersonas,
+            perPersonaQuota: shared.perPersonaQuotaCount,
+            fewShotExemplarCount: shared.fewShotExemplarCount,
+            brainstormBullets,
+            sampling: shared.llmSampling,
+            broadenSystemNudge,
+          },
+          {
+            warn: (_message, meta) => {
+              logger.warn(
+                {
+                  error: meta.error,
+                  personaId: meta.personaId,
+                  tickerId: shared.tickerId,
+                  language,
+                },
+                "query-analysis persona LLM call failed; skipping persona",
+              );
+            },
+          },
+        ).then((rows) => rows.map((row) => ({ ...row, language }))),
+      logWarn: (message, meta) => {
+        logger.warn({ ...meta, tickerId: shared.tickerId, language }, message);
+      },
+    });
+    llmCandidates = gateResult.candidates.map((row) => ({ ...row, language }));
+    diversityScore = gateResult.diversityScore;
+    diversityRegenerateFired = gateResult.diversityRegenerateFired;
+
+    if (diversityRegenerateFired && shared.semanticDedupeEnabled) {
+      diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
+        llmCandidates,
+        {
+          apiKey: shared.openaiApiKey,
+          embeddingModel: shared.embeddingModel,
+          tickerId: shared.tickerId,
+        },
+      );
+      diversityScore = computeDiversityScore(
+        toDiversityScoreRows(llmCandidates),
+        {
+          weights: diversityGate.weights,
+          embeddingsByText: diversityEmbeddingsByText,
+        },
+      );
+    }
+  }
+
+  const merged = mergeQueryCandidates({
+    deterministic,
+    llm: llmCandidates,
+    queryCount: languageQuota.queryCount,
+    minDeterministicCount: params.minDeterministicCount,
+    weights: shared.intentWeights,
+  });
+
+  return {
+    merged,
+    diversityScore,
+    diversityRegenerateFired,
+    selfCritiqueReplacedCount,
+    selfCritiqueSkippedDueToDeadline,
+  };
+};
+
+/**
+ * Concatenates per-language merged rows and reassigns contiguous ranks.
+ *
+ * @param slices - Ordered language slice merge results.
+ * @returns Flattened rows with ranks 1..N.
+ */
+export const concatenateLanguageMergedRows = (
+  slices: MergedQueryRow[][],
+): MergedQueryRow[] => {
+  const combined = slices.flat();
+  return combined.map((row, index) => ({ ...row, rank: index + 1 }));
+};
+
 /**
  * Runs the query-analysis agent for one ticker and persists an active query set.
  *
@@ -271,16 +645,33 @@ export const runQueryAnalysis = async (
     tickerId: input.tickerId,
   });
   const templatePack = config.templatePack!;
-
-  const deterministic = buildDeterministicQueries(queryContext, {
-    pack: templatePack,
-  });
+  const kgTemplateCap = config.kgTemplateCap!;
 
   // Zod applies defaults in `createAgentApp` before calling `run`.
   const queryCount = config.queryCount!;
-  const allowedLanguages = config.allowedLanguages!;
+  const wildcardFraction = config.wildcardFraction!;
+  const wildcardTemperature = config.wildcardTemperature!;
+  const wildcardCount = computeWildcardCount(queryCount, wildcardFraction);
+  const standardQueryCount = queryCount - wildcardCount;
+  const languageQuotas = resolveLanguageQuotas(config);
   const minDeterministicCount = config.minDeterministicCount!;
-  const intentWeights = resolveIntentWeights(config);
+  const baseIntentWeights = resolveIntentWeights(config);
+  const temporalBias = resolveTemporalBiasConfig(config);
+  const { intentWeights, appliedEventBias } = resolveIntentWeightsWithEventBias(
+    baseIntentWeights,
+    queryContext,
+    temporalBias,
+  );
+  if (appliedEventBias !== undefined) {
+    logger.info(
+      {
+        tickerId: input.tickerId,
+        firedRuleIds: appliedEventBias.firedRuleIds,
+        multipliers: appliedEventBias.multipliers,
+      },
+      "query-analysis temporal event bias applied",
+    );
+  }
   const openaiModel = config.openaiModel!;
   const maxTokens = config.maxTokens!;
   const temperature = config.temperature!;
@@ -305,255 +696,121 @@ export const runQueryAnalysis = async (
     },
   });
 
-  if (
-    resolvedPersonas.length > 0 &&
-    resolvedPersonas.length * perPersonaQuotaCount > queryCount * 3
-  ) {
+  const languageCount = languageQuotas.length;
+  const personaCellCount = resolvedPersonas.length * languageCount;
+  if (personaCellCount > 0 && personaCellCount * perPersonaQuotaCount > standardQueryCount * 3) {
     const clamped = clampPerPersonaQuotaCount(
-      resolvedPersonas.length,
+      personaCellCount,
       perPersonaQuotaCount,
-      queryCount,
+      standardQueryCount,
     );
     logger.warn(
       {
         tickerId: input.tickerId,
         personas: resolvedPersonas.length,
+        languages: languageCount,
         configuredPerPersonaQuotaCount: perPersonaQuotaCount,
         clampedPerPersonaQuotaCount: clamped,
-        queryCount,
+        queryCount: standardQueryCount,
       },
-      "query-analysis persona fan-out exceeds cost guard; clamping perPersonaQuotaCount",
+      "query-analysis persona × language fan-out exceeds cost guard; clamping perPersonaQuotaCount",
     );
     perPersonaQuotaCount = clamped;
   }
 
-  const strategyPrompt = {
-    queryCount,
-    allowedLanguages,
+  const distributedStandard = distributeQueryCountAcrossLanguages(
+    standardQueryCount,
+    languageQuotas,
+  );
+  const distributedMinDeterministic = distributeQueryCountAcrossLanguages(
     minDeterministicCount,
-    intentWeights,
-  };
-
-  const systemContent = resolveQueryAnalysisSystemContent(
-    config.prompts?.systemPrompt,
-    strategyPrompt,
-  );
-  const userContent = resolveQueryAnalysisUserContent(
-    config.prompts?.userPromptTemplate,
-    queryContext,
+    languageQuotas,
   );
 
-  const llmPromptFingerprint = computeLlmPromptFingerprint(
-    systemContent,
-    userContent,
-  );
-
-  let llmCandidates: LlmCandidate[] = [];
-  let brainstormBullets: string[] | undefined;
-  try {
-    if (useBrainstormPass) {
-      brainstormBullets = await fetchBrainstormBullets({
-        apiKey: config.openaiApiKey,
-        model: brainstormModel,
-        maxOutputTokens: maxTokens,
-        strategy: strategyPrompt,
-        context: queryContext,
-        sampling: {
-          temperature,
-          topP,
-          presencePenalty,
-          frequencyPenalty,
-          ...(seed !== undefined ? { seed } : {}),
-        },
-      });
-    }
-
-    if (resolvedPersonas.length > 0) {
-      llmCandidates = await fetchLlmQueryCandidatesByPersona(
-        {
-          apiKey: config.openaiApiKey,
-          model: openaiModel,
-          maxOutputTokens: maxTokens,
-          systemContent,
-          userContent,
-          personas: resolvedPersonas,
-          perPersonaQuota: perPersonaQuotaCount,
-          fewShotExemplarCount,
-          brainstormBullets,
-          sampling: {
-            temperature,
-            topP,
-            presencePenalty,
-            frequencyPenalty,
-            ...(seed !== undefined ? { seed } : {}),
-          },
-        },
-        {
-          warn: (_message, meta) => {
-            logger.warn(
-              {
-                error: meta.error,
-                personaId: meta.personaId,
-                tickerId: input.tickerId,
-              },
-              "query-analysis persona LLM call failed; skipping persona",
-            );
-          },
-        },
-      );
-    }
-  } catch (error) {
-    logger.warn(
-      { error, tickerId: input.tickerId },
-      "query-analysis LLM failed; using deterministic candidates only",
-    );
-  }
-
-  let selfCritiqueReplacedCount = 0;
-  let selfCritiqueSkippedDueToDeadline = false;
-  if (useSelfCritique && llmCandidates.length > 0) {
-    if (Date.now() - runStartMs > DEFAULT_CRITIC_PASS_DEADLINE_MS) {
-      selfCritiqueSkippedDueToDeadline = true;
-      logger.warn(
-        {
-          tickerId: input.tickerId,
-          elapsedMs: Date.now() - runStartMs,
-          deadlineMs: DEFAULT_CRITIC_PASS_DEADLINE_MS,
-        },
-        "query-analysis self-critique skipped due to deadline; shipping original LLM candidates",
-      );
-    } else {
-      try {
-        const critiqueResult = await applySelfCritiquePass({
-          apiKey: config.openaiApiKey,
-          critiqueModel,
-          generationModel: openaiModel,
-          maxOutputTokens: maxTokens,
-          systemContent,
-          userContent,
-          context: queryContext,
-          candidates: llmCandidates,
-          dropFraction: critiqueDropFraction,
-          fewShotExemplarCount,
-          sampling: {
-            temperature,
-            topP,
-            presencePenalty,
-            frequencyPenalty,
-            ...(seed !== undefined ? { seed } : {}),
-          },
-          runStartMs,
-          deadlineMs: DEFAULT_CRITIC_PASS_DEADLINE_MS,
-        });
-        llmCandidates = critiqueResult.candidates;
-        selfCritiqueReplacedCount = critiqueResult.replacedCount;
-        selfCritiqueSkippedDueToDeadline = critiqueResult.skippedDueToDeadline;
-        if (critiqueResult.skippedDueToDeadline) {
-          logger.warn(
-            { tickerId: input.tickerId },
-            "query-analysis self-critique aborted mid-pass due to deadline",
-          );
-        }
-      } catch (error) {
-        logger.warn(
-          { error, tickerId: input.tickerId },
-          "query-analysis self-critique failed; using pre-critique LLM candidates",
-        );
-      }
-    }
-  }
+  const llmSampling = buildLlmSamplingFromConfig({
+    temperature,
+    topP,
+    presencePenalty,
+    frequencyPenalty,
+    ...(seed !== undefined ? { seed } : {}),
+  });
 
   const diversityGate = resolveDiversityGateConfig(config);
   const semanticDedupeConfig = config.semanticDedupe;
   const embeddingModel =
     semanticDedupeConfig?.embeddingModel ?? "text-embedding-3-small";
 
-  const personaFetchSampling = {
-    temperature,
-    topP,
-    presencePenalty,
-    frequencyPenalty,
-    ...(seed !== undefined ? { seed } : {}),
-  };
-  const personaFetchDeps: PersonaFetchDeps = {
-    warn: (_message, meta) => {
-      logger.warn(
-        {
-          error: meta.error,
-          personaId: meta.personaId,
-          tickerId: input.tickerId,
-        },
-        "query-analysis persona LLM call failed; skipping persona",
-      );
-    },
-  };
-  const buildPersonaFetchParams = (
-    broadenSystemNudge?: string,
-  ): PersonaFetchParams => ({
-    apiKey: config.openaiApiKey,
-    model: openaiModel,
-    maxOutputTokens: maxTokens,
-    systemContent,
-    userContent,
-    personas: resolvedPersonas,
-    perPersonaQuota: perPersonaQuotaCount,
-    fewShotExemplarCount,
-    brainstormBullets,
-    sampling: personaFetchSampling,
-    ...(broadenSystemNudge !== undefined ? { broadenSystemNudge } : {}),
-  });
+  const primaryLanguage = languageQuotas[0]?.language ?? "en";
+  const llmPromptFingerprint = computeLlmPromptFingerprint(
+    resolveQueryAnalysisSystemContent(config.prompts?.systemPrompt, {
+      queryCount: standardQueryCount,
+      language: primaryLanguage,
+      minDeterministicCount,
+      intentWeights,
+    }),
+    resolveQueryAnalysisUserContent(
+      config.prompts?.userPromptTemplate,
+      queryContext,
+      primaryLanguage,
+    ),
+  );
 
-  let diversityEmbeddingsByText: Map<string, number[]> | undefined;
-  if (semanticDedupeConfig?.enabled && llmCandidates.length >= 2) {
-    diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
-      llmCandidates,
-      {
-        apiKey: config.openaiApiKey,
-        embeddingModel,
-        tickerId: input.tickerId,
-      },
-    );
+  const sharedSliceConfig: LanguageSliceSharedConfig = {
+    openaiApiKey: config.openaiApiKey,
+    openaiModel,
+    maxTokens,
+    globalTemplatePack: templatePack,
+    kgTemplateCap,
+    intentWeights,
+    llmSampling,
+    useBrainstormPass,
+    brainstormModel,
+    fewShotExemplarCount,
+    useSelfCritique,
+    critiqueDropFraction,
+    critiqueModel,
+    perPersonaQuotaCount,
+    diversityGate,
+    semanticDedupeEnabled: semanticDedupeConfig?.enabled ?? false,
+    embeddingModel,
+    configuredSystemPrompt: config.prompts?.systemPrompt,
+    configuredUserPromptTemplate: config.prompts?.userPromptTemplate,
+    runStartMs,
+    tickerId: input.tickerId,
+  };
+
+  const sliceResults = await Promise.all(
+    distributedStandard.map((languageQuota) => {
+      const minDet =
+        distributedMinDeterministic.find(
+          (row) => row.language === languageQuota.language,
+        )?.queryCount ?? 0;
+      return runLanguageQuerySlice({
+        languageQuota,
+        minDeterministicCount: minDet,
+        queryContext,
+        personas: resolvedPersonas,
+        shared: sharedSliceConfig,
+      });
+    }),
+  );
+
+  let selfCritiqueReplacedCount = 0;
+  let selfCritiqueSkippedDueToDeadline = false;
+  let diversityRegenerateFired = false;
+  let diversityScore: DiversityScoreResult | undefined;
+  for (const slice of sliceResults) {
+    selfCritiqueReplacedCount += slice.selfCritiqueReplacedCount;
+    selfCritiqueSkippedDueToDeadline =
+      selfCritiqueSkippedDueToDeadline || slice.selfCritiqueSkippedDueToDeadline;
+    diversityRegenerateFired =
+      diversityRegenerateFired || slice.diversityRegenerateFired;
+    if (slice.diversityScore !== undefined) {
+      diversityScore = slice.diversityScore;
+    }
   }
 
-  let diversityScore: DiversityScoreResult | undefined;
-  let diversityRegenerateFired = false;
-  if (llmCandidates.length > 0) {
-    const gateResult = await applyDiversityGatePass({
-      llmCandidates,
-      diversityGate,
-      embeddingsByText: diversityEmbeddingsByText,
-      allowRegenerate: resolvedPersonas.length > 0,
-      fetchBroadenBatch: (broadenSystemNudge) =>
-        fetchLlmQueryCandidatesByPersona(
-          buildPersonaFetchParams(broadenSystemNudge),
-          personaFetchDeps,
-        ),
-      logWarn: (message, meta) => {
-        logger.warn({ ...meta, tickerId: input.tickerId }, message);
-      },
-    });
-    llmCandidates = gateResult.candidates;
-    diversityScore = gateResult.diversityScore;
-    diversityRegenerateFired = gateResult.diversityRegenerateFired;
-
-    if (diversityRegenerateFired && semanticDedupeConfig?.enabled) {
-      diversityEmbeddingsByText = await buildLlmEmbeddingsForDiversity(
-        llmCandidates,
-        {
-          apiKey: config.openaiApiKey,
-          embeddingModel,
-          tickerId: input.tickerId,
-        },
-      );
-      diversityScore = computeDiversityScore(
-        toDiversityScoreRows(llmCandidates),
-        {
-          weights: diversityGate.weights,
-          embeddingsByText: diversityEmbeddingsByText,
-        },
-      );
-    }
-
+  if (diversityScore !== undefined) {
     logger.info(
       {
         tickerId: input.tickerId,
@@ -565,34 +822,89 @@ export const runQueryAnalysis = async (
     );
   }
 
-  let semanticEmbedder: Awaited<
-    ReturnType<typeof buildSemanticEmbedderForMerge>
-  > = undefined;
-  if (semanticDedupeConfig?.enabled) {
-    semanticEmbedder = await buildSemanticEmbedderForMerge({
-      apiKey: config.openaiApiKey,
-      deterministic,
-      llmCandidates,
-      threshold: semanticDedupeConfig.threshold ?? 0.85,
-      embeddingModel,
-      tickerId: input.tickerId,
-    });
-  }
+  const mergedStandard = concatenateLanguageMergedRows(
+    sliceResults.map((slice) => slice.merged),
+  );
 
-  const merged = mergeQueryCandidates({
-    deterministic,
-    llm: llmCandidates,
-    queryCount,
-    minDeterministicCount,
-    weights: intentWeights,
-    ...(semanticEmbedder ? { embedder: semanticEmbedder } : {}),
-  });
+  const wildcardLanguages = languageQuotas.map((quota) => quota.language);
+
+  let merged = mergedStandard;
+  if (wildcardCount > 0) {
+    const seenKeys = new Set(
+      mergedStandard.map((row) => normalizeQueryKey(row.text)),
+    );
+    let wildcardBatch: LlmCandidate[] = [];
+    try {
+      wildcardBatch = await fetchWildcardCandidates({
+        apiKey: config.openaiApiKey,
+        model: openaiModel,
+        maxOutputTokens: maxTokens,
+        count: wildcardCount,
+        context: queryContext,
+        allowedLanguages: wildcardLanguages,
+        sampling: llmSampling,
+        wildcardTemperature,
+      });
+    } catch (error) {
+      logger.warn(
+        { error, tickerId: input.tickerId, wildcardCount },
+        "query-analysis wildcard LLM failed; shipping standard set only",
+      );
+    }
+
+    const wildcardRows = await finalizeWildcardCandidates({
+      wildcards: wildcardBatch,
+      seenKeys,
+      wildcardCount,
+      retryFetch:
+        wildcardCount > 0
+          ? async (avoidTexts) => {
+              try {
+                return await fetchWildcardCandidates({
+                  apiKey: config.openaiApiKey,
+                  model: openaiModel,
+                  maxOutputTokens: maxTokens,
+                  count: wildcardCount,
+                  context: queryContext,
+                  allowedLanguages: wildcardLanguages,
+                  sampling: llmSampling,
+                  wildcardTemperature,
+                  avoidTexts,
+                });
+              } catch (error) {
+                logger.warn(
+                  { error, tickerId: input.tickerId, wildcardCount },
+                  "query-analysis wildcard retry failed; keeping accepted wildcard rows",
+                );
+                return [];
+              }
+            }
+          : undefined,
+    });
+    merged = appendWildcardRowsToMerged(
+      mergedStandard,
+      wildcardRows,
+      queryCount,
+    );
+  }
 
   const strategySnapshot = {
     queryCount,
-    allowedLanguages,
+    wildcardFraction,
+    wildcardTemperature,
+    wildcardCount,
+    kgTemplateCap,
+    languageQuotas,
     minDeterministicCount,
     intentWeights,
+    ...(appliedEventBias !== undefined
+      ? {
+          appliedEventBias: {
+            firedRuleIds: appliedEventBias.firedRuleIds,
+            multipliers: appliedEventBias.multipliers,
+          },
+        }
+      : {}),
     model: openaiModel,
     maxTokens,
     temperature,

--- a/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
@@ -49,7 +49,9 @@ export const buildDeterministicQueries = (
       candidates.push({
         text,
         intent: row.intent,
-        ...(options.language !== undefined ? { language: options.language } : {}),
+        ...(options.language !== undefined
+          ? { language: options.language }
+          : {}),
       });
     }
   }
@@ -63,7 +65,9 @@ export const buildDeterministicQueries = (
         kgTemplateCap,
       ).map((row) => ({
         ...row,
-        ...(options.language !== undefined ? { language: options.language } : {}),
+        ...(options.language !== undefined
+          ? { language: options.language }
+          : {}),
       })),
     );
   }

--- a/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/build-deterministic-queries.ts
@@ -7,21 +7,29 @@ import {
 } from "./deterministic-packs";
 import {
   type SlotResolverClock,
+  expandKgRelationQueries,
   resolveTemplatePattern,
   resolveSlots,
 } from "./slot-resolver";
 
+/** Default cap for KG-derived deterministic query rows. */
+export const DEFAULT_KG_TEMPLATE_CAP = 6;
+
 /** Options for building deterministic query candidates from a template pack. */
 export type BuildDeterministicQueriesOptions = {
-  pack?: DeterministicPackName;
+  pack?: DeterministicPackName | string;
   clock?: SlotResolverClock;
+  /** Maximum KG relation rows to expand (`0` disables KG templates). */
+  kgTemplateCap?: number;
+  /** BCP-47 language for localized slot resolution and row tagging. */
+  language?: string;
 };
 
 /**
  * Builds deterministic baseline query candidates from context and a named pack.
  *
  * @param context - GET /query-analysis response (ticker, entities, themes).
- * @param options - Pack name and clock for time slots (defaults: `default-v1`, now).
+ * @param options - Pack name, clock, KG cap, and optional language tag.
  * @returns Rendered candidates; templates with unresolved slots are omitted.
  */
 export const buildDeterministicQueries = (
@@ -30,15 +38,34 @@ export const buildDeterministicQueries = (
 ): DeterministicCandidate[] => {
   const packName = options.pack ?? "default-v1";
   const clock = options.clock ?? (() => new Date());
+  const kgTemplateCap = options.kgTemplateCap ?? DEFAULT_KG_TEMPLATE_CAP;
   const pack = getDeterministicPack(packName);
-  const slots = resolveSlots(context, clock);
+  const slots = resolveSlots(context, clock, options.language);
   const candidates: DeterministicCandidate[] = [];
 
   for (const row of pack.templates) {
     const text = resolveTemplatePattern(row.template, slots);
     if (text) {
-      candidates.push({ text, intent: row.intent });
+      candidates.push({
+        text,
+        intent: row.intent,
+        ...(options.language !== undefined ? { language: options.language } : {}),
+      });
     }
+  }
+
+  if (pack.kgRelationTemplates) {
+    candidates.push(
+      ...expandKgRelationQueries(
+        context,
+        pack.kgRelationTemplates,
+        slots,
+        kgTemplateCap,
+      ).map((row) => ({
+        ...row,
+        ...(options.language !== undefined ? { language: options.language } : {}),
+      })),
+    );
   }
 
   return candidates;

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
@@ -146,3 +146,108 @@ describe("rich-v2-extended pack", () => {
     ).toBeLessThanOrEqual(MAX_TEMPLATES_PER_PACK);
   });
 });
+
+describe("kg-aware-v1 pack", () => {
+  const kgContext: GetQueryAnalysisResponse = {
+    ...fullContext,
+    recentRelationDeltas: [
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Delta One",
+        relationType: "supplies",
+        change: "added",
+      },
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Delta Two",
+        relationType: "partners_with",
+        change: "updated",
+      },
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Delta Three",
+        relationType: "competes_with",
+        change: "removed",
+      },
+    ],
+    kgNeighborhood: [
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Nb One",
+        relationType: "supplies",
+      },
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Nb Two",
+        relationType: "partners_with",
+      },
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Nb Three",
+        relationType: "competes_with",
+      },
+      {
+        fromEntity: "Acme Co",
+        toEntity: "Nb Four",
+        relationType: "regulates",
+      },
+    ],
+  };
+
+  it("expands deltas first then neighborhood rows up to kgTemplateCap", () => {
+    const queries = buildDeterministicQueries(kgContext, {
+      pack: "kg-aware-v1",
+      clock: FIXED_CLOCK,
+      kgTemplateCap: 6,
+    });
+
+    const kgQueries = queries.filter(
+      (row) =>
+        row.text.includes("Delta One") ||
+        row.text.includes("Delta Two") ||
+        row.text.includes("Delta Three") ||
+        row.text.includes("Nb One") ||
+        row.text.includes("Nb Two") ||
+        row.text.includes("Nb Three") ||
+        row.text.includes("Nb Four"),
+    );
+
+    expect(kgQueries).toHaveLength(6);
+    expect(kgQueries[0]?.text).toContain("Delta One");
+    expect(kgQueries[1]?.text).toContain("Delta Two");
+    expect(kgQueries[2]?.text).toContain("Delta Three");
+    expect(kgQueries[3]?.text).toContain("Nb One");
+    expect(kgQueries[4]?.text).toContain("Nb Two");
+    expect(kgQueries[5]?.text).toContain("Nb Three");
+    expect(kgQueries.every((row) => !row.text.includes("Nb Four"))).toBe(true);
+  });
+
+  it("tags delta rows as kg_change and neighborhood rows as competitor", () => {
+    const queries = buildDeterministicQueries(kgContext, {
+      pack: "kg-aware-v1",
+      clock: FIXED_CLOCK,
+      kgTemplateCap: 6,
+    });
+
+    const deltaQueries = queries.filter((row) => row.text.includes("Delta"));
+    const neighborhoodQueries = queries.filter((row) =>
+      row.text.includes("Nb "),
+    );
+
+    expect(deltaQueries.every((row) => row.intent === "kg_change")).toBe(true);
+    expect(
+      neighborhoodQueries.every((row) => row.intent === "competitor"),
+    ).toBe(true);
+  });
+
+  it("skips KG expansion when kgTemplateCap is zero", () => {
+    const queries = buildDeterministicQueries(kgContext, {
+      pack: "kg-aware-v1",
+      clock: FIXED_CLOCK,
+      kgTemplateCap: 0,
+    });
+
+    expect(queries.every((row) => !row.text.includes("Delta One"))).toBe(true);
+    expect(queries.every((row) => !row.text.includes("Nb One"))).toBe(true);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -75,7 +75,10 @@ const defaultIdV1Pack: DeterministicPack = {
     { template: "berita terbaru {symbol}", intent: "breaking" },
     { template: "berita terbaru {name}", intent: "breaking" },
     { template: "perubahan relasi {name}", intent: "kg_change" },
-    { template: "laporan keuangan {name} {currentQuarter}", intent: "fundamental" },
+    {
+      template: "laporan keuangan {name} {currentQuarter}",
+      intent: "fundamental",
+    },
     { template: "prospek saham {name}", intent: "fundamental" },
     { template: "update regulasi {name}", intent: "fundamental" },
   ],

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -1,10 +1,15 @@
 import type { QueryAnalysisIntent } from "@workspace/agent-data-api-contract";
 
+import type { KgRelationTemplate } from "./slot-resolver";
+
 /** Named deterministic template pack identifiers. */
 export const DETERMINISTIC_PACK_NAMES = [
   "default-v1",
+  "default-en-v1",
+  "default-id-v1",
   "rich-v2",
   "rich-v2-extended",
+  "kg-aware-v1",
 ] as const;
 
 /** Valid `templatePack` config value. */
@@ -26,6 +31,16 @@ export type DeterministicTemplate = {
 export type DeterministicPack = {
   name: DeterministicPackName;
   templates: DeterministicTemplate[];
+  /** Optional per-relation templates expanded from KG deltas and neighborhood rows. */
+  kgRelationTemplates?: KgRelationTemplate[];
+};
+
+/** Default localized pack per primary language subtag. */
+export const DEFAULT_TEMPLATE_PACK_BY_LANGUAGE: Partial<
+  Record<string, DeterministicPackName>
+> = {
+  en: "default-en-v1",
+  id: "default-id-v1",
 };
 
 /** Original five-template baseline (symbol/name only). */
@@ -37,6 +52,32 @@ const defaultV1Pack: DeterministicPack = {
     { template: "{name} relation changes", intent: "kg_change" },
     { template: "{name} earnings guidance", intent: "fundamental" },
     { template: "{name} regulatory update", intent: "fundamental" },
+  ],
+};
+
+/** English locale pack mirroring `default-v1` with natural search phrasing. */
+const defaultEnV1Pack: DeterministicPack = {
+  name: "default-en-v1",
+  templates: [
+    { template: "{symbol} latest news", intent: "breaking" },
+    { template: "{name} breaking news", intent: "breaking" },
+    { template: "{name} relation changes", intent: "kg_change" },
+    { template: "{name} earnings guidance", intent: "fundamental" },
+    { template: "{name} regulatory update", intent: "fundamental" },
+    { template: "{name} {currentQuarter} earnings", intent: "fundamental" },
+  ],
+};
+
+/** Bahasa Indonesia locale pack with natural IDX search phrasing. */
+const defaultIdV1Pack: DeterministicPack = {
+  name: "default-id-v1",
+  templates: [
+    { template: "berita terbaru {symbol}", intent: "breaking" },
+    { template: "berita terbaru {name}", intent: "breaking" },
+    { template: "perubahan relasi {name}", intent: "kg_change" },
+    { template: "laporan keuangan {name} {currentQuarter}", intent: "fundamental" },
+    { template: "prospek saham {name}", intent: "fundamental" },
+    { template: "update regulasi {name}", intent: "fundamental" },
   ],
 };
 
@@ -106,14 +147,49 @@ const richV2ExtendedPack: DeterministicPack = {
   ],
 };
 
+/** KG-relation templates layered on top of rich-v2 static templates. */
+const KG_AWARE_RELATION_TEMPLATES: KgRelationTemplate[] = [
+  {
+    template: "{name} {relationVerb} {toEntity}",
+    intent: "kg_change",
+    sources: ["delta"],
+  },
+  {
+    template: "why did {name} stop {relationVerb} {toEntity}",
+    intent: "kg_change",
+    sources: ["delta"],
+    whenChange: "removed",
+  },
+  {
+    template: "impact on {name} from {fromEntity} {relationVerb} {toEntity}",
+    intent: "kg_change",
+    sources: ["delta", "neighborhood"],
+  },
+  {
+    template: "{name} {relationVerb} {toEntity}",
+    intent: "competitor",
+    sources: ["neighborhood"],
+  },
+];
+
+/** Extends rich-v2 with relation-driven deterministic queries from KG context. */
+const kgAwareV1Pack: DeterministicPack = {
+  name: "kg-aware-v1",
+  templates: richV2Pack.templates,
+  kgRelationTemplates: KG_AWARE_RELATION_TEMPLATES,
+};
+
 /** All registered deterministic template packs keyed by name. */
 export const DETERMINISTIC_PACKS: Record<
   DeterministicPackName,
   DeterministicPack
 > = {
   "default-v1": defaultV1Pack,
+  "default-en-v1": defaultEnV1Pack,
+  "default-id-v1": defaultIdV1Pack,
   "rich-v2": richV2Pack,
   "rich-v2-extended": richV2ExtendedPack,
+  "kg-aware-v1": kgAwareV1Pack,
 };
 
 /**

--- a/apps/mediapulse/agents/query-analysis/src/templates/relation-verbs.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/relation-verbs.test.ts
@@ -1,0 +1,24 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { resolveRelationVerb } from "./relation-verbs";
+
+describe("resolveRelationVerb", () => {
+  it('maps ("supplies", "removed") to "stops supplying"', () => {
+    expect(resolveRelationVerb("supplies", "removed")).toBe("stops supplying");
+  });
+
+  it("uses the static verb for neighborhood rows without a change", () => {
+    expect(resolveRelationVerb("supplies")).toBe("supplies");
+  });
+
+  it("uses the past verb for added deltas", () => {
+    expect(resolveRelationVerb("partners_with", "added")).toBe(
+      "partnered with",
+    );
+  });
+
+  it("returns the raw relation type as a fallback verb for unknown labels", () => {
+    expect(resolveRelationVerb("custom_edge_type")).toBe("custom edge type");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/templates/relation-verbs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/relation-verbs.ts
@@ -1,0 +1,74 @@
+/** Verb forms for a bounded KG `relationType` label. */
+export type RelationVerbEntry = {
+  verb: string;
+  negativeVerb: string;
+  pastVerb: string;
+};
+
+/** Static map from common relation types to searchable verb phrases. */
+export const RELATION_VERB_MAP: Record<string, RelationVerbEntry> = {
+  supplies: {
+    verb: "supplies",
+    negativeVerb: "stops supplying",
+    pastVerb: "started supplying",
+  },
+  competes_with: {
+    verb: "competes with",
+    negativeVerb: "no longer competes with",
+    pastVerb: "began competing with",
+  },
+  subsidiary_of: {
+    verb: "is subsidiary of",
+    negativeVerb: "is no longer subsidiary of",
+    pastVerb: "became subsidiary of",
+  },
+  partners_with: {
+    verb: "partners with",
+    negativeVerb: "stops partnering with",
+    pastVerb: "partnered with",
+  },
+  regulates: {
+    verb: "regulates",
+    negativeVerb: "stops regulating",
+    pastVerb: "began regulating",
+  },
+  acquired_by: {
+    verb: "was acquired by",
+    negativeVerb: "is no longer owned by",
+    pastVerb: "was acquired by",
+  },
+};
+
+/**
+ * Normalizes a relation type key for dictionary lookup.
+ *
+ * @param relationType - Raw KG relation label.
+ * @returns Lowercase trimmed key.
+ */
+export const normalizeRelationTypeKey = (relationType: string): string =>
+  relationType.trim().toLowerCase();
+
+/**
+ * Resolves the human-readable verb phrase for a relation edge.
+ *
+ * @param relationType - KG relation label (directional subject is `fromEntity`).
+ * @param change - Optional delta change kind; neighborhood rows omit this.
+ * @returns Verb phrase, falling back to the raw type with underscores as spaces.
+ */
+export const resolveRelationVerb = (
+  relationType: string,
+  change?: "added" | "removed" | "updated",
+): string => {
+  const key = normalizeRelationTypeKey(relationType);
+  const entry = RELATION_VERB_MAP[key];
+  if (!entry) {
+    return relationType.trim().replace(/_/g, " ");
+  }
+  if (change === "removed") {
+    return entry.negativeVerb;
+  }
+  if (change === "added") {
+    return entry.pastVerb;
+  }
+  return entry.verb;
+};

--- a/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
 
 import {
+  collectOrderedKgRelationRows,
   extractSlotsFromPattern,
   formatCurrentQuarter,
   resolveSlots,
@@ -98,6 +99,54 @@ describe("resolveSlots", () => {
     // Assert
     expect(slots.topEntity).toBeUndefined();
     expect(slots.recentTheme).toBeUndefined();
+    expect(slots.daysToEarnings).toBeUndefined();
+    expect(slots.lastEventType).toBeUndefined();
+  });
+
+  it("resolves earnings and calendar slots when present", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...sparseContext,
+      calendar: {
+        recentEventTypes: ["regulatory_filing"],
+        nextEarningsAt: "2026-05-28T12:00:00.000Z",
+      },
+    };
+
+    const slots = resolveSlots(context, FIXED_CLOCK);
+
+    expect(slots.daysToEarnings).toBe("7");
+    expect(slots.lastEventType).toBe("regulatory_filing");
+  });
+});
+
+describe("collectOrderedKgRelationRows", () => {
+  it("drains relation deltas before static neighborhood rows", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...sparseContext,
+      recentRelationDeltas: [
+        {
+          fromEntity: "Acme Co",
+          toEntity: "Delta One",
+          relationType: "supplies",
+          change: "added",
+        },
+      ],
+      kgNeighborhood: [
+        {
+          fromEntity: "Acme Co",
+          toEntity: "Nb One",
+          relationType: "partners_with",
+        },
+      ],
+    };
+
+    const rows = collectOrderedKgRelationRows(context, 2);
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.source).toBe("delta");
+    expect(rows[0]?.toEntity).toBe("Delta One");
+    expect(rows[1]?.source).toBe("neighborhood");
+    expect(rows[1]?.toEntity).toBe("Nb One");
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.ts
@@ -1,4 +1,11 @@
-import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+import type {
+  GetQueryAnalysisResponse,
+  QueryAnalysisIntent,
+} from "@workspace/agent-data-api-contract";
+
+import { daysUntilEarnings } from "../temporal/event-bias";
+import { resolveEntityDisplayName } from "../i18n/entity-aliases";
+import { resolveRelationVerb } from "./relation-verbs";
 
 /** Clock dependency for time-anchored template slots. */
 export type SlotResolverClock = () => Date;
@@ -12,6 +19,29 @@ export type ResolvedTemplateSlots = {
   currentQuarter: string;
   currentYear: string;
   currentMonth: string;
+  daysToEarnings?: string;
+  lastEventType?: string;
+};
+
+/** Per-relation slot values merged with {@link ResolvedTemplateSlots}. */
+export type KgRelationSlots = {
+  fromEntity: string;
+  toEntity: string;
+  relationVerb: string;
+};
+
+/** One KG relation row prioritized for template expansion. */
+export type OrderedKgRelationRow = KgRelationSlots & {
+  source: "delta" | "neighborhood";
+  change?: "added" | "removed" | "updated";
+};
+
+/** KG relation template applied per relation row during expansion. */
+export type KgRelationTemplate = {
+  template: string;
+  intent: QueryAnalysisIntent;
+  sources: Array<"delta" | "neighborhood">;
+  whenChange?: "added" | "removed" | "updated";
 };
 
 const TEMPLATE_SLOT_PATTERN = /\{([a-zA-Z]+)\}/g;
@@ -54,6 +84,103 @@ export const formatCurrentMonth = (date: Date): string =>
   date.toLocaleString("en-US", { month: "long" });
 
 /**
+ * Formats days-until-earnings for template slots when calendar data is present.
+ *
+ * @param context - GET /query-analysis response.
+ * @param clock - Reference instant (default: now).
+ * @returns Day count as a string, or `undefined` when earnings date is absent.
+ */
+export const formatDaysToEarnings = (
+  context: GetQueryAnalysisResponse,
+  clock: SlotResolverClock = () => new Date(),
+): string | undefined => {
+  const days = daysUntilEarnings(context, clock);
+  return days === undefined ? undefined : String(days);
+};
+
+/**
+ * Collects relation rows for KG template expansion: deltas first, then neighborhood.
+ *
+ * @param context - GET /query-analysis response.
+ * @param cap - Maximum relation rows to include (`0` yields an empty list).
+ * @returns Ordered relation rows with resolved verb phrases.
+ */
+export const collectOrderedKgRelationRows = (
+  context: GetQueryAnalysisResponse,
+  cap: number,
+): OrderedKgRelationRow[] => {
+  if (cap <= 0) {
+    return [];
+  }
+
+  const rows: OrderedKgRelationRow[] = [];
+
+  for (const delta of context.recentRelationDeltas ?? []) {
+    if (rows.length >= cap) {
+      break;
+    }
+    rows.push({
+      source: "delta",
+      change: delta.change,
+      fromEntity: delta.fromEntity,
+      toEntity: delta.toEntity,
+      relationVerb: resolveRelationVerb(delta.relationType, delta.change),
+    });
+  }
+
+  for (const edge of context.kgNeighborhood) {
+    if (rows.length >= cap) {
+      break;
+    }
+    rows.push({
+      source: "neighborhood",
+      fromEntity: edge.fromEntity,
+      toEntity: edge.toEntity,
+      relationVerb: resolveRelationVerb(edge.relationType),
+    });
+  }
+
+  return rows;
+};
+
+/**
+ * Selects the best KG relation template for a row (specific `whenChange` wins over generic).
+ *
+ * @param templates - KG relation templates from the active pack.
+ * @param row - Ordered relation row with source and optional change.
+ * @returns First matching template in pack order, or `undefined` when none apply.
+ */
+export const selectKgRelationTemplate = (
+  templates: KgRelationTemplate[],
+  row: OrderedKgRelationRow,
+): KgRelationTemplate | undefined => {
+  const matching = templates.filter(
+    (template) =>
+      template.sources.includes(row.source) &&
+      (template.whenChange === undefined || template.whenChange === row.change),
+  );
+  if (matching.length === 0) {
+    return undefined;
+  }
+
+  const sourceSpecific = matching.filter((template) => {
+    if (row.source === "delta") {
+      return (
+        template.sources.includes("delta") &&
+        !template.sources.includes("neighborhood")
+      );
+    }
+    return (
+      template.sources.includes("neighborhood") &&
+      !template.sources.includes("delta")
+    );
+  });
+  const pool = sourceSpecific.length > 0 ? sourceSpecific : matching;
+
+  return pool.find((template) => template.whenChange !== undefined) ?? pool[0];
+};
+
+/**
  * Resolves slot values from query-analysis context and an injectable clock.
  *
  * @param context - GET /query-analysis response.
@@ -63,8 +190,17 @@ export const formatCurrentMonth = (date: Date): string =>
 export const resolveSlots = (
   context: GetQueryAnalysisResponse,
   clock: SlotResolverClock = () => new Date(),
+  language?: string,
 ): ResolvedTemplateSlots => {
   const now = clock();
+  const companyName =
+    language !== undefined
+      ? resolveEntityDisplayName(
+          context.ticker.symbol,
+          context.ticker.name,
+          language,
+        )
+      : context.ticker.name;
   const topEntity =
     context.topEntities.length > 0
       ? [...context.topEntities].sort(
@@ -74,12 +210,14 @@ export const resolveSlots = (
 
   return {
     symbol: context.ticker.symbol,
-    name: context.ticker.name,
+    name: companyName,
     topEntity,
     recentTheme: context.recentThemes[0]?.theme,
     currentQuarter: formatCurrentQuarter(now),
     currentYear: String(now.getFullYear()),
     currentMonth: formatCurrentMonth(now),
+    daysToEarnings: formatDaysToEarnings(context, clock),
+    lastEventType: context.calendar.recentEventTypes[0],
   };
 };
 
@@ -87,12 +225,13 @@ export const resolveSlots = (
  * Renders a template when every referenced slot resolves to a non-empty string.
  *
  * @param pattern - Template text with `{slot}` placeholders.
- * @param slots - Resolved slot values from {@link resolveSlots}.
+ * @param slots - Resolved slot values from {@link resolveSlots} plus optional KG slots.
  * @returns Rendered query text, or `null` when a required slot is missing.
  */
 export const resolveTemplatePattern = (
   pattern: string,
   slots: ResolvedTemplateSlots,
+  kgSlots?: KgRelationSlots,
 ): string | null => {
   const required = extractSlotsFromPattern(pattern);
   const slotRecord: Record<string, string | undefined> = {
@@ -103,6 +242,11 @@ export const resolveTemplatePattern = (
     currentQuarter: slots.currentQuarter,
     currentYear: slots.currentYear,
     currentMonth: slots.currentMonth,
+    daysToEarnings: slots.daysToEarnings,
+    lastEventType: slots.lastEventType,
+    fromEntity: kgSlots?.fromEntity,
+    toEntity: kgSlots?.toEntity,
+    relationVerb: kgSlots?.relationVerb,
   };
 
   for (const name of required) {
@@ -116,4 +260,44 @@ export const resolveTemplatePattern = (
     const value = slotRecord[key];
     return value?.trim() ?? "";
   });
+};
+
+/**
+ * Expands KG relation templates into one deterministic query per relation row.
+ *
+ * @param context - GET /query-analysis response.
+ * @param templates - KG relation templates from the active pack.
+ * @param baseSlots - Ticker-level slots from {@link resolveSlots}.
+ * @param cap - Maximum KG-derived rows (`0` disables expansion).
+ * @returns Rendered KG query candidates in delta-first order.
+ */
+export const expandKgRelationQueries = (
+  context: GetQueryAnalysisResponse,
+  templates: KgRelationTemplate[],
+  baseSlots: ResolvedTemplateSlots,
+  cap: number,
+): Array<{ text: string; intent: QueryAnalysisIntent }> => {
+  if (cap <= 0 || templates.length === 0) {
+    return [];
+  }
+
+  const rows = collectOrderedKgRelationRows(context, cap);
+  const candidates: Array<{ text: string; intent: QueryAnalysisIntent }> = [];
+
+  for (const row of rows) {
+    const template = selectKgRelationTemplate(templates, row);
+    if (!template) {
+      continue;
+    }
+    const text = resolveTemplatePattern(template.template, baseSlots, {
+      fromEntity: row.fromEntity,
+      toEntity: row.toEntity,
+      relationVerb: row.relationVerb,
+    });
+    if (text) {
+      candidates.push({ text, intent: template.intent });
+    }
+  }
+
+  return candidates;
 };

--- a/apps/mediapulse/agents/query-analysis/src/temporal/default-rules.ts
+++ b/apps/mediapulse/agents/query-analysis/src/temporal/default-rules.ts
@@ -1,0 +1,28 @@
+import type { EventBiasRule } from "./event-bias";
+import {
+  daysUntilEarnings,
+  hasRecentMergerDelta,
+  hasRecentRegulatoryEvent,
+} from "./event-bias";
+
+/** Default conservative event-bias rules (multipliers ≤ 2, never below 1×). */
+export const DEFAULT_EVENT_BIAS_RULES: EventBiasRule[] = [
+  {
+    id: "near-earnings",
+    when: (context, clock) => {
+      const days = daysUntilEarnings(context, clock);
+      return days !== undefined && days <= 14;
+    },
+    bias: { fundamental: 2, sentiment: 1.5 },
+  },
+  {
+    id: "recent-merger-delta",
+    when: (context) => hasRecentMergerDelta(context),
+    bias: { kg_change: 2, competitor: 1.5 },
+  },
+  {
+    id: "recent-regulatory-event",
+    when: (context) => hasRecentRegulatoryEvent(context),
+    bias: { macro: 1.5 },
+  },
+];

--- a/apps/mediapulse/agents/query-analysis/src/temporal/event-bias.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/temporal/event-bias.test.ts
@@ -1,0 +1,184 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { GetQueryAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+import { DEFAULT_EVENT_BIAS_RULES } from "./default-rules";
+import {
+  applyEventBiasToIntentWeights,
+  computeEventBias,
+  daysUntilEarnings,
+  hasRecentMergerDelta,
+  hasRecentRegulatoryEvent,
+  mergeEventBiasMultipliers,
+} from "./event-bias";
+
+const FIXED_NOW = new Date("2026-05-21T12:00:00.000Z");
+const FIXED_CLOCK = (): Date => FIXED_NOW;
+
+const baseContext: GetQueryAnalysisResponse = {
+  ticker: {
+    id: "11111111-1111-4111-a111-111111111111",
+    symbol: "ACME",
+    name: "Acme Co",
+    metadata: null,
+  },
+  topEntities: [],
+  recentThemes: [],
+  peers: [],
+  calendar: { recentEventTypes: [] },
+  headlineSamples: [],
+  kgNeighborhood: [],
+};
+
+describe("daysUntilEarnings", () => {
+  it("returns undefined when next earnings is absent", () => {
+    expect(daysUntilEarnings(baseContext, FIXED_CLOCK)).toBeUndefined();
+  });
+
+  it("returns whole days until the next earnings date", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      calendar: {
+        recentEventTypes: [],
+        nextEarningsAt: "2026-05-28T12:00:00.000Z",
+      },
+    };
+
+    expect(daysUntilEarnings(context, FIXED_CLOCK)).toBe(7);
+  });
+});
+
+describe("hasRecentMergerDelta", () => {
+  it("detects merger-style relation deltas", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      recentRelationDeltas: [
+        {
+          fromEntity: "Acme",
+          toEntity: "Target Co",
+          relationType: "merger",
+          change: "added",
+        },
+      ],
+    };
+
+    expect(hasRecentMergerDelta(context)).toBe(true);
+  });
+});
+
+describe("hasRecentRegulatoryEvent", () => {
+  it("detects regulatory calendar event types", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      calendar: { recentEventTypes: ["regulatory_filing"] },
+    };
+
+    expect(hasRecentRegulatoryEvent(context)).toBe(true);
+  });
+});
+
+describe("mergeEventBiasMultipliers", () => {
+  it("multiplies overlapping intents across rules", () => {
+    const merged = mergeEventBiasMultipliers(
+      { fundamental: 2 },
+      { fundamental: 1.5, sentiment: 1.5 },
+    );
+
+    expect(merged).toEqual({ fundamental: 3, sentiment: 1.5 });
+  });
+});
+
+describe("computeEventBias", () => {
+  it("fires the near-earnings rule when earnings are within 14 days", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      calendar: {
+        recentEventTypes: [],
+        nextEarningsAt: "2026-05-28T12:00:00.000Z",
+      },
+    };
+
+    const result = computeEventBias(
+      context,
+      FIXED_CLOCK,
+      DEFAULT_EVENT_BIAS_RULES,
+    );
+
+    expect(result.firedRuleIds).toContain("near-earnings");
+    expect(result.multipliers.fundamental).toBe(2);
+    expect(result.multipliers.sentiment).toBe(1.5);
+  });
+
+  it("does not fire near-earnings when earnings are more than 14 days out", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      calendar: {
+        recentEventTypes: [],
+        nextEarningsAt: "2026-06-21T12:00:00.000Z",
+      },
+    };
+
+    const result = computeEventBias(
+      context,
+      FIXED_CLOCK,
+      DEFAULT_EVENT_BIAS_RULES,
+    );
+
+    expect(result.firedRuleIds).not.toContain("near-earnings");
+    expect(result.multipliers.fundamental).toBeUndefined();
+  });
+
+  it("fires merger boost regardless of earnings timing", () => {
+    const context: GetQueryAnalysisResponse = {
+      ...baseContext,
+      calendar: {
+        recentEventTypes: [],
+        nextEarningsAt: "2026-08-01T12:00:00.000Z",
+      },
+      recentRelationDeltas: [
+        {
+          fromEntity: "Acme",
+          toEntity: "Rival",
+          relationType: "acquisition",
+          change: "added",
+        },
+      ],
+    };
+
+    const result = computeEventBias(
+      context,
+      FIXED_CLOCK,
+      DEFAULT_EVENT_BIAS_RULES,
+    );
+
+    expect(result.firedRuleIds).toContain("recent-merger-delta");
+    expect(result.firedRuleIds).not.toContain("near-earnings");
+    expect(result.multipliers.kg_change).toBe(2);
+    expect(result.multipliers.competitor).toBe(1.5);
+  });
+});
+
+describe("applyEventBiasToIntentWeights", () => {
+  it("multiplies only intents present in the bias map", () => {
+    const adjusted = applyEventBiasToIntentWeights(
+      {
+        breaking: 1,
+        kg_change: 0.8,
+        fundamental: 0.6,
+        sentiment: 0.5,
+        competitor: 0.5,
+        supply_chain: 0.4,
+        esg: 0.3,
+        macro: 0.4,
+        technical: 0.3,
+        wildcard: 0,
+      },
+      { fundamental: 2, sentiment: 1.5 },
+    );
+
+    expect(adjusted.fundamental).toBe(1.2);
+    expect(adjusted.sentiment).toBe(0.75);
+    expect(adjusted.breaking).toBe(1);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/temporal/event-bias.ts
+++ b/apps/mediapulse/agents/query-analysis/src/temporal/event-bias.ts
@@ -1,0 +1,157 @@
+import {
+  QUERY_ANALYSIS_INTENTS,
+  type GetQueryAnalysisResponse,
+  type QueryAnalysisIntent,
+  type QueryAnalysisIntentWeights,
+} from "@workspace/agent-data-api-contract";
+
+/** Injectable clock for temporal predicates and slot resolution. */
+export type EventBiasClock = () => Date;
+
+/** Per-intent multipliers contributed by a single event-bias rule (values ≥ 1). */
+export type EventBiasMultipliers = Partial<Record<QueryAnalysisIntent, number>>;
+
+/** Declarative rule: predicate plus intent multipliers when it matches. */
+export type EventBiasRule = {
+  id: string;
+  when: (context: GetQueryAnalysisResponse, clock: EventBiasClock) => boolean;
+  bias: EventBiasMultipliers;
+};
+
+/** Outcome of walking the rule library against live GET context. */
+export type EventBiasResult = {
+  multipliers: EventBiasMultipliers;
+  firedRuleIds: string[];
+};
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Returns whole days from `clock` until the next earnings date, when known.
+ *
+ * @param context - GET /query-analysis payload with optional calendar.
+ * @param clock - Reference instant (default: now).
+ * @returns Non-negative day count, or `undefined` when earnings date is absent.
+ */
+export const daysUntilEarnings = (
+  context: GetQueryAnalysisResponse,
+  clock: EventBiasClock = () => new Date(),
+): number | undefined => {
+  const nextEarningsAt = context.calendar.nextEarningsAt;
+  if (!nextEarningsAt) {
+    return undefined;
+  }
+  const target = new Date(nextEarningsAt);
+  if (Number.isNaN(target.getTime())) {
+    return undefined;
+  }
+  const diffMs = target.getTime() - clock().getTime();
+  if (diffMs <= 0) {
+    return 0;
+  }
+  return Math.ceil(diffMs / MS_PER_DAY);
+};
+
+/** Relation-type tokens that indicate a recent merger or acquisition delta. */
+const MERGER_RELATION_PATTERN =
+  /merger|acquisition|acquire|acquired|m&a|takeover/i;
+
+/**
+ * Returns whether recent relation deltas include a merger-style edge.
+ *
+ * @param context - GET /query-analysis payload with optional relation deltas.
+ * @returns `true` when a non-removed merger-like delta is present.
+ */
+export const hasRecentMergerDelta = (
+  context: GetQueryAnalysisResponse,
+): boolean =>
+  (context.recentRelationDeltas ?? []).some(
+    (delta) =>
+      delta.change !== "removed" &&
+      MERGER_RELATION_PATTERN.test(delta.relationType),
+  );
+
+/** Calendar event-type tokens treated as regulatory catalysts. */
+const REGULATORY_EVENT_PATTERN =
+  /regulat|compliance|antitrust|policy|sanction|sec_|fda_|investigation/i;
+
+/**
+ * Returns whether recent calendar event types include a regulatory catalyst.
+ *
+ * @param context - GET /query-analysis payload with calendar event types.
+ * @returns `true` when a regulatory-like event type appears in the window.
+ */
+export const hasRecentRegulatoryEvent = (
+  context: GetQueryAnalysisResponse,
+): boolean =>
+  context.calendar.recentEventTypes.some((eventType) =>
+    REGULATORY_EVENT_PATTERN.test(eventType),
+  );
+
+/**
+ * Merges per-intent multipliers by taking the product across fired rules.
+ *
+ * @param left - Accumulated multipliers so far.
+ * @param right - Multipliers from the next matching rule.
+ * @returns Combined multiplier map.
+ */
+export const mergeEventBiasMultipliers = (
+  left: EventBiasMultipliers,
+  right: EventBiasMultipliers,
+): EventBiasMultipliers => {
+  const merged: EventBiasMultipliers = { ...left };
+  for (const [intent, multiplier] of Object.entries(right) as Array<
+    [QueryAnalysisIntent, number]
+  >) {
+    merged[intent] = (merged[intent] ?? 1) * multiplier;
+  }
+  return merged;
+};
+
+/**
+ * Walks predicate rules in order and returns merged intent multipliers plus fired ids.
+ *
+ * @param context - Live GET /query-analysis context.
+ * @param clock - Reference instant for temporal predicates.
+ * @param rules - Rule library (default supplied by caller).
+ * @returns Per-intent multipliers and ids of rules that matched.
+ */
+export const computeEventBias = (
+  context: GetQueryAnalysisResponse,
+  clock: EventBiasClock = () => new Date(),
+  rules: EventBiasRule[],
+): EventBiasResult => {
+  let multipliers: EventBiasMultipliers = {};
+  const firedRuleIds: string[] = [];
+
+  for (const rule of rules) {
+    if (!rule.when(context, clock)) {
+      continue;
+    }
+    firedRuleIds.push(rule.id);
+    multipliers = mergeEventBiasMultipliers(multipliers, rule.bias);
+  }
+
+  return { multipliers, firedRuleIds };
+};
+
+/**
+ * Multiplies configured intent weights by event-bias multipliers (intents without bias unchanged).
+ *
+ * @param weights - Base intent weights from Hermes config.
+ * @param multipliers - Per-intent products from {@link computeEventBias}.
+ * @returns Adjusted weights for prompt target counts and merge ordering.
+ */
+export const applyEventBiasToIntentWeights = (
+  weights: QueryAnalysisIntentWeights,
+  multipliers: EventBiasMultipliers,
+): QueryAnalysisIntentWeights => {
+  const adjusted = { ...weights };
+  for (const intent of QUERY_ANALYSIS_INTENTS) {
+    const multiplier = multipliers[intent];
+    if (multiplier !== undefined) {
+      adjusted[intent] = weights[intent] * multiplier;
+    }
+  }
+  return adjusted;
+};

--- a/packages/mediapulse/database/prisma/migrations/20260521130000_add_search_query_intent_wildcard/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260521130000_add_search_query_intent_wildcard/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'wildcard';

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -34,6 +34,7 @@ enum SearchQueryIntent {
   esg
   macro
   technical
+  wildcard
 }
 
 model DataSource {

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -97,6 +97,7 @@ export {
   queryAnalysisConfigSnapshotSchema,
   queryAnalysisIntentSchema,
   QUERY_ANALYSIS_INTENTS,
+  QUERY_ANALYSIS_STANDARD_INTENTS,
   DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
   queryAnalysisRecentThemeSchema,
   queryAnalysisRelationDeltaSchema,

--- a/packages/shared/agent-data-api-contract/src/query-analysis.test.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.test.ts
@@ -27,6 +27,16 @@ describe("queryAnalysisIntentSchema", () => {
     expect(parsed.intent).toBe("esg");
   });
 
+  it("accepts wildcard intent rows", () => {
+    const parsed = queryAnalysisPostQuerySchema.parse({
+      text: "Oblique cultural narrative angle",
+      source: "llm",
+      intent: "wildcard",
+      rank: 10,
+    });
+    expect(parsed.intent).toBe("wildcard");
+  });
+
   it("rejects unknown intent labels", () => {
     const result = queryAnalysisIntentSchema.safeParse("unknown_intent");
     expect(result.success).toBe(false);

--- a/packages/shared/agent-data-api-contract/src/query-analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.ts
@@ -11,6 +11,20 @@ export const QUERY_ANALYSIS_INTENTS = [
   "esg",
   "macro",
   "technical",
+  "wildcard",
+] as const;
+
+/** Intent labels used by the standard (non-wildcard) query-generation pipeline. */
+export const QUERY_ANALYSIS_STANDARD_INTENTS = [
+  "breaking",
+  "kg_change",
+  "fundamental",
+  "sentiment",
+  "competitor",
+  "supply_chain",
+  "esg",
+  "macro",
+  "technical",
 ] as const;
 
 export const queryAnalysisIntentSchema = z.enum(QUERY_ANALYSIS_INTENTS);
@@ -31,6 +45,7 @@ export const DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS: Record<
   esg: 0.3,
   macro: 0.4,
   technical: 0.3,
+  wildcard: 0,
 };
 
 export const queryAnalysisSourceSchema = z.enum(["deterministic", "llm"]);


### PR DESCRIPTION
## Summary

This extends the query-analysis agent with four creativity layers that were planned after the base template-pack and persona work landed. Wildcard slots reserve a small budget for lateral queries. Calendar rules nudge intent weights when earnings or merger signals are present. KG relations produce deterministic search strings even when the LLM fails. Language quotas split the set across locales with native template phrasing instead of hoping the model code-mixes.

## Related issues

Closes #545

## Important changes

- **`wildcard` intent** — dedicated prompt and structured-output pass; reserved slots retry on dedup collision instead of shrinking the budget
- **Temporal event bias** — pure predicate rules multiply intent weights before prompts and merge; fired rule ids land in `appliedEventBias` on the strategy snapshot
- **KG-aware templates** — `kg-aware-v1` pack, relation-verb map, delta-first expansion capped by `kgTemplateCap`
- **Multilingual quotas** — `languageQuotas` replaces flat `allowedLanguages`; per-language pipeline with `default-en-v1` / `default-id-v1` packs and entity alias support
- **Contract** — `wildcard` added to the query-analysis intent schema

## Other changes

- Persona `preferredLanguages` filters fan-out per language slice
- Cost guard scales by personas × languages
- Legacy `allowedLanguages` still lifts to equal shares when `languageQuotas` is omitted

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/run.ts` — orchestration: event bias, language fan-out, wildcard append
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — wildcard fetch, single-language system prompt
- `apps/mediapulse/agents/query-analysis/src/language-quotas.ts` — share validation and count distribution
- `apps/mediapulse/agents/query-analysis/src/temporal/event-bias.ts` — rule evaluation and weight folding
- `apps/mediapulse/agents/query-analysis/src/templates/slot-resolver.ts` — KG relation slot expansion
- `apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts` — locale and KG packs
- `packages/shared/agent-data-api-contract/src/query-analysis.ts` — `wildcard` intent

## How to test

1. `cd apps/mediapulse/agents/query-analysis && npx vitest run` — expect 172 passing tests
2. `cd apps/mediapulse/agents/query-analysis && npx tsc --noEmit` — no type errors
3. `cd packages/shared/agent-data-api-contract && npx vitest run` — contract tests pass
4. Spot-check config: `languageQuotas: [{language:"en",share:0.6},{language:"id",share:0.4}]` with `queryCount: 10` yields 6 English + 4 Indonesian deterministic rows
5. Spot-check `wildcardFraction: 0.2` on `queryCount: 10` persists 2 rows with `intent: "wildcard"`
