### PR TITLE
Improve article-analysis extraction pipeline with quality gates and grounding

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-scoring.ts
@@ -115,7 +115,10 @@ export const computeWeightedScore = (
 /**
  * Builds a relevance POST row with `selected: false` (selection applied later).
  *
- * @param signals - Source signals after extraction caps.
+ * Expects {@link PerSourceRelevanceSignals} counts after post-extraction entity grounding
+ * so ticker salience and mention confidence reflect grounded entities only.
+ *
+ * @param signals - Source signals after extraction caps and grounding.
  * @param scoreBreakdownVersion - `_version` in breakdown JSON.
  * @param weights - Hermes-configured weights.
  * @returns One `articleRelevances` element.

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -151,7 +151,14 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
       articlesScored: 2,
       articlesSelected: 1,
       relevanceAggregate: null,
-      llmUsage: { promptTokens: 10, completionTokens: 20, totalTokens: 30 },
+      llmUsage: {
+        promptTokens: 10,
+        completionTokens: 20,
+        totalTokens: 30,
+        brainstormCalls: 1,
+        brainstormPromptTokens: 5,
+        brainstormCompletionTokens: 7,
+      },
       extractionLatencyMsTotal: 300,
       extractionCalls: 2,
       runStatusLabel: "partial_success",
@@ -176,6 +183,9 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.entityReuseRatio).toBe(0.5);
     expect(payload.avgExtractionLatencyMs).toBe(150);
     expect(payload.llmTotalTokens).toBe(30);
+    expect(payload.llmBrainstormCalls).toBe(1);
+    expect(payload.llmBrainstormPromptTokens).toBe(5);
+    expect(payload.llmBrainstormCompletionTokens).toBe(7);
     expect(payload.schemaValidationFailureCount).toBe(3);
     expect(payload.failureCountsByKind).toEqual({
       llm: 1,
@@ -304,5 +314,123 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     });
     expect(payload.semanticFailureReason).toBe("empty vocabulary");
     expect(payload.error).toEqual({ type: "Error", message: "network" });
+  });
+
+  it("includes droppedByContentQuality when provided", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 4,
+      extractionSuccessCount: 1,
+      extractionFailures: [],
+      droppedByContentQuality: {
+        prefilter_blocked_host: 0,
+        prefilter_blocked_path: 0,
+        prefilter_index_title: 0,
+        content_no_title: 0,
+        content_soft_404: 1,
+        content_access_gated: 1,
+        content_too_short: 1,
+        content_repetitive: 0,
+      },
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 1,
+    });
+
+    expect(payload.droppedByContentQuality).toEqual({
+      prefilter_blocked_host: 0,
+      prefilter_blocked_path: 0,
+      prefilter_index_title: 0,
+      content_no_title: 0,
+      content_soft_404: 1,
+      content_access_gated: 1,
+      content_too_short: 1,
+      content_repetitive: 0,
+    });
+  });
+
+  it("includes truncation aggregates when provided", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 1,
+      extractionSuccessCount: 1,
+      extractionFailures: [],
+      truncation: {
+        leadCharsKept: 120,
+        tickerSentencesKept: 1,
+        paragraphsKept: 4,
+        paragraphsDropped: 2,
+      },
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 1,
+    });
+
+    expect(payload.truncation).toEqual({
+      leadCharsKept: 120,
+      tickerSentencesKept: 1,
+      paragraphsKept: 4,
+      paragraphsDropped: 2,
+    });
+  });
+
+  it("includes exemplars counters when provided", () => {
+    const payload = buildArticleAnalysisRunSummaryPayload({
+      outcome: "success",
+      articlesProcessed: 1,
+      extractionSuccessCount: 1,
+      extractionFailures: [],
+      exemplars: {
+        requestedCount: 4,
+        resolvedCount: 2,
+        appliedArchetypes: ["earnings", "leadership"],
+      },
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 0,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 0,
+      articlesSelected: 0,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 0,
+      extractionCalls: 1,
+    });
+
+    expect(payload.exemplarsRequestedCount).toBe(4);
+    expect(payload.exemplarsResolvedCount).toBe(2);
+    expect(payload.exemplarsApplied).toEqual(["earnings", "leadership"]);
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -4,6 +4,9 @@ import type {
   ArticleAnalysisExtractionFailureRecord,
   ArticleAnalysisPostFailureRecord,
 } from "./article-analysis-run-policy.js";
+import type { QualityDropReason } from "./utilities/content-quality-gate.js";
+import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
+import type { GroundingObservabilityAggregate } from "./utilities/entity-grounding.js";
 
 /** Stable name for grep / log pipelines. */
 export const ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE =
@@ -210,6 +213,22 @@ export type LlmUsageTotals = {
   promptTokens: number;
   completionTokens: number;
   totalTokens: number;
+  brainstormCalls: number;
+  brainstormPromptTokens: number;
+  brainstormCompletionTokens: number;
+};
+
+export type TruncationObservabilityAggregate = {
+  leadCharsKept: number;
+  tickerSentencesKept: number;
+  paragraphsKept: number;
+  paragraphsDropped: number;
+};
+
+export type ExemplarsObservabilityAggregate = {
+  requestedCount: number;
+  resolvedCount: number;
+  appliedArchetypes: readonly ExtractionExemplarArchetype[];
 };
 
 export type ArticleAnalysisRunSummaryInput = {
@@ -217,6 +236,10 @@ export type ArticleAnalysisRunSummaryInput = {
   articlesProcessed: number;
   extractionSuccessCount: number;
   extractionFailures: readonly ArticleAnalysisExtractionFailureRecord[];
+  droppedByContentQuality?: Record<QualityDropReason, number>;
+  truncation?: TruncationObservabilityAggregate;
+  exemplars?: ExemplarsObservabilityAggregate;
+  grounding?: GroundingObservabilityAggregate;
   relevanceRowValidationFailures: number;
   chunkParseCounts: ChunkBuildParseCounts;
   postFailures: readonly ArticleAnalysisPostFailureRecord[];
@@ -229,6 +252,7 @@ export type ArticleAnalysisRunSummaryInput = {
   llmUsage: LlmUsageTotals | null;
   extractionLatencyMsTotal: number;
   extractionCalls: number;
+  brainstormCalls?: number;
   runStatusLabel?: string;
   semanticFailureReason?: string;
   topLevelError?: ReturnType<typeof toSafeLogError>;
@@ -289,6 +313,7 @@ export const buildArticleAnalysisRunSummaryPayload = (
     postByKind.article_relevances;
 
   const extractionCalls = input.extractionCalls;
+  const brainstormCalls = input.brainstormCalls ?? 0;
   const avgExtractionLatencyMs =
     extractionCalls > 0
       ? input.extractionLatencyMsTotal / extractionCalls
@@ -346,6 +371,7 @@ export const buildArticleAnalysisRunSummaryPayload = (
     articlesSelected: input.articlesSelected,
     extractionLatencyMsTotal: input.extractionLatencyMsTotal,
     extractionCalls,
+    brainstormCalls,
     avgExtractionLatencyMs,
   };
 
@@ -366,6 +392,10 @@ export const buildArticleAnalysisRunSummaryPayload = (
     base.llmPromptTokens = input.llmUsage.promptTokens;
     base.llmCompletionTokens = input.llmUsage.completionTokens;
     base.llmTotalTokens = input.llmUsage.totalTokens;
+    base.llmBrainstormCalls = input.llmUsage.brainstormCalls;
+    base.llmBrainstormPromptTokens = input.llmUsage.brainstormPromptTokens;
+    base.llmBrainstormCompletionTokens =
+      input.llmUsage.brainstormCompletionTokens;
   }
   if (input.relevanceAggregate !== null) {
     base.relevanceRowCount = input.relevanceAggregate.rowCount;
@@ -377,6 +407,24 @@ export const buildArticleAnalysisRunSummaryPayload = (
     base.breakdownKeyMeans = input.relevanceAggregate.breakdownKeyMeans;
     base.breakdownKeyMins = input.relevanceAggregate.breakdownKeyMins;
     base.breakdownKeyMaxs = input.relevanceAggregate.breakdownKeyMaxs;
+  }
+
+  if (input.droppedByContentQuality !== undefined) {
+    base.droppedByContentQuality = input.droppedByContentQuality;
+  }
+
+  if (input.truncation !== undefined) {
+    base.truncation = input.truncation;
+  }
+
+  if (input.exemplars !== undefined) {
+    base.exemplarsRequestedCount = input.exemplars.requestedCount;
+    base.exemplarsResolvedCount = input.exemplars.resolvedCount;
+    base.exemplarsApplied = input.exemplars.appliedArchetypes;
+  }
+
+  if (input.grounding !== undefined) {
+    base.grounding = input.grounding;
   }
 
   return base;

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -141,6 +141,18 @@ describe("resolveArticleAnalysisConfig", () => {
     expect(resolved.analysisGetDataSourceLimitMax).toBe(
       articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,
     );
+    expect(resolved.useStructureAwareTruncation).toBe(false);
+    expect(resolved.truncationLeadParagraphsAlwaysKept).toBe(2);
+    expect(resolved.truncationFinancialKeywordsExtra).toEqual([]);
+    expect(resolved.fewShotExemplarCount).toBe(0);
+    expect(resolved.useBrainstormPass).toBe(false);
+    expect(resolved.brainstormModel).toBe(
+      articleAnalysisConfigDefaults.openaiModel,
+    );
+    expect(resolved.brainstormMaxOutputTokens).toBe(800);
+    expect(resolved.runDeadlineMs).toBe(Number.POSITIVE_INFINITY);
+    expect(resolved.entityGroundingPolicy).toBe("off");
+    expect(resolved.entityGroundingMinTitleHits).toBe(0);
   });
 
   it("preserves Hermes debounce and defaultMaxBatchSize overrides", () => {

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,6 +1,7 @@
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
 import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
 import type { ArticleAnalysisRunPolicy } from "./article-analysis-run-policy.js";
+import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
 import {
   ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_PLACEHOLDERS,
   ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_PLACEHOLDERS,
@@ -8,6 +9,13 @@ import {
 } from "./article-extraction-prompt-defaults.js";
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import { z } from "zod";
+
+const extractionExemplarArchetypeSchema = z.enum([
+  "earnings",
+  "legal",
+  "leadership",
+  "product",
+]);
 
 const articleAnalysisRunPolicySchema = z.object({
   minSuccessfulSources: z.number().int().nonnegative().optional(),
@@ -29,6 +37,30 @@ export const articleAnalysisConfigSchema = z
     maxOutputTokens: z.number().int().positive().optional(),
     /** Truncate article text in the LLM user message (full text remains in DB). */
     maxContentChars: z.number().int().positive().optional(),
+    /** When true, use structure-aware paragraph truncation instead of naive slice. */
+    useStructureAwareTruncation: z.boolean().optional(),
+    /** Lead paragraphs always kept before score-ranked allocation. */
+    truncationLeadParagraphsAlwaysKept: z.number().int().min(0).max(8).optional(),
+    /** Operator-extensible financial keywords for truncation scoring. */
+    truncationFinancialKeywordsExtra: z.array(z.string()).optional(),
+    /** Number of few-shot extraction exemplars to inject (0 disables). */
+    fewShotExemplarCount: z.number().int().min(0).max(4).optional(),
+    /** When set, only these archetypes are eligible for few-shot selection. */
+    fewShotExemplarArchetypes: z
+      .array(extractionExemplarArchetypeSchema)
+      .optional(),
+    /** When true, run a free-form brainstorm pass before structured extraction. */
+    useBrainstormPass: z.boolean().optional(),
+    /** Chat model for the brainstorm pass (defaults to `openaiModel`). */
+    brainstormModel: z.string().min(1).optional(),
+    /** Max output tokens for the brainstorm `generateText` call. */
+    brainstormMaxOutputTokens: z.number().int().positive().optional(),
+    /** Wall-clock budget in ms; after this elapsed time, skip brainstorm on remaining sources. */
+    runDeadlineMs: z.number().positive().optional(),
+    /** Post-extraction grounding policy for hallucinated entities. */
+    entityGroundingPolicy: z.enum(["drop", "flag", "off"]).optional(),
+    /** When greater than zero, entity must appear in the title to count as grounded. */
+    entityGroundingMinTitleHits: z.number().int().nonnegative().optional(),
     maxEntitiesPerArticle: z.number().int().positive().optional(),
     maxRelationsPerArticle: z.number().int().positive().optional(),
     maxEntitiesPerRun: z.number().int().positive().optional(),
@@ -166,6 +198,17 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   openaiModel: string;
   maxOutputTokens: number;
   maxContentChars: number;
+  useStructureAwareTruncation: boolean;
+  truncationLeadParagraphsAlwaysKept: number;
+  truncationFinancialKeywordsExtra: string[];
+  fewShotExemplarCount: number;
+  fewShotExemplarArchetypes?: ExtractionExemplarArchetype[];
+  useBrainstormPass: boolean;
+  brainstormModel: string;
+  brainstormMaxOutputTokens: number;
+  runDeadlineMs: number;
+  entityGroundingPolicy: "drop" | "flag" | "off";
+  entityGroundingMinTitleHits: number;
   maxEntitiesPerArticle: number;
   maxRelationsPerArticle: number;
   maxEntitiesPerRun: number;
@@ -199,6 +242,15 @@ export const articleAnalysisConfigDefaults = {
   openaiModel: "gpt-4o-mini",
   maxOutputTokens: 8192,
   maxContentChars: 12_000,
+  useStructureAwareTruncation: false,
+  truncationLeadParagraphsAlwaysKept: 2,
+  truncationFinancialKeywordsExtra: [],
+  fewShotExemplarCount: 0,
+  useBrainstormPass: false,
+  brainstormMaxOutputTokens: 800,
+  runDeadlineMs: Number.POSITIVE_INFINITY,
+  entityGroundingPolicy: "off",
+  entityGroundingMinTitleHits: 0,
   maxEntitiesPerArticle: 20,
   maxRelationsPerArticle: 20,
   maxEntitiesPerRun: 200,
@@ -239,14 +291,46 @@ export const articleAnalysisConfigDefaults = {
 export const resolveArticleAnalysisConfig = (
   config: ArticleAnalysisConfig,
 ): ResolvedArticleAnalysisConfig => {
+  const openaiModel =
+    config.openaiModel ?? articleAnalysisConfigDefaults.openaiModel;
+
   return {
     ...config,
-    openaiModel:
-      config.openaiModel ?? articleAnalysisConfigDefaults.openaiModel,
+    openaiModel,
     maxOutputTokens:
       config.maxOutputTokens ?? articleAnalysisConfigDefaults.maxOutputTokens,
     maxContentChars:
       config.maxContentChars ?? articleAnalysisConfigDefaults.maxContentChars,
+    useStructureAwareTruncation:
+      config.useStructureAwareTruncation ??
+      articleAnalysisConfigDefaults.useStructureAwareTruncation,
+    truncationLeadParagraphsAlwaysKept:
+      config.truncationLeadParagraphsAlwaysKept ??
+      articleAnalysisConfigDefaults.truncationLeadParagraphsAlwaysKept,
+    truncationFinancialKeywordsExtra:
+      config.truncationFinancialKeywordsExtra ??
+      [...articleAnalysisConfigDefaults.truncationFinancialKeywordsExtra],
+    fewShotExemplarCount:
+      config.fewShotExemplarCount ??
+      articleAnalysisConfigDefaults.fewShotExemplarCount,
+    ...(config.fewShotExemplarArchetypes !== undefined
+      ? { fewShotExemplarArchetypes: config.fewShotExemplarArchetypes }
+      : {}),
+    useBrainstormPass:
+      config.useBrainstormPass ??
+      articleAnalysisConfigDefaults.useBrainstormPass,
+    brainstormModel: config.brainstormModel ?? openaiModel,
+    brainstormMaxOutputTokens:
+      config.brainstormMaxOutputTokens ??
+      articleAnalysisConfigDefaults.brainstormMaxOutputTokens,
+    runDeadlineMs:
+      config.runDeadlineMs ?? articleAnalysisConfigDefaults.runDeadlineMs,
+    entityGroundingPolicy:
+      config.entityGroundingPolicy ??
+      articleAnalysisConfigDefaults.entityGroundingPolicy,
+    entityGroundingMinTitleHits:
+      config.entityGroundingMinTitleHits ??
+      articleAnalysisConfigDefaults.entityGroundingMinTitleHits,
     maxEntitiesPerArticle:
       config.maxEntitiesPerArticle ??
       articleAnalysisConfigDefaults.maxEntitiesPerArticle,

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -40,7 +40,12 @@ export const articleAnalysisConfigSchema = z
     /** When true, use structure-aware paragraph truncation instead of naive slice. */
     useStructureAwareTruncation: z.boolean().optional(),
     /** Lead paragraphs always kept before score-ranked allocation. */
-    truncationLeadParagraphsAlwaysKept: z.number().int().min(0).max(8).optional(),
+    truncationLeadParagraphsAlwaysKept: z
+      .number()
+      .int()
+      .min(0)
+      .max(8)
+      .optional(),
     /** Operator-extensible financial keywords for truncation scoring. */
     truncationFinancialKeywordsExtra: z.array(z.string()).optional(),
     /** Number of few-shot extraction exemplars to inject (0 disables). */
@@ -308,8 +313,9 @@ export const resolveArticleAnalysisConfig = (
       config.truncationLeadParagraphsAlwaysKept ??
       articleAnalysisConfigDefaults.truncationLeadParagraphsAlwaysKept,
     truncationFinancialKeywordsExtra:
-      config.truncationFinancialKeywordsExtra ??
-      [...articleAnalysisConfigDefaults.truncationFinancialKeywordsExtra],
+      config.truncationFinancialKeywordsExtra ?? [
+        ...articleAnalysisConfigDefaults.truncationFinancialKeywordsExtra,
+      ],
     fewShotExemplarCount:
       config.fewShotExemplarCount ??
       articleAnalysisConfigDefaults.fewShotExemplarCount,

--- a/apps/mediapulse/agents/article-analysis/src/exemplars/default-extraction-exemplars.ts
+++ b/apps/mediapulse/agents/article-analysis/src/exemplars/default-extraction-exemplars.ts
@@ -1,0 +1,269 @@
+import type { LlmExtractionWireOutput } from "../llm-extract-entities.js";
+
+export type ExtractionExemplarArchetype =
+  | "earnings"
+  | "legal"
+  | "leadership"
+  | "product";
+
+/** Wire output shape with sentinel placeholders in UUID fields before resolution. */
+export type ExtractionExemplarExpectedOutput = {
+  entities: Array<{
+    canonicalName: string;
+    typeId: string;
+    description: string;
+    aliases: string[];
+  }>;
+  relations: Array<{
+    fromEntityName: string;
+    toEntityName: string;
+    relationTypeId: string;
+  }>;
+  articleMentions: Array<{
+    entityName: string;
+    mentionCount: number;
+    confidence: number;
+    sentiment: "POSITIVE" | "NEGATIVE" | "NEUTRAL" | "NONE";
+  }>;
+};
+
+export type ExtractionExemplar = {
+  archetype: ExtractionExemplarArchetype;
+  articleSnippet: string;
+  expectedOutput: ExtractionExemplarExpectedOutput;
+};
+
+export type ResolvedExemplar = {
+  archetype: ExtractionExemplarArchetype;
+  articleSnippet: string;
+  expectedOutput: LlmExtractionWireOutput;
+};
+
+const earningsExemplar: ExtractionExemplar = {
+  archetype: "earnings",
+  articleSnippet: [
+    "Jakarta — Bank Central Asia reported fourth-quarter net income of Rp 12.4 trillion,",
+    "beating analyst estimates as net interest margins expanded to 6.1%.",
+    "Management raised full-year guidance and said loan growth should stay above 10%",
+    "despite tighter liquidity in Indonesia. The bank noted deposit inflows remained",
+    "strong in retail and small-business segments. Shares of BBCA.JK rose 2.3% in",
+    "afternoon trading after the company said credit costs normalized and fee income",
+    "from wealth products continued to offset slower corporate lending. CFO Dian",
+    "Permata told investors the beat reflected disciplined pricing rather than",
+    "one-off gains, and that the lender would keep returning excess capital through",
+    "dividends while funding digital onboarding and branch automation.",
+  ].join(" "),
+  expectedOutput: {
+    entities: [
+      {
+        canonicalName: "Bank Central Asia",
+        typeId: "{{ENTITY_TYPE:COMPANY}}",
+        description: "Indonesian lender reporting earnings beat and raised guidance",
+        aliases: ["BBCA", "the bank"],
+      },
+      {
+        canonicalName: "Dian Permata",
+        typeId: "{{ENTITY_TYPE:PERSON}}",
+        description: "CFO commenting on margins and capital returns",
+        aliases: [],
+      },
+    ],
+    relations: [],
+    articleMentions: [
+      {
+        entityName: "Bank Central Asia",
+        mentionCount: 6,
+        confidence: 0.95,
+        sentiment: "POSITIVE",
+      },
+      {
+        entityName: "Dian Permata",
+        mentionCount: 1,
+        confidence: 0.85,
+        sentiment: "NEUTRAL",
+      },
+    ],
+  },
+};
+
+const legalExemplar: ExtractionExemplar = {
+  archetype: "legal",
+  articleSnippet: [
+    "Washington — The Securities and Exchange Commission opened a formal investigation",
+    "into NovaTech Systems after whistleblowers alleged the cloud vendor misstated",
+    "recurring revenue in its S-1 filing. Regulators requested internal spreadsheets,",
+    "customer contracts, and board minutes dating back to 2022. NovaTech said it would",
+    "cooperate fully and has not been accused of wrongdoing. Analysts warned that a",
+    "prolonged probe could delay the company's planned secondary offering and pressure",
+    "enterprise customers to pause renewals. Legal experts noted the SEC typically",
+    "focuses first on disclosure controls before deciding whether to bring enforcement",
+    "action. NovaTech shares fell 8% in after-hours trading on the news.",
+  ].join(" "),
+  expectedOutput: {
+    entities: [
+      {
+        canonicalName: "NovaTech Systems",
+        typeId: "{{ENTITY_TYPE:COMPANY}}",
+        description: "Cloud vendor under SEC investigation over revenue disclosures",
+        aliases: ["NovaTech", "the company"],
+      },
+      {
+        canonicalName: "Securities and Exchange Commission",
+        typeId: "{{ENTITY_TYPE:Regulator}}",
+        description: "US regulator investigating alleged misstated recurring revenue",
+        aliases: ["SEC", "regulators"],
+      },
+    ],
+    relations: [],
+    articleMentions: [
+      {
+        entityName: "NovaTech Systems",
+        mentionCount: 4,
+        confidence: 0.92,
+        sentiment: "NEGATIVE",
+      },
+      {
+        entityName: "Securities and Exchange Commission",
+        mentionCount: 3,
+        confidence: 0.9,
+        sentiment: "NEUTRAL",
+      },
+    ],
+  },
+};
+
+const leadershipExemplar: ExtractionExemplar = {
+  archetype: "leadership",
+  articleSnippet: [
+    "San Francisco — Horizon Robotics named Maria Chen as chief executive officer,",
+    "replacing founder James Okonkwo who will become executive chairman. Chen joins",
+    "from Apex Motors where she led autonomous-driving partnerships across Asia.",
+    "The board said the transition follows a year-long succession review and that",
+    "Okonkwo will remain involved in strategy and major customer relationships.",
+    "Horizon also promoted its finance chief to president while keeping the COO in",
+    "place to run manufacturing. Investors welcomed the move, citing Chen's track",
+    "record scaling supplier deals, though some analysts asked whether the handoff",
+    "would slow product launches scheduled for late 2026.",
+  ].join(" "),
+  expectedOutput: {
+    entities: [
+      {
+        canonicalName: "Horizon Robotics",
+        typeId: "{{ENTITY_TYPE:COMPANY}}",
+        description: "Robotics company announcing CEO succession",
+        aliases: ["Horizon"],
+      },
+      {
+        canonicalName: "Maria Chen",
+        typeId: "{{ENTITY_TYPE:PERSON}}",
+        description: "Incoming CEO previously at Apex Motors",
+        aliases: ["Chen"],
+      },
+      {
+        canonicalName: "James Okonkwo",
+        typeId: "{{ENTITY_TYPE:PERSON}}",
+        description: "Founder moving to executive chairman role",
+        aliases: ["Okonkwo"],
+      },
+    ],
+    relations: [
+      {
+        fromEntityName: "Maria Chen",
+        toEntityName: "Horizon Robotics",
+        relationTypeId: "{{RELATION_TYPE:CEO_OF}}",
+      },
+    ],
+    articleMentions: [
+      {
+        entityName: "Horizon Robotics",
+        mentionCount: 4,
+        confidence: 0.93,
+        sentiment: "POSITIVE",
+      },
+      {
+        entityName: "Maria Chen",
+        mentionCount: 3,
+        confidence: 0.9,
+        sentiment: "POSITIVE",
+      },
+      {
+        entityName: "James Okonkwo",
+        mentionCount: 2,
+        confidence: 0.88,
+        sentiment: "NEUTRAL",
+      },
+    ],
+  },
+};
+
+const productExemplar: ExtractionExemplar = {
+  archetype: "product",
+  articleSnippet: [
+    "Seattle — CloudScale Inc unveiled Atlas Edge, a managed inference platform",
+    "aimed at retailers that need low-latency model hosting outside public clouds.",
+    "The company said Atlas Edge integrates with existing Kubernetes clusters and",
+    "ships with pre-built adapters for major payment gateways. CloudScale also",
+    "announced a multi-year partnership with RetailNext to co-sell the platform to",
+    "grocery chains in North America. RetailNext will provide onboarding teams while",
+    "CloudScale handles model optimization and uptime guarantees. Early adopters",
+    "include two regional grocers testing dynamic pricing models during peak hours.",
+    "Management expects Atlas Edge to contribute to recurring revenue in 2027.",
+  ].join(" "),
+  expectedOutput: {
+    entities: [
+      {
+        canonicalName: "CloudScale Inc",
+        typeId: "{{ENTITY_TYPE:COMPANY}}",
+        description: "Vendor launching Atlas Edge inference platform",
+        aliases: ["CloudScale", "the company"],
+      },
+      {
+        canonicalName: "Atlas Edge",
+        typeId: "{{ENTITY_TYPE:PRODUCT}}",
+        description: "Managed inference platform for low-latency model hosting",
+        aliases: [],
+      },
+      {
+        canonicalName: "RetailNext",
+        typeId: "{{ENTITY_TYPE:COMPANY}}",
+        description: "Partner co-selling Atlas Edge to grocery chains",
+        aliases: [],
+      },
+    ],
+    relations: [
+      {
+        fromEntityName: "CloudScale Inc",
+        toEntityName: "RetailNext",
+        relationTypeId: "{{RELATION_TYPE:PARTNER_OF}}",
+      },
+    ],
+    articleMentions: [
+      {
+        entityName: "CloudScale Inc",
+        mentionCount: 5,
+        confidence: 0.94,
+        sentiment: "POSITIVE",
+      },
+      {
+        entityName: "Atlas Edge",
+        mentionCount: 4,
+        confidence: 0.91,
+        sentiment: "POSITIVE",
+      },
+      {
+        entityName: "RetailNext",
+        mentionCount: 2,
+        confidence: 0.87,
+        sentiment: "NEUTRAL",
+      },
+    ],
+  },
+};
+
+/** Curated few-shot extraction exemplars in deterministic archetype order. */
+export const DEFAULT_EXTRACTION_EXEMPLARS: readonly ExtractionExemplar[] = [
+  earningsExemplar,
+  legalExemplar,
+  leadershipExemplar,
+  productExemplar,
+];

--- a/apps/mediapulse/agents/article-analysis/src/exemplars/default-extraction-exemplars.ts
+++ b/apps/mediapulse/agents/article-analysis/src/exemplars/default-extraction-exemplars.ts
@@ -58,7 +58,8 @@ const earningsExemplar: ExtractionExemplar = {
       {
         canonicalName: "Bank Central Asia",
         typeId: "{{ENTITY_TYPE:COMPANY}}",
-        description: "Indonesian lender reporting earnings beat and raised guidance",
+        description:
+          "Indonesian lender reporting earnings beat and raised guidance",
         aliases: ["BBCA", "the bank"],
       },
       {
@@ -104,13 +105,15 @@ const legalExemplar: ExtractionExemplar = {
       {
         canonicalName: "NovaTech Systems",
         typeId: "{{ENTITY_TYPE:COMPANY}}",
-        description: "Cloud vendor under SEC investigation over revenue disclosures",
+        description:
+          "Cloud vendor under SEC investigation over revenue disclosures",
         aliases: ["NovaTech", "the company"],
       },
       {
         canonicalName: "Securities and Exchange Commission",
         typeId: "{{ENTITY_TYPE:Regulator}}",
-        description: "US regulator investigating alleged misstated recurring revenue",
+        description:
+          "US regulator investigating alleged misstated recurring revenue",
         aliases: ["SEC", "regulators"],
       },
     ],

--- a/apps/mediapulse/agents/article-analysis/src/exemplars/resolve-extraction-exemplars.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/exemplars/resolve-extraction-exemplars.test.ts
@@ -1,0 +1,114 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_EXTRACTION_EXEMPLARS } from "./default-extraction-exemplars.js";
+import {
+  resolveExemplarForContext,
+  resolveExemplarsForContext,
+} from "./resolve-extraction-exemplars.js";
+
+const COMPANY_ID = "11111111-1111-4111-a111-111111111111";
+const PERSON_ID = "22222222-2222-4222-a222-222222222222";
+const PRODUCT_ID = "33333333-3333-4333-a333-333333333333";
+const CEO_OF_ID = "44444444-4444-4444-a444-444444444444";
+const PARTNER_OF_ID = "55555555-5555-4555-a555-555555555555";
+
+const baseVocabulary = {
+  entityTypes: [
+    { id: COMPANY_ID, name: "COMPANY", description: null },
+    { id: PERSON_ID, name: "PERSON", description: null },
+    { id: PRODUCT_ID, name: "PRODUCT", description: null },
+  ],
+  relationTypes: [
+    { id: CEO_OF_ID, name: "CEO_OF", description: null },
+    { id: PARTNER_OF_ID, name: "PARTNER_OF", description: null },
+  ],
+};
+
+describe("resolveExemplarForContext", () => {
+  it("materializes sentinel placeholders into vocabulary UUIDs", () => {
+    // Act
+    const resolved = resolveExemplarForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS[0]!,
+      baseVocabulary,
+    );
+
+    // Assert
+    expect(resolved).not.toBeNull();
+    expect(resolved?.expectedOutput.entities[0]?.typeId).toBe(COMPANY_ID);
+  });
+
+  it("returns null when a referenced entity type is missing from vocabulary", () => {
+    // Act
+    const resolved = resolveExemplarForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS[1]!,
+      baseVocabulary,
+    );
+
+    // Assert
+    expect(resolved).toBeNull();
+  });
+});
+
+describe("resolveExemplarsForContext", () => {
+  it("skips legal exemplar when Regulator is absent and returns remaining archetypes", () => {
+    // Act
+    const resolved = resolveExemplarsForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS,
+      baseVocabulary,
+      4,
+    );
+
+    // Assert
+    expect(resolved.map((exemplar) => exemplar.archetype)).toEqual([
+      "earnings",
+      "leadership",
+      "product",
+    ]);
+  });
+
+  it("returns at most the requested count in library order", () => {
+    // Act
+    const resolved = resolveExemplarsForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS,
+      baseVocabulary,
+      2,
+    );
+
+    // Assert
+    expect(resolved).toHaveLength(2);
+    expect(resolved.map((exemplar) => exemplar.archetype)).toEqual([
+      "earnings",
+      "leadership",
+    ]);
+  });
+
+  it("returns an empty list when count is zero", () => {
+    // Act
+    const resolved = resolveExemplarsForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS,
+      baseVocabulary,
+      0,
+    );
+
+    // Assert
+    expect(resolved).toEqual([]);
+  });
+
+  it("filters by allowed archetypes when configured", () => {
+    // Act
+    const resolved = resolveExemplarsForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS,
+      baseVocabulary,
+      2,
+      ["product", "earnings"],
+    );
+
+    // Assert
+    expect(resolved.map((exemplar) => exemplar.archetype)).toEqual([
+      "earnings",
+      "product",
+    ]);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/exemplars/resolve-extraction-exemplars.ts
+++ b/apps/mediapulse/agents/article-analysis/src/exemplars/resolve-extraction-exemplars.ts
@@ -1,0 +1,186 @@
+import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
+
+import type {
+  ExtractionExemplar,
+  ExtractionExemplarArchetype,
+  ExtractionExemplarExpectedOutput,
+  ResolvedExemplar,
+} from "./default-extraction-exemplars.js";
+
+const ENTITY_TYPE_SENTINEL = /^\{\{ENTITY_TYPE:([^}]+)\}\}$/;
+const RELATION_TYPE_SENTINEL = /^\{\{RELATION_TYPE:([^}]+)\}\}$/;
+
+type AnalysisVocabularyContext = Pick<
+  GetAnalysisResponse,
+  "entityTypes" | "relationTypes"
+>;
+
+/**
+ * Finds an entity type UUID by label (case-insensitive).
+ *
+ * @param ctx - Analysis GET vocabulary.
+ * @param label - Entity type name from a sentinel placeholder.
+ */
+const resolveEntityTypeId = (
+  ctx: AnalysisVocabularyContext,
+  label: string,
+): string | null => {
+  const normalized = label.trim().toLowerCase();
+  const match = ctx.entityTypes.find(
+    (entityType) => entityType.name.toLowerCase() === normalized,
+  );
+  return match?.id ?? null;
+};
+
+/**
+ * Finds a relation type UUID by label (case-insensitive).
+ *
+ * @param ctx - Analysis GET vocabulary.
+ * @param label - Relation type name from a sentinel placeholder.
+ */
+const resolveRelationTypeId = (
+  ctx: AnalysisVocabularyContext,
+  label: string,
+): string | null => {
+  const normalized = label.trim().toLowerCase();
+  const match = ctx.relationTypes.find(
+    (relationType) => relationType.name.toLowerCase() === normalized,
+  );
+  return match?.id ?? null;
+};
+
+/**
+ * Resolves one sentinel UUID field against analysis GET vocabulary.
+ *
+ * @param value - Raw field value that may contain a sentinel placeholder.
+ * @param ctx - Analysis GET vocabulary.
+ */
+const resolveSentinelUuid = (
+  value: string,
+  ctx: AnalysisVocabularyContext,
+): string | null => {
+  const entityMatch = value.match(ENTITY_TYPE_SENTINEL);
+  if (entityMatch?.[1]) {
+    return resolveEntityTypeId(ctx, entityMatch[1]);
+  }
+
+  const relationMatch = value.match(RELATION_TYPE_SENTINEL);
+  if (relationMatch?.[1]) {
+    return resolveRelationTypeId(ctx, relationMatch[1]);
+  }
+
+  return value;
+};
+
+/**
+ * Materializes sentinel placeholders in one exemplar output; returns null when any UUID is missing.
+ *
+ * @param expectedOutput - Unresolved exemplar output with sentinel placeholders.
+ * @param ctx - Analysis GET vocabulary.
+ */
+const resolveExpectedOutput = (
+  expectedOutput: ExtractionExemplarExpectedOutput,
+  ctx: AnalysisVocabularyContext,
+): ResolvedExemplar["expectedOutput"] | null => {
+  const entities: ResolvedExemplar["expectedOutput"]["entities"] = [];
+
+  for (const entity of expectedOutput.entities) {
+    const typeId = resolveSentinelUuid(entity.typeId, ctx);
+    if (typeId === null) {
+      return null;
+    }
+    entities.push({
+      canonicalName: entity.canonicalName,
+      typeId,
+      description: entity.description,
+      aliases: entity.aliases,
+    });
+  }
+
+  const relations: ResolvedExemplar["expectedOutput"]["relations"] = [];
+
+  for (const relation of expectedOutput.relations) {
+    const relationTypeId = resolveSentinelUuid(relation.relationTypeId, ctx);
+    if (relationTypeId === null) {
+      return null;
+    }
+    relations.push({
+      fromEntityName: relation.fromEntityName,
+      toEntityName: relation.toEntityName,
+      relationTypeId,
+    });
+  }
+
+  return {
+    entities,
+    relations,
+    articleMentions: expectedOutput.articleMentions.map((mention) => ({
+      ...mention,
+    })),
+  };
+};
+
+/**
+ * Resolves one exemplar against ticker vocabulary, skipping it when sentinels cannot be mapped.
+ *
+ * @param exemplar - Static exemplar definition.
+ * @param ctx - Analysis GET vocabulary.
+ */
+export const resolveExemplarForContext = (
+  exemplar: ExtractionExemplar,
+  ctx: AnalysisVocabularyContext,
+): ResolvedExemplar | null => {
+  const expectedOutput = resolveExpectedOutput(exemplar.expectedOutput, ctx);
+  if (expectedOutput === null) {
+    return null;
+  }
+
+  return {
+    archetype: exemplar.archetype,
+    articleSnippet: exemplar.articleSnippet,
+    expectedOutput,
+  };
+};
+
+/**
+ * Selects and resolves up to `count` exemplars for the current ticker vocabulary.
+ *
+ * @param exemplars - Static exemplar library.
+ * @param ctx - Analysis GET vocabulary.
+ * @param count - Maximum exemplars to inject (0 disables few-shot).
+ * @param allowedArchetypes - Optional archetype filter from Hermes config.
+ */
+export const resolveExemplarsForContext = (
+  exemplars: readonly ExtractionExemplar[],
+  ctx: AnalysisVocabularyContext,
+  count: number,
+  allowedArchetypes?: readonly ExtractionExemplarArchetype[],
+): ResolvedExemplar[] => {
+  if (count <= 0) {
+    return [];
+  }
+
+  const allowed =
+    allowedArchetypes === undefined
+      ? null
+      : new Set<ExtractionExemplarArchetype>(allowedArchetypes);
+
+  const candidates = exemplars.filter((exemplar) =>
+    allowed === null ? true : allowed.has(exemplar.archetype),
+  );
+
+  const resolved: ResolvedExemplar[] = [];
+
+  for (const exemplar of candidates) {
+    if (resolved.length >= count) {
+      break;
+    }
+
+    const materialized = resolveExemplarForContext(exemplar, ctx);
+    if (materialized !== null) {
+      resolved.push(materialized);
+    }
+  }
+
+  return resolved;
+};

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
@@ -93,9 +93,8 @@ describe("shouldHardDeleteDataSourceForNonArticleReason", () => {
     const paywall = shouldHardDeleteDataSourceForNonArticleReason(
       "content_access_gated",
     );
-    const tooShort = shouldHardDeleteDataSourceForNonArticleReason(
-      "content_too_short",
-    );
+    const tooShort =
+      shouldHardDeleteDataSourceForNonArticleReason("content_too_short");
 
     // Assert
     expect(paywall).toBe(false);

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.test.ts
@@ -78,4 +78,27 @@ describe("shouldHardDeleteDataSourceForNonArticleReason", () => {
     // Assert
     expect(result).toBe(false);
   });
+
+  it("returns true for soft-404 content drops", () => {
+    // Act
+    const result =
+      shouldHardDeleteDataSourceForNonArticleReason("content_soft_404");
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for recoverable content quality drops", () => {
+    // Act
+    const paywall = shouldHardDeleteDataSourceForNonArticleReason(
+      "content_access_gated",
+    );
+    const tooShort = shouldHardDeleteDataSourceForNonArticleReason(
+      "content_too_short",
+    );
+
+    // Assert
+    expect(paywall).toBe(false);
+    expect(tooShort).toBe(false);
+  });
 });

--- a/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
+++ b/apps/mediapulse/agents/article-analysis/src/extraction-failure-pruning.ts
@@ -36,7 +36,9 @@ export const shouldHardDeleteDataSourceForExtractionError = (
 export const shouldHardDeleteDataSourceForNonArticleReason = (
   reason: NonArticleReason,
 ): boolean =>
-  reason === "prefilter_blocked_host" || reason === "prefilter_blocked_path";
+  reason === "prefilter_blocked_host" ||
+  reason === "prefilter_blocked_path" ||
+  reason === "content_soft_404";
 
 /**
  * Hard-deletes a data source row through agent-data-api.

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -1,11 +1,20 @@
 /** @vitest-environment node */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { ResolvedExemplar } from "./exemplars/default-extraction-exemplars.js";
 import {
+  buildExtractionModelMessages,
   buildExtractionSystemContent,
   buildExtractionUserContent,
+  buildBrainstormFollowUpUserContent,
+  buildBrainstormSystemContent,
+  buildBrainstormUserContent,
+  extractEntitiesAndRelationsForSource,
+  fetchArticleBrainstorm,
+  llmExtractionOpenAiWireSchema,
   normalizeLlmExtractionWire,
   normalizeLlmUsageFromSdk,
+  parseArticleBrainstormText,
   resolveArticleAnalysisExtractionSystemContent,
   resolveArticleAnalysisExtractionUserContent,
 } from "./llm-extract-entities.js";
@@ -106,6 +115,307 @@ describe("buildExtractionUserContent", () => {
     expect(u).toContain("T");
     expect(u).toContain("Hello");
     expect(u).toContain("Body text");
+  });
+});
+
+describe("buildExtractionModelMessages", () => {
+  const systemContent = "system prompt";
+  const userContent = "real article user prompt";
+
+  const exemplar = (
+    id: string,
+    snippet: string,
+  ): ResolvedExemplar => ({
+    archetype: "earnings",
+    articleSnippet: snippet,
+    expectedOutput: {
+      entities: [
+        {
+          canonicalName: id,
+          typeId: TID,
+          description: "",
+          aliases: [],
+        },
+      ],
+      relations: [],
+      articleMentions: [],
+    },
+  });
+
+  it("inserts exemplar turns between system and the real user message", () => {
+    // Act
+    const messages = buildExtractionModelMessages(systemContent, userContent, [
+      exemplar("One", "snippet one"),
+      exemplar("Two", "snippet two"),
+    ]);
+
+    // Assert
+    expect(messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+    ]);
+    expect(messages[1]?.content).toContain("snippet one");
+    expect(messages[2]?.content).toContain('"One"');
+    expect(messages[3]?.content).toContain("snippet two");
+    expect(messages[5]?.content).toBe(userContent);
+  });
+
+  it("returns the existing two-turn shape when no exemplars are provided", () => {
+    // Act
+    const messages = buildExtractionModelMessages(systemContent, userContent);
+
+    // Assert
+    expect(messages).toEqual([
+      { role: "system", content: systemContent },
+      { role: "user", content: userContent },
+    ]);
+  });
+
+  it("appends a brainstorm follow-up user turn after the article user message", () => {
+    const brainstormText =
+      "KEY PLAYERS:\n- Apple\n- Tim Cook\nEVENTS:\n- Q2 earnings beat";
+
+    // Act
+    const messages = buildExtractionModelMessages(
+      systemContent,
+      userContent,
+      [],
+      brainstormText,
+    );
+
+    // Assert
+    expect(messages.map((message) => message.role)).toEqual([
+      "system",
+      "user",
+      "user",
+    ]);
+    expect(messages[2]?.content).toBe(
+      buildBrainstormFollowUpUserContent(brainstormText),
+    );
+    expect(String(messages[2]?.content)).toContain("Apple");
+  });
+});
+
+describe("extractEntitiesAndRelationsForSource", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes few-shot turns to generateObject in order", async () => {
+    // Setup
+    const generateObjectForExtraction = vi.fn().mockResolvedValue({
+      object: {
+        entities: [],
+        relations: [],
+        articleMentions: [],
+      },
+      usage: null,
+    });
+    const exemplars: ResolvedExemplar[] = [
+      {
+        archetype: "earnings",
+        articleSnippet: "snippet one",
+        expectedOutput: {
+          entities: [
+            {
+              canonicalName: "One",
+              typeId: TID,
+              description: "",
+              aliases: [],
+            },
+          ],
+          relations: [],
+          articleMentions: [],
+        },
+      },
+      {
+        archetype: "leadership",
+        articleSnippet: "snippet two",
+        expectedOutput: {
+          entities: [
+            {
+              canonicalName: "Two",
+              typeId: TID,
+              description: "",
+              aliases: [],
+            },
+          ],
+          relations: [],
+          articleMentions: [],
+        },
+      },
+    ];
+
+    // Act
+    await extractEntitiesAndRelationsForSource(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        messages: [
+          { role: "system", content: "system prompt" },
+          { role: "user", content: "real user prompt" },
+        ],
+        exemplars,
+      },
+      { generateObjectForExtraction },
+    );
+
+    // Assert
+    const capturedMessages =
+      generateObjectForExtraction.mock.calls[0]?.[0]?.messages;
+    expect(
+      capturedMessages?.map((message: { role: string }) => message.role),
+    ).toEqual(["system", "user", "assistant", "user", "assistant", "user"]);
+    expect(capturedMessages?.[5]?.content).toBe("real user prompt");
+  });
+
+  it("keeps the legacy two-turn message array when exemplars are omitted", async () => {
+    // Setup
+    const generateObjectForExtraction = vi.fn().mockResolvedValue({
+      object: {
+        entities: [],
+        relations: [],
+        articleMentions: [],
+      },
+      usage: null,
+    });
+    const messages = [
+      { role: "system" as const, content: "system prompt" },
+      { role: "user" as const, content: "real user prompt" },
+    ];
+
+    // Act
+    await extractEntitiesAndRelationsForSource(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        messages,
+      },
+      { generateObjectForExtraction },
+    );
+
+    // Assert
+    expect(generateObjectForExtraction.mock.calls[0]?.[0]?.messages).toEqual(
+      messages,
+    );
+  });
+
+  it("includes brainstorm text in the structured-pass messages when provided", async () => {
+    // Setup
+    const generateObjectForExtraction = vi.fn().mockResolvedValue({
+      object: {
+        entities: [],
+        relations: [],
+        articleMentions: [],
+      },
+      usage: null,
+    });
+    const brainstormText =
+      "KEY PLAYERS:\n- Apple\n- Tim Cook\nEVENTS:\n- Q2 earnings beat";
+    const messages = [
+      { role: "system" as const, content: "system prompt" },
+      { role: "user" as const, content: "real user prompt" },
+    ];
+
+    // Act
+    await extractEntitiesAndRelationsForSource(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 100,
+        messages,
+        brainstormText,
+      },
+      { generateObjectForExtraction },
+    );
+
+    // Assert
+    const capturedMessages =
+      generateObjectForExtraction.mock.calls[0]?.[0]?.messages;
+    expect(capturedMessages?.at(-1)?.content).toBe(
+      buildBrainstormFollowUpUserContent(brainstormText),
+    );
+    expect(String(capturedMessages?.at(-1)?.content)).toContain("Apple");
+  });
+});
+
+describe("buildBrainstormSystemContent", () => {
+  it("returns plain-text instructions without JSON schema wording", () => {
+    const text = buildBrainstormSystemContent({
+      entityTypes: [{ id: TID, name: "Company", description: null }],
+      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
+    });
+
+    expect(text).toContain("KEY PLAYERS");
+    expect(text).toContain("Plain text only, no JSON");
+    expect(text).not.toContain(TID);
+  });
+});
+
+describe("buildBrainstormUserContent", () => {
+  it("matches extraction user content for the same article fields", () => {
+    const args = {
+      tickerId: "T",
+      title: "Hello",
+      contentTruncated: "Body text",
+    };
+
+    expect(buildBrainstormUserContent(args)).toBe(buildExtractionUserContent(args));
+  });
+});
+
+describe("parseArticleBrainstormText", () => {
+  it("parses bullet sections into ArticleBrainstorm arrays", () => {
+    const parsed = parseArticleBrainstormText(
+      [
+        "KEY PLAYERS:",
+        "- Apple",
+        "- Tim Cook",
+        "EVENTS:",
+        "- Q2 earnings beat",
+      ].join("\n"),
+    );
+
+    expect(parsed.keyPlayers).toEqual(["Apple", "Tim Cook"]);
+    expect(parsed.events).toEqual(["Q2 earnings beat"]);
+    expect(parsed.relationships).toEqual([]);
+    expect(parsed.sentimentNotes).toEqual([]);
+  });
+});
+
+describe("fetchArticleBrainstorm", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns text and usage from generateText", async () => {
+    const generateTextForBrainstorm = vi.fn().mockResolvedValue({
+      text: "KEY PLAYERS:\n- Apple",
+      usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+    });
+
+    const result = await fetchArticleBrainstorm(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        maxOutputTokens: 800,
+        messages: [{ role: "user", content: "article" }],
+      },
+      { generateTextForBrainstorm },
+    );
+
+    expect(result.text).toContain("Apple");
+    expect(result.usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+    });
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -122,10 +122,7 @@ describe("buildExtractionModelMessages", () => {
   const systemContent = "system prompt";
   const userContent = "real article user prompt";
 
-  const exemplar = (
-    id: string,
-    snippet: string,
-  ): ResolvedExemplar => ({
+  const exemplar = (id: string, snippet: string): ResolvedExemplar => ({
     archetype: "earnings",
     articleSnippet: snippet,
     expectedOutput: {
@@ -366,7 +363,9 @@ describe("buildBrainstormUserContent", () => {
       contentTruncated: "Body text",
     };
 
-    expect(buildBrainstormUserContent(args)).toBe(buildExtractionUserContent(args));
+    expect(buildBrainstormUserContent(args)).toBe(
+      buildExtractionUserContent(args),
+    );
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -328,7 +328,9 @@ export const parseArticleBrainstormText = (text: string): ArticleBrainstorm => {
 
     const matchedSection = sectionMatchers.find((section) =>
       section.labels.some(
-        (label) => line.toUpperCase() === label || line.toUpperCase().startsWith(`${label} `),
+        (label) =>
+          line.toUpperCase() === label ||
+          line.toUpperCase().startsWith(`${label} `),
       ),
     );
     if (matchedSection) {
@@ -446,7 +448,8 @@ export const extractEntitiesAndRelationsForSource = async (
   const userContent = String(params.messages.at(-1)?.content ?? "");
   const shouldBuildMessages =
     (params.exemplars !== undefined && params.exemplars.length > 0) ||
-    (params.brainstormText !== undefined && params.brainstormText.trim().length > 0);
+    (params.brainstormText !== undefined &&
+      params.brainstormText.trim().length > 0);
   const messages = shouldBuildMessages
     ? buildExtractionModelMessages(
         systemContent,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -1,5 +1,5 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateObject, type ModelMessage } from "ai";
+import { generateObject, generateText, type ModelMessage } from "ai";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
@@ -9,11 +9,12 @@ import {
   formatArticleAnalysisEntityTypesBlock,
   formatArticleAnalysisRelationTypesBlock,
 } from "./article-extraction-prompt-defaults.js";
+import type { ResolvedExemplar } from "./exemplars/default-extraction-exemplars.js";
 import { substituteLlmPromptTemplate } from "@workspace/agent-llm-prompt-template";
 
 const sentimentSchema = z.enum(["POSITIVE", "NEGATIVE", "NEUTRAL"]);
 
-const llmExtractionOpenAiWireSchema = z.object({
+export const llmExtractionOpenAiWireSchema = z.object({
   entities: z.array(
     z.object({
       canonicalName: z.string().trim().min(1),
@@ -71,6 +72,25 @@ export const llmExtractionOutputSchema = z.object({
 });
 
 export type LlmExtractionOutput = z.infer<typeof llmExtractionOutputSchema>;
+
+/** In-memory contract for brainstorm sections passed into the structured pass. */
+export type ArticleBrainstorm = {
+  keyPlayers: string[];
+  events: string[];
+  relationships: string[];
+  sentimentNotes: string[];
+};
+
+export type ArticleBrainstormCallResult = {
+  text: string;
+  usage: LlmExtractionUsage | null;
+};
+
+export type GenerateTextForBrainstorm = (args: {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  maxOutputTokens: number;
+  messages: ModelMessage[];
+}) => Promise<ArticleBrainstormCallResult>;
 
 /**
  * Maps OpenAI wire payload to the normalized extraction shape (null = none).
@@ -151,6 +171,33 @@ const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
   };
 };
 
+const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
+  args,
+) => {
+  const result = await generateText(args);
+  return {
+    text: result.text,
+    usage: normalizeLlmUsageFromSdk(result.usage),
+  };
+};
+
+const BRAINSTORM_SYSTEM_PROMPT = [
+  "You are an equity analyst reading ONE article.",
+  "List the article's contents in four short bullet sections:",
+  "KEY PLAYERS (named entities the article discusses),",
+  "EVENTS (things that happened — earnings, lawsuits, deals),",
+  "RELATIONSHIPS (who-did-what-to-whom in plain prose),",
+  "SENTIMENT NOTES (tone signals, hedge words, certainty markers).",
+  "4–7 bullets per section.",
+  "Use the company's own words where natural.",
+  "Plain text only, no JSON.",
+].join(" ");
+
+const BRAINSTORM_FOLLOW_UP_PREFIX = [
+  "Here are your prior notes on this article.",
+  "Now produce the structured extraction — refine, dedupe, and assign each entity an entityTypeId from the vocabulary above.",
+].join(" ");
+
 /**
  * Resolves the extraction system prompt after merging Hermes `prompts.systemPrompt` with code defaults.
  *
@@ -219,9 +266,165 @@ export const buildExtractionUserContent = (args: {
 }): string => resolveArticleAnalysisExtractionUserContent(undefined, args);
 
 /**
+ * Returns the brainstorm-pass system prompt (plain-text enumeration, no JSON schema).
+ *
+ * @param _ctx - Reserved for future host-specific brainstorm guidance.
+ */
+export const buildBrainstormSystemContent = (
+  _ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">,
+): string => BRAINSTORM_SYSTEM_PROMPT;
+
+/**
+ * Builds the brainstorm user message using the same title and body block as extraction.
+ *
+ * @param args - Ticker, title, and truncated article body.
+ */
+export const buildBrainstormUserContent = (args: {
+  tickerId: string;
+  title: string;
+  contentTruncated: string;
+}): string => buildExtractionUserContent(args);
+
+/**
+ * Formats brainstorm plain text as the structured pass follow-up user turn.
+ *
+ * @param brainstormText - Free-form brainstorm output from the first pass.
+ */
+export const buildBrainstormFollowUpUserContent = (
+  brainstormText: string,
+): string => `${BRAINSTORM_FOLLOW_UP_PREFIX}\n\n${brainstormText}`;
+
+/**
+ * Parses brainstorm plain text into the in-memory {@link ArticleBrainstorm} contract.
+ *
+ * @param text - Raw brainstorm model output.
+ */
+export const parseArticleBrainstormText = (text: string): ArticleBrainstorm => {
+  const sections: ArticleBrainstorm = {
+    keyPlayers: [],
+    events: [],
+    relationships: [],
+    sentimentNotes: [],
+  };
+
+  const sectionMatchers: Array<{
+    key: keyof ArticleBrainstorm;
+    labels: string[];
+  }> = [
+    { key: "keyPlayers", labels: ["KEY PLAYERS", "KEY PLAYERS:"] },
+    { key: "events", labels: ["EVENTS", "EVENTS:"] },
+    { key: "relationships", labels: ["RELATIONSHIPS", "RELATIONSHIPS:"] },
+    { key: "sentimentNotes", labels: ["SENTIMENT NOTES", "SENTIMENT NOTES:"] },
+  ];
+
+  const lines = text.split("\n");
+  let currentKey: keyof ArticleBrainstorm | null = null;
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim();
+    if (line.length === 0) {
+      continue;
+    }
+
+    const matchedSection = sectionMatchers.find((section) =>
+      section.labels.some(
+        (label) => line.toUpperCase() === label || line.toUpperCase().startsWith(`${label} `),
+      ),
+    );
+    if (matchedSection) {
+      currentKey = matchedSection.key;
+      continue;
+    }
+
+    if (currentKey === null) {
+      continue;
+    }
+
+    const bullet = line.replace(/^[-*•]\s*/, "").trim();
+    if (bullet.length > 0) {
+      sections[currentKey].push(bullet);
+    }
+  }
+
+  return sections;
+};
+
+/**
+ * Runs the free-form brainstorm pass for one article via `generateText`.
+ *
+ * @param params - API key, model, token limit, and chat messages.
+ * @param deps - Injectable `generateText` wrapper (tests swap mock).
+ */
+export const fetchArticleBrainstorm = async (
+  params: {
+    apiKey: string;
+    model: string;
+    maxOutputTokens: number;
+    messages: ModelMessage[];
+  },
+  deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
+    generateTextForBrainstorm: defaultGenerateTextForBrainstorm,
+  },
+): Promise<ArticleBrainstormCallResult> => {
+  const openai = createOpenAI({ apiKey: params.apiKey });
+  return deps.generateTextForBrainstorm({
+    model: openai(params.model),
+    maxOutputTokens: params.maxOutputTokens,
+    messages: params.messages,
+  });
+};
+
+/**
+ * Formats one few-shot exemplar snippet as a user turn.
+ *
+ * @param articleSnippet - Curated article excerpt for the exemplar.
+ */
+const formatExemplarUserContent = (articleSnippet: string): string =>
+  `Example article:\n\n${articleSnippet}`;
+
+/**
+ * Builds chat messages for extraction, optionally injecting few-shot exemplar turns.
+ *
+ * @param systemContent - Resolved system prompt.
+ * @param userContent - Resolved real-article user prompt.
+ * @param exemplars - Resolved few-shot exemplars to inject before the real user turn.
+ * @param brainstormText - Optional brainstorm notes appended as a follow-up user turn.
+ */
+export const buildExtractionModelMessages = (
+  systemContent: string,
+  userContent: string,
+  exemplars: readonly ResolvedExemplar[] = [],
+  brainstormText?: string,
+): ModelMessage[] => {
+  const messages: ModelMessage[] = [{ role: "system", content: systemContent }];
+
+  for (const exemplar of exemplars) {
+    messages.push({
+      role: "user",
+      content: formatExemplarUserContent(exemplar.articleSnippet),
+    });
+    messages.push({
+      role: "assistant",
+      content: JSON.stringify(exemplar.expectedOutput, null, 2),
+    });
+  }
+
+  messages.push({ role: "user", content: userContent });
+
+  if (brainstormText !== undefined && brainstormText.trim().length > 0) {
+    messages.push({
+      role: "user",
+      content: buildBrainstormFollowUpUserContent(brainstormText),
+    });
+  }
+
+  return messages;
+};
+
+/**
  * Runs structured extraction for one data source via `generateObject`.
  *
- * @param params - API key, model, token limit, chat messages.
+ * @param params - API key, model, token limit, chat messages, optional few-shot exemplars and brainstorm notes.
  * @param deps - Injectable `generateObject` wrapper (tests swap mock).
  * @returns Parsed entities and relations plus optional tokenizer usage.
  */
@@ -231,17 +434,32 @@ export const extractEntitiesAndRelationsForSource = async (
     model: string;
     maxOutputTokens: number;
     messages: ModelMessage[];
+    exemplars?: readonly ResolvedExemplar[];
+    brainstormText?: string;
   },
   deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
     generateObjectForExtraction: defaultGenerateObjectForExtraction,
   },
 ): Promise<LlmExtractionCallResult> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
+  const systemContent = String(params.messages[0]?.content ?? "");
+  const userContent = String(params.messages.at(-1)?.content ?? "");
+  const shouldBuildMessages =
+    (params.exemplars !== undefined && params.exemplars.length > 0) ||
+    (params.brainstormText !== undefined && params.brainstormText.trim().length > 0);
+  const messages = shouldBuildMessages
+    ? buildExtractionModelMessages(
+        systemContent,
+        userContent,
+        params.exemplars ?? [],
+        params.brainstormText,
+      )
+    : params.messages;
   const raw = await deps.generateObjectForExtraction({
     model: openai(params.model),
     schema: llmExtractionOpenAiWireSchema,
     maxOutputTokens: params.maxOutputTokens,
-    messages: params.messages,
+    messages,
   });
   return {
     object: normalizeLlmExtractionWire(raw.object),

--- a/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.test.ts
@@ -8,7 +8,7 @@ describe("classifyNonArticleSource", () => {
     // Act
     const result = classifyNonArticleSource(
       "https://finance.yahoo.com/quote/BBCA.JK/",
-      "BBCA Quote",
+      "BBCA Quote Page Title",
       "Some long placeholder content ".repeat(20),
     );
 
@@ -20,7 +20,7 @@ describe("classifyNonArticleSource", () => {
     // Act
     const result = classifyNonArticleSource(
       "https://www.linkedin.com/posts/example_company-update",
-      "Post title",
+      "LinkedIn company update post",
       "content",
     );
 

--- a/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.ts
+++ b/apps/mediapulse/agents/article-analysis/src/non-article-source-filter.ts
@@ -1,49 +1,9 @@
-import { classifyNoisyUrl } from "@workspace/utils";
-
-const NON_ARTICLE_TITLE_MARKERS = [
-  "key statistics",
-  "historical data",
-  "financial summary",
-  "company profile",
-  "consensus estimates",
-] as const;
-
-export type NonArticleReason =
-  | "prefilter_blocked_host"
-  | "prefilter_blocked_path"
-  | "prefilter_index_title";
-
-/**
- * Classifies whether a source is clearly non-article before running extraction.
- *
- * @param sourceUrl - Data source URL.
- * @param sourceTitle - Source title.
- * @param sourceContent - Source content (unused; reserved for future heuristics).
- * @returns Null for likely article content, otherwise a concrete non-article reason.
- */
-export const classifyNonArticleSource = (
-  sourceUrl: string,
-  sourceTitle: string,
-  _sourceContent: string,
-): NonArticleReason | null => {
-  try {
-    new URL(sourceUrl);
-  } catch {
-    return null;
-  }
-
-  const urlDecision = classifyNoisyUrl(sourceUrl);
-  if (urlDecision.blocked) {
-    if (urlDecision.reason === "blocked_host") {
-      return "prefilter_blocked_host";
-    }
-    return "prefilter_blocked_path";
-  }
-
-  const titleLower = sourceTitle.toLowerCase();
-  if (NON_ARTICLE_TITLE_MARKERS.some((marker) => titleLower.includes(marker))) {
-    return "prefilter_index_title";
-  }
-
-  return null;
-};
+export {
+  classifyNonArticleSource,
+  countRepeatedShingles,
+  createEmptyQualityCounters,
+  runArticleQualityGate,
+  type NonArticleReason,
+  type QualityDecision,
+  type QualityDropReason,
+} from "./utilities/content-quality-gate.js";

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -91,6 +91,57 @@ const TYPE_ID = "11111111-1111-4111-a111-111111111111";
 const REL_ID = "22222222-2222-4222-a222-222222222222";
 const DS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const DS_ID_2 = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const DS_ID_3 = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const DS_ID_4 = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+
+const VALID_SOURCE_URL = "https://example.com/news/article";
+const VALID_SOURCE_TITLE = "Company expands regional operations headline";
+
+/** Builds article-like body text with at least 120 unique words. */
+const validSourceContent = (): string =>
+  [
+    "Bank Central Asia announced strategic expansion plans across regional markets.",
+    ...Array.from(
+      { length: 130 },
+      (_, index) =>
+        `Analyst note ${index} discusses lending trends and deposit growth in Indonesia.`,
+    ),
+  ].join(" ");
+
+/** Builds paywall stub text with low alphabetic density. */
+const paywallSourceContent = (): string =>
+  "!!! $$$ ### subscribe to read !!! $$$ ### ".repeat(25);
+
+/** Builds soft-404 stub text under the length threshold. */
+const soft404SourceContent = (): string =>
+  `Sorry, page not found. ${"x".repeat(200)}`;
+
+/** Builds body text below the minimum word count. */
+const shortSourceContent = (): string => "word ".repeat(50);
+
+/** Builds a long article body for structure-aware truncation tests. */
+const longTruncationFixtureContent = (): string =>
+  [
+    "Structure headline",
+    "",
+    "Lead paragraph one without ticker mention in this opening block.",
+    "",
+    "Lead paragraph two without ticker mention in this opening block.",
+    "",
+    "Filler paragraph three has generic market commentary only here.",
+    "",
+    "Filler paragraph four has generic market commentary only here.",
+    "",
+    "Apple reported earnings and AAPL shares rose on guidance today.",
+    "",
+    "Sign up for our newsletter",
+    "",
+    ...Array.from(
+      { length: 130 },
+      (_, index) =>
+        `Trailing filler paragraph ${index} adds length beyond the truncation budget.`,
+    ),
+  ].join("\n");
 
 /** Required on `analysis.get` responses (see `getAnalysisResponseSchema`). */
 const relevanceSelectionState = {
@@ -159,9 +210,9 @@ describe("run", () => {
 
   const source = {
     id: DS_ID,
-    url: "u",
-    title: "T",
-    content: "c",
+    url: VALID_SOURCE_URL,
+    title: VALID_SOURCE_TITLE,
+    content: validSourceContent(),
     tickerId: "ticker-1",
     createdAt: new Date("2026-01-01T00:00:00.000Z"),
   };
@@ -298,7 +349,7 @@ describe("run", () => {
           {
             ...source,
             id: DS_ID_2,
-            title: "T2",
+            title: "Article headline two test",
           },
         ],
         entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
@@ -468,9 +519,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -552,9 +603,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -623,9 +674,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -689,9 +740,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -836,16 +887,16 @@ describe("run", () => {
           {
             id: DS_ID,
             url: "u1",
-            title: "T1",
-            content: "c",
+            title: "Article headline one test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
           {
             id: DS_ID_2,
             url: "u2",
-            title: "T2",
-            content: "c",
+            title: "Article headline two test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -933,9 +984,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -999,9 +1050,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1078,9 +1129,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1166,17 +1217,17 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
           {
             id: DS_ID_2,
             url: "u2",
-            title: "T2",
-            content: "c",
+            title: "Article headline two test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1218,8 +1269,8 @@ describe("run", () => {
           {
             id: DS_ID,
             url: "https://finance.yahoo.com/quote/BBCA.JK/",
-            title: "BBCA quote",
-            content: "Long but non-article page body ".repeat(20),
+            title: "BBCA Quote Page Title",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1248,15 +1299,197 @@ describe("run", () => {
     ).toBe("prefilter");
   });
 
+  it("tracks droppedByContentQuality counters and only extracts clean sources", async () => {
+    // Setup
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_2,
+            url: "https://example.com/paywall",
+            title: "Premium article headline here",
+            content: paywallSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_3,
+            url: "https://example.com/missing",
+            title: "Missing article headline here",
+            content: soft404SourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_4,
+            url: "https://example.com/stub",
+            title: "Wire stub headline here",
+            content: shortSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    const extractSpy = vi.spyOn(
+      Llm,
+      "extractEntitiesAndRelationsForSource",
+    ).mockResolvedValue(
+      llmResult({
+        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 0,
+    });
+
+    // Act
+    await run(runContext({ input: { tickerId: "ticker-1" } }));
+
+    // Assert
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect(
+      (summaryCall?.[0] as { droppedByContentQuality: Record<string, number> })
+        .droppedByContentQuality,
+    ).toEqual({
+      prefilter_blocked_host: 0,
+      prefilter_blocked_path: 0,
+      prefilter_index_title: 0,
+      content_no_title: 0,
+      content_soft_404: 1,
+      content_access_gated: 1,
+      content_too_short: 1,
+      content_repetitive: 0,
+    });
+    expect(
+      (summaryCall?.[0] as { extractionCalls: number }).extractionCalls,
+    ).toBe(1);
+  });
+
+  it("uses structure-aware truncation when enabled and naive slice when disabled", async () => {
+    const COMPANY_TYPE_ID = "33333333-3333-4333-a333-333333333333";
+    const longContent = longTruncationFixtureContent();
+    const baseGetResponse = analysisGetOk({
+      dataSources: [
+        {
+          id: DS_ID,
+          url: VALID_SOURCE_URL,
+          title: VALID_SOURCE_TITLE,
+          content: longContent,
+          tickerId: "ticker-1",
+          createdAt: new Date(),
+        },
+      ],
+      entityTypes: [
+        { id: TYPE_ID, name: "Co", description: null },
+        { id: COMPANY_TYPE_ID, name: "Company", description: null },
+      ],
+      relationTypes: [{ id: REL_ID, name: "r", description: null }],
+      existingEntities: [
+        {
+          id: "eeeeeeee-eeee-4eee-aeee-eeeeeeeeeeee",
+          canonicalName: "AAPL",
+          typeId: COMPANY_TYPE_ID,
+          aliases: ["Apple Inc"],
+        },
+      ],
+      relevanceSelectionState,
+      lastRelevanceScoredAtIso: null,
+    });
+
+    analysisGet.mockResolvedValue(baseGetResponse);
+    const extractSpy = vi
+      .spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValue(
+        llmResult({
+          entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+          relations: [],
+          articleMentions: [],
+        }),
+      );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 0,
+    });
+
+    await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          useStructureAwareTruncation: true,
+          maxContentChars: 260,
+        },
+      }),
+    );
+
+    const structuredUserMessage = extractSpy.mock.calls[0]?.[0]?.messages?.[1]
+      ?.content as string;
+    expect(structuredUserMessage).toContain("AAPL shares rose");
+    expect(structuredUserMessage).not.toContain(
+      "Sign up for our newsletter",
+    );
+
+    extractSpy.mockClear();
+    analysisGet.mockResolvedValue(baseGetResponse);
+
+    await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          useStructureAwareTruncation: false,
+          maxContentChars: 260,
+        },
+      }),
+    );
+
+    const slicedUserMessage = extractSpy.mock.calls[0]?.[0]?.messages?.[1]
+      ?.content as string;
+    expect(slicedUserMessage).toContain(
+      longContent.slice(0, 260).slice(0, 40),
+    );
+    expect(slicedUserMessage).not.toContain("AAPL shares rose");
+  });
+
   it("logs safe error shape when LLM extraction throws", async () => {
     analysisGet.mockResolvedValue(
       analysisGetOk({
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "short",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1294,9 +1527,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: secretBody,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: `${secretBody} ${validSourceContent()}`,
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1382,16 +1615,16 @@ describe("run", () => {
           {
             id: DS_ID,
             url: "u1",
-            title: "T1",
-            content: "c",
+            title: "Article headline one test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
           {
             id: DS_ID_2,
             url: "u2",
-            title: "T2",
-            content: "c",
+            title: "Article headline two test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1446,17 +1679,17 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
           {
             id: DS_ID_2,
             url: "u2",
-            title: "T2",
-            content: "c",
+            title: "Article headline two test",
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1497,9 +1730,9 @@ describe("run", () => {
         dataSources: [
           {
             id: DS_ID,
-            url: "u",
-            title: "T",
-            content: "c",
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
             tickerId: "ticker-1",
             createdAt: new Date(),
           },
@@ -1531,5 +1764,346 @@ describe("run", () => {
           "debounce_min_minutes_since_last_score",
     );
     expect(summaryCall).toBeDefined();
+  });
+
+  it("falls back to single-pass extraction when brainstorm fails", async () => {
+    // Setup
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "fetchArticleBrainstorm").mockRejectedValue(
+      new Error("timeout"),
+    );
+    const extractSpy = vi
+      .spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValue(
+        llmResult({
+          entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+          relations: [],
+          articleMentions: [],
+        }),
+      );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    // Act
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { useBrainstormPass: true },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(extractSpy).toHaveBeenCalledTimes(1);
+    expect(extractSpy.mock.calls[0]?.[0]?.brainstormText).toBeUndefined();
+    expect(mockLog.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dataSourceId: DS_ID,
+        stage: "brainstorm",
+      }),
+      "article-analysis brainstorm pass failed; falling back to single-pass extraction",
+    );
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect((summaryCall?.[0] as { brainstormCalls?: number }).brainstormCalls).toBe(
+      0,
+    );
+    expect(
+      (summaryCall?.[0] as { extractionCalls?: number }).extractionCalls,
+    ).toBe(1);
+    expect(
+      (summaryCall?.[0] as { extractionSuccessCount?: number })
+        .extractionSuccessCount,
+    ).toBe(1);
+  });
+
+  it("passes brainstorm notes into structured extraction when enabled", async () => {
+    // Setup
+    const brainstormText =
+      "KEY PLAYERS:\n- Apple\n- Tim Cook\nEVENTS:\n- Q2 earnings beat";
+    const entityCounts: number[] = [];
+    const buildWire = (count: number) => ({
+      entities: Array.from({ length: count }, (_, index) => ({
+        canonicalName: `Entity${String(index)}`,
+        typeId: TYPE_ID,
+        description: "",
+        aliases: [] as string[],
+      })),
+      relations: [],
+      articleMentions: [],
+    });
+    const extractSpy = vi
+      .spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockImplementation(async (params) => {
+        const count = params.brainstormText ? 2 : 1;
+        entityCounts.push(count);
+        const wire = buildWire(count);
+        expect(Llm.llmExtractionOpenAiWireSchema.safeParse(wire).success).toBe(
+          true,
+        );
+        return llmResult({
+          entities: wire.entities.map((entity) => ({
+            canonicalName: entity.canonicalName,
+            typeId: entity.typeId,
+            description: entity.description,
+            aliases: entity.aliases,
+          })),
+          relations: wire.relations,
+          articleMentions: wire.articleMentions,
+        });
+      });
+
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 2,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+    vi.spyOn(Llm, "fetchArticleBrainstorm").mockResolvedValue({
+      text: brainstormText,
+      usage: { inputTokens: 12, outputTokens: 8, totalTokens: 20 },
+    });
+
+    // Act — with brainstorm
+    const withBrainstorm = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { useBrainstormPass: true },
+      }),
+    );
+
+    // Assert
+    expect(withBrainstorm.success).toBe(true);
+    expect(extractSpy.mock.calls[0]?.[0]?.brainstormText).toBe(brainstormText);
+
+    // Act — without brainstorm on the same fixture
+    const withoutBrainstorm = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { useBrainstormPass: false },
+      }),
+    );
+
+    expect(withoutBrainstorm.success).toBe(true);
+    expect(extractSpy.mock.calls[1]?.[0]?.brainstormText).toBeUndefined();
+    expect(entityCounts).toEqual([2, 1]);
+    expect(entityCounts[0]).toBeGreaterThanOrEqual(entityCounts[1] ?? 0);
+  });
+
+  it("drops ungrounded entities and relations under the drop grounding policy", async () => {
+    const appleArticleContent = (): string =>
+      `${validSourceContent()} Apple expanded manufacturing capacity this year.`;
+    const hallucinatedExtraction = llmResult({
+      entities: [
+        { canonicalName: "FakeCo", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "Apple", typeId: TYPE_ID, aliases: [] },
+      ],
+      relations: [
+        {
+          fromEntityName: "FakeCo",
+          toEntityName: "Apple",
+          relationTypeId: REL_ID,
+        },
+      ],
+      articleMentions: [
+        {
+          entityName: "FakeCo",
+          mentionCount: 2,
+          confidence: 0.95,
+          sentiment: null,
+        },
+      ],
+    });
+
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: appleArticleContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      hallucinatedExtraction,
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { entityGroundingPolicy: "drop" },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    const postedEntities = analysisCreate.mock.calls[0]?.[0]?.entities as
+      | Array<{ canonicalName: string }>
+      | undefined;
+    expect(postedEntities?.map((entity) => entity.canonicalName)).toEqual([
+      "Apple",
+    ]);
+    expect(analysisCreate.mock.calls[0]?.[0]?.relations).toEqual([]);
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (c) =>
+        typeof c[0] === "object" &&
+        c[0] !== null &&
+        (c[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(
+      (summaryCall?.[0] as { grounding?: { entitiesUngroundedTotal: number } })
+        .grounding?.entitiesUngroundedTotal,
+    ).toBe(1);
+  });
+
+  it("flags ungrounded entities but drops their relations under the flag policy", async () => {
+    const appleArticleContent = (): string =>
+      `${validSourceContent()} Apple expanded manufacturing capacity this year.`;
+    const hallucinatedExtraction = llmResult({
+      entities: [
+        { canonicalName: "FakeCo", typeId: TYPE_ID, aliases: [] },
+        { canonicalName: "Apple", typeId: TYPE_ID, aliases: [] },
+      ],
+      relations: [
+        {
+          fromEntityName: "FakeCo",
+          toEntityName: "Apple",
+          relationTypeId: REL_ID,
+        },
+      ],
+      articleMentions: [
+        {
+          entityName: "FakeCo",
+          mentionCount: 2,
+          confidence: 0.95,
+          sentiment: null,
+        },
+      ],
+    });
+
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: appleArticleContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      hallucinatedExtraction,
+    );
+    analysisCreate
+      .mockResolvedValueOnce({
+        entitiesCreated: 2,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 0,
+        articlesSelected: 0,
+      })
+      .mockResolvedValueOnce({
+        entitiesCreated: 0,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+      });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: { entityGroundingPolicy: "flag" },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    const postedEntities = analysisCreate.mock.calls[0]?.[0]?.entities as
+      | Array<{ canonicalName: string }>
+      | undefined;
+    expect(postedEntities?.map((entity) => entity.canonicalName).sort()).toEqual(
+      ["Apple", "FakeCo"],
+    );
+    expect(analysisCreate.mock.calls[0]?.[0]?.relations).toEqual([]);
+    expect(
+      analysisCreate.mock.calls[1]?.[0]?.articleEntities?.[0]?.confidence,
+    ).toBe(0.4);
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -1344,16 +1344,15 @@ describe("run", () => {
         lastRelevanceScoredAtIso: null,
       }),
     );
-    const extractSpy = vi.spyOn(
-      Llm,
-      "extractEntitiesAndRelationsForSource",
-    ).mockResolvedValue(
-      llmResult({
-        entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
-        relations: [],
-        articleMentions: [],
-      }),
-    );
+    const extractSpy = vi
+      .spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValue(
+        llmResult({
+          entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+          relations: [],
+          articleMentions: [],
+        }),
+      );
     analysisCreate.mockResolvedValue({
       entitiesCreated: 1,
       entitiesReused: 0,
@@ -1456,9 +1455,7 @@ describe("run", () => {
     const structuredUserMessage = extractSpy.mock.calls[0]?.[0]?.messages?.[1]
       ?.content as string;
     expect(structuredUserMessage).toContain("AAPL shares rose");
-    expect(structuredUserMessage).not.toContain(
-      "Sign up for our newsletter",
-    );
+    expect(structuredUserMessage).not.toContain("Sign up for our newsletter");
 
     extractSpy.mockClear();
     analysisGet.mockResolvedValue(baseGetResponse);
@@ -1475,9 +1472,7 @@ describe("run", () => {
 
     const slicedUserMessage = extractSpy.mock.calls[0]?.[0]?.messages?.[1]
       ?.content as string;
-    expect(slicedUserMessage).toContain(
-      longContent.slice(0, 260).slice(0, 40),
-    );
+    expect(slicedUserMessage).toContain(longContent.slice(0, 260).slice(0, 40));
     expect(slicedUserMessage).not.toContain("AAPL shares rose");
   });
 
@@ -1835,9 +1830,9 @@ describe("run", () => {
           ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
     );
     expect(summaryCall).toBeDefined();
-    expect((summaryCall?.[0] as { brainstormCalls?: number }).brainstormCalls).toBe(
-      0,
-    );
+    expect(
+      (summaryCall?.[0] as { brainstormCalls?: number }).brainstormCalls,
+    ).toBe(0);
     expect(
       (summaryCall?.[0] as { extractionCalls?: number }).extractionCalls,
     ).toBe(1);
@@ -2098,9 +2093,9 @@ describe("run", () => {
     const postedEntities = analysisCreate.mock.calls[0]?.[0]?.entities as
       | Array<{ canonicalName: string }>
       | undefined;
-    expect(postedEntities?.map((entity) => entity.canonicalName).sort()).toEqual(
-      ["Apple", "FakeCo"],
-    );
+    expect(
+      postedEntities?.map((entity) => entity.canonicalName).sort(),
+    ).toEqual(["Apple", "FakeCo"]);
     expect(analysisCreate.mock.calls[0]?.[0]?.relations).toEqual([]);
     expect(
       analysisCreate.mock.calls[1]?.[0]?.articleEntities?.[0]?.confidence,

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -48,6 +48,7 @@ import {
   toSafeLogError,
   type ArticleAnalysisRunSummaryInput,
   type ChunkBuildParseCounts,
+  type ExemplarsObservabilityAggregate,
   type LlmUsageTotals,
 } from "./article-analysis-observability.js";
 import {
@@ -66,9 +67,14 @@ import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-sche
 import {
   resolveArticleAnalysisExtractionSystemContent,
   resolveArticleAnalysisExtractionUserContent,
+  buildBrainstormSystemContent,
+  buildBrainstormUserContent,
   extractEntitiesAndRelationsForSource,
+  fetchArticleBrainstorm,
   type LlmExtractionUsage,
 } from "./llm-extract-entities.js";
+import { DEFAULT_EXTRACTION_EXEMPLARS } from "./exemplars/default-extraction-exemplars.js";
+import { resolveExemplarsForContext } from "./exemplars/resolve-extraction-exemplars.js";
 import {
   buildAnalysisGetQuery,
   applyMaxBatchSizeCap,
@@ -80,7 +86,22 @@ import {
   shouldHardDeleteDataSourceForExtractionError,
 } from "./extraction-failure-pruning.js";
 import { normalizeEntityName } from "./normalize-entity-name.js";
-import { classifyNonArticleSource } from "./non-article-source-filter.js";
+import {
+  accumulateTruncationMeta,
+  createEmptyTruncationTotals,
+  resolveTruncationTickerContext,
+  truncateArticleForExtraction,
+} from "./utilities/article-content-truncator.js";
+import {
+  createEmptyQualityCounters,
+  runArticleQualityGate,
+  type QualityDropReason,
+} from "./utilities/content-quality-gate.js";
+import {
+  accumulateGroundingCounters,
+  applyExtractionEntityGrounding,
+  createEmptyGroundingTotals,
+} from "./utilities/entity-grounding.js";
 
 type ExistingEntity = {
   canonicalName: string;
@@ -247,7 +268,37 @@ export const run = async ({
 
   const emitRunSummary = (summary: ArticleAnalysisRunSummaryInput): void => {
     log.info(
-      buildArticleAnalysisRunSummaryPayload(summary),
+      buildArticleAnalysisRunSummaryPayload({
+        ...summary,
+        droppedByContentQuality:
+          summary.droppedByContentQuality ?? { ...droppedByContentQuality },
+        truncation:
+          summary.truncation ??
+          (truncationTotals.paragraphsKept > 0 ||
+          truncationTotals.paragraphsDropped > 0 ||
+          truncationTotals.leadCharsKept > 0 ||
+          truncationTotals.tickerSentencesKept > 0
+            ? {
+                leadCharsKept: truncationTotals.leadCharsKept,
+                tickerSentencesKept: truncationTotals.tickerSentencesKept,
+                paragraphsKept: truncationTotals.paragraphsKept,
+                paragraphsDropped: truncationTotals.paragraphsDropped,
+              }
+            : undefined),
+        exemplars: summary.exemplars ?? exemplarsObservability ?? undefined,
+        grounding:
+          summary.grounding ??
+          (groundingTotals.entitiesUngroundedTotal > 0 ||
+          groundingTotals.relationsDroppedTotal > 0 ||
+          groundingTotals.mentionsDroppedTotal > 0
+            ? {
+                entitiesUngroundedTotal:
+                  groundingTotals.entitiesUngroundedTotal,
+                relationsDroppedTotal: groundingTotals.relationsDroppedTotal,
+                mentionsDroppedTotal: groundingTotals.mentionsDroppedTotal,
+              }
+            : undefined),
+      }),
       ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
     );
   };
@@ -275,13 +326,21 @@ export const run = async ({
     promptTokens: 0,
     completionTokens: 0,
     totalTokens: 0,
+    brainstormCalls: 0,
+    brainstormPromptTokens: 0,
+    brainstormCompletionTokens: 0,
   };
   let llmUsageAccumulated = false;
   let extractionLatencyMsTotal = 0;
   let extractionCalls = 0;
+  let brainstormCalls = 0;
   let lastLlmPromptFingerprint: string | undefined;
   let relevanceRowsForObservability: ArticleRelevanceRow[] | null = null;
+  let exemplarsObservability: ExemplarsObservabilityAggregate | null = null;
   const extractionFailures: ArticleAnalysisExtractionFailureRecord[] = [];
+  const droppedByContentQuality = createEmptyQualityCounters();
+  const truncationTotals = createEmptyTruncationTotals();
+  const groundingTotals = createEmptyGroundingTotals();
   let extractionSuccessCount = 0;
   const postFailures: ArticleAnalysisPostFailureRecord[] = [];
   let entitiesCreated = 0;
@@ -298,6 +357,16 @@ export const run = async ({
     llmUsageTotals.promptTokens += usage.inputTokens;
     llmUsageTotals.completionTokens += usage.outputTokens;
     llmUsageTotals.totalTokens += usage.totalTokens;
+  };
+
+  const accumulateBrainstormUsage = (usage: LlmExtractionUsage | null): void => {
+    if (!usage) {
+      return;
+    }
+    llmUsageAccumulated = true;
+    llmUsageTotals.brainstormCalls += 1;
+    llmUsageTotals.brainstormPromptTokens += usage.inputTokens;
+    llmUsageTotals.brainstormCompletionTokens += usage.outputTokens;
   };
 
   try {
@@ -499,6 +568,17 @@ export const run = async ({
       cfg.prompts?.systemPrompt,
       ctx,
     );
+    const resolvedExemplars = resolveExemplarsForContext(
+      DEFAULT_EXTRACTION_EXEMPLARS,
+      ctx,
+      cfg.fewShotExemplarCount,
+      cfg.fewShotExemplarArchetypes,
+    );
+    exemplarsObservability = {
+      requestedCount: cfg.fewShotExemplarCount,
+      resolvedCount: resolvedExemplars.length,
+      appliedArchetypes: resolvedExemplars.map((exemplar) => exemplar.archetype),
+    };
     const existingLookup = buildExistingEntityLookup(ctx.existingEntities);
 
     const mergedEntities: EntityProposal[] = [];
@@ -507,13 +587,21 @@ export const run = async ({
     const perSourceSignals: PerSourceRelevanceSignals[] = [];
     let vocabularyFailures = 0;
 
+    const truncationTickerContext = resolveTruncationTickerContext(
+      ctx.entityTypes,
+      ctx.existingEntities,
+    );
+    const runProcessingStartedAt = Date.now();
+
     for (const source of batch) {
-      const nonArticleReason = classifyNonArticleSource(
+      const qualityDecision = runArticleQualityGate(
         source.url,
         source.title,
         source.content,
       );
-      if (nonArticleReason) {
+      if (qualityDecision.blocked) {
+        const nonArticleReason: QualityDropReason = qualityDecision.reason;
+        droppedByContentQuality[nonArticleReason] += 1;
         extractionFailures.push({
           dataSourceId: source.id,
           stage: "prefilter",
@@ -556,8 +644,20 @@ export const run = async ({
         continue;
       }
 
-      const truncated =
-        source.content.length > cfg.maxContentChars
+      const truncated = cfg.useStructureAwareTruncation
+        ? (() => {
+            const result = truncateArticleForExtraction(source.content, {
+              maxChars: cfg.maxContentChars,
+              tickerSymbols: truncationTickerContext.tickerSymbols,
+              companyAliases: truncationTickerContext.companyAliases,
+              leadParagraphsAlwaysKept:
+                cfg.truncationLeadParagraphsAlwaysKept,
+              financialKeywordsExtra: cfg.truncationFinancialKeywordsExtra,
+            });
+            accumulateTruncationMeta(truncationTotals, result.meta);
+            return result.content;
+          })()
+        : source.content.length > cfg.maxContentChars
           ? source.content.slice(0, cfg.maxContentChars)
           : source.content;
 
@@ -576,6 +676,59 @@ export const run = async ({
           systemContent,
           extractionUserContent,
         );
+
+        let brainstormText: string | undefined;
+        const runElapsedMs = Date.now() - runProcessingStartedAt;
+        const shouldRunBrainstorm =
+          cfg.useBrainstormPass && runElapsedMs < cfg.runDeadlineMs;
+
+        if (shouldRunBrainstorm) {
+          try {
+            const brainstormResult = await fetchArticleBrainstorm({
+              apiKey: cfg.openaiApiKey,
+              model: cfg.brainstormModel,
+              maxOutputTokens: cfg.brainstormMaxOutputTokens,
+              messages: [
+                {
+                  role: "system",
+                  content: buildBrainstormSystemContent(ctx),
+                },
+                {
+                  role: "user",
+                  content: buildBrainstormUserContent({
+                    tickerId: input.tickerId,
+                    title: source.title,
+                    contentTruncated: truncated,
+                  }),
+                },
+              ],
+            });
+            brainstormCalls += 1;
+            accumulateBrainstormUsage(brainstormResult.usage);
+            if (brainstormResult.text.trim().length > 0) {
+              brainstormText = brainstormResult.text;
+            }
+          } catch (brainstormErr) {
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "brainstorm",
+                err: toSafeLogError(brainstormErr),
+              },
+              "article-analysis brainstorm pass failed; falling back to single-pass extraction",
+            );
+          }
+        } else if (cfg.useBrainstormPass && runElapsedMs >= cfg.runDeadlineMs) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              runElapsedMs,
+              runDeadlineMs: cfg.runDeadlineMs,
+            },
+            "article-analysis skipping brainstorm pass due to run deadline",
+          );
+        }
+
         const extractedResult = await extractEntitiesAndRelationsForSource({
           apiKey: cfg.openaiApiKey,
           model: cfg.openaiModel,
@@ -587,6 +740,10 @@ export const run = async ({
               content: extractionUserContent,
             },
           ],
+          ...(resolvedExemplars.length > 0
+            ? { exemplars: resolvedExemplars }
+            : {}),
+          ...(brainstormText !== undefined ? { brainstormText } : {}),
         });
         extractionLatencyMsTotal += Date.now() - t0;
         extractionCalls += 1;
@@ -615,9 +772,35 @@ export const run = async ({
           continue;
         }
 
+        const groundedExtraction = applyExtractionEntityGrounding({
+          entities: extracted.entities,
+          relations: extracted.relations,
+          mentions: extracted.articleMentions,
+          articleText: source.content,
+          title: source.title,
+          policy: cfg.entityGroundingPolicy,
+          entityGroundingMinTitleHits: cfg.entityGroundingMinTitleHits,
+        });
+        accumulateGroundingCounters(groundingTotals, groundedExtraction.counters);
+        if (cfg.verbose && cfg.entityGroundingPolicy !== "off") {
+          log.info(
+            {
+              dataSourceId: source.id,
+              ungroundedEntityCount:
+                groundedExtraction.counters.ungroundedEntityCount,
+              relationsDroppedDueToUngroundedEndpoint:
+                groundedExtraction.counters
+                  .relationsDroppedDueToUngroundedEndpoint,
+              mentionsDroppedDueToUngroundedEntity:
+                groundedExtraction.counters.mentionsDroppedDueToUngroundedEntity,
+            },
+            "article-analysis entity grounding applied for source",
+          );
+        }
+
         const resolved = resolveAgainstExistingEntities(
-          extracted.entities,
-          extracted.relations,
+          groundedExtraction.entities,
+          groundedExtraction.relations,
           existingLookup,
         );
         const capped = applyPerArticleExtractionCaps(
@@ -633,7 +816,7 @@ export const run = async ({
           capped.entities,
         );
         const mentionFiltered = filterMentionsToArticleEntityCatalog(
-          extracted.articleMentions,
+          groundedExtraction.mentions,
           allowedCatalog,
         );
         const mentionCapped = applyPerArticleArticleMentionCap(
@@ -1225,6 +1408,7 @@ export const run = async ({
       llmUsage: llmUsageAccumulated ? llmUsageTotals : null,
       extractionLatencyMsTotal,
       extractionCalls,
+      brainstormCalls,
       runStatusLabel: runStatus,
       ...(lastLlmPromptFingerprint !== undefined
         ? { llmPromptFingerprint: lastLlmPromptFingerprint }

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -270,8 +270,9 @@ export const run = async ({
     log.info(
       buildArticleAnalysisRunSummaryPayload({
         ...summary,
-        droppedByContentQuality:
-          summary.droppedByContentQuality ?? { ...droppedByContentQuality },
+        droppedByContentQuality: summary.droppedByContentQuality ?? {
+          ...droppedByContentQuality,
+        },
         truncation:
           summary.truncation ??
           (truncationTotals.paragraphsKept > 0 ||
@@ -359,7 +360,9 @@ export const run = async ({
     llmUsageTotals.totalTokens += usage.totalTokens;
   };
 
-  const accumulateBrainstormUsage = (usage: LlmExtractionUsage | null): void => {
+  const accumulateBrainstormUsage = (
+    usage: LlmExtractionUsage | null,
+  ): void => {
     if (!usage) {
       return;
     }
@@ -577,7 +580,9 @@ export const run = async ({
     exemplarsObservability = {
       requestedCount: cfg.fewShotExemplarCount,
       resolvedCount: resolvedExemplars.length,
-      appliedArchetypes: resolvedExemplars.map((exemplar) => exemplar.archetype),
+      appliedArchetypes: resolvedExemplars.map(
+        (exemplar) => exemplar.archetype,
+      ),
     };
     const existingLookup = buildExistingEntityLookup(ctx.existingEntities);
 
@@ -650,8 +655,7 @@ export const run = async ({
               maxChars: cfg.maxContentChars,
               tickerSymbols: truncationTickerContext.tickerSymbols,
               companyAliases: truncationTickerContext.companyAliases,
-              leadParagraphsAlwaysKept:
-                cfg.truncationLeadParagraphsAlwaysKept,
+              leadParagraphsAlwaysKept: cfg.truncationLeadParagraphsAlwaysKept,
               financialKeywordsExtra: cfg.truncationFinancialKeywordsExtra,
             });
             accumulateTruncationMeta(truncationTotals, result.meta);
@@ -781,7 +785,10 @@ export const run = async ({
           policy: cfg.entityGroundingPolicy,
           entityGroundingMinTitleHits: cfg.entityGroundingMinTitleHits,
         });
-        accumulateGroundingCounters(groundingTotals, groundedExtraction.counters);
+        accumulateGroundingCounters(
+          groundingTotals,
+          groundedExtraction.counters,
+        );
         if (cfg.verbose && cfg.entityGroundingPolicy !== "off") {
           log.info(
             {
@@ -792,7 +799,8 @@ export const run = async ({
                 groundedExtraction.counters
                   .relationsDroppedDueToUngroundedEndpoint,
               mentionsDroppedDueToUngroundedEntity:
-                groundedExtraction.counters.mentionsDroppedDueToUngroundedEntity,
+                groundedExtraction.counters
+                  .mentionsDroppedDueToUngroundedEntity,
             },
             "article-analysis entity grounding applied for source",
           );

--- a/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.test.ts
@@ -1,0 +1,186 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  allocateBudget,
+  dropBoilerplateParagraphs,
+  scoreParagraphForTicker,
+  splitParagraphs,
+  truncateArticleForExtraction,
+} from "./article-content-truncator.js";
+
+describe("splitParagraphs", () => {
+  it("splits on double newlines and drops empty blocks", () => {
+    // Act
+    const paragraphs = splitParagraphs("One\n\nTwo\n\n\nThree");
+
+    // Assert
+    expect(paragraphs).toEqual(["One", "Two", "Three"]);
+  });
+
+  it("falls back to sentence boundaries when no paragraph breaks exist", () => {
+    // Act
+    const paragraphs = splitParagraphs(
+      "First sentence here. Second sentence starts now.",
+    );
+
+    // Assert
+    expect(paragraphs).toEqual([
+      "First sentence here.",
+      "Second sentence starts now.",
+    ]);
+  });
+});
+
+describe("dropBoilerplateParagraphs", () => {
+  it("removes short fragments and footer chrome", () => {
+    // Act
+    const kept = dropBoilerplateParagraphs([
+      "Real lead paragraph with enough length to survive the filter.",
+      "Newsletter signup",
+      "Home · Markets · Tech · About",
+    ]);
+
+    // Assert
+    expect(kept).toEqual([
+      "Real lead paragraph with enough length to survive the filter.",
+    ]);
+  });
+});
+
+describe("scoreParagraphForTicker", () => {
+  it("adds higher score for ticker symbols than aliases", () => {
+    // Act
+    const symbolScore = scoreParagraphForTicker(
+      "Shares of AAPL rose after earnings.",
+      ["AAPL"],
+      ["Apple Inc"],
+    );
+    const aliasScore = scoreParagraphForTicker(
+      "Apple Inc reported revenue growth.",
+      ["AAPL"],
+      ["Apple Inc"],
+    );
+
+    // Assert
+    expect(symbolScore).toBeGreaterThan(aliasScore);
+  });
+});
+
+describe("truncateArticleForExtraction", () => {
+  it("keeps the headline and lead paragraphs under a tight budget", () => {
+    // Setup
+    const raw = [
+      "Title",
+      "",
+      "Lead paragraph one with enough words to count as real content.",
+      "",
+      "Lead paragraph two with enough words to count as real content.",
+      "",
+      "Boilerplate footer",
+      "",
+      "Newsletter signup",
+      "",
+      "More content that should not fit in the budget.",
+    ].join("\n");
+
+    // Act
+    const result = truncateArticleForExtraction(raw, {
+      maxChars: 180,
+      tickerSymbols: [],
+      companyAliases: [],
+      leadParagraphsAlwaysKept: 2,
+    });
+
+    // Assert
+    expect(result.content).toContain("Title");
+    expect(result.content).toContain("Lead paragraph one");
+    expect(result.content).toContain("Lead paragraph two");
+    expect(result.content).not.toContain("Newsletter signup");
+    expect(result.content).not.toContain("Boilerplate footer");
+  });
+
+  it("prioritizes ticker-anchored paragraphs after the lead", () => {
+    // Setup
+    const raw = [
+      "Ticker priority headline",
+      "",
+      "Lead paragraph one without ticker mention in this opening block.",
+      "",
+      "Lead paragraph two without ticker mention in this opening block.",
+      "",
+      "Filler paragraph three has generic market commentary only here.",
+      "",
+      "Filler paragraph four has generic market commentary only here.",
+      "",
+      "Apple reported earnings and AAPL shares rose on guidance today.",
+      "",
+      "More filler paragraph six with extra detail that should stay out.",
+    ].join("\n");
+
+    // Act
+    const result = truncateArticleForExtraction(raw, {
+      maxChars: 230,
+      tickerSymbols: ["AAPL"],
+      companyAliases: ["Apple Inc"],
+      leadParagraphsAlwaysKept: 2,
+    });
+
+    // Assert
+    expect(result.content).toContain("Ticker priority headline");
+    expect(result.content).toContain("Lead paragraph one");
+    expect(result.content).toContain("Lead paragraph two");
+    expect(result.content).toContain("AAPL shares rose");
+    expect(result.content).not.toContain("Filler paragraph three");
+    expect(result.content).not.toContain("Filler paragraph four");
+  });
+
+  it("returns cleaned content unchanged when the budget exceeds body length", () => {
+    // Setup
+    const raw = [
+      "Headline",
+      "",
+      "Lead paragraph one with enough words to count as real content.",
+      "",
+      "Lead paragraph two with enough words to count as real content.",
+      "",
+      "Newsletter signup",
+      "",
+      "Closing paragraph with enough words to count as real content here.",
+    ].join("\n");
+    const expectedCleaned = [
+      "Headline",
+      "Lead paragraph one with enough words to count as real content.",
+      "Lead paragraph two with enough words to count as real content.",
+      "Closing paragraph with enough words to count as real content here.",
+    ].join("\n\n");
+
+    // Act
+    const result = truncateArticleForExtraction(raw, {
+      maxChars: expectedCleaned.length + 500,
+      tickerSymbols: [],
+      companyAliases: [],
+      leadParagraphsAlwaysKept: 2,
+    });
+
+    // Assert
+    expect(result.content).toBe(expectedCleaned);
+  });
+});
+
+describe("allocateBudget", () => {
+  it("keeps higher-scored paragraphs before lower-scored ones", () => {
+    // Act
+    const allocated = allocateBudget(
+      null,
+      ["Low score paragraph here.", "AAPL beat earnings expectations."],
+      [0, 3],
+      40,
+      0,
+    );
+
+    // Assert
+    expect(allocated.content).toBe("AAPL beat earnings expectations.");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.ts
@@ -159,15 +159,11 @@ export const scoreParagraphForTicker = (
 ): number => {
   let score = 0;
 
-  if (
-    tickerSymbols.some((symbol) => matchesWordBoundary(paragraph, symbol))
-  ) {
+  if (tickerSymbols.some((symbol) => matchesWordBoundary(paragraph, symbol))) {
     score += 3;
   }
 
-  if (
-    companyAliases.some((alias) => matchesWordBoundary(paragraph, alias))
-  ) {
+  if (companyAliases.some((alias) => matchesWordBoundary(paragraph, alias))) {
     score += 2;
   }
 
@@ -176,9 +172,7 @@ export const scoreParagraphForTicker = (
     ...financialKeywords.map((keyword) => keyword.trim().toLowerCase()),
   ].filter(Boolean);
 
-  if (
-    keywords.some((keyword) => matchesWordBoundary(paragraph, keyword))
-  ) {
+  if (keywords.some((keyword) => matchesWordBoundary(paragraph, keyword))) {
     score += 1;
   }
 

--- a/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.ts
@@ -1,0 +1,466 @@
+const BOILERPLATE_FRAGMENTS = [
+  "share this",
+  "read more",
+  "follow us on",
+  "terms of service",
+  "privacy policy",
+  "cookie policy",
+  "all rights reserved",
+  "sign up for our newsletter",
+] as const;
+
+const DEFAULT_FINANCIAL_KEYWORDS = [
+  "earnings",
+  "revenue",
+  "eps",
+  "guidance",
+  "ceo",
+  "product",
+  "announce",
+] as const;
+
+const NAV_SEPARATOR_PATTERN = /[|·•›>]/g;
+const NAV_SEPARATOR_RATIO_THRESHOLD = 0.08;
+const HEADLINE_MAX_LENGTH = 200;
+const MIN_PARAGRAPH_LENGTH = 25;
+const PARAGRAPH_JOIN = "\n\n";
+
+export type TruncationTickerContext = {
+  tickerSymbols: readonly string[];
+  companyAliases: readonly string[];
+};
+
+export type TruncateArticleForExtractionOptions = {
+  maxChars: number;
+  tickerSymbols?: readonly string[];
+  companyAliases?: readonly string[];
+  leadParagraphsAlwaysKept?: number;
+  financialKeywordsExtra?: readonly string[];
+};
+
+export type TruncateArticleForExtractionMeta = {
+  kept: number;
+  dropped: number;
+  leadCharsKept: number;
+  tickerSentencesKept: number;
+  paragraphsKept: number;
+  paragraphsDropped: number;
+};
+
+export type TruncateArticleForExtractionResult = {
+  content: string;
+  meta: TruncateArticleForExtractionMeta;
+};
+
+type ScoredParagraph = {
+  text: string;
+  index: number;
+  score: number;
+};
+
+/**
+ * Escapes user-provided text for safe use inside a RegExp.
+ *
+ * @param value - Raw string.
+ */
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+/**
+ * Returns whether `needle` appears in `haystack` with word-boundary safety.
+ *
+ * @param haystack - Text to search.
+ * @param needle - Token or phrase to find.
+ */
+const matchesWordBoundary = (haystack: string, needle: string): boolean => {
+  const normalized = needle.trim();
+  if (normalized.length === 0) {
+    return false;
+  }
+
+  const pattern = new RegExp(
+    `(?<![a-z0-9.])${escapeRegExp(normalized)}(?![a-z0-9])`,
+    "i",
+  );
+  return pattern.test(haystack);
+};
+
+/**
+ * Collapses 3+ newlines to 2, splits on double newlines, trims, and drops empties.
+ * Falls back to sentence boundaries when no paragraph breaks exist.
+ *
+ * @param text - Raw article body.
+ */
+export const splitParagraphs = (text: string): string[] => {
+  const normalized = text.replace(/\n{3,}/g, "\n\n").trim();
+  if (normalized.length === 0) {
+    return [];
+  }
+
+  if (/\n{2,}/.test(normalized)) {
+    return normalized
+      .split(/\n{2,}/)
+      .map((paragraph) => paragraph.trim())
+      .filter(Boolean);
+  }
+
+  return normalized
+    .split(/(?<=[.!?])\s+(?=[A-Z])/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+};
+
+/**
+ * Returns whether a paragraph looks like nav crumbs or footer chrome.
+ *
+ * @param paragraph - Candidate paragraph.
+ */
+const isBoilerplateParagraph = (paragraph: string): boolean => {
+  const trimmed = paragraph.trim();
+  if (trimmed.length < MIN_PARAGRAPH_LENGTH) {
+    return true;
+  }
+
+  const lower = trimmed.toLowerCase();
+  if (BOILERPLATE_FRAGMENTS.some((fragment) => lower.includes(fragment))) {
+    return true;
+  }
+
+  const separatorMatches = trimmed.match(NAV_SEPARATOR_PATTERN)?.length ?? 0;
+  const separatorRatio =
+    trimmed.length === 0 ? 0 : separatorMatches / trimmed.length;
+
+  return separatorRatio > NAV_SEPARATOR_RATIO_THRESHOLD;
+};
+
+/**
+ * Removes short fragments, nav crumbs, and canonical footer chrome paragraphs.
+ *
+ * @param paragraphs - Paragraphs in source order.
+ */
+export const dropBoilerplateParagraphs = (
+  paragraphs: readonly string[],
+): string[] =>
+  paragraphs.filter((paragraph) => !isBoilerplateParagraph(paragraph));
+
+/**
+ * Scores a paragraph for ticker, company-alias, and financial-keyword overlap.
+ *
+ * @param paragraph - Paragraph text.
+ * @param tickerSymbols - Exchange symbols to match with word boundaries.
+ * @param companyAliases - Company names and aliases to match.
+ * @param financialKeywords - Extra financial tokens beyond the built-in list.
+ */
+export const scoreParagraphForTicker = (
+  paragraph: string,
+  tickerSymbols: readonly string[],
+  companyAliases: readonly string[],
+  financialKeywords: readonly string[] = [],
+): number => {
+  let score = 0;
+
+  if (
+    tickerSymbols.some((symbol) => matchesWordBoundary(paragraph, symbol))
+  ) {
+    score += 3;
+  }
+
+  if (
+    companyAliases.some((alias) => matchesWordBoundary(paragraph, alias))
+  ) {
+    score += 2;
+  }
+
+  const keywords = [
+    ...DEFAULT_FINANCIAL_KEYWORDS,
+    ...financialKeywords.map((keyword) => keyword.trim().toLowerCase()),
+  ].filter(Boolean);
+
+  if (
+    keywords.some((keyword) => matchesWordBoundary(paragraph, keyword))
+  ) {
+    score += 1;
+  }
+
+  return score;
+};
+
+/**
+ * Extracts an optional headline from the first non-empty line when it is short enough.
+ *
+ * @param text - Raw article body.
+ */
+const extractHeadline = (
+  text: string,
+): { headline: string | null; body: string } => {
+  const normalized = text.replace(/\n{3,}/g, "\n\n").trim();
+  const firstBreak = normalized.search(/\n{2,}/);
+
+  if (firstBreak === -1) {
+    const firstLine = normalized.split("\n")[0]?.trim() ?? "";
+    if (
+      firstLine.length > 0 &&
+      firstLine.length <= HEADLINE_MAX_LENGTH &&
+      normalized.includes("\n")
+    ) {
+      return {
+        headline: firstLine,
+        body: normalized.slice(firstLine.length).trim(),
+      };
+    }
+    return { headline: null, body: normalized };
+  }
+
+  const headline = normalized.slice(0, firstBreak).trim();
+  const body = normalized.slice(firstBreak).trim();
+
+  if (headline.length > 0 && headline.length <= HEADLINE_MAX_LENGTH) {
+    return { headline, body };
+  }
+
+  return { headline: null, body: normalized };
+};
+
+/**
+ * Allocates the character budget across headline, lead paragraphs, and score-ranked body.
+ *
+ * @param headline - Optional headline kept first.
+ * @param paragraphs - Boilerplate-filtered paragraphs in source order.
+ * @param scores - Parallel paragraph scores.
+ * @param maxChars - Maximum output length.
+ * @param leadParagraphsAlwaysKept - Count of opening paragraphs to always retain.
+ */
+export const allocateBudget = (
+  headline: string | null,
+  paragraphs: readonly string[],
+  scores: readonly number[],
+  maxChars: number,
+  leadParagraphsAlwaysKept: number,
+): {
+  content: string;
+  leadCharsKept: number;
+  tickerSentencesKept: number;
+  paragraphsKept: number;
+  paragraphsDropped: number;
+} => {
+  const selected: string[] = [];
+  const selectedIndexes = new Set<number>();
+  let usedChars = 0;
+
+  const tryAdd = (text: string): boolean => {
+    const addition =
+      selected.length === 0 ? text.length : PARAGRAPH_JOIN.length + text.length;
+    if (usedChars + addition > maxChars) {
+      return false;
+    }
+    selected.push(text);
+    usedChars += addition;
+    return true;
+  };
+
+  if (headline !== null) {
+    tryAdd(headline);
+  }
+
+  let leadCharsKept = 0;
+  const leadCount = Math.min(leadParagraphsAlwaysKept, paragraphs.length);
+  for (let index = 0; index < leadCount; index += 1) {
+    const paragraph = paragraphs[index];
+    if (paragraph === undefined || selectedIndexes.has(index)) {
+      continue;
+    }
+    if (tryAdd(paragraph)) {
+      selectedIndexes.add(index);
+      leadCharsKept += paragraph.length;
+    }
+  }
+
+  const remaining = paragraphs
+    .map((text, index) => ({
+      text,
+      index,
+      score: scores[index] ?? 0,
+    }))
+    .filter((entry) => !selectedIndexes.has(entry.index))
+    .sort((left, right) => {
+      if (right.score !== left.score) {
+        return right.score - left.score;
+      }
+      return left.index - right.index;
+    });
+
+  for (const entry of remaining) {
+    if (tryAdd(entry.text)) {
+      selectedIndexes.add(entry.index);
+    }
+  }
+
+  const tickerSentencesKept = [...selectedIndexes].filter(
+    (index) => (scores[index] ?? 0) >= 3,
+  ).length;
+
+  return {
+    content: selected.join(PARAGRAPH_JOIN),
+    leadCharsKept,
+    tickerSentencesKept,
+    paragraphsKept: selectedIndexes.size,
+    paragraphsDropped: paragraphs.length - selectedIndexes.size,
+  };
+};
+
+/**
+ * Builds ticker symbols and company aliases from analysis GET vocabulary.
+ *
+ * @param entityTypes - Entity types from analysis GET.
+ * @param existingEntities - Existing KG entities scoped to the ticker.
+ */
+export const resolveTruncationTickerContext = (
+  entityTypes: readonly { id: string; name: string }[],
+  existingEntities: readonly {
+    canonicalName: string;
+    typeId: string;
+    aliases: readonly string[];
+  }[],
+): TruncationTickerContext => {
+  const companyType = entityTypes.find(
+    (entityType) => entityType.name.toLowerCase() === "company",
+  );
+  const companyEntities = companyType
+    ? existingEntities.filter((entity) => entity.typeId === companyType.id)
+    : existingEntities;
+
+  const tickerSymbols: string[] = [];
+  const companyAliases: string[] = [];
+  const seenSymbols = new Set<string>();
+  const seenAliases = new Set<string>();
+
+  for (const entity of companyEntities) {
+    const canonical = entity.canonicalName.trim();
+    const symbolKey = canonical.toLowerCase();
+    if (canonical.length > 0 && !seenSymbols.has(symbolKey)) {
+      seenSymbols.add(symbolKey);
+      tickerSymbols.push(canonical);
+    }
+
+    for (const alias of [entity.canonicalName, ...entity.aliases]) {
+      const trimmed = alias.trim();
+      const aliasKey = trimmed.toLowerCase();
+      if (trimmed.length > 0 && !seenAliases.has(aliasKey)) {
+        seenAliases.add(aliasKey);
+        companyAliases.push(trimmed);
+      }
+    }
+  }
+
+  return { tickerSymbols, companyAliases };
+};
+
+/**
+ * Truncates article content for LLM extraction using structure-aware paragraph selection.
+ *
+ * @param rawContent - Full article body from the data source.
+ * @param options - Character budget, ticker context, and tuning knobs.
+ */
+export const truncateArticleForExtraction = (
+  rawContent: string,
+  options: TruncateArticleForExtractionOptions,
+): TruncateArticleForExtractionResult => {
+  const leadParagraphsAlwaysKept = options.leadParagraphsAlwaysKept ?? 2;
+  const tickerSymbols = options.tickerSymbols ?? [];
+  const companyAliases = options.companyAliases ?? [];
+  const financialKeywordsExtra = options.financialKeywordsExtra ?? [];
+
+  const { headline, body } = extractHeadline(rawContent);
+  const paragraphs = splitParagraphs(body);
+  const cleanedParagraphs = dropBoilerplateParagraphs(paragraphs);
+  const cleanedContent =
+    headline === null
+      ? cleanedParagraphs.join(PARAGRAPH_JOIN)
+      : [headline, ...cleanedParagraphs].join(PARAGRAPH_JOIN);
+
+  if (options.maxChars >= cleanedContent.length) {
+    return {
+      content: cleanedContent,
+      meta: {
+        kept: cleanedContent.length,
+        dropped: Math.max(0, rawContent.length - cleanedContent.length),
+        leadCharsKept: cleanedParagraphs
+          .slice(0, leadParagraphsAlwaysKept)
+          .reduce((sum, paragraph) => sum + paragraph.length, 0),
+        tickerSentencesKept: cleanedParagraphs.filter(
+          (paragraph) =>
+            scoreParagraphForTicker(
+              paragraph,
+              tickerSymbols,
+              companyAliases,
+              financialKeywordsExtra,
+            ) >= 3,
+        ).length,
+        paragraphsKept: cleanedParagraphs.length,
+        paragraphsDropped: paragraphs.length - cleanedParagraphs.length,
+      },
+    };
+  }
+
+  const scores = cleanedParagraphs.map((paragraph) =>
+    scoreParagraphForTicker(
+      paragraph,
+      tickerSymbols,
+      companyAliases,
+      financialKeywordsExtra,
+    ),
+  );
+
+  const allocated = allocateBudget(
+    headline,
+    cleanedParagraphs,
+    scores,
+    options.maxChars,
+    leadParagraphsAlwaysKept,
+  );
+
+  return {
+    content: allocated.content,
+    meta: {
+      kept: allocated.content.length,
+      dropped: Math.max(0, rawContent.length - allocated.content.length),
+      leadCharsKept: allocated.leadCharsKept,
+      tickerSentencesKept: allocated.tickerSentencesKept,
+      paragraphsKept: allocated.paragraphsKept,
+      paragraphsDropped:
+        allocated.paragraphsDropped +
+        (paragraphs.length - cleanedParagraphs.length),
+    },
+  };
+};
+
+/**
+ * Returns zeroed truncation totals for run-level observability aggregation.
+ */
+export const createEmptyTruncationTotals =
+  (): TruncateArticleForExtractionMeta => ({
+    kept: 0,
+    dropped: 0,
+    leadCharsKept: 0,
+    tickerSentencesKept: 0,
+    paragraphsKept: 0,
+    paragraphsDropped: 0,
+  });
+
+/**
+ * Adds one source-level truncation meta into running batch totals.
+ *
+ * @param totals - Mutable aggregate updated in place.
+ * @param meta - Per-source truncation meta.
+ */
+export const accumulateTruncationMeta = (
+  totals: TruncateArticleForExtractionMeta,
+  meta: TruncateArticleForExtractionMeta,
+): void => {
+  totals.kept += meta.kept;
+  totals.dropped += meta.dropped;
+  totals.leadCharsKept += meta.leadCharsKept;
+  totals.tickerSentencesKept += meta.tickerSentencesKept;
+  totals.paragraphsKept += meta.paragraphsKept;
+  totals.paragraphsDropped += meta.paragraphsDropped;
+};

--- a/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.test.ts
@@ -1,0 +1,220 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyNonArticleSource,
+  countRepeatedShingles,
+  createEmptyQualityCounters,
+  runArticleQualityGate,
+} from "./content-quality-gate.js";
+
+/** Builds article-like body text with at least 120 unique words. */
+const cleanArticleBody = (): string =>
+  [
+    "Bank Central Asia announced strategic expansion plans across regional markets.",
+    "The company reported improved margins, higher loan growth, and stronger risk controls.",
+    ...Array.from(
+      { length: 130 },
+      (_, index) =>
+        `Analyst note ${index} discusses lending trends and deposit growth in Indonesia.`,
+    ),
+  ].join(" ");
+
+/** Builds paywall stub text with low alphabetic density. */
+const paywallBody = (): string =>
+  "!!! $$$ ### subscribe to read !!! $$$ ### ".repeat(25);
+
+/** Builds soft-404 stub text under the length threshold. */
+const soft404Body = (): string => `Sorry, page not found. ${"x".repeat(200)}`;
+
+/** Builds body text below the minimum word count. */
+const shortBody = (): string => "word ".repeat(50);
+
+/** Builds nav-heavy body where one six-word shingle exceeds 18% of shingles. */
+const repetitiveBody = (): string => "home about contact ".repeat(300);
+
+describe("createEmptyQualityCounters", () => {
+  it("returns zeroed counters for every drop reason", () => {
+    // Act
+    const counters = createEmptyQualityCounters();
+
+    // Assert
+    expect(counters).toEqual({
+      prefilter_blocked_host: 0,
+      prefilter_blocked_path: 0,
+      prefilter_index_title: 0,
+      content_no_title: 0,
+      content_soft_404: 0,
+      content_access_gated: 0,
+      content_too_short: 0,
+      content_repetitive: 0,
+    });
+  });
+});
+
+describe("countRepeatedShingles", () => {
+  it("returns zero when content has fewer words than the shingle width", () => {
+    // Act
+    const fraction = countRepeatedShingles("one two three", 6);
+
+    // Assert
+    expect(fraction).toBe(0);
+  });
+});
+
+describe("runArticleQualityGate", () => {
+  it("allows clean article content", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/article",
+      "Bank Central Asia expands regional operations",
+      cleanArticleBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({ blocked: false });
+    expect(
+      classifyNonArticleSource(
+        "https://example.com/article",
+        "Bank Central Asia expands regional operations",
+        cleanArticleBody(),
+      ),
+    ).toBeNull();
+  });
+
+  it("blocks empty or challenge-page titles first", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/challenge",
+      "Just a moment...",
+      cleanArticleBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_no_title",
+    });
+  });
+
+  it("blocks titles shorter than twelve characters", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/short-title",
+      "Short",
+      cleanArticleBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_no_title",
+    });
+  });
+
+  it("blocks known quote pages via URL prefilter", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://finance.yahoo.com/quote/BBCA.JK/",
+      "BBCA Quote Page Title Here",
+      cleanArticleBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "prefilter_blocked_path",
+    });
+  });
+
+  it("blocks index-like title markers", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/news/earnings-update",
+      "Company profile and key statistics",
+      cleanArticleBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "prefilter_index_title",
+    });
+  });
+
+  it("blocks soft-404 pages with short bodies", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/missing",
+      "Missing article headline here",
+      soft404Body(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_soft_404",
+    });
+  });
+
+  it("blocks paywall stubs with low alphabetic density", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/paywall",
+      "Premium article headline here",
+      paywallBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_access_gated",
+    });
+  });
+
+  it("blocks bodies below the minimum word count", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/stub",
+      "Wire stub headline here",
+      shortBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_too_short",
+    });
+  });
+
+  it("blocks nav-heavy repetitive boilerplate", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/shadow",
+      "Shadow article skeleton headline",
+      repetitiveBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_repetitive",
+    });
+  });
+
+  it("returns the first matching rule only", () => {
+    // Act
+    const decision = runArticleQualityGate(
+      "https://example.com/challenge",
+      "Access denied",
+      shortBody(),
+    );
+
+    // Assert
+    expect(decision).toEqual({
+      blocked: true,
+      reason: "content_no_title",
+    });
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.ts
@@ -1,0 +1,340 @@
+import { classifyNoisyUrl } from "@workspace/utils";
+
+const NON_ARTICLE_TITLE_MARKERS = [
+  "key statistics",
+  "historical data",
+  "financial summary",
+  "company profile",
+  "consensus estimates",
+] as const;
+
+const BLOCKED_TITLES = [
+  "just a moment...",
+  "attention required! | cloudflare",
+  "access denied",
+  "403 forbidden",
+  "page not found",
+  "are you a robot",
+] as const;
+
+const SOFT_NOT_FOUND_PHRASES = [
+  "page not found",
+  "404 not found",
+  "this page doesn't exist",
+  "the page you requested could not be found",
+  "we can't find that page",
+] as const;
+
+const ACCESS_GATED_PHRASES = [
+  "subscribe to read",
+  "subscribers only",
+  "sign in to continue reading",
+  "create a free account to continue",
+  "log in to read",
+  "enable cookies",
+  "enable javascript",
+  "please disable your ad blocker",
+] as const;
+
+const MIN_TITLE_LENGTH = 12;
+const MIN_WORD_COUNT = 120;
+const SOFT_404_MAX_LENGTH = 1500;
+const MIN_ALPHA_DENSITY = 0.55;
+const REPETITION_SHINGLE_SIZE = 6;
+const REPETITION_THRESHOLD = 0.18;
+
+export type QualityDropReason =
+  | "prefilter_blocked_host"
+  | "prefilter_blocked_path"
+  | "prefilter_index_title"
+  | "content_no_title"
+  | "content_soft_404"
+  | "content_access_gated"
+  | "content_too_short"
+  | "content_repetitive";
+
+/** @deprecated Use {@link QualityDropReason} */
+export type NonArticleReason = QualityDropReason;
+
+export type QualityDecision =
+  | { blocked: true; reason: QualityDropReason }
+  | { blocked: false };
+
+type QualityRuleContext = {
+  url: string;
+  title: string;
+  content: string;
+};
+
+type QualityRule = (ctx: QualityRuleContext) => QualityDecision;
+
+/**
+ * Returns an empty counter map with one bucket per quality-gate drop reason.
+ *
+ * @returns Zeroed counters for all {@link QualityDropReason} values.
+ */
+export const createEmptyQualityCounters = (): Record<
+  QualityDropReason,
+  number
+> => ({
+  prefilter_blocked_host: 0,
+  prefilter_blocked_path: 0,
+  prefilter_index_title: 0,
+  content_no_title: 0,
+  content_soft_404: 0,
+  content_access_gated: 0,
+  content_too_short: 0,
+  content_repetitive: 0,
+});
+
+/**
+ * Returns whether `haystack` contains any phrase from `needles` (case-insensitive).
+ *
+ * @param haystack - Text to search.
+ * @param needles - Phrases to look for.
+ */
+const includesAnyPhrase = (
+  haystack: string,
+  needles: readonly string[],
+): boolean => {
+  const lowerHaystack = haystack.toLowerCase();
+  return needles.some((needle) => lowerHaystack.includes(needle.toLowerCase()));
+};
+
+/**
+ * Computes the ratio of alphabetic characters to total characters.
+ *
+ * @param text - Input text.
+ */
+const computeAlphaDensity = (text: string): number => {
+  if (text.length === 0) {
+    return 0;
+  }
+  const alphaCount = (text.match(/[a-zA-Z]/g) ?? []).length;
+  return alphaCount / text.length;
+};
+
+/**
+ * Strips URLs and collapses whitespace for prose-density checks.
+ *
+ * @param content - Raw page body.
+ */
+const normalizeProseContent = (content: string): string =>
+  content
+    .replace(/https?:\/\/[^\s]+/gi, " ")
+    .replace(/www\.[^\s]+/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/**
+ * Returns the largest share of identical n-word shingles in `content`.
+ *
+ * @param content - Body text to analyze.
+ * @param n - Shingle width in words (default 6).
+ */
+export const countRepeatedShingles = (
+  content: string,
+  n = REPETITION_SHINGLE_SIZE,
+): number => {
+  const words = content.split(/\s+/).filter(Boolean);
+  if (words.length < n) {
+    return 0;
+  }
+
+  const counts = new Map<string, number>();
+  for (let index = 0; index <= words.length - n; index += 1) {
+    const shingle = words
+      .slice(index, index + n)
+      .join(" ")
+      .toLowerCase();
+    counts.set(shingle, (counts.get(shingle) ?? 0) + 1);
+  }
+
+  const totalShingles = words.length - n + 1;
+  let maxCount = 0;
+  for (const count of counts.values()) {
+    if (count > maxCount) {
+      maxCount = count;
+    }
+  }
+
+  return maxCount / totalShingles;
+};
+
+/**
+ * Blocks pages with missing, too-short, or known challenge-page titles.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const titleEmptyOrTooShort = (ctx: QualityRuleContext): QualityDecision => {
+  const trimmed = ctx.title.trim();
+  const normalizedTitle = trimmed.toLowerCase();
+  const matchesBlockedTitle = BLOCKED_TITLES.some(
+    (blocked) => blocked === normalizedTitle,
+  );
+
+  if (trimmed.length < MIN_TITLE_LENGTH || matchesBlockedTitle) {
+    return { blocked: true, reason: "content_no_title" };
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Blocks known non-article hosts and URL path patterns.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const blockedUrl = (ctx: QualityRuleContext): QualityDecision => {
+  try {
+    new URL(ctx.url);
+  } catch {
+    return { blocked: false };
+  }
+
+  const urlDecision = classifyNoisyUrl(ctx.url);
+  if (!urlDecision.blocked) {
+    return { blocked: false };
+  }
+
+  if (urlDecision.reason === "blocked_host") {
+    return { blocked: true, reason: "prefilter_blocked_host" };
+  }
+
+  return { blocked: true, reason: "prefilter_blocked_path" };
+};
+
+/**
+ * Blocks index-like financial summary titles.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const indexLikeTitle = (ctx: QualityRuleContext): QualityDecision => {
+  const titleLower = ctx.title.toLowerCase();
+  if (
+    NON_ARTICLE_TITLE_MARKERS.some((marker) => titleLower.includes(marker))
+  ) {
+    return { blocked: true, reason: "prefilter_index_title" };
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Blocks soft-404 pages that mention missing content in a short body.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const softNotFound = (ctx: QualityRuleContext): QualityDecision => {
+  const normalized = ctx.content.trim();
+  if (
+    normalized.length < SOFT_404_MAX_LENGTH &&
+    includesAnyPhrase(normalized, SOFT_NOT_FOUND_PHRASES)
+  ) {
+    return { blocked: true, reason: "content_soft_404" };
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Blocks paywall, login, and cookie-wall stubs with thin prose density.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const accessGated = (ctx: QualityRuleContext): QualityDecision => {
+  const normalized = ctx.content.trim();
+  if (
+    includesAnyPhrase(normalized, ACCESS_GATED_PHRASES) &&
+    computeAlphaDensity(normalized) < MIN_ALPHA_DENSITY
+  ) {
+    return { blocked: true, reason: "content_access_gated" };
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Blocks bodies with fewer than the minimum word count after URL stripping.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const proseDensity = (ctx: QualityRuleContext): QualityDecision => {
+  const normalized = normalizeProseContent(ctx.content);
+  const wordCount = normalized.split(/\s+/).filter(Boolean).length;
+
+  if (wordCount < MIN_WORD_COUNT) {
+    return { blocked: true, reason: "content_too_short" };
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Blocks nav-heavy pages where one phrase repeats across most shingles.
+ *
+ * @param ctx - URL, title, and content under test.
+ */
+const repetitiveBoilerplate = (ctx: QualityRuleContext): QualityDecision => {
+  if (countRepeatedShingles(ctx.content) > REPETITION_THRESHOLD) {
+    return { blocked: true, reason: "content_repetitive" };
+  }
+
+  return { blocked: false };
+};
+
+const qualityRules: QualityRule[] = [
+  titleEmptyOrTooShort,
+  blockedUrl,
+  indexLikeTitle,
+  softNotFound,
+  accessGated,
+  proseDensity,
+  repetitiveBoilerplate,
+];
+
+/**
+ * Runs the article quality gate rule chain; the first matching rule wins.
+ *
+ * @param url - Data source URL.
+ * @param title - Source title.
+ * @param content - Source body (raw, not truncated for LLM).
+ * @returns Decision indicating whether the source should skip LLM extraction.
+ */
+export const runArticleQualityGate = (
+  url: string,
+  title: string,
+  content: string,
+): QualityDecision => {
+  const ctx: QualityRuleContext = { url, title, content };
+
+  for (const rule of qualityRules) {
+    const decision = rule(ctx);
+    if (decision.blocked) {
+      return decision;
+    }
+  }
+
+  return { blocked: false };
+};
+
+/**
+ * Classifies whether a source is clearly non-article before running extraction.
+ *
+ * @param sourceUrl - Data source URL.
+ * @param sourceTitle - Source title.
+ * @param sourceContent - Source content.
+ * @returns Null for likely article content, otherwise a concrete drop reason.
+ */
+export const classifyNonArticleSource = (
+  sourceUrl: string,
+  sourceTitle: string,
+  sourceContent: string,
+): QualityDropReason | null => {
+  const decision = runArticleQualityGate(
+    sourceUrl,
+    sourceTitle,
+    sourceContent,
+  );
+  return decision.blocked ? decision.reason : null;
+};

--- a/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.ts
@@ -211,9 +211,7 @@ const blockedUrl = (ctx: QualityRuleContext): QualityDecision => {
  */
 const indexLikeTitle = (ctx: QualityRuleContext): QualityDecision => {
   const titleLower = ctx.title.toLowerCase();
-  if (
-    NON_ARTICLE_TITLE_MARKERS.some((marker) => titleLower.includes(marker))
-  ) {
+  if (NON_ARTICLE_TITLE_MARKERS.some((marker) => titleLower.includes(marker))) {
     return { blocked: true, reason: "prefilter_index_title" };
   }
 
@@ -331,10 +329,6 @@ export const classifyNonArticleSource = (
   sourceTitle: string,
   sourceContent: string,
 ): QualityDropReason | null => {
-  const decision = runArticleQualityGate(
-    sourceUrl,
-    sourceTitle,
-    sourceContent,
-  );
+  const decision = runArticleQualityGate(sourceUrl, sourceTitle, sourceContent);
   return decision.blocked ? decision.reason : null;
 };

--- a/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.test.ts
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { EntityProposal } from "../analysis-vocabulary.js";
+import {
+  isAcronymName,
+  isLooseMatch,
+  stripCorporateSuffixes,
+  verifyEntityGrounding,
+} from "./entity-grounding.js";
+
+const TYPE_ID = "11111111-1111-4111-a111-111111111111";
+
+const entity = (
+  canonicalName: string,
+  aliases: string[] = [],
+): EntityProposal => ({
+  canonicalName,
+  typeId: TYPE_ID,
+  description: null,
+  aliases,
+});
+
+describe("stripCorporateSuffixes", () => {
+  it("removes Inc suffix from company names", () => {
+    expect(stripCorporateSuffixes("Apple Inc.")).toBe("Apple");
+  });
+});
+
+describe("isAcronymName", () => {
+  it("treats short and all-caps names as acronyms", () => {
+    expect(isAcronymName("IBM")).toBe(true);
+    expect(isAcronymName("CEO")).toBe(true);
+    expect(isAcronymName("Apple")).toBe(false);
+  });
+});
+
+describe("isLooseMatch", () => {
+  it("matches suffix-stripped company names against shorter body text", () => {
+    expect(isLooseMatch("Apple Inc.", "Shares of Apple rose today.")).not.toBeNull();
+  });
+
+  it("does not loose-match acronyms against punctuated variants", () => {
+    expect(isLooseMatch("IBM", "I.B.M. reported earnings.")).toBeNull();
+  });
+});
+
+describe("verifyEntityGrounding", () => {
+  it("grounds Apple Inc. when the body contains Apple", () => {
+    const result = verifyEntityGrounding({
+      entity: entity("Apple Inc."),
+      articleText: "Shares of Apple rose after earnings.",
+      title: "Market wrap",
+    });
+
+    expect(result.grounded).toBe(true);
+    expect(result.matchedAlias).toBe("Apple Inc.");
+    expect(result.matchedIn).toBe("body");
+  });
+
+  it("does not ground IBM when the body only contains I.B.M.", () => {
+    const result = verifyEntityGrounding({
+      entity: entity("IBM"),
+      articleText: "I.B.M. reported earnings.",
+      title: "Tech headline today",
+    });
+
+    expect(result.grounded).toBe(false);
+    expect(result.matchedAlias).toBeNull();
+    expect(result.matchedIn).toBeNull();
+  });
+
+  it("grounds Tesla when the name appears only in the title", () => {
+    const result = verifyEntityGrounding({
+      entity: entity("Tesla"),
+      articleText: "Electric vehicle demand softened in Europe.",
+      title: "Tesla cuts prices in key markets",
+    });
+
+    expect(result.grounded).toBe(true);
+    expect(result.matchedAlias).toBe("Tesla");
+    expect(result.matchedIn).toBe("title");
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.test.ts
@@ -37,7 +37,9 @@ describe("isAcronymName", () => {
 
 describe("isLooseMatch", () => {
   it("matches suffix-stripped company names against shorter body text", () => {
-    expect(isLooseMatch("Apple Inc.", "Shares of Apple rose today.")).not.toBeNull();
+    expect(
+      isLooseMatch("Apple Inc.", "Shares of Apple rose today."),
+    ).not.toBeNull();
   });
 
   it("does not loose-match acronyms against punctuated variants", () => {

--- a/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.ts
@@ -1,0 +1,381 @@
+import type { ArticleMentionProposal } from "../analysis-article-mentions.js";
+import type {
+  EntityProposal,
+  RelationProposal,
+} from "../analysis-vocabulary.js";
+import { normalizeEntityName } from "../normalize-entity-name.js";
+
+/** How ungrounded entities are handled after LLM extraction. */
+export type EntityGroundingPolicy = "drop" | "flag" | "off";
+
+/** Result of verifying one entity against article title and body. */
+export type EntityGroundingResult = {
+  grounded: boolean;
+  matchedAlias: string | null;
+  matchedIn: "title" | "body" | null;
+};
+
+/** Per-source counters emitted when grounding filters extraction output. */
+export type PerSourceGroundingCounters = {
+  ungroundedEntityCount: number;
+  relationsDroppedDueToUngroundedEndpoint: number;
+  mentionsDroppedDueToUngroundedEntity: number;
+};
+
+/** Run-level grounding totals for observability. */
+export type GroundingObservabilityAggregate = {
+  entitiesUngroundedTotal: number;
+  relationsDroppedTotal: number;
+  mentionsDroppedTotal: number;
+};
+
+/** Max mention confidence for ungrounded entities under the `flag` policy. */
+export const FLAG_POLICY_MAX_MENTION_CONFIDENCE = 0.4;
+
+const CORPORATE_SUFFIXES = [
+  "Inc",
+  "Inc.",
+  "Corp",
+  "Corp.",
+  "Ltd",
+  "Ltd.",
+  "LLC",
+  "LLC.",
+  "plc",
+  "S.A.",
+] as const;
+
+/**
+ * Returns zeroed run-level grounding counters.
+ */
+export const createEmptyGroundingTotals = (): GroundingObservabilityAggregate => ({
+  entitiesUngroundedTotal: 0,
+  relationsDroppedTotal: 0,
+  mentionsDroppedTotal: 0,
+});
+
+/**
+ * Adds per-source grounding counters into run-level totals.
+ *
+ * @param totals - Mutable aggregate updated in place.
+ * @param counters - Counters from one source.
+ */
+export const accumulateGroundingCounters = (
+  totals: GroundingObservabilityAggregate,
+  counters: PerSourceGroundingCounters,
+): void => {
+  totals.entitiesUngroundedTotal += counters.ungroundedEntityCount;
+  totals.relationsDroppedTotal +=
+    counters.relationsDroppedDueToUngroundedEndpoint;
+  totals.mentionsDroppedTotal += counters.mentionsDroppedDueToUngroundedEntity;
+};
+
+/**
+ * Returns whether a name should use exact matching only (no suffix/whitespace loosening).
+ *
+ * @param name - Candidate entity name or alias.
+ */
+export const isAcronymName = (name: string): boolean => {
+  const trimmed = name.trim();
+  if (trimmed.length <= 3) {
+    return true;
+  }
+  return trimmed.length > 0 && trimmed === trimmed.toUpperCase() && /[A-Z]/.test(trimmed);
+};
+
+/**
+ * Collapses internal whitespace to a single space and trims ends.
+ *
+ * @param value - Raw string.
+ */
+export const collapseInnerWhitespace = (value: string): string =>
+  value.replace(/\s+/g, " ").trim();
+
+/**
+ * Strips trailing corporate suffix tokens from an entity name.
+ *
+ * @param name - Raw entity name or alias.
+ */
+export const stripCorporateSuffixes = (name: string): string => {
+  let result = name.trim();
+  for (const suffix of CORPORATE_SUFFIXES) {
+    const escaped = suffix.replaceAll(".", "\\.");
+    const pattern = new RegExp(`\\s+${escaped}$`, "i");
+    result = result.replace(pattern, "").trim();
+  }
+  return result;
+};
+
+/**
+ * Normalizes text for grounding substring checks (trim, lowercase, collapsed whitespace).
+ *
+ * @param value - Raw string from the article or entity label.
+ */
+export const normalizeForGroundingMatch = (value: string): string =>
+  normalizeEntityName(collapseInnerWhitespace(value));
+
+/**
+ * Finds an exact normalized substring of `name` inside `haystack`.
+ *
+ * @param name - Needle entity name or alias.
+ * @param haystack - Title or body text.
+ * @returns The original-casing matched span from `haystack`, or `null`.
+ */
+export const findExactNormalizedSubstring = (
+  name: string,
+  haystack: string,
+): string | null => {
+  const needle = normalizeForGroundingMatch(name);
+  if (needle.length === 0) {
+    return null;
+  }
+  const normalizedHaystack = normalizeForGroundingMatch(haystack);
+  const index = normalizedHaystack.indexOf(needle);
+  if (index === -1) {
+    return null;
+  }
+  return haystack.slice(index, index + needle.length);
+};
+
+/**
+ * Performs relaxed grounding match: exact substring, optional suffix strip, whitespace collapse.
+ * Acronyms use exact normalized substring only.
+ *
+ * @param name - Entity canonical name or alias to locate.
+ * @param haystack - Title or article body text.
+ * @returns Matched span from `haystack`, or `null` when no rule matches.
+ */
+export const isLooseMatch = (name: string, haystack: string): string | null => {
+  const exact = findExactNormalizedSubstring(name, haystack);
+  if (exact !== null) {
+    return exact;
+  }
+
+  if (isAcronymName(name)) {
+    return null;
+  }
+
+  const suffixStripped = stripCorporateSuffixes(name);
+  if (suffixStripped !== name.trim()) {
+    const strippedMatch = findExactNormalizedSubstring(suffixStripped, haystack);
+    if (strippedMatch !== null) {
+      return strippedMatch;
+    }
+  }
+
+  const collapsedHaystack = normalizeForGroundingMatch(haystack);
+  const needle = normalizeForGroundingMatch(name);
+  if (needle.length > 0 && collapsedHaystack.includes(needle)) {
+    return name.trim();
+  }
+
+  const strippedNeedle = normalizeForGroundingMatch(suffixStripped);
+  if (
+    strippedNeedle.length > 0 &&
+    strippedNeedle !== needle &&
+    collapsedHaystack.includes(strippedNeedle)
+  ) {
+    return suffixStripped;
+  }
+
+  return null;
+};
+
+/**
+ * Verifies whether an extracted entity appears in the article title or full body.
+ *
+ * @param params - Entity proposal, full article text, title, and optional title-hit requirement.
+ */
+export const verifyEntityGrounding = (params: {
+  entity: EntityProposal;
+  articleText: string;
+  title: string;
+  entityGroundingMinTitleHits?: number;
+}): EntityGroundingResult => {
+  const candidates = [
+    params.entity.canonicalName,
+    ...params.entity.aliases,
+  ];
+  let bodyMatch: { alias: string } | null = null;
+  let titleMatch: { alias: string } | null = null;
+
+  for (const alias of candidates) {
+    if (bodyMatch === null && isLooseMatch(alias, params.articleText) !== null) {
+      bodyMatch = { alias };
+    }
+    if (titleMatch === null && isLooseMatch(alias, params.title) !== null) {
+      titleMatch = { alias };
+    }
+  }
+
+  const minTitleHits = params.entityGroundingMinTitleHits ?? 0;
+  if (minTitleHits > 0) {
+    if (titleMatch === null) {
+      return { grounded: false, matchedAlias: null, matchedIn: null };
+    }
+    return {
+      grounded: true,
+      matchedAlias: titleMatch.alias,
+      matchedIn: "title",
+    };
+  }
+
+  if (bodyMatch !== null) {
+    return {
+      grounded: true,
+      matchedAlias: bodyMatch.alias,
+      matchedIn: "body",
+    };
+  }
+  if (titleMatch !== null) {
+    return {
+      grounded: true,
+      matchedAlias: titleMatch.alias,
+      matchedIn: "title",
+    };
+  }
+
+  return { grounded: false, matchedAlias: null, matchedIn: null };
+};
+
+/**
+ * Builds the normalized set of grounded entity canonical names.
+ *
+ * @param entities - Extracted entities.
+ * @param articleText - Full article body (not truncated prompt text).
+ * @param title - Article title.
+ * @param entityGroundingMinTitleHits - Strict title requirement when greater than zero.
+ */
+export const buildGroundedCanonicalNameSet = (
+  entities: readonly EntityProposal[],
+  articleText: string,
+  title: string,
+  entityGroundingMinTitleHits: number,
+): Set<string> => {
+  const grounded = new Set<string>();
+  for (const entity of entities) {
+    const result = verifyEntityGrounding({
+      entity,
+      articleText,
+      title,
+      entityGroundingMinTitleHits,
+    });
+    if (result.grounded) {
+      grounded.add(normalizeEntityName(entity.canonicalName));
+    }
+  }
+  return grounded;
+};
+
+/**
+ * Applies post-extraction entity grounding to entities, relations, and mentions.
+ *
+ * @param params - Raw LLM extraction slice, policy knobs, and article ground-truth text.
+ */
+export const applyExtractionEntityGrounding = (params: {
+  entities: readonly EntityProposal[];
+  relations: readonly RelationProposal[];
+  mentions: readonly ArticleMentionProposal[];
+  articleText: string;
+  title: string;
+  policy: EntityGroundingPolicy;
+  entityGroundingMinTitleHits: number;
+}): {
+  entities: EntityProposal[];
+  relations: RelationProposal[];
+  mentions: ArticleMentionProposal[];
+  counters: PerSourceGroundingCounters;
+} => {
+  if (params.policy === "off") {
+    return {
+      entities: [...params.entities],
+      relations: [...params.relations],
+      mentions: [...params.mentions],
+      counters: {
+        ungroundedEntityCount: 0,
+        relationsDroppedDueToUngroundedEndpoint: 0,
+        mentionsDroppedDueToUngroundedEntity: 0,
+      },
+    };
+  }
+
+  const groundedNames = buildGroundedCanonicalNameSet(
+    params.entities,
+    params.articleText,
+    params.title,
+    params.entityGroundingMinTitleHits,
+  );
+
+  const groundedEntities: EntityProposal[] = [];
+  const flaggedEntities: EntityProposal[] = [];
+  let ungroundedEntityCount = 0;
+
+  for (const entity of params.entities) {
+    const isGrounded = groundedNames.has(
+      normalizeEntityName(entity.canonicalName),
+    );
+    if (isGrounded) {
+      groundedEntities.push(entity);
+      continue;
+    }
+    ungroundedEntityCount += 1;
+    if (params.policy === "flag") {
+      flaggedEntities.push(entity);
+    }
+  }
+
+  const entitiesAfterPolicy =
+    params.policy === "drop"
+      ? groundedEntities
+      : [...groundedEntities, ...flaggedEntities];
+
+  const relationsAfterGrounding: RelationProposal[] = [];
+  let relationsDroppedDueToUngroundedEndpoint = 0;
+  for (const relation of params.relations) {
+    const fromGrounded = groundedNames.has(
+      normalizeEntityName(relation.fromEntityName),
+    );
+    const toGrounded = groundedNames.has(
+      normalizeEntityName(relation.toEntityName),
+    );
+    if (fromGrounded && toGrounded) {
+      relationsAfterGrounding.push(relation);
+    } else {
+      relationsDroppedDueToUngroundedEndpoint += 1;
+    }
+  }
+
+  const mentionsAfterGrounding: ArticleMentionProposal[] = [];
+  let mentionsDroppedDueToUngroundedEntity = 0;
+  for (const mention of params.mentions) {
+    const mentionGrounded = groundedNames.has(
+      normalizeEntityName(mention.entityName),
+    );
+    if (!mentionGrounded) {
+      if (params.policy === "flag") {
+        mentionsAfterGrounding.push({
+          ...mention,
+          confidence: Math.min(
+            mention.confidence,
+            FLAG_POLICY_MAX_MENTION_CONFIDENCE,
+          ),
+        });
+        continue;
+      }
+      mentionsDroppedDueToUngroundedEntity += 1;
+      continue;
+    }
+    mentionsAfterGrounding.push(mention);
+  }
+
+  return {
+    entities: entitiesAfterPolicy,
+    relations: relationsAfterGrounding,
+    mentions: mentionsAfterGrounding,
+    counters: {
+      ungroundedEntityCount,
+      relationsDroppedDueToUngroundedEndpoint,
+      mentionsDroppedDueToUngroundedEntity,
+    },
+  };
+};

--- a/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.ts
@@ -48,11 +48,12 @@ const CORPORATE_SUFFIXES = [
 /**
  * Returns zeroed run-level grounding counters.
  */
-export const createEmptyGroundingTotals = (): GroundingObservabilityAggregate => ({
-  entitiesUngroundedTotal: 0,
-  relationsDroppedTotal: 0,
-  mentionsDroppedTotal: 0,
-});
+export const createEmptyGroundingTotals =
+  (): GroundingObservabilityAggregate => ({
+    entitiesUngroundedTotal: 0,
+    relationsDroppedTotal: 0,
+    mentionsDroppedTotal: 0,
+  });
 
 /**
  * Adds per-source grounding counters into run-level totals.
@@ -80,7 +81,11 @@ export const isAcronymName = (name: string): boolean => {
   if (trimmed.length <= 3) {
     return true;
   }
-  return trimmed.length > 0 && trimmed === trimmed.toUpperCase() && /[A-Z]/.test(trimmed);
+  return (
+    trimmed.length > 0 &&
+    trimmed === trimmed.toUpperCase() &&
+    /[A-Z]/.test(trimmed)
+  );
 };
 
 /**
@@ -157,7 +162,10 @@ export const isLooseMatch = (name: string, haystack: string): string | null => {
 
   const suffixStripped = stripCorporateSuffixes(name);
   if (suffixStripped !== name.trim()) {
-    const strippedMatch = findExactNormalizedSubstring(suffixStripped, haystack);
+    const strippedMatch = findExactNormalizedSubstring(
+      suffixStripped,
+      haystack,
+    );
     if (strippedMatch !== null) {
       return strippedMatch;
     }
@@ -192,15 +200,15 @@ export const verifyEntityGrounding = (params: {
   title: string;
   entityGroundingMinTitleHits?: number;
 }): EntityGroundingResult => {
-  const candidates = [
-    params.entity.canonicalName,
-    ...params.entity.aliases,
-  ];
+  const candidates = [params.entity.canonicalName, ...params.entity.aliases];
   let bodyMatch: { alias: string } | null = null;
   let titleMatch: { alias: string } | null = null;
 
   for (const alias of candidates) {
-    if (bodyMatch === null && isLooseMatch(alias, params.articleText) !== null) {
+    if (
+      bodyMatch === null &&
+      isLooseMatch(alias, params.articleText) !== null
+    ) {
       bodyMatch = { alias };
     }
     if (titleMatch === null && isLooseMatch(alias, params.title) !== null) {

--- a/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/analysis.mdx
@@ -55,7 +55,7 @@ Every run emits a structured **info** log with message `article_analysis.run.sum
 | Correlation     | Log child bindings: `component`, `runId`, `tickerId`, and optional Hermes ids (`jobId`, `executionId`, `scheduleId`, `scheduleExecutionId`, `pipelineStepId`) when invoke headers are present                                                                                                                                                                                                                  |
 | Outcome         | `event`, `outcome` (`success` \| `failure`), `runStatus` (when applicable), `semanticFailureReason` for semantic exits (e.g. empty vocabulary, run policy, **`debounce_min_unanalyzed_count`**, **`debounce_min_minutes_since_last_score`**, pre-POST **`relevance_row_validation`**, relevance chunk build **`relevance_chunk_parse`**)                                                                       |
 | Stages          | **`stageMetrics.extract`** (`articlesProcessed`, `articlesSucceeded`, `articlesFailedExtraction`), **`stageMetrics.scorePrepare.schemaValidationFailures`**, **`stageMetrics.persist`** (`postChunkFailures`, `articlesScored`, `articlesSelected`)                                                                                                                                                            |
-| Extraction      | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`**                                                                                                                                                                                                                                                                     |
+| Extraction      | `articlesProcessed`, `extractionSuccessCount`, `extractionFailureCount`, **`extractionFailuresVocabulary`** vs **`extractionFailuresLlm`**, **`droppedByContentQuality`** (per-rule prefilter counters)                                                                                                                                                                                                                                                                     |
 | Validation      | **`relevanceRowValidationFailures`**, **`chunkParseErrors*`**, rolled-up **`schemaValidationFailureCount`**; **`failureCountsByKind`** splits **`llm`**, **`vocabulary`**, **`schemaValidation`**, **`persistenceHttp`**, **`persistenceOther`** from POST failures                                                                                                                                            |
 | Persist         | `postFailureCount`, **`postFailuresByChunkKind`**, **`postFailuresByErrorCategory`** (`agent_data_api_http` vs `unknown`)                                                                                                                                                                                                                                                                                      |
 | KG tallies      | `entitiesCreated`, `entitiesReused`, **`entityReuseRatio`**, `relationsCreated`, `articlesScored`, `articlesSelected`                                                                                                                                                                                                                                                                                          |
@@ -83,6 +83,23 @@ Optional guards reduce thrash when schedules fire more often than needed. All ar
 - **`analysisGetDataSourceLimitMax`** — Upper bound for **`analysis.get`** `limit` (API hard cap **10**). Default **10**; lower it in Hermes **Agent configs** when you want smaller GET batches than `maxBatchSize` / `defaultMaxBatchSize`.
 
 These are **additive** to calendar staggering: prefer running **data-collection** before **article-analysis** so backlog exists when analysis runs.
+
+## Content quality gate
+
+Before LLM extraction, each source runs through a deterministic pre-extraction quality gate in `src/utilities/content-quality-gate.ts` (`runArticleQualityGate`). Rules run in order; the first match wins and the source is skipped with that reason. This mirrors the [data-collection content quality gate](/mediapulse/apps/agents/data-collection#content-quality-gate) (plan 20), but runs at analysis time on bodies that already passed collection — catching challenge pages, soft-404s, paywall stubs, and nav-heavy skeletons that slipped through or only show up as text shape.
+
+| Rule | Drop reason | Example trigger |
+| --- | --- | --- |
+| Title empty or too short | `content_no_title` | Title `Access denied`, `Just a moment...`, or any title under 12 characters |
+| Blocked host | `prefilter_blocked_host` | URL on a known non-article host (e.g. LinkedIn posts) |
+| Blocked path | `prefilter_blocked_path` | URL path patterns such as Yahoo Finance quote pages |
+| Index-like title | `prefilter_index_title` | Title contains financial summary markers (e.g. `key statistics`, `company profile`) |
+| Soft 404 | `content_soft_404` | Body contains `page not found` and is under 1,500 characters |
+| Access gated | `content_access_gated` | Body contains `subscribe to read` with alphabetic density below 55% |
+| Minimum prose | `content_too_short` | Body has fewer than 120 words after URL stripping |
+| Repetitive boilerplate | `content_repetitive` | One six-word shingle accounts for more than 18% of all shingles |
+
+Each run logs a `droppedByContentQuality` breakdown in the `article_analysis.run.summary` structured log so operators can see which gate fires most often. Only `content_soft_404` is hard-delete-eligible alongside URL-based blocks; other content drops are soft-skips because the page may recover (paywall lifted, JS render, transient cookie wall).
 
 ## I/O contract
 

--- a/dev-docs/docs/mediapulse/apps/agents/article-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/article-analysis.mdx
@@ -1,0 +1,78 @@
+---
+title: Article Analysis Agent
+description: Pre-LLM content quality gate reference for the article-analysis agent
+icon: Brain
+---
+
+## Content quality gate
+
+Before LLM extraction, each source runs through a deterministic pre-extraction quality gate in `src/utilities/content-quality-gate.ts` (`runArticleQualityGate`). Rules run in order; the first match wins and the source is skipped with that reason. This mirrors the [data-collection content quality gate](/mediapulse/apps/agents/data-collection#content-quality-gate) (plan 20), but runs at analysis time on bodies that already passed collection — catching challenge pages, soft-404s, paywall stubs, and nav-heavy skeletons that slipped through or only show up as text shape.
+
+| Rule | Drop reason | Example trigger |
+| --- | --- | --- |
+| Title empty or too short | `content_no_title` | Title `Access denied`, `Just a moment...`, or any title under 12 characters |
+| Blocked host | `prefilter_blocked_host` | URL on a known non-article host (e.g. LinkedIn posts) |
+| Blocked path | `prefilter_blocked_path` | URL path patterns such as Yahoo Finance quote pages |
+| Index-like title | `prefilter_index_title` | Title contains financial summary markers (e.g. `key statistics`, `company profile`) |
+| Soft 404 | `content_soft_404` | Body contains `page not found` and is under 1,500 characters |
+| Access gated | `content_access_gated` | Body contains `subscribe to read` with alphabetic density below 55% |
+| Minimum prose | `content_too_short` | Body has fewer than 120 words after URL stripping |
+| Repetitive boilerplate | `content_repetitive` | One six-word shingle accounts for more than 18% of all shingles |
+
+Each run logs a `droppedByContentQuality` breakdown in the `article_analysis.run.summary` structured log so operators can see which gate fires most often. Only `content_soft_404` is hard-delete-eligible alongside URL-based blocks; other content drops are soft-skips because the page may recover (paywall lifted, JS render, transient cookie wall).
+
+## Few-shot exemplars
+
+The extraction prompt can include curated `(article snippet → structured JSON)` pairs so the model sees concrete examples of entity granularity, alias handling, mention confidence, and relation direction. Exemplars live in `src/exemplars/default-extraction-exemplars.ts` and are resolved once per run against the ticker's `entityTypes` / `relationTypes` vocabulary.
+
+| Archetype | When it helps | Example snippet theme |
+| --- | --- | --- |
+| `earnings` | Guidance beats, margin commentary, CFO quotes | Bank reports Q4 beat and raises outlook |
+| `legal` | Regulatory probes, enforcement risk | SEC opens investigation into revenue disclosures |
+| `leadership` | CEO/C-suite transitions | Board names new CEO and founder becomes chairman |
+| `product` | Launches and partnerships | Vendor unveils platform and signs co-sell deal |
+
+Hermes config knobs:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `fewShotExemplarCount` | `0` | How many exemplars to inject (`0` disables few-shot entirely) |
+| `fewShotExemplarArchetypes` | omitted | Optional allow-list of archetypes eligible for selection |
+
+Selection is deterministic: the library order is earnings → legal → leadership → product, and the resolver takes the first N exemplars whose sentinel placeholders (`{{ENTITY_TYPE:COMPANY}}`, `{{RELATION_TYPE:CEO_OF}}`, etc.) map to UUIDs present in the ticker's vocabulary. Archetypes with missing types are skipped rather than substituted with the wrong UUID.
+
+When enabled, each exemplar becomes one `user` turn (snippet) plus one `assistant` turn (JSON output) inserted between the system prompt and the real article user message:
+
+```text
+system → user(exemplar 1) → assistant(JSON 1) → user(exemplar 2) → assistant(JSON 2) → user(real article)
+```
+
+The run summary logs `exemplarsRequestedCount`, `exemplarsResolvedCount`, and `exemplarsApplied` so operators can audit token cost. Bumping `fewShotExemplarCount` from `0` to `2` roughly increases per-source input tokens by 1.5–2× depending on snippet length; output tokens are unchanged.
+
+## Entity grounding
+
+After LLM extraction and vocabulary validation, each entity is verified against the **full** article body (`source.content`) and title — not the truncated text sent to the model. Structure-aware truncation may remove paragraphs from the prompt, but grounding still checks the persisted body so a mention in a dropped paragraph counts as grounded.
+
+Matching is deterministic:
+
+| Rule | Behavior |
+| --- | --- |
+| Exact substring | Case-insensitive match after trim and whitespace collapse (`normalizeEntityName` rules) |
+| Corporate suffix strip | `Apple Inc.` matches body text containing `Apple` |
+| Whitespace collapse | Inner whitespace in the haystack is collapsed before comparison |
+| Acronyms | Names ≤ 3 characters or all-uppercase use exact match only — `IBM` does **not** match `I.B.M.` |
+
+Hermes config:
+
+| Field | Default | Purpose |
+| --- | --- | --- |
+| `entityGroundingPolicy` | `off` | `drop` removes ungrounded entities; `flag` keeps them but caps mention confidence at `0.4` and still drops their relations; `off` is legacy behavior |
+| `entityGroundingMinTitleHits` | `0` | When greater than zero, the entity must appear in the title to count as grounded |
+
+Relations require **both** endpoints to be grounded — even under `flag`, a relation touching an ungrounded entity is dropped. Relevance scoring (`perSourceSignals.entityCount`, `mentionCount`, `avgMentionConfidence`) uses post-grounding counts so ticker salience is not inflated by hallucinated entities.
+
+The run summary includes `grounding.entitiesUngroundedTotal`, `grounding.relationsDroppedTotal`, and `grounding.mentionsDroppedTotal`. Per-source counters are logged at info level when `verbose` is true and grounding is enabled.
+
+## Related docs
+
+- [Analysis Agent](/mediapulse/apps/agents/analysis) — full agent reference (extraction, relevance, observability, config)


### PR DESCRIPTION
## Summary

Article-analysis now filters junk before it hits OpenAI, sends the model a denser article slice, and optionally uses few-shot exemplars, a brainstorm pass, and post-extraction entity grounding. Every new knob defaults to off so production runs behave the same until someone turns a feature on.

## Related issues

Closes #554

## Important changes

- **Pre-LLM quality gate** — deterministic rules for bad titles, soft-404s, paywall stubs, short prose, and nav-bar repetition; per-rule counters in `article_analysis.run.summary`
- **Structure-aware truncation** — keeps headline, lead paragraphs, and ticker-scored paragraphs within `maxContentChars` when `useStructureAwareTruncation` is true
- **Few-shot exemplars** — four hand-authored archetypes (earnings, legal, leadership, product) resolved against ticker vocabulary and injected as user/assistant turns
- **Two-pass brainstorm** — optional `generateText` brainstorm before structured extraction, with fallback to single-pass on failure and separate token accounting
- **Entity grounding** — verifies extracted names against the full article body; `drop` removes hallucinations, `flag` keeps them but caps mention confidence and still drops ungrounded relations

## Other changes

- Dev docs for content quality gate, few-shot exemplars, and entity grounding in `article-analysis.mdx`
- Cross-link from the main analysis agent doc
- `content_soft_404` added to hard-delete-eligible prefilter reasons

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/utilities/content-quality-gate.ts` — pre-LLM rule chain
- `apps/mediapulse/agents/article-analysis/src/utilities/article-content-truncator.ts` — paragraph scoring and budget allocation
- `apps/mediapulse/agents/article-analysis/src/exemplars/` — exemplar library and vocabulary resolver
- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` — brainstorm pass and exemplar message assembly
- `apps/mediapulse/agents/article-analysis/src/utilities/entity-grounding.ts` — substring grounding with suffix strip and acronym rules
- `apps/mediapulse/agents/article-analysis/src/run.ts` — wiring, observability, and per-source counters
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` — all new Hermes config knobs

## How to test

1. `pnpm --filter @mediapulse/article-analysis test` — 186 unit/integration tests should pass
2. `pnpm --filter @mediapulse/article-analysis type:check` — no TypeScript errors
3. Enable knobs individually in Hermes agent config and confirm run summary fields:
   - Quality gate: submit a paywall stub source and check `droppedByContentQuality`
   - Truncation: `useStructureAwareTruncation: true` on a long article
   - Exemplars: `fewShotExemplarCount: 2` and check `exemplarsResolvedCount` in summary
   - Brainstorm: `useBrainstormPass: true` and check `brainstormCalls` / `llmBrainstormPromptTokens`
   - Grounding: `entityGroundingPolicy: "drop"` with a fixture containing a hallucinated entity name
