### PR TITLE
Add parallel extraction, yield observability, and contract cleanup to article-analysis

### DIFF
--- a/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/README.md
+++ b/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/README.md
@@ -23,11 +23,11 @@ Repeat after checking out:
 pnpm dev:hermes
 ```
 
-Use **`focus=prompts`** so the screenshot shows only the prompt textareas (not the full 30+ field config):
+Use **`focus=prompts`** so the screenshot shows only the prompt textareas (not the full config):
 
-- http://localhost:3001/dev/ui/mp-agent-prompts-hermes?agent=article-analysis&focus=prompts
-- http://localhost:3001/dev/ui/mp-agent-prompts-hermes?agent=query-analysis&focus=prompts
 - http://localhost:3001/dev/ui/mp-agent-prompts-hermes?agent=content-generation&focus=prompts
+
+`article-analysis` and `query-analysis` no longer expose Hermes `prompts` overrides; use `content-generation` for prompts-only capture on this fixture.
 
 Automated capture (waits for two `<textarea>` elements, then screenshots the prompts panel):
 

--- a/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/mp-agent-prompts-schemaform-fixture.test.tsx
+++ b/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/mp-agent-prompts-schemaform-fixture.test.tsx
@@ -29,13 +29,27 @@ describe("MpAgentPromptsSchemaformFixture", () => {
   it("renders prompts-only mode when focus is prompts", () => {
     render(
       <MpAgentPromptsSchemaformFixture
-        agentId="article-analysis"
+        agentId="content-generation"
         focus="prompts"
       />,
     );
 
     expect(screen.getByText(/^Prompts$/i)).toBeInTheDocument();
     expect(screen.getByText(/focus=prompts/i)).toBeInTheDocument();
+  });
+
+  it("shows no prompts sub-schema for article-analysis in prompts-only mode", () => {
+    render(
+      <MpAgentPromptsSchemaformFixture
+        agentId="article-analysis"
+        focus="prompts"
+      />,
+    );
+
+    expect(
+      screen.getByText(/has no prompts sub-schema on this branch/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("schema-form")).not.toBeInTheDocument();
   });
 
   it("shows an error message for an unknown agent id", () => {

--- a/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/mp-agent-prompts-schemaform-fixture.tsx
+++ b/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/mp-agent-prompts-schemaform-fixture.tsx
@@ -33,7 +33,7 @@ const PROMPTS_SEED: Record<string, string> = {
 const seedConfigForAgent = (agentId: string): Record<string, unknown> => {
   const prompts = { ...PROMPTS_SEED };
   if (agentId === "article-analysis" || agentId === "query-analysis") {
-    return { openaiApiKey: "sk-visual-proof", prompts };
+    return { openaiApiKey: "sk-visual-proof" };
   }
   if (agentId === "content-generation") {
     return { openai: { apiKey: "sk-visual-proof" }, prompts };

--- a/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/schemas/article-analysis.json
+++ b/apps/hermes/dashboard/app/dev/ui/mp-agent-prompts-hermes/schemas/article-analysis.json
@@ -110,7 +110,7 @@
       "type": "integer",
       "exclusiveMinimum": 0
     },
-    "defaultMaxBatchSize": {
+    "maxBatchSize": {
       "type": "integer",
       "exclusiveMinimum": 0
     },
@@ -126,24 +126,6 @@
     "debounceMinMinutesSinceLastScore": {
       "type": "integer",
       "minimum": 0
-    },
-    "prompts": {
-      "type": "object",
-      "properties": {
-        "systemPrompt": {
-          "type": "string",
-          "maxLength": 50000,
-          "description": "Optional full system prompt for entity extraction. When omitted, a built-in default is used. Supported placeholders: {{entityTypesBlock}}, {{relationTypesBlock}} (vocabulary from analysis GET).",
-          "format": "textarea"
-        },
-        "userPromptTemplate": {
-          "type": "string",
-          "maxLength": 50000,
-          "description": "Optional user message template for extraction. Supported placeholders: {{tickerId}}, {{title}}, {{articleContent}} (truncated article body per maxContentChars).",
-          "format": "textarea"
-        }
-      },
-      "additionalProperties": false
     }
   },
   "required": ["openaiApiKey"],

--- a/apps/hermes/dashboard/scripts/capture-mp-agent-prompts-screenshots.mjs
+++ b/apps/hermes/dashboard/scripts/capture-mp-agent-prompts-screenshots.mjs
@@ -18,11 +18,6 @@ const baseUrl = "http://127.0.0.1:3001/dev/ui/mp-agent-prompts-hermes";
 
 const shots = [
   {
-    agent: "article-analysis",
-    file: "478-article-analysis-prompts-textarea.png",
-  },
-  { agent: "query-analysis", file: "480-query-analysis-prompts-textarea.png" },
-  {
     agent: "content-generation",
     file: "481-content-generation-prompts-textarea.png",
   },

--- a/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
@@ -4,15 +4,15 @@ import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-templat
 import { describe, expect, it } from "vitest";
 
 import {
-  resolveArticleAnalysisExtractionSystemContent,
-  resolveArticleAnalysisExtractionUserContent,
+  buildArticleAnalysisExtractionSystemContent,
+  buildArticleAnalysisExtractionUserContent,
 } from "./llm-extract-entities.js";
 
 const TID = "11111111-1111-4111-a111-111111111111";
 const RID = "22222222-2222-4222-a222-222222222222";
 
 describe("agent prompt fingerprinting (REQ-011)", () => {
-  it("differs when Hermes system prompt override differs but user and context match", () => {
+  it("is stable for the same vocabulary and user args", () => {
     const ctx = {
       entityTypes: [{ id: TID, name: "Company", description: null }],
       relationTypes: [{ id: RID, name: "PART_OF", description: null }],
@@ -22,21 +22,43 @@ describe("agent prompt fingerprinting (REQ-011)", () => {
       title: "Title",
       contentTruncated: "Body",
     };
-    const user = resolveArticleAnalysisExtractionUserContent(
-      undefined,
-      userArgs,
-    );
-    const sysA = resolveArticleAnalysisExtractionSystemContent(undefined, ctx);
-    const sysB = resolveArticleAnalysisExtractionSystemContent(
-      "Custom intro\n\nENTITY TYPES (uuid — label):\n{{entityTypesBlock}}\n\nRELATION TYPES (uuid — label):\n{{relationTypesBlock}}",
-      ctx,
+    const sys = buildArticleAnalysisExtractionSystemContent(ctx);
+    const user = buildArticleAnalysisExtractionUserContent(userArgs);
+
+    const fpA = computeLlmPromptFingerprint(sys, user);
+    const fpB = computeLlmPromptFingerprint(
+      buildArticleAnalysisExtractionSystemContent(ctx),
+      buildArticleAnalysisExtractionUserContent(userArgs),
     );
 
-    // Act
+    expect(fpA).toBe(fpB);
+  });
+
+  it("differs when analysis GET vocabulary differs but user args match", () => {
+    const userArgs = {
+      tickerId: "t-1",
+      title: "Title",
+      contentTruncated: "Body",
+    };
+    const user = buildArticleAnalysisExtractionUserContent(userArgs);
+    const sysA = buildArticleAnalysisExtractionSystemContent({
+      entityTypes: [{ id: TID, name: "Company", description: null }],
+      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
+    });
+    const sysB = buildArticleAnalysisExtractionSystemContent({
+      entityTypes: [
+        {
+          id: "33333333-3333-4333-a333-333333333333",
+          name: "Person",
+          description: null,
+        },
+      ],
+      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
+    });
+
     const fpA = computeLlmPromptFingerprint(sysA, user);
     const fpB = computeLlmPromptFingerprint(sysB, user);
 
-    // Assert
     expect(fpA).not.toBe(fpB);
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.test.ts
@@ -4,11 +4,16 @@ import { describe, expect, it } from "vitest";
 import type { ArticleRelevanceRow } from "./analysis-relevance-scoring.js";
 import {
   ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+  ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
   aggregateRelevanceObservability,
   buildArticleAnalysisRunSummaryPayload,
+  buildYieldSnapshot,
+  compareYieldAgainstBaseline,
+  percentileOf,
   scoreBucketFor,
   toSafeLogError,
 } from "./article-analysis-observability.js";
+import { createEmptyQualityCounters } from "./utilities/content-quality-gate.js";
 
 describe("toSafeLogError", () => {
   it("returns name and message for Error", () => {
@@ -435,5 +440,147 @@ describe("buildArticleAnalysisRunSummaryPayload", () => {
     expect(payload.exemplarsRequestedCount).toBe(4);
     expect(payload.exemplarsResolvedCount).toBe(2);
     expect(payload.exemplarsApplied).toEqual(["earnings", "leadership"]);
+  });
+});
+
+describe("percentileOf", () => {
+  it("returns null for an empty sample", () => {
+    expect(percentileOf([], 0.5)).toBeNull();
+  });
+
+  it("returns the median for an odd-length sample", () => {
+    expect(percentileOf([100, 200, 300], 0.5)).toBe(200);
+  });
+});
+
+describe("buildYieldSnapshot", () => {
+  it("derives pass counts and extraction yield from run summary counters", () => {
+    const droppedByContentQuality = createEmptyQualityCounters();
+    droppedByContentQuality.content_soft_404 = 1;
+    droppedByContentQuality.content_too_short = 1;
+
+    const snapshot = buildYieldSnapshot({
+      outcome: "success",
+      articlesProcessed: 10,
+      extractionSuccessCount: 6,
+      extractionFailures: [
+        {
+          dataSourceId: "vocab",
+          stage: "vocabulary",
+          message: "bad type",
+        },
+      ],
+      droppedByContentQuality,
+      grounding: {
+        entitiesUngroundedTotal: 1,
+        relationsDroppedTotal: 0,
+        mentionsDroppedTotal: 0,
+      },
+      vocabularyPartitioning: {
+        badEntitiesDropped: 1,
+        badRelationsDropped: 0,
+        repairCallsAttempted: 0,
+        repairCallsSucceeded: 0,
+        repairCallsFailed: 0,
+        rowsRecoveredByRepair: 0,
+      },
+      relevanceRowValidationFailures: 0,
+      chunkParseCounts: {
+        entityRelationChunkParseErrors: 0,
+        articleEntityChunkParseErrors: 0,
+        articleRelevanceChunkParseErrors: 0,
+      },
+      postFailures: [],
+      entitiesCreated: 6,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 6,
+      articlesSelected: 2,
+      relevanceAggregate: null,
+      llmUsage: null,
+      extractionLatencyMsTotal: 600,
+      extractionCalls: 6,
+      perSourceLatency: {
+        extractionMs: [100, 200, 300, 400, 500, 600],
+        brainstormMs: [50],
+        critiqueMs: [75],
+      },
+    });
+
+    expect(snapshot.batchSize).toBe(10);
+    expect(snapshot.passed.qualityGate).toBe(8);
+    expect(snapshot.passed.grounding).toBe(7);
+    expect(snapshot.passed.vocabulary).toBe(6);
+    expect(snapshot.ratios.extractionYield).toBe(0.6);
+    expect(snapshot.dropped.byGrounding.entities).toBe(1);
+    expect(snapshot.dropped.byVocabulary.entities).toBe(1);
+    expect(snapshot.latency.extractionMsP50).toBe(300);
+    expect(snapshot.latency.brainstormMsP50).toBe(50);
+    expect(snapshot.latency.critiqueMsP50).toBe(75);
+  });
+});
+
+describe("compareYieldAgainstBaseline", () => {
+  it("flags regression when a ratio drops more than 15 points below baseline", () => {
+    const comparison = compareYieldAgainstBaseline(
+      buildYieldSnapshot({
+        outcome: "success",
+        articlesProcessed: 10,
+        extractionSuccessCount: 6,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: {
+          entityRelationChunkParseErrors: 0,
+          articleEntityChunkParseErrors: 0,
+          articleRelevanceChunkParseErrors: 0,
+        },
+        postFailures: [],
+        entitiesCreated: 6,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 6,
+        articlesSelected: 2,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 6,
+      }),
+      { extractionYieldP50: 0.8 },
+    );
+
+    expect(comparison.regression).toBe(true);
+    expect(comparison.deltas?.extractionYieldDelta).toBeCloseTo(-0.2);
+  });
+
+  it("returns no regression when baseline is unset", () => {
+    const comparison = compareYieldAgainstBaseline(
+      buildYieldSnapshot({
+        outcome: "success",
+        articlesProcessed: 1,
+        extractionSuccessCount: 1,
+        extractionFailures: [],
+        relevanceRowValidationFailures: 0,
+        chunkParseCounts: {
+          entityRelationChunkParseErrors: 0,
+          articleEntityChunkParseErrors: 0,
+          articleRelevanceChunkParseErrors: 0,
+        },
+        postFailures: [],
+        entitiesCreated: 1,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 1,
+        articlesSelected: 1,
+        relevanceAggregate: null,
+        llmUsage: null,
+        extractionLatencyMsTotal: 0,
+        extractionCalls: 1,
+      }),
+      undefined,
+    );
+
+    expect(comparison.regression).toBe(false);
+    expect(comparison.baseline).toBe("unset");
+    expect(comparison.deltas).toBeNull();
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -5,12 +5,24 @@ import type {
   ArticleAnalysisPostFailureRecord,
 } from "./article-analysis-run-policy.js";
 import type { QualityDropReason } from "./utilities/content-quality-gate.js";
+import { createEmptyQualityCounters } from "./utilities/content-quality-gate.js";
 import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
 import type { GroundingObservabilityAggregate } from "./utilities/entity-grounding.js";
 
 /** Stable name for grep / log pipelines. */
 export const ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE =
   "article_analysis.run.summary";
+
+/** Stable name for per-run yield attribution logs. */
+export const ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE =
+  "article_analysis.yield.snapshot";
+
+/** Stable name for yield regression warnings against operator baseline. */
+export const ARTICLE_ANALYSIS_YIELD_REGRESSION_MESSAGE =
+  "article_analysis.yield.regression";
+
+/** Regression threshold: a ratio more than 15 points below baseline triggers a warning. */
+export const YIELD_REGRESSION_DELTA_THRESHOLD = -0.15;
 
 /**
  * Serializes an unknown error for structured logs without attaching rich provider payloads.
@@ -268,6 +280,75 @@ export type ExemplarsObservabilityAggregate = {
   appliedArchetypes: readonly ExtractionExemplarArchetype[];
 };
 
+export type ParallelismObservabilityAggregate = {
+  concurrency: number;
+  peakInFlight: number;
+  extractionSkippedDueToDeadline: number;
+  deadlineFiredAtMs?: number;
+};
+
+/** Per-source latency samples collected during parallel extraction. */
+export type PerSourceLatencyObservability = {
+  extractionMs: number[];
+  brainstormMs: number[];
+  critiqueMs: number[];
+};
+
+/** Operator-supplied P50 baselines for yield regression comparison (not auto-computed). */
+export type HistoricalYieldBaseline = {
+  extractionYieldP50?: number;
+  groundingYieldP50?: number;
+  vocabularyYieldP50?: number;
+};
+
+export type YieldSnapshotRatios = {
+  extractionYield: number;
+  groundingYield: number;
+  vocabularyYield: number;
+  selectionYield: number;
+};
+
+export type YieldSnapshotLatency = {
+  extractionMsP50: number | null;
+  extractionMsP95: number | null;
+  brainstormMsP50: number | null;
+  critiqueMsP50: number | null;
+};
+
+/** Per-run rollup of pass/drop attribution across pipeline stages. */
+export type YieldSnapshot = {
+  batchSize: number;
+  passed: {
+    qualityGate: number;
+    grounding: number;
+    vocabulary: number;
+    scoring: number;
+    selection: number;
+  };
+  dropped: {
+    byContentQuality: Record<QualityDropReason, number>;
+    byGrounding: { entities: number; relations: number; mentions: number };
+    byVocabulary: { entities: number; relations: number; repaired: number };
+    bySelectionDiversification: number;
+    byDeadline: number;
+    byCritique: number;
+  };
+  ratios: YieldSnapshotRatios;
+  latency: YieldSnapshotLatency;
+};
+
+export type YieldBaselineComparisonDeltas = {
+  extractionYieldDelta?: number;
+  groundingYieldDelta?: number;
+  vocabularyYieldDelta?: number;
+};
+
+export type YieldBaselineComparison = {
+  regression: boolean;
+  baseline: HistoricalYieldBaseline | "unset";
+  deltas: YieldBaselineComparisonDeltas | null;
+};
+
 export type ArticleAnalysisRunSummaryInput = {
   outcome: "success" | "failure";
   articlesProcessed: number;
@@ -299,6 +380,174 @@ export type ArticleAnalysisRunSummaryInput = {
   topLevelError?: ReturnType<typeof toSafeLogError>;
   /** Fingerprint of the last extraction system+user prompts sent to the LLM (REQ-011). */
   llmPromptFingerprint?: string;
+  parallelism?: ParallelismObservabilityAggregate;
+  perSourceLatency?: PerSourceLatencyObservability;
+};
+
+/**
+ * Computes the p-th percentile (0–1) from a numeric sample.
+ *
+ * @param values - Unsorted latency or score samples.
+ * @param p - Percentile in `[0, 1]` (e.g. `0.5` for median).
+ * @returns Percentile value or `null` when `values` is empty.
+ */
+export const percentileOf = (
+  values: readonly number[],
+  p: number,
+): number | null => {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(p * sorted.length) - 1),
+  );
+  return sorted[index] ?? null;
+};
+
+/**
+ * Rolls up per-stage pass/drop counters and ratios from a run summary input.
+ *
+ * @param input - Same counters emitted on `article_analysis.run.summary`.
+ * @returns Forward-compatible yield snapshot for logs and agent result details.
+ */
+export const buildYieldSnapshot = (
+  input: ArticleAnalysisRunSummaryInput,
+): YieldSnapshot => {
+  const batchSize = input.articlesProcessed;
+  const byContentQuality = {
+    ...createEmptyQualityCounters(),
+    ...(input.droppedByContentQuality ?? {}),
+  };
+  const contentQualityDrops = Object.values(byContentQuality).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+  const deadlineDrops = input.parallelism?.extractionSkippedDueToDeadline ?? 0;
+
+  const llmFails = input.extractionFailures.filter(
+    (failure) => failure.stage === "llm",
+  ).length;
+  const vocabFails = input.extractionFailures.filter(
+    (failure) => failure.stage === "vocabulary",
+  ).length;
+
+  const passedQualityGate = batchSize - contentQualityDrops - deadlineDrops;
+  const passedGrounding = passedQualityGate - llmFails - vocabFails;
+  const passedVocabulary = input.extractionSuccessCount;
+  const passedScoring = input.articlesScored;
+  const passedSelection = input.articlesSelected;
+
+  const grounding = input.grounding;
+  const vocabulary = input.vocabularyPartitioning;
+  const selection = input.selection;
+  const relationCritique = input.relationCritique;
+
+  const safeRatio = (numerator: number): number =>
+    batchSize > 0 ? numerator / batchSize : 0;
+
+  const latencySamples = input.perSourceLatency ?? {
+    extractionMs: [],
+    brainstormMs: [],
+    critiqueMs: [],
+  };
+
+  return {
+    batchSize,
+    passed: {
+      qualityGate: passedQualityGate,
+      grounding: passedGrounding,
+      vocabulary: passedVocabulary,
+      scoring: passedScoring,
+      selection: passedSelection,
+    },
+    dropped: {
+      byContentQuality,
+      byGrounding: {
+        entities: grounding?.entitiesUngroundedTotal ?? 0,
+        relations: grounding?.relationsDroppedTotal ?? 0,
+        mentions: grounding?.mentionsDroppedTotal ?? 0,
+      },
+      byVocabulary: {
+        entities: vocabulary?.badEntitiesDropped ?? 0,
+        relations: vocabulary?.badRelationsDropped ?? 0,
+        repaired: vocabulary?.rowsRecoveredByRepair ?? 0,
+      },
+      bySelectionDiversification: selection?.suppressedAsDuplicates ?? 0,
+      byDeadline: deadlineDrops,
+      byCritique: relationCritique?.relationsDroppedByCritique ?? 0,
+    },
+    ratios: {
+      extractionYield: safeRatio(passedVocabulary),
+      groundingYield: safeRatio(passedGrounding),
+      vocabularyYield: safeRatio(passedVocabulary),
+      selectionYield: safeRatio(passedSelection),
+    },
+    latency: {
+      extractionMsP50: percentileOf(latencySamples.extractionMs, 0.5),
+      extractionMsP95: percentileOf(latencySamples.extractionMs, 0.95),
+      brainstormMsP50: percentileOf(latencySamples.brainstormMs, 0.5),
+      critiqueMsP50: percentileOf(latencySamples.critiqueMs, 0.5),
+    },
+  };
+};
+
+/** Alias for {@link buildYieldSnapshot} used when attaching yield to run results. */
+export const getRunYieldSnapshot = buildYieldSnapshot;
+
+/**
+ * Builds a JSON-safe log payload for `article_analysis.yield.snapshot`.
+ *
+ * @param snapshot - Derived yield snapshot for one run.
+ * @returns Payload to pass as first argument to `log.info`.
+ */
+export const buildYieldSnapshotLogPayload = (
+  snapshot: YieldSnapshot,
+): Record<string, unknown> => ({
+  event: ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
+  ...snapshot,
+});
+
+/**
+ * Compares run yield ratios against operator-supplied P50 baselines.
+ *
+ * @param snapshot - Current run yield snapshot.
+ * @param baseline - Optional Hermes config baselines; when unset, comparison is silent.
+ * @returns Regression flag and per-dimension deltas (null when baseline unset).
+ */
+export const compareYieldAgainstBaseline = (
+  snapshot: YieldSnapshot,
+  baseline: HistoricalYieldBaseline | undefined,
+): YieldBaselineComparison => {
+  if (
+    baseline === undefined ||
+    (baseline.extractionYieldP50 === undefined &&
+      baseline.groundingYieldP50 === undefined &&
+      baseline.vocabularyYieldP50 === undefined)
+  ) {
+    return { regression: false, baseline: "unset", deltas: null };
+  }
+
+  const deltas: YieldBaselineComparisonDeltas = {};
+  if (baseline.extractionYieldP50 !== undefined) {
+    deltas.extractionYieldDelta =
+      snapshot.ratios.extractionYield - baseline.extractionYieldP50;
+  }
+  if (baseline.groundingYieldP50 !== undefined) {
+    deltas.groundingYieldDelta =
+      snapshot.ratios.groundingYield - baseline.groundingYieldP50;
+  }
+  if (baseline.vocabularyYieldP50 !== undefined) {
+    deltas.vocabularyYieldDelta =
+      snapshot.ratios.vocabularyYield - baseline.vocabularyYieldP50;
+  }
+
+  const regression = Object.values(deltas).some(
+    (delta) => delta !== undefined && delta <= YIELD_REGRESSION_DELTA_THRESHOLD,
+  );
+
+  return { regression, baseline, deltas };
 };
 
 /**
@@ -485,6 +734,10 @@ export const buildArticleAnalysisRunSummaryPayload = (
 
   if (input.selection !== undefined) {
     base.selection = input.selection;
+  }
+
+  if (input.parallelism !== undefined) {
+    base.parallelism = input.parallelism;
   }
 
   return base;

--- a/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
@@ -1,29 +1,7 @@
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 
-/** Maximum characters allowed for each Hermes `prompts.*` string on article-analysis. */
-export const ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
-
-/** Allowed `{{...}}` names in `prompts.systemPrompt` (Hermes config). */
-export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_PLACEHOLDERS = [
-  "entityTypesBlock",
-  "relationTypesBlock",
-] as const;
-
-/** Allowed `{{...}}` names in `prompts.userPromptTemplate` (Hermes config). */
-export const ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_PLACEHOLDERS = [
-  "tickerId",
-  "title",
-  "articleContent",
-] as const;
-
-/** Allowed `{{...}}` names in the vocabulary-repair system prompt template. */
-export const ARTICLE_ANALYSIS_REPAIR_SYSTEM_PROMPT_PLACEHOLDERS = [
-  "entityTypesBlock",
-  "relationTypesBlock",
-] as const;
-
 /**
- * Default system prompt for the vocabulary-repair `generateObject` pass.
+ * System prompt for the vocabulary-repair `generateObject` pass.
  * Must include `{{entityTypesBlock}}` and `{{relationTypesBlock}}`.
  */
 export const ARTICLE_ANALYSIS_REPAIR_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
@@ -36,7 +14,7 @@ export const ARTICLE_ANALYSIS_REPAIR_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
 ].join("\n\n");
 
 /**
- * Default extraction system prompt template (code default when Hermes omits `prompts.systemPrompt`).
+ * Extraction system prompt template (in-code default).
  * Must include `{{entityTypesBlock}}` and `{{relationTypesBlock}}`.
  */
 export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
@@ -54,7 +32,7 @@ export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
 ].join("\n\n");
 
 /**
- * Default extraction user prompt template (code default when Hermes omits `prompts.userPromptTemplate`).
+ * Extraction user prompt template (in-code default).
  */
 export const ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_TEMPLATE_DEFAULT = [
   "tickerId: {{tickerId}}",

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -1,9 +1,7 @@
 /** @vitest-environment node */
 
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
-import { enrichConfigSchemaForHermesUi } from "@workspace/agent-runtime";
 import { describe, expect, it } from "vitest";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 import {
   buildDraftRelevanceRow,
@@ -15,7 +13,6 @@ import {
   resolveArticleAnalysisConfig,
   toRelevanceWeightMapV1,
 } from "./config-schema.js";
-import { ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH } from "./article-extraction-prompt-defaults.js";
 
 const minimalConfig = {
   openaiApiKey: "sk-test",
@@ -34,95 +31,47 @@ const minimalSignals = {
 } satisfies PerSourceRelevanceSignals;
 
 describe("articleAnalysisConfigSchema", () => {
-  it("rejects unknown placeholder in prompts.userPromptTemplate", () => {
+  it("rejects prompts block under strict mode", () => {
     const result = articleAnalysisConfigSchema.safeParse({
       ...minimalConfig,
       prompts: {
-        userPromptTemplate: "{{tickerId}} {{oops}}",
+        systemPrompt: "x",
       },
     });
 
     expect(result.success).toBe(false);
     if (!result.success) {
-      const messages = result.error.issues.map((i) => i.message).join(" ");
-      expect(messages).toContain("{{oops}}");
+      expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
     }
   });
 
-  it("rejects unknown placeholder in prompts.systemPrompt", () => {
-    const result = articleAnalysisConfigSchema.safeParse({
-      ...minimalConfig,
-      prompts: {
-        systemPrompt: "Hello {{entityTypesBlock}} {{typo}}",
-      },
-    });
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const messages = result.error.issues.map((i) => i.message).join(" ");
-      expect(messages).toContain("{{typo}}");
-    }
-  });
-
-  it("rejects prompts.systemPrompt over max length", () => {
-    const result = articleAnalysisConfigSchema.safeParse({
-      ...minimalConfig,
-      prompts: {
-        systemPrompt: "x".repeat(
-          ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH + 1,
-        ),
-      },
-    });
-
-    expect(result.success).toBe(false);
-  });
-
-  it("exposes prompts fields as textarea in Hermes config JSON Schema", () => {
-    const jsonSchema = enrichConfigSchemaForHermesUi(
-      zodToJsonSchema(articleAnalysisConfigSchema, {
-        $refStrategy: "none",
-      }) as Record<string, unknown>,
-    );
-    const promptProps = (
-      (jsonSchema.properties as Record<string, unknown>).prompts as Record<
-        string,
-        unknown
-      >
-    ).properties as Record<string, { format?: string }>;
-
-    expect(promptProps.systemPrompt?.format).toBe("textarea");
-    expect(promptProps.userPromptTemplate?.format).toBe("textarea");
-  });
-
-  it("accepts valid prompts with known placeholders only", () => {
-    const parsed = articleAnalysisConfigSchema.parse({
-      ...minimalConfig,
-      prompts: {
-        systemPrompt:
-          "Types:\n{{entityTypesBlock}}\nRels:\n{{relationTypesBlock}}",
-        userPromptTemplate: "{{tickerId}}\n{{title}}\n{{articleContent}}",
-      },
-    });
-
-    expect(parsed.prompts?.systemPrompt).toContain("{{entityTypesBlock}}");
-    expect(parsed.prompts?.userPromptTemplate).toContain("{{tickerId}}");
-  });
-
-  it("parses optional debounce and default batch fields", () => {
+  it("parses optional debounce and batch fields", () => {
     // Act
     const parsed = articleAnalysisConfigSchema.parse({
       ...minimalConfig,
       debounceMinUnanalyzedCount: 3,
       debounceMinMinutesSinceLastScore: 15,
-      defaultMaxBatchSize: 20,
+      maxBatchSize: 20,
       analysisGetDataSourceLimitMax: 8,
     });
 
     // Assert
     expect(parsed.debounceMinUnanalyzedCount).toBe(3);
     expect(parsed.debounceMinMinutesSinceLastScore).toBe(15);
-    expect(parsed.defaultMaxBatchSize).toBe(20);
+    expect(parsed.maxBatchSize).toBe(20);
     expect(parsed.analysisGetDataSourceLimitMax).toBe(8);
+  });
+
+  it("rejects legacy defaultMaxBatchSize key under strict mode", () => {
+    const result = articleAnalysisConfigSchema.safeParse({
+      ...minimalConfig,
+      defaultMaxBatchSize: 10,
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
+    }
   });
 });
 
@@ -136,8 +85,8 @@ describe("resolveArticleAnalysisConfig", () => {
     // Assert
     expect(resolved.debounceMinUnanalyzedCount).toBe(0);
     expect(resolved.debounceMinMinutesSinceLastScore).toBe(0);
-    expect(resolved.defaultMaxBatchSize).toBe(
-      articleAnalysisConfigDefaults.defaultMaxBatchSize,
+    expect(resolved.maxBatchSize).toBe(
+      articleAnalysisConfigDefaults.maxBatchSize,
     );
     expect(resolved.analysisGetDataSourceLimitMax).toBe(
       articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,
@@ -151,26 +100,27 @@ describe("resolveArticleAnalysisConfig", () => {
       articleAnalysisConfigDefaults.openaiModel,
     );
     expect(resolved.brainstormMaxOutputTokens).toBe(800);
-    expect(resolved.runDeadlineMs).toBe(Number.POSITIVE_INFINITY);
+    expect(resolved.extractionConcurrency).toBe(1);
+    expect(resolved.runDeadlineMs).toBeUndefined();
     expect(resolved.entityGroundingPolicy).toBe("off");
     expect(resolved.entityGroundingMinTitleHits).toBe(0);
   });
 
-  it("preserves Hermes debounce and defaultMaxBatchSize overrides", () => {
+  it("preserves Hermes debounce and maxBatchSize overrides", () => {
     // Act
     const resolved = resolveArticleAnalysisConfig(
       articleAnalysisConfigSchema.parse({
         ...minimalConfig,
         debounceMinUnanalyzedCount: 5,
         debounceMinMinutesSinceLastScore: 30,
-        defaultMaxBatchSize: 12,
+        maxBatchSize: 12,
       }),
     );
 
     // Assert
     expect(resolved.debounceMinUnanalyzedCount).toBe(5);
     expect(resolved.debounceMinMinutesSinceLastScore).toBe(30);
-    expect(resolved.defaultMaxBatchSize).toBe(12);
+    expect(resolved.maxBatchSize).toBe(12);
   });
 
   it("preserves analysisGetDataSourceLimitMax override from Hermes", () => {

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -2,12 +2,6 @@ import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-co
 import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
 import type { ArticleAnalysisRunPolicy } from "./article-analysis-run-policy.js";
 import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
-import {
-  ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_PLACEHOLDERS,
-  ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_PLACEHOLDERS,
-  ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH,
-} from "./article-extraction-prompt-defaults.js";
-import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import { z } from "zod";
 
 const extractionExemplarArchetypeSchema = z.enum([
@@ -60,8 +54,10 @@ export const articleAnalysisConfigSchema = z
     brainstormModel: z.string().min(1).optional(),
     /** Max output tokens for the brainstorm `generateText` call. */
     brainstormMaxOutputTokens: z.number().int().positive().optional(),
-    /** Wall-clock budget in ms; after this elapsed time, skip brainstorm on remaining sources. */
-    runDeadlineMs: z.number().positive().optional(),
+    /** Max concurrent per-source extractions (1 = sequential; opt-in parallelism). */
+    extractionConcurrency: z.number().int().min(1).max(16).optional(),
+    /** Wall-clock budget in ms from run start; skips undispatched sources and late brainstorm/critique. */
+    runDeadlineMs: z.number().int().positive().optional(),
     /** When true, run a second LLM pass to critique and prune noisy relation triples. */
     useRelationSelfCritique: z.boolean().optional(),
     /** Max fraction of relations per source that critique may drop (hard cap). */
@@ -140,11 +136,11 @@ export const articleAnalysisConfigSchema = z
     /** Initial backoff in ms; delay doubles each retry (`base * 2^attempt`). */
     postTransientRetryBaseDelayMs: z.number().int().positive().optional(),
     /**
-     * When Hermes run input omits `maxBatchSize`, cap how many data sources are loaded and processed per run
+     * Cap on data sources loaded and processed per run
      * (also bounds `analysis.get` `limit` together with `analysisGetDataSourceLimitMax`).
      * Override in Hermes agent config; package default applies when omitted.
      */
-    defaultMaxBatchSize: z.number().int().positive().optional(),
+    maxBatchSize: z.number().int().positive().optional(),
     /**
      * Max `analysis.get` `limit` (must not exceed `ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX` from `@workspace/agent-data-api-contract`).
      * Actual limit is `min(maxBatchSize, analysisGetDataSourceLimitMax)`. Set in Hermes agent config JSON.
@@ -164,70 +160,17 @@ export const articleAnalysisConfigSchema = z
      */
     debounceMinMinutesSinceLastScore: z.number().int().nonnegative().optional(),
     /**
-     * Optional overrides for extraction LLM system/user wording (Hermes agent config).
-     * Defaults remain in code; merge is `configured ?? default` before each extraction call.
-     * Do not put API keys or other secrets in prompt strings.
+     * Operator-supplied yield P50 baselines for regression warnings (not auto-computed from history).
      */
-    prompts: z
+    yieldBaseline: z
       .object({
-        systemPrompt: z
-          .string()
-          .max(ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH, {
-            message: `prompts.systemPrompt must be at most ${String(ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-          })
-          .describe(
-            "Optional full system prompt for entity extraction. When omitted, a built-in default is used. Supported placeholders: {{entityTypesBlock}}, {{relationTypesBlock}} (vocabulary from analysis GET).",
-          )
-          .optional(),
-        userPromptTemplate: z
-          .string()
-          .max(ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH, {
-            message: `prompts.userPromptTemplate must be at most ${String(ARTICLE_ANALYSIS_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-          })
-          .describe(
-            "Optional user message template for extraction. Supported placeholders: {{tickerId}}, {{title}}, {{articleContent}} (truncated article body per maxContentChars).",
-          )
-          .optional(),
+        extractionYieldP50: z.number().min(0).max(1).optional(),
+        groundingYieldP50: z.number().min(0).max(1).optional(),
+        vocabularyYieldP50: z.number().min(0).max(1).optional(),
       })
-      .strict()
       .optional(),
   })
-  .superRefine((data, ctx) => {
-    const prompts = data.prompts;
-    if (!prompts) {
-      return;
-    }
-    const systemAllowed = new Set<string>(
-      ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_PLACEHOLDERS,
-    );
-    const userAllowed = new Set<string>(
-      ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_PLACEHOLDERS,
-    );
-    if (prompts.systemPrompt) {
-      for (const token of findUnknownLlmPromptPlaceholderTokens(
-        prompts.systemPrompt,
-        systemAllowed,
-      )) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Unknown placeholder {{${token}}} in prompts.systemPrompt`,
-          path: ["prompts", "systemPrompt"],
-        });
-      }
-    }
-    if (prompts.userPromptTemplate) {
-      for (const token of findUnknownLlmPromptPlaceholderTokens(
-        prompts.userPromptTemplate,
-        userAllowed,
-      )) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Unknown placeholder {{${token}}} in prompts.userPromptTemplate`,
-          path: ["prompts", "userPromptTemplate"],
-        });
-      }
-    }
-  });
+  .strict();
 
 export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
 
@@ -244,7 +187,8 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   useBrainstormPass: boolean;
   brainstormModel: string;
   brainstormMaxOutputTokens: number;
-  runDeadlineMs: number;
+  extractionConcurrency: number;
+  runDeadlineMs?: number;
   useRelationSelfCritique: boolean;
   relationCritiqueDropFraction: number;
   relationCritiqueMinRelationCount: number;
@@ -284,8 +228,8 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   postTransientRetryBaseDelayMs: number;
   debounceMinUnanalyzedCount: number;
   debounceMinMinutesSinceLastScore: number;
-  /** Cap on sources per run when Hermes input omits `maxBatchSize`. */
-  defaultMaxBatchSize: number;
+  /** Cap on sources per run (Hermes agent config). */
+  maxBatchSize: number;
   /** Upper bound for `analysis.get` `limit` (see `analysisGetDataSourceLimitMax` on Hermes config). */
   analysisGetDataSourceLimitMax: number;
 };
@@ -301,7 +245,7 @@ export const articleAnalysisConfigDefaults = {
   fewShotExemplarCount: 0,
   useBrainstormPass: false,
   brainstormMaxOutputTokens: 800,
-  runDeadlineMs: Number.POSITIVE_INFINITY,
+  extractionConcurrency: 1,
   useRelationSelfCritique: false,
   relationCritiqueDropFraction: 0.25,
   relationCritiqueMinRelationCount: 3,
@@ -339,13 +283,13 @@ export const articleAnalysisConfigDefaults = {
   postTransientRetryBaseDelayMs: 500,
   debounceMinUnanalyzedCount: 0,
   debounceMinMinutesSinceLastScore: 0,
-  defaultMaxBatchSize: 10,
+  maxBatchSize: 10,
   analysisGetDataSourceLimitMax: ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX,
 } as const;
 
 /**
  * Returns effective config with defaults applied for optional numeric/string fields,
- * including debounce knobs, `defaultMaxBatchSize`, and `analysisGetDataSourceLimitMax`
+ * including debounce knobs, `maxBatchSize`, and `analysisGetDataSourceLimitMax`
  * (Hermes config overrides or package defaults).
  *
  * @param config - Parsed Hermes config.
@@ -387,8 +331,12 @@ export const resolveArticleAnalysisConfig = (
     brainstormMaxOutputTokens:
       config.brainstormMaxOutputTokens ??
       articleAnalysisConfigDefaults.brainstormMaxOutputTokens,
-    runDeadlineMs:
-      config.runDeadlineMs ?? articleAnalysisConfigDefaults.runDeadlineMs,
+    extractionConcurrency:
+      config.extractionConcurrency ??
+      articleAnalysisConfigDefaults.extractionConcurrency,
+    ...(config.runDeadlineMs !== undefined
+      ? { runDeadlineMs: config.runDeadlineMs }
+      : {}),
     useRelationSelfCritique:
       config.useRelationSelfCritique ??
       articleAnalysisConfigDefaults.useRelationSelfCritique,
@@ -506,9 +454,8 @@ export const resolveArticleAnalysisConfig = (
     debounceMinMinutesSinceLastScore:
       config.debounceMinMinutesSinceLastScore ??
       articleAnalysisConfigDefaults.debounceMinMinutesSinceLastScore,
-    defaultMaxBatchSize:
-      config.defaultMaxBatchSize ??
-      articleAnalysisConfigDefaults.defaultMaxBatchSize,
+    maxBatchSize:
+      config.maxBatchSize ?? articleAnalysisConfigDefaults.maxBatchSize,
     analysisGetDataSourceLimitMax:
       config.analysisGetDataSourceLimitMax ??
       articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,

--- a/apps/mediapulse/agents/article-analysis/src/index.ts
+++ b/apps/mediapulse/agents/article-analysis/src/index.ts
@@ -22,7 +22,7 @@ const app = createAgentApp<
     agentId: "article-analysis",
     agentVersion: "1.0.0",
     description:
-      "Loads analysis context (incremental or reanalyze), extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api. Supports configurable runPolicy for partial extraction failure, per-chunk POST error isolation with optional transient retries, structured diagnostics (MP-ART-ANALYSIS-007), and structured run-summary observability with safe log fields (MP-ART-ANALYSIS-008).",
+      "Loads analysis context incrementally, extracts KG entities/relations and per-article entity mentions via LLM with vocabulary constraints, canonicalizes against existing KG entities, scores article relevance with canonical breakdown v1, and persists entities/relations, articleEntities, and articleRelevances in chunked POSTs to agent-data-api. Supports configurable runPolicy for partial extraction failure, per-chunk POST error isolation with optional transient retries, structured diagnostics (MP-ART-ANALYSIS-007), and structured run-summary observability with safe log fields (MP-ART-ANALYSIS-008).",
     inputSchema: articleAnalysisInputSchema,
     configSchema: articleAnalysisConfigSchema,
     run,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -26,79 +26,10 @@ import {
   normalizeLlmExtractionWire,
   normalizeLlmUsageFromSdk,
   parseArticleBrainstormText,
-  resolveArticleAnalysisExtractionSystemContent,
-  resolveArticleAnalysisExtractionUserContent,
 } from "./llm-extract-entities.js";
 
 const TID = "11111111-1111-4111-a111-111111111111";
 const RID = "22222222-2222-4222-a222-222222222222";
-
-describe("resolveArticleAnalysisExtractionSystemContent", () => {
-  it("matches buildExtractionSystemContent when Hermes omits override", () => {
-    const ctx = {
-      entityTypes: [{ id: TID, name: "Company", description: null }],
-      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
-    };
-
-    // Act
-    const resolved = resolveArticleAnalysisExtractionSystemContent(
-      undefined,
-      ctx,
-    );
-    const legacy = buildExtractionSystemContent(ctx);
-
-    // Assert
-    expect(resolved).toBe(legacy);
-  });
-
-  it("applies configured system template with placeholders", () => {
-    const ctx = {
-      entityTypes: [{ id: TID, name: "Company", description: null }],
-      relationTypes: [{ id: RID, name: "PART_OF", description: null }],
-    };
-    const text = resolveArticleAnalysisExtractionSystemContent(
-      "E:\n{{entityTypesBlock}}\nR:\n{{relationTypesBlock}}",
-      ctx,
-    );
-
-    expect(text).toContain(TID);
-    expect(text).toContain("E:");
-    expect(text.startsWith("E:")).toBe(true);
-  });
-});
-
-describe("resolveArticleAnalysisExtractionUserContent", () => {
-  it("matches buildExtractionUserContent when Hermes omits override", () => {
-    const args = {
-      tickerId: "T",
-      title: "Hello",
-      contentTruncated: "Body text",
-    };
-
-    // Act
-    const resolved = resolveArticleAnalysisExtractionUserContent(
-      undefined,
-      args,
-    );
-    const legacy = buildExtractionUserContent(args);
-
-    // Assert
-    expect(resolved).toBe(legacy);
-  });
-
-  it("uses custom user template with placeholders", () => {
-    const u = resolveArticleAnalysisExtractionUserContent(
-      "ID={{tickerId}} BODY={{articleContent}}",
-      {
-        tickerId: "ABC",
-        title: "ignored",
-        contentTruncated: "X",
-      },
-    );
-
-    expect(u).toBe("ID=ABC BODY=X");
-  });
-});
 
 describe("buildExtractionSystemContent", () => {
   it("includes vocabulary ids and labels", () => {

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -304,71 +304,49 @@ const BRAINSTORM_FOLLOW_UP_PREFIX = [
 ].join(" ");
 
 /**
- * Resolves the extraction system prompt after merging Hermes `prompts.systemPrompt` with code defaults.
- *
- * @param configuredSystemPrompt - Optional override from Hermes agent config.
- * @param ctx - Vocabulary from analysis GET.
- * @returns System message string (no article body, no secrets).
- */
-export const resolveArticleAnalysisExtractionSystemContent = (
-  configuredSystemPrompt: string | undefined,
-  ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">,
-): string => {
-  const template =
-    configuredSystemPrompt ??
-    ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT;
-  return substituteLlmPromptTemplate(template, {
-    entityTypesBlock: formatArticleAnalysisEntityTypesBlock(ctx),
-    relationTypesBlock: formatArticleAnalysisRelationTypesBlock(ctx),
-  });
-};
-
-/**
- * Resolves the extraction user prompt after merging Hermes `prompts.userPromptTemplate` with code defaults.
- *
- * @param configuredUserPromptTemplate - Optional override from Hermes agent config.
- * @param args - Ticker, title, truncated body (already capped for token budget).
- * @returns User message string.
- */
-export const resolveArticleAnalysisExtractionUserContent = (
-  configuredUserPromptTemplate: string | undefined,
-  args: {
-    tickerId: string;
-    title: string;
-    contentTruncated: string;
-  },
-): string => {
-  const template =
-    configuredUserPromptTemplate ??
-    ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_TEMPLATE_DEFAULT;
-  return substituteLlmPromptTemplate(template, {
-    tickerId: args.tickerId,
-    title: args.title,
-    articleContent: args.contentTruncated,
-  });
-};
-
-/**
- * System prompt listing allowed entity and relation type UUIDs from analysis GET (package defaults only).
+ * Builds the extraction system prompt from the in-code default template.
  *
  * @param ctx - Vocabulary from analysis GET.
  * @returns System message string (no article body, no secrets).
  */
-export const buildExtractionSystemContent = (
+export const buildArticleAnalysisExtractionSystemContent = (
   ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">,
-): string => resolveArticleAnalysisExtractionSystemContent(undefined, ctx);
+): string =>
+  substituteLlmPromptTemplate(
+    ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT,
+    {
+      entityTypesBlock: formatArticleAnalysisEntityTypesBlock(ctx),
+      relationTypesBlock: formatArticleAnalysisRelationTypesBlock(ctx),
+    },
+  );
 
 /**
- * User message with ticker metadata and truncated article text (package defaults only).
+ * Builds the extraction user prompt from the in-code default template.
  *
  * @param args - Ticker, title, truncated body (already capped for token budget).
  * @returns User message string.
  */
-export const buildExtractionUserContent = (args: {
+export const buildArticleAnalysisExtractionUserContent = (args: {
   tickerId: string;
   title: string;
   contentTruncated: string;
-}): string => resolveArticleAnalysisExtractionUserContent(undefined, args);
+}): string =>
+  substituteLlmPromptTemplate(
+    ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_TEMPLATE_DEFAULT,
+    {
+      tickerId: args.tickerId,
+      title: args.title,
+      articleContent: args.contentTruncated,
+    },
+  );
+
+/** @see {@link buildArticleAnalysisExtractionSystemContent} */
+export const buildExtractionSystemContent =
+  buildArticleAnalysisExtractionSystemContent;
+
+/** @see {@link buildArticleAnalysisExtractionUserContent} */
+export const buildExtractionUserContent =
+  buildArticleAnalysisExtractionUserContent;
 
 /**
  * Returns the brainstorm-pass system prompt (plain-text enumeration, no JSON schema).

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.test.ts
@@ -1,8 +1,6 @@
 /** @vitest-environment node */
 import { describe, expect, it } from "vitest";
 
-import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
-import { articleAnalysisInputSchema } from "./schemas/article-analysis-input-schema.js";
 import {
   applyMaxBatchSizeCap,
   buildAnalysisGetQuery,
@@ -11,49 +9,14 @@ import {
 
 describe("buildAnalysisGetQuery", () => {
   it("maps incremental run to unanalyzed true", () => {
-    const input = articleAnalysisInputSchema.parse({
-      tickerId: "tick-a",
-    });
-    expect(buildAnalysisGetQuery(input)).toEqual({
+    expect(buildAnalysisGetQuery("tick-a")).toEqual({
       tickerId: "tick-a",
       unanalyzed: true,
-    });
-  });
-
-  it("maps reanalyze to unanalyzed false", () => {
-    const input = articleAnalysisInputSchema.parse({
-      tickerId: "tick-b",
-      reanalyze: true,
-      maxBatchSize: 5,
-    });
-    expect(buildAnalysisGetQuery(input)).toEqual({
-      tickerId: "tick-b",
-      unanalyzed: false,
-    });
-  });
-
-  it("forwards timeWindow start and end", () => {
-    const input: ArticleAnalysisInput = {
-      tickerId: "tick-c",
-      reanalyze: false,
-      timeWindow: {
-        start: "2026-01-01T00:00:00.000Z",
-        end: "2026-01-31T00:00:00.000Z",
-      },
-    };
-    expect(buildAnalysisGetQuery(input)).toEqual({
-      tickerId: "tick-c",
-      unanalyzed: true,
-      start: "2026-01-01T00:00:00.000Z",
-      end: "2026-01-31T00:00:00.000Z",
     });
   });
 
   it("includes limit when options provide it", () => {
-    const input = articleAnalysisInputSchema.parse({
-      tickerId: "tick-d",
-    });
-    expect(buildAnalysisGetQuery(input, { limit: 10 })).toEqual({
+    expect(buildAnalysisGetQuery("tick-d", { limit: 10 })).toEqual({
       tickerId: "tick-d",
       unanalyzed: true,
       limit: 10,

--- a/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-helpers.ts
@@ -1,43 +1,25 @@
 import type { GetAnalysisQuery } from "@workspace/agent-data-api-contract";
 
-import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
-
 export type BuildAnalysisGetQueryOptions = {
   /** Passed as analysis GET `limit` (caller should use resolved Hermes `analysisGetDataSourceLimitMax`). */
   limit?: number;
 };
 
 /**
- * Builds the typed agent-data-api `analysis.get` query from validated run input.
+ * Builds the typed agent-data-api `analysis.get` query for an incremental run.
  *
- * @param input - Parsed article-analysis input (`timeWindow` bounds forward as `start` / `end` when set).
+ * @param tickerId - Hermes run input ticker id.
  * @param options - Optional `limit` to cap rows returned from agent-data-api.
  * @returns Query object for `createAgentDataApiClient().analysis.get`.
  */
 export const buildAnalysisGetQuery = (
-  input: ArticleAnalysisInput,
+  tickerId: string,
   options?: BuildAnalysisGetQueryOptions,
-): GetAnalysisQuery => {
-  const reanalyze = input.reanalyze ?? false;
-  const base = {
-    tickerId: input.tickerId,
-    unanalyzed: !reanalyze,
-    ...(options?.limit !== undefined ? { limit: options.limit } : {}),
-  } satisfies Pick<GetAnalysisQuery, "tickerId" | "unanalyzed" | "limit">;
-
-  const start = input.timeWindow?.start;
-  const end = input.timeWindow?.end;
-  if (start !== undefined && end !== undefined) {
-    return { ...base, start, end };
-  }
-  if (start !== undefined) {
-    return { ...base, start };
-  }
-  if (end !== undefined) {
-    return { ...base, end };
-  }
-  return base;
-};
+): GetAnalysisQuery => ({
+  tickerId,
+  unanalyzed: true,
+  ...(options?.limit !== undefined ? { limit: options.limit } : {}),
+});
 
 /**
  * Returns a new array sorted by `createdAt` ascending, then `id` lexicographically for stable ordering.

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -1,0 +1,695 @@
+import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
+import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
+import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
+
+import { applyPerArticleExtractionCaps } from "./analysis-caps-dedupe.js";
+import {
+  applyPerArticleArticleMentionCap,
+  buildNormalizedEntityCatalogForArticle,
+  filterMentionsToArticleEntityCatalog,
+  toArticleEntityRowsForSource,
+  type ArticleEntityRow,
+} from "./analysis-article-mentions.js";
+import type { PerSourceRelevanceSignals } from "./analysis-relevance-scoring.js";
+import {
+  partitionExtractionByVocabulary,
+  validateExtractionVocabulary,
+  type EntityProposal,
+  type RelationProposal,
+} from "./analysis-vocabulary.js";
+import { toSafeLogError } from "./article-analysis-observability.js";
+import type { ArticleAnalysisExtractionFailureRecord } from "./article-analysis-run-policy.js";
+import type { ResolvedArticleAnalysisConfig } from "./config-schema.js";
+import {
+  buildArticleAnalysisExtractionUserContent,
+  buildBrainstormSystemContent,
+  buildBrainstormUserContent,
+  applyRelationCritiqueDrops,
+  buildRelationCritiqueModelMessages,
+  critiqueExtractedRelations,
+  relationCritiqueRowKey,
+  extractEntitiesAndRelationsForSource,
+  fetchArticleBrainstorm,
+  repairExtractionVocabulary,
+  type LlmExtractionUsage,
+} from "./llm-extract-entities.js";
+import type { ExtractionExemplar } from "./exemplars/default-extraction-exemplars.js";
+import {
+  hardDeleteDataSourceById,
+  shouldHardDeleteDataSourceForNonArticleReason,
+  shouldHardDeleteDataSourceForExtractionError,
+} from "./extraction-failure-pruning.js";
+import {
+  truncateArticleForExtraction,
+  type TruncateArticleForExtractionMeta,
+  type TruncationTickerContext,
+} from "./utilities/article-content-truncator.js";
+import {
+  computeSourceQualityWithMeta,
+  type HostTier,
+  type SourceQualityComputeCtx,
+} from "./utilities/source-quality.js";
+import { buildEntityNamesForDiversification } from "./utilities/selection-diversification.js";
+import {
+  runArticleQualityGate,
+  type QualityDropReason,
+} from "./utilities/content-quality-gate.js";
+import {
+  applyExtractionEntityGrounding,
+  type PerSourceGroundingCounters,
+} from "./utilities/entity-grounding.js";
+
+type ExistingEntity = {
+  canonicalName: string;
+  typeId: string;
+  aliases: string[];
+};
+
+type AnalysisContext = Pick<
+  GetAnalysisResponse,
+  "entityTypes" | "relationTypes"
+>;
+
+type BatchSource = {
+  id: string;
+  url: string;
+  title: string;
+  content: string;
+  createdAt: Date;
+  publishedAt?: Date | null;
+};
+
+/** Per-source extraction deltas merged in original batch order after parallel walk. */
+export type SourceProcessingOutcome = {
+  mergedEntities: EntityProposal[];
+  mergedRelations: RelationProposal[];
+  mergedArticleEntityRows: ArticleEntityRow[];
+  perSourceSignal?: PerSourceRelevanceSignals;
+  extractionFailures: ArticleAnalysisExtractionFailureRecord[];
+  droppedByContentQualityDelta: Partial<Record<QualityDropReason, number>>;
+  truncationMeta?: TruncateArticleForExtractionMeta;
+  groundingCounters?: PerSourceGroundingCounters;
+  llmPromptFingerprint?: string;
+  extractionUsage?: LlmExtractionUsage | null;
+  repairUsage?: LlmExtractionUsage | null;
+  brainstormUsage?: LlmExtractionUsage | null;
+  critiqueUsage?: LlmExtractionUsage | null;
+  extractionLatencyMs: number;
+  extractionCalls: number;
+  brainstormCalls: number;
+  brainstormLatencyMs: number;
+  critiqueLatencyMs: number;
+  vocabularyFailures: number;
+  badEntitiesDropped: number;
+  badRelationsDropped: number;
+  vocabularyRepairCallsAttempted: number;
+  vocabularyRepairCallsSucceeded: number;
+  vocabularyRepairCallsFailed: number;
+  vocabularyRepairFailures: number;
+  rowsRecoveredByRepair: number;
+  relationsCritiquedSources: number;
+  relationsCritiqueSkippedDueToDeadline: number;
+  relationsDroppedByCritique: number;
+  relationCritiqueCalls: number;
+  sourceQualityTier?: HostTier;
+  sourceQualityRecencyHours?: number | null;
+  sourceQualityScore?: number;
+};
+
+/** Returns an empty per-source outcome for early-return paths. */
+export const createEmptySourceProcessingOutcome =
+  (): SourceProcessingOutcome => ({
+    mergedEntities: [],
+    mergedRelations: [],
+    mergedArticleEntityRows: [],
+    extractionFailures: [],
+    droppedByContentQualityDelta: {},
+    extractionLatencyMs: 0,
+    extractionCalls: 0,
+    brainstormCalls: 0,
+    brainstormLatencyMs: 0,
+    critiqueLatencyMs: 0,
+    vocabularyFailures: 0,
+    badEntitiesDropped: 0,
+    badRelationsDropped: 0,
+    vocabularyRepairCallsAttempted: 0,
+    vocabularyRepairCallsSucceeded: 0,
+    vocabularyRepairCallsFailed: 0,
+    vocabularyRepairFailures: 0,
+    rowsRecoveredByRepair: 0,
+    relationsCritiquedSources: 0,
+    relationsCritiqueSkippedDueToDeadline: 0,
+    relationsDroppedByCritique: 0,
+    relationCritiqueCalls: 0,
+  });
+
+export type ProcessOneSourceDeps = {
+  cfg: ResolvedArticleAnalysisConfig;
+  ctx: AnalysisContext;
+  tickerId: string;
+  systemContent: string;
+  resolvedExemplars: readonly ExtractionExemplar[];
+  existingLookup: ReadonlyMap<string, ExistingEntity>;
+  truncationTickerContext: TruncationTickerContext;
+  sourceQualityHostTiers: SourceQualityComputeCtx["hostTiers"];
+  runStart: number;
+  isRunDeadlineElapsed: () => boolean;
+  resolveAgainstExistingEntities: (
+    entities: readonly EntityProposal[],
+    relations: readonly RelationProposal[],
+    existingLookup: ReadonlyMap<string, ExistingEntity>,
+  ) => { entities: EntityProposal[]; relations: RelationProposal[] };
+  dataApiClient: Pick<
+    ReturnType<typeof createAgentDataApiClient>,
+    "analysisDataSourceDelete"
+  >;
+  log: {
+    info: (obj: Record<string, unknown>, msg: string) => void;
+    warn: (obj: Record<string, unknown>, msg: string) => void;
+  };
+  hardDeleteDataSource: typeof hardDeleteDataSourceById;
+};
+
+/**
+ * Builds the per-source extraction worker used by bounded parallel dispatch.
+ *
+ * @param deps - Run-scoped config, context, and collaborators captured once per run.
+ * @returns Async processor for one batch source returning mergeable deltas.
+ */
+export const createProcessOneSource =
+  (deps: ProcessOneSourceDeps) =>
+  async (source: BatchSource): Promise<SourceProcessingOutcome> => {
+    const {
+      cfg,
+      ctx,
+      tickerId,
+      systemContent,
+      resolvedExemplars,
+      existingLookup,
+      truncationTickerContext,
+      sourceQualityHostTiers,
+      isRunDeadlineElapsed,
+      resolveAgainstExistingEntities,
+      dataApiClient,
+      log,
+      hardDeleteDataSource,
+    } = deps;
+
+    const outcome = createEmptySourceProcessingOutcome();
+
+    const qualityDecision = runArticleQualityGate(
+      source.url,
+      source.title,
+      source.content,
+    );
+    if (qualityDecision.blocked) {
+      const nonArticleReason: QualityDropReason = qualityDecision.reason;
+      outcome.droppedByContentQualityDelta[nonArticleReason] = 1;
+      outcome.extractionFailures.push({
+        dataSourceId: source.id,
+        stage: "prefilter",
+        message: nonArticleReason,
+      });
+      log.info(
+        {
+          dataSourceId: source.id,
+          stage: "prefilter",
+          nonArticleReason,
+        },
+        "article-analysis skipped source with non-article prefilter",
+      );
+      if (shouldHardDeleteDataSourceForNonArticleReason(nonArticleReason)) {
+        try {
+          await hardDeleteDataSource(source.id, {
+            dataApiClient,
+            tickerId,
+          });
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "prefilter",
+              nonArticleReason,
+            },
+            "article-analysis hard-deleted data source after non-article prefilter",
+          );
+        } catch (deleteErr) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "prefilter",
+              err: toSafeLogError(deleteErr),
+              nonArticleReason,
+            },
+            "article-analysis failed to hard-delete data source after non-article prefilter",
+          );
+        }
+      }
+      return outcome;
+    }
+
+    const truncated = cfg.useStructureAwareTruncation
+      ? (() => {
+          const result = truncateArticleForExtraction(source.content, {
+            maxChars: cfg.maxContentChars,
+            tickerSymbols: truncationTickerContext.tickerSymbols,
+            companyAliases: truncationTickerContext.companyAliases,
+            leadParagraphsAlwaysKept: cfg.truncationLeadParagraphsAlwaysKept,
+            financialKeywordsExtra: cfg.truncationFinancialKeywordsExtra,
+          });
+          outcome.truncationMeta = result.meta;
+          return result.content;
+        })()
+      : source.content.length > cfg.maxContentChars
+        ? source.content.slice(0, cfg.maxContentChars)
+        : source.content;
+
+    try {
+      const t0 = Date.now();
+      const extractionUserContent = buildArticleAnalysisExtractionUserContent({
+        tickerId,
+        title: source.title,
+        contentTruncated: truncated,
+      });
+      outcome.llmPromptFingerprint = computeLlmPromptFingerprint(
+        systemContent,
+        extractionUserContent,
+      );
+
+      let brainstormText: string | undefined;
+      const shouldRunBrainstorm =
+        cfg.useBrainstormPass && !isRunDeadlineElapsed();
+
+      if (shouldRunBrainstorm) {
+        try {
+          const brainstormStartedAt = Date.now();
+          const brainstormResult = await fetchArticleBrainstorm({
+            apiKey: cfg.openaiApiKey,
+            model: cfg.brainstormModel,
+            maxOutputTokens: cfg.brainstormMaxOutputTokens,
+            messages: [
+              {
+                role: "system",
+                content: buildBrainstormSystemContent(ctx),
+              },
+              {
+                role: "user",
+                content: buildBrainstormUserContent({
+                  tickerId,
+                  title: source.title,
+                  contentTruncated: truncated,
+                }),
+              },
+            ],
+          });
+          outcome.brainstormCalls = 1;
+          outcome.brainstormLatencyMs = Date.now() - brainstormStartedAt;
+          outcome.brainstormUsage = brainstormResult.usage;
+          if (brainstormResult.text.trim().length > 0) {
+            brainstormText = brainstormResult.text;
+          }
+        } catch (brainstormErr) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "brainstorm",
+              err: toSafeLogError(brainstormErr),
+            },
+            "article-analysis brainstorm pass failed; falling back to single-pass extraction",
+          );
+        }
+      } else if (cfg.useBrainstormPass && isRunDeadlineElapsed()) {
+        log.warn(
+          {
+            dataSourceId: source.id,
+            runElapsedMs: Date.now() - deps.runStart,
+            runDeadlineMs: cfg.runDeadlineMs,
+          },
+          "article-analysis skipping brainstorm pass due to run deadline",
+        );
+      }
+
+      const extractedResult = await extractEntitiesAndRelationsForSource({
+        apiKey: cfg.openaiApiKey,
+        model: cfg.openaiModel,
+        maxOutputTokens: cfg.maxOutputTokens,
+        messages: [
+          { role: "system", content: systemContent },
+          {
+            role: "user",
+            content: extractionUserContent,
+          },
+        ],
+        ...(resolvedExemplars.length > 0
+          ? { exemplars: resolvedExemplars }
+          : {}),
+        ...(brainstormText !== undefined ? { brainstormText } : {}),
+      });
+      outcome.extractionLatencyMs = Date.now() - t0;
+      outcome.extractionCalls = 1;
+      outcome.extractionUsage = extractedResult.usage;
+      const extracted = extractedResult.object;
+
+      let entitiesForPipeline: EntityProposal[] = [...extracted.entities];
+      let relationsForPipeline: RelationProposal[] = [...extracted.relations];
+
+      if (cfg.vocabularyPolicy === "strict") {
+        const vocab = validateExtractionVocabulary(
+          entitiesForPipeline,
+          relationsForPipeline,
+          ctx,
+        );
+        if (!vocab.ok) {
+          outcome.vocabularyFailures = 1;
+          outcome.extractionFailures.push({
+            dataSourceId: source.id,
+            stage: "vocabulary",
+            message: vocab.message,
+          });
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "vocabulary",
+            },
+            "article-analysis vocabulary validation failed for source; skipping",
+          );
+          return outcome;
+        }
+      } else {
+        const partitioned = partitionExtractionByVocabulary(
+          entitiesForPipeline,
+          relationsForPipeline,
+          ctx,
+        );
+        outcome.badEntitiesDropped = partitioned.badEntities.length;
+        outcome.badRelationsDropped = partitioned.badRelations.length;
+        entitiesForPipeline = [...partitioned.okEntities];
+        relationsForPipeline = [...partitioned.okRelations];
+
+        const rejectedCount =
+          partitioned.badEntities.length + partitioned.badRelations.length;
+
+        if (
+          cfg.vocabularyPolicy === "repair" &&
+          rejectedCount > 0 &&
+          rejectedCount <= cfg.vocabularyRepairMaxItems
+        ) {
+          outcome.vocabularyRepairCallsAttempted = 1;
+          try {
+            const repairResult = await repairExtractionVocabulary({
+              apiKey: cfg.openaiApiKey,
+              model: cfg.vocabularyRepairModel,
+              maxOutputTokens: cfg.maxOutputTokens,
+              ctx,
+              badEntities: partitioned.badEntities,
+              badRelations: partitioned.badRelations,
+            });
+            outcome.repairUsage = repairResult.usage;
+
+            const repairedPartition = partitionExtractionByVocabulary(
+              repairResult.entities,
+              repairResult.relations,
+              ctx,
+            );
+            outcome.badEntitiesDropped += repairedPartition.badEntities.length;
+            outcome.badRelationsDropped +=
+              repairedPartition.badRelations.length;
+
+            const recoveredCount =
+              repairedPartition.okEntities.length +
+              repairedPartition.okRelations.length;
+            if (recoveredCount > 0) {
+              outcome.vocabularyRepairCallsSucceeded = 1;
+              outcome.rowsRecoveredByRepair = recoveredCount;
+              entitiesForPipeline.push(...repairedPartition.okEntities);
+              relationsForPipeline.push(...repairedPartition.okRelations);
+            } else {
+              outcome.vocabularyRepairCallsFailed = 1;
+            }
+          } catch (repairErr) {
+            outcome.vocabularyRepairFailures = 1;
+            outcome.vocabularyRepairCallsFailed = 1;
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "vocabulary_repair",
+                err: toSafeLogError(repairErr),
+              },
+              "article-analysis vocabulary repair failed; keeping partitioned good rows only",
+            );
+          }
+        } else if (
+          cfg.vocabularyPolicy === "repair" &&
+          rejectedCount > cfg.vocabularyRepairMaxItems
+        ) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              rejectedCount,
+              vocabularyRepairMaxItems: cfg.vocabularyRepairMaxItems,
+            },
+            "article-analysis skipping vocabulary repair due to rejected row cap",
+          );
+        }
+
+        if (
+          entitiesForPipeline.length === 0 &&
+          relationsForPipeline.length === 0
+        ) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "vocabulary",
+              vocabularyPolicy: cfg.vocabularyPolicy,
+            },
+            "article-analysis no vocabulary-valid rows remain for source; skipping",
+          );
+          return outcome;
+        }
+      }
+
+      const groundedExtraction = applyExtractionEntityGrounding({
+        entities: entitiesForPipeline,
+        relations: relationsForPipeline,
+        mentions: extracted.articleMentions,
+        articleText: source.content,
+        title: source.title,
+        policy: cfg.entityGroundingPolicy,
+        entityGroundingMinTitleHits: cfg.entityGroundingMinTitleHits,
+      });
+      outcome.groundingCounters = groundedExtraction.counters;
+      if (cfg.verbose && cfg.entityGroundingPolicy !== "off") {
+        log.info(
+          {
+            dataSourceId: source.id,
+            ungroundedEntityCount:
+              groundedExtraction.counters.ungroundedEntityCount,
+            relationsDroppedDueToUngroundedEndpoint:
+              groundedExtraction.counters
+                .relationsDroppedDueToUngroundedEndpoint,
+            mentionsDroppedDueToUngroundedEntity:
+              groundedExtraction.counters.mentionsDroppedDueToUngroundedEntity,
+          },
+          "article-analysis entity grounding applied for source",
+        );
+      }
+
+      const resolved = resolveAgainstExistingEntities(
+        groundedExtraction.entities,
+        groundedExtraction.relations,
+        existingLookup,
+      );
+
+      let relationsAfterCritique = resolved.relations;
+      const critiqueEligible =
+        cfg.useRelationSelfCritique &&
+        resolved.relations.length >= cfg.relationCritiqueMinRelationCount;
+
+      if (critiqueEligible && isRunDeadlineElapsed()) {
+        outcome.relationsCritiqueSkippedDueToDeadline = 1;
+        log.warn(
+          {
+            dataSourceId: source.id,
+            runElapsedMs: Date.now() - deps.runStart,
+            runDeadlineMs: cfg.runDeadlineMs,
+            relationCount: resolved.relations.length,
+          },
+          "article-analysis skipping relation critique due to run deadline",
+        );
+      } else if (critiqueEligible) {
+        try {
+          const critiqueStartedAt = Date.now();
+          const critiqueResult = await critiqueExtractedRelations({
+            apiKey: cfg.openaiApiKey,
+            model: cfg.relationCritiqueModel,
+            maxOutputTokens: cfg.maxOutputTokens,
+            messages: buildRelationCritiqueModelMessages(ctx, {
+              articleTitle: source.title,
+              articleBody: source.content,
+              candidates: resolved.relations,
+            }),
+          });
+          outcome.relationCritiqueCalls = 1;
+          outcome.critiqueLatencyMs = Date.now() - critiqueStartedAt;
+          outcome.relationsCritiquedSources = 1;
+          outcome.critiqueUsage = critiqueResult.usage;
+          const critiqueApplied = applyRelationCritiqueDrops(
+            resolved.relations,
+            critiqueResult.ratings,
+            cfg.relationCritiqueDropFraction,
+          );
+          outcome.relationsDroppedByCritique = critiqueApplied.droppedCount;
+          relationsAfterCritique = critiqueApplied.relations;
+          for (const relation of resolved.relations) {
+            const evidenceSpan = critiqueApplied.evidenceByKey.get(
+              relationCritiqueRowKey(relation),
+            );
+            if (evidenceSpan !== undefined) {
+              log.info(
+                {
+                  dataSourceId: source.id,
+                  from: relation.fromEntityName,
+                  to: relation.toEntityName,
+                  relationTypeId: relation.relationTypeId,
+                  evidenceSpan,
+                },
+                "article-analysis relation critique evidence",
+              );
+            }
+          }
+        } catch (critiqueErr) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "relation_critique",
+              err: toSafeLogError(critiqueErr),
+            },
+            "article-analysis relation critique failed; keeping post-grounding relations",
+          );
+        }
+      }
+
+      const capped = applyPerArticleExtractionCaps(
+        resolved.entities,
+        relationsAfterCritique,
+        cfg.maxEntitiesPerArticle,
+        cfg.maxRelationsPerArticle,
+      );
+      outcome.mergedEntities = capped.entities;
+      outcome.mergedRelations = capped.relations;
+
+      const allowedCatalog = buildNormalizedEntityCatalogForArticle(
+        capped.entities,
+      );
+      const mentionFiltered = filterMentionsToArticleEntityCatalog(
+        groundedExtraction.mentions,
+        allowedCatalog,
+      );
+      const mentionCapped = applyPerArticleArticleMentionCap(
+        mentionFiltered,
+        cfg.maxArticleEntitiesPerArticle,
+      );
+      outcome.mergedArticleEntityRows = toArticleEntityRowsForSource(
+        source.id,
+        mentionCapped,
+      );
+
+      const avgMentionConfidence =
+        mentionCapped.length === 0
+          ? 0
+          : mentionCapped.reduce((s, m) => s + m.confidence, 0) /
+            mentionCapped.length;
+
+      if (cfg.useSourceQualityV2) {
+        const qualityMeta = computeSourceQualityWithMeta(
+          {
+            url: source.url,
+            title: source.title,
+            content: source.content,
+            createdAt: source.createdAt,
+            publishedAt: source.publishedAt,
+          },
+          {
+            now: new Date(),
+            recencyHalfLifeHours: cfg.sourceQualityRecencyHalfLifeHours,
+            hostTiers: sourceQualityHostTiers,
+          },
+        );
+        outcome.sourceQualityScore = qualityMeta.qualityScore;
+        outcome.sourceQualityTier = qualityMeta.hostTier;
+        outcome.sourceQualityRecencyHours = qualityMeta.ageHours;
+        if (cfg.verbose) {
+          log.info(
+            {
+              dataSourceId: source.id,
+              hostTier: qualityMeta.hostTier,
+              hostClassScore: qualityMeta.hostClassScore,
+              recencyScore: qualityMeta.recencyScore,
+              ageHours: qualityMeta.ageHours,
+              structuralScore: qualityMeta.structuralScore,
+              qualityScore: qualityMeta.qualityScore,
+            },
+            "article-analysis source quality breakdown",
+          );
+        }
+      }
+
+      outcome.perSourceSignal = {
+        dataSourceId: source.id,
+        createdAt: source.createdAt,
+        entityCount: capped.entities.length,
+        relationCount: capped.relations.length,
+        mentionCount: mentionCapped.length,
+        avgMentionConfidence,
+        titleLower: source.title.toLowerCase(),
+        textLower: truncated.toLowerCase(),
+        entityNames: buildEntityNamesForDiversification(
+          capped.entities,
+          mentionCapped.map((mention) => mention.entityName),
+        ),
+        ...(outcome.sourceQualityScore !== undefined
+          ? { sourceQualityScore: outcome.sourceQualityScore }
+          : {}),
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      outcome.extractionFailures.push({
+        dataSourceId: source.id,
+        stage: "llm",
+        message,
+      });
+      log.warn(
+        {
+          dataSourceId: source.id,
+          stage: "llm",
+          err: toSafeLogError(err),
+        },
+        "article-analysis LLM extraction failed for source; skipping",
+      );
+      if (shouldHardDeleteDataSourceForExtractionError(message)) {
+        try {
+          await hardDeleteDataSource(source.id, {
+            dataApiClient,
+            tickerId,
+          });
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "llm",
+            },
+            "article-analysis hard-deleted data source after unrecoverable extraction parse failure",
+          );
+        } catch (deleteErr) {
+          log.warn(
+            {
+              dataSourceId: source.id,
+              stage: "llm",
+              err: toSafeLogError(deleteErr),
+            },
+            "article-analysis failed to hard-delete data source after extraction parse failure",
+          );
+        }
+      }
+    }
+
+    return outcome;
+  };

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -2,15 +2,15 @@
 import type { AgentRunContext } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE } from "./article-analysis-observability.js";
+import {
+  ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+  ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
+} from "./article-analysis-observability.js";
 import * as RelevancePostChunks from "./analysis-relevance-post-chunks.js";
 import * as Llm from "./llm-extract-entities.js";
 import * as RelevanceScoring from "./analysis-relevance-scoring.js";
 import * as RelevanceSelection from "./analysis-relevance-selection.js";
-import {
-  articleAnalysisConfigDefaults,
-  type ArticleAnalysisConfig,
-} from "./config-schema.js";
+import { type ArticleAnalysisConfig } from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
 import { run } from "./run.js";
 
@@ -237,34 +237,6 @@ describe("run", () => {
     expect(analysisCreate).not.toHaveBeenCalled();
   });
 
-  it("uses unanalyzed false when reanalyze with maxBatchSize", async () => {
-    analysisGet.mockResolvedValue(
-      analysisGetOk({
-        dataSources: [],
-        entityTypes: [],
-        relationTypes: [],
-        existingEntities: [],
-        relevanceSelectionState,
-      }),
-    );
-
-    await run(
-      runContext({
-        input: {
-          tickerId: "ticker-r",
-          reanalyze: true,
-          maxBatchSize: 3,
-        },
-      }),
-    );
-
-    expect(analysisGet).toHaveBeenCalledWith({
-      tickerId: "ticker-r",
-      unanalyzed: false,
-      limit: 3,
-    });
-  });
-
   it("caps analysis GET limit by analysisGetDataSourceLimitMax from Hermes config", async () => {
     analysisGet.mockResolvedValue(
       analysisGetOk({
@@ -280,9 +252,8 @@ describe("run", () => {
       runContext({
         input: {
           tickerId: "ticker-cap",
-          maxBatchSize: 10,
         },
-        config: { analysisGetDataSourceLimitMax: 4 },
+        config: { maxBatchSize: 10, analysisGetDataSourceLimitMax: 4 },
       }),
     );
 
@@ -293,7 +264,7 @@ describe("run", () => {
     });
   });
 
-  it("passes timeWindow as start and end on GET", async () => {
+  it("uses cfg.maxBatchSize as analysis GET limit when under API cap", async () => {
     analysisGet.mockResolvedValue(
       analysisGetOk({
         dataSources: [],
@@ -306,22 +277,15 @@ describe("run", () => {
 
     await run(
       runContext({
-        input: {
-          tickerId: "ticker-w",
-          timeWindow: {
-            start: "2026-01-01T00:00:00.000Z",
-            end: "2026-01-31T00:00:00.000Z",
-          },
-        },
+        input: { tickerId: "ticker-limit" },
+        config: { maxBatchSize: 3 },
       }),
     );
 
     expect(analysisGet).toHaveBeenCalledWith({
-      tickerId: "ticker-w",
+      tickerId: "ticker-limit",
       unanalyzed: true,
-      start: "2026-01-01T00:00:00.000Z",
-      end: "2026-01-31T00:00:00.000Z",
-      limit: articleAnalysisConfigDefaults.defaultMaxBatchSize,
+      limit: 3,
     });
   });
 
@@ -811,6 +775,14 @@ describe("run", () => {
     expect(result).toEqual({
       success: false,
       message: "upstream error",
+      details: {
+        yieldSnapshot: expect.objectContaining({
+          batchSize: 0,
+          ratios: expect.objectContaining({
+            extractionYield: 0,
+          }),
+        }),
+      },
     });
     expect(mockLog.error).toHaveBeenCalled();
   });
@@ -1605,7 +1577,7 @@ describe("run", () => {
     expect(mockLog.info).toHaveBeenCalled();
   });
 
-  it("applies defaultMaxBatchSize on incremental runs when input omits maxBatchSize", async () => {
+  it("applies maxBatchSize from config on incremental runs", async () => {
     analysisGet.mockResolvedValue(
       analysisGetOk({
         dataSources: [
@@ -1663,7 +1635,7 @@ describe("run", () => {
     await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { defaultMaxBatchSize: 1 },
+        config: { maxBatchSize: 1 },
       }),
     );
 
@@ -2687,5 +2659,262 @@ describe("run", () => {
       budget!,
     );
     expect(classicSpy.mock.results[0]?.value).toEqual(expected);
+  });
+
+  const sleepMs = (ms: number): Promise<void> =>
+    new Promise((resolve) => setTimeout(resolve, ms));
+
+  const buildIndexedSources = (count: number) =>
+    Array.from({ length: count }, (_, index) => ({
+      id: `${String(index).padStart(8, "0")}-0000-4000-8000-000000000001`,
+      url: `https://example.com/news/article-${String(index)}`,
+      title: `Indexed headline ${String(index)} ${VALID_SOURCE_TITLE}`,
+      content: validSourceContent(),
+      tickerId: "ticker-1",
+      createdAt: new Date(
+        `2026-01-${String(index + 1).padStart(2, "0")}T00:00:00.000Z`,
+      ),
+    }));
+
+  const mockIndexedExtraction = (
+    sources: ReturnType<typeof buildIndexedSources>,
+    delayForIndex: (index: number) => number,
+  ): void => {
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockImplementation(
+      async (params) => {
+        const rawUserContent = params.messages.find(
+          (message) => message.role === "user",
+        )?.content;
+        const userContent =
+          typeof rawUserContent === "string" ? rawUserContent : "";
+        const index = sources.findIndex((row) =>
+          userContent.includes(row.title),
+        );
+        if (index < 0) {
+          throw new Error("unknown source in extraction mock");
+        }
+        await sleepMs(delayForIndex(index));
+        return llmResult({
+          entities: [
+            {
+              canonicalName: `Entity-${String(index)}`,
+              typeId: TYPE_ID,
+              aliases: [],
+            },
+          ],
+          relations: [],
+          articleMentions: [],
+        });
+      },
+    );
+  };
+
+  it("preserves merged entity order under parallel extraction", async () => {
+    const sources = buildIndexedSources(5);
+
+    const runWithConcurrency = async (concurrency: number) => {
+      mockIndexedExtraction(sources, (index) => (index === 3 ? 1000 : 10));
+      analysisGet.mockResolvedValue(
+        analysisGetOk({
+          dataSources: sources,
+          entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+          relationTypes: [{ id: REL_ID, name: "r", description: null }],
+          existingEntities: [],
+          relevanceSelectionState,
+          lastRelevanceScoredAtIso: null,
+        }),
+      );
+      analysisCreate.mockResolvedValue({
+        entitiesCreated: 5,
+        entitiesReused: 0,
+        relationsCreated: 0,
+        articlesScored: 5,
+        articlesSelected: 5,
+      });
+
+      const result = await run(
+        runContext({
+          input: { tickerId: "ticker-1" },
+          config: { extractionConcurrency: concurrency, maxBatchSize: 5 },
+        }),
+      );
+
+      expect(result.success).toBe(true);
+      return analysisCreate.mock.calls[0]?.[0]?.entities.map(
+        (entity: { canonicalName: string }) => entity.canonicalName,
+      );
+    };
+
+    const sequentialOrder = await runWithConcurrency(1);
+    analysisGet.mockReset();
+    analysisCreate.mockReset();
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockReset();
+
+    const parallelOrder = await runWithConcurrency(4);
+
+    expect(parallelOrder).toEqual(sequentialOrder);
+    expect(parallelOrder).toEqual([
+      "Entity-0",
+      "Entity-1",
+      "Entity-2",
+      "Entity-3",
+      "Entity-4",
+    ]);
+  });
+
+  it("completes partial success when run deadline skips remaining sources", async () => {
+    const sources = buildIndexedSources(10);
+    mockIndexedExtraction(sources, () => 100);
+
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: sources,
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 2,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 2,
+      articlesSelected: 2,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          extractionConcurrency: 1,
+          runDeadlineMs: 200,
+          maxBatchSize: 10,
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.details?.extractionSuccessCount).toBe(2);
+    expect(analysisCreate).toHaveBeenCalled();
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(
+      (
+        summaryCall?.[0] as {
+          parallelism?: { extractionSkippedDueToDeadline: number };
+        }
+      ).parallelism?.extractionSkippedDueToDeadline,
+    ).toBe(8);
+  });
+
+  it("emits one yield snapshot log per run with stage attribution", async () => {
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: paywallSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_2,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: `${validSourceContent()} Apple expanded manufacturing capacity this year.`,
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockResolvedValue(
+      llmResult({
+        entities: [
+          { canonicalName: "FakeCo", typeId: TYPE_ID, aliases: [] },
+          { canonicalName: "Apple", typeId: TYPE_ID, aliases: [] },
+        ],
+        relations: [],
+        articleMentions: [],
+      }),
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          maxBatchSize: 2,
+          entityGroundingPolicy: "drop",
+          useSelectionDiversification: true,
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.details?.yieldSnapshot).toMatchObject({
+      batchSize: 2,
+      passed: expect.objectContaining({
+        qualityGate: expect.any(Number),
+        grounding: expect.any(Number),
+        vocabulary: expect.any(Number),
+      }),
+      dropped: expect.objectContaining({
+        byContentQuality: expect.any(Object),
+        byGrounding: expect.objectContaining({
+          entities: expect.any(Number),
+        }),
+      }),
+      ratios: expect.objectContaining({
+        extractionYield: expect.any(Number),
+      }),
+      latency: expect.objectContaining({
+        extractionMsP50: expect.any(Number),
+      }),
+    });
+
+    const summaryLogs = mockLog.info.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    const yieldLogs = mockLog.info.mock.calls.filter(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
+    );
+
+    expect(summaryLogs).toHaveLength(1);
+    expect(yieldLogs).toHaveLength(1);
+    expect(yieldLogs[0]?.[1]).toBe(ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE);
+    expect(yieldLogs[0]?.[0]).toMatchObject({
+      event: ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
+      batchSize: 2,
+    });
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -2,26 +2,20 @@ import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-article-analysis";
 import { logger } from "@workspace/logger";
-import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import crypto from "node:crypto";
 
 import {
-  applyPerArticleExtractionCaps,
   applyPerRunCaps,
   dedupeEntities,
   dedupeRelations,
 } from "./analysis-caps-dedupe.js";
 import {
-  applyPerArticleArticleMentionCap,
   applyPerRunArticleEntityCap,
   buildArticleEntityPostChunks,
-  buildNormalizedEntityCatalogForArticle,
   buildNormalizedEntityCatalogFromProposals,
   canonicalizeArticleEntityRowsToRunEntities,
   dedupeArticleEntityMentions,
   filterArticleEntityRowsToRunCatalog,
-  filterMentionsToArticleEntityCatalog,
-  toArticleEntityRowsForSource,
   type ArticleEntityRow,
 } from "./analysis-article-mentions.js";
 import { buildArticleRelevancePostChunks } from "./analysis-relevance-post-chunks.js";
@@ -36,8 +30,6 @@ import {
   applyRelevanceSelectionDiversified,
 } from "./analysis-relevance-selection.js";
 import {
-  partitionExtractionByVocabulary,
-  validateExtractionVocabulary,
   type EntityProposal,
   type RelationProposal,
 } from "./analysis-vocabulary.js";
@@ -47,8 +39,13 @@ import {
 } from "./article-analysis-agent-data-api-post.js";
 import {
   ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+  ARTICLE_ANALYSIS_YIELD_REGRESSION_MESSAGE,
+  ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
   aggregateRelevanceObservability,
   buildArticleAnalysisRunSummaryPayload,
+  buildYieldSnapshotLogPayload,
+  compareYieldAgainstBaseline,
+  getRunYieldSnapshot,
   toSafeLogError,
   type ArticleAnalysisRunSummaryInput,
   type ChunkBuildParseCounts,
@@ -56,6 +53,7 @@ import {
   type LlmUsageTotals,
   type RelationCritiqueObservabilityAggregate,
   type VocabularyPartitioningObservabilityAggregate,
+  type YieldSnapshot,
 } from "./article-analysis-observability.js";
 import {
   deriveArticleAnalysisRunStatusLabel,
@@ -71,17 +69,7 @@ import {
 } from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
 import {
-  resolveArticleAnalysisExtractionSystemContent,
-  resolveArticleAnalysisExtractionUserContent,
-  buildBrainstormSystemContent,
-  buildBrainstormUserContent,
-  applyRelationCritiqueDrops,
-  buildRelationCritiqueModelMessages,
-  critiqueExtractedRelations,
-  relationCritiqueRowKey,
-  extractEntitiesAndRelationsForSource,
-  fetchArticleBrainstorm,
-  repairExtractionVocabulary,
+  buildArticleAnalysisExtractionSystemContent,
   type LlmExtractionUsage,
 } from "./llm-extract-entities.js";
 import { DEFAULT_EXTRACTION_EXEMPLARS } from "./exemplars/default-extraction-exemplars.js";
@@ -91,32 +79,28 @@ import {
   applyMaxBatchSizeCap,
   sortAnalysisDataSourcesByCreatedAt,
 } from "./run-helpers.js";
-import {
-  hardDeleteDataSourceById,
-  shouldHardDeleteDataSourceForNonArticleReason,
-  shouldHardDeleteDataSourceForExtractionError,
-} from "./extraction-failure-pruning.js";
+import { hardDeleteDataSourceById } from "./extraction-failure-pruning.js";
 import { normalizeEntityName } from "./normalize-entity-name.js";
 import {
   accumulateTruncationMeta,
   createEmptyTruncationTotals,
   resolveTruncationTickerContext,
-  truncateArticleForExtraction,
 } from "./utilities/article-content-truncator.js";
 import {
-  computeSourceQualityWithMeta,
+  createProcessOneSource,
+  type SourceProcessingOutcome,
+} from "./run-process-one-source.js";
+import { runExtractionsInParallel } from "./utilities/parallel-extraction.js";
+import {
   type HostTier,
   type SourceQualityComputeCtx,
 } from "./utilities/source-quality.js";
-import { buildEntityNamesForDiversification } from "./utilities/selection-diversification.js";
 import {
   createEmptyQualityCounters,
-  runArticleQualityGate,
   type QualityDropReason,
 } from "./utilities/content-quality-gate.js";
 import {
   accumulateGroundingCounters,
-  applyExtractionEntityGrounding,
   createEmptyGroundingTotals,
 } from "./utilities/entity-grounding.js";
 
@@ -259,10 +243,9 @@ export const run = async ({
   ArticleAnalysisInput,
   ArticleAnalysisConfig
 >): Promise<AgentRunResult> => {
-  const reanalyze = input.reanalyze ?? false;
-  const inputForQuery = { ...input, reanalyze };
   const cfg = resolveArticleAnalysisConfig(config);
   const runId = crypto.randomUUID();
+  const runStart = Date.now();
 
   const log = logger.child({
     component: "article-analysis",
@@ -283,103 +266,150 @@ export const run = async ({
       : {}),
   });
 
-  const emitRunSummary = (summary: ArticleAnalysisRunSummaryInput): void => {
+  const mergeRunSummaryInput = (
+    summary: ArticleAnalysisRunSummaryInput,
+  ): ArticleAnalysisRunSummaryInput => ({
+    ...summary,
+    perSourceLatency: summary.perSourceLatency ?? {
+      extractionMs: perSourceExtractionLatencyMs,
+      brainstormMs: perSourceBrainstormLatencyMs,
+      critiqueMs: perSourceCritiqueLatencyMs,
+    },
+    droppedByContentQuality: summary.droppedByContentQuality ?? {
+      ...droppedByContentQuality,
+    },
+    truncation:
+      summary.truncation ??
+      (truncationTotals.paragraphsKept > 0 ||
+      truncationTotals.paragraphsDropped > 0 ||
+      truncationTotals.leadCharsKept > 0 ||
+      truncationTotals.tickerSentencesKept > 0
+        ? {
+            leadCharsKept: truncationTotals.leadCharsKept,
+            tickerSentencesKept: truncationTotals.tickerSentencesKept,
+            paragraphsKept: truncationTotals.paragraphsKept,
+            paragraphsDropped: truncationTotals.paragraphsDropped,
+          }
+        : undefined),
+    exemplars: summary.exemplars ?? exemplarsObservability ?? undefined,
+    grounding:
+      summary.grounding ??
+      (groundingTotals.entitiesUngroundedTotal > 0 ||
+      groundingTotals.relationsDroppedTotal > 0 ||
+      groundingTotals.mentionsDroppedTotal > 0
+        ? {
+            entitiesUngroundedTotal: groundingTotals.entitiesUngroundedTotal,
+            relationsDroppedTotal: groundingTotals.relationsDroppedTotal,
+            mentionsDroppedTotal: groundingTotals.mentionsDroppedTotal,
+          }
+        : undefined),
+    relationCritique:
+      summary.relationCritique ??
+      (relationsCritiquedSources > 0 ||
+      relationsDroppedByCritique > 0 ||
+      relationsCritiqueSkippedDueToDeadline > 0 ||
+      relationCritiqueCalls > 0
+        ? {
+            sourcesCritiqued: relationsCritiquedSources,
+            relationsDroppedByCritique,
+            critiqueCalls: relationCritiqueCalls,
+            critiquePromptTokens: llmUsageTotals.critiquePromptTokens,
+            critiqueCompletionTokens: llmUsageTotals.critiqueCompletionTokens,
+          }
+        : undefined),
+    vocabularyPartitioning:
+      summary.vocabularyPartitioning ??
+      (badEntitiesDropped > 0 ||
+      badRelationsDropped > 0 ||
+      vocabularyRepairCallsAttempted > 0 ||
+      rowsRecoveredByRepair > 0
+        ? {
+            badEntitiesDropped,
+            badRelationsDropped,
+            repairCallsAttempted: vocabularyRepairCallsAttempted,
+            repairCallsSucceeded: vocabularyRepairCallsSucceeded,
+            repairCallsFailed: vocabularyRepairCallsFailed,
+            rowsRecoveredByRepair,
+          }
+        : undefined),
+    sourceQuality:
+      summary.sourceQuality ??
+      (sourceQualityScoredSourceCount > 0
+        ? {
+            tier1Sources: sourceQualityTier1Sources,
+            tier2Sources: sourceQualityTier2Sources,
+            tier3Sources: sourceQualityTier3Sources,
+            unknownHostSources: sourceQualityUnknownHostSources,
+            avgRecencyHours:
+              sourceQualityRecencyHoursCount > 0
+                ? sourceQualityRecencyHoursSum / sourceQualityRecencyHoursCount
+                : null,
+            avgQualityScore:
+              sourceQualityScoreSum / sourceQualityScoredSourceCount,
+          }
+        : undefined),
+    selection:
+      summary.selection ??
+      (selectionEligibleRows > 0 ||
+      selectionSuppressedAsDuplicates > 0 ||
+      selectionClustersFormed > 0
+        ? {
+            eligibleRows: selectionEligibleRows,
+            clustersFormed: selectionClustersFormed,
+            selectedAfterDiversification: selectionSelectedAfterDiversification,
+            suppressedAsDuplicates: selectionSuppressedAsDuplicates,
+            largestClusterSize: selectionLargestClusterSize,
+          }
+        : undefined),
+    parallelism:
+      summary.parallelism ??
+      (cfg.extractionConcurrency > 1 ||
+      extractionSkippedDueToDeadline > 0 ||
+      parallelPeakInFlight > 0
+        ? {
+            concurrency: cfg.extractionConcurrency,
+            peakInFlight: parallelPeakInFlight,
+            extractionSkippedDueToDeadline,
+            ...(parallelDeadlineFiredAtMs !== undefined
+              ? { deadlineFiredAtMs: parallelDeadlineFiredAtMs }
+              : {}),
+          }
+        : undefined),
+  });
+
+  /**
+   * Emits run summary and yield snapshot logs; returns snapshot for agent details.
+   *
+   * @param summary - Partial run summary; missing counters are filled from run scope.
+   * @returns Yield snapshot derived from the merged summary input.
+   */
+  const emitRunSummaryAndYield = (
+    summary: ArticleAnalysisRunSummaryInput,
+  ): YieldSnapshot => {
+    const merged = mergeRunSummaryInput(summary);
     log.info(
-      buildArticleAnalysisRunSummaryPayload({
-        ...summary,
-        droppedByContentQuality: summary.droppedByContentQuality ?? {
-          ...droppedByContentQuality,
-        },
-        truncation:
-          summary.truncation ??
-          (truncationTotals.paragraphsKept > 0 ||
-          truncationTotals.paragraphsDropped > 0 ||
-          truncationTotals.leadCharsKept > 0 ||
-          truncationTotals.tickerSentencesKept > 0
-            ? {
-                leadCharsKept: truncationTotals.leadCharsKept,
-                tickerSentencesKept: truncationTotals.tickerSentencesKept,
-                paragraphsKept: truncationTotals.paragraphsKept,
-                paragraphsDropped: truncationTotals.paragraphsDropped,
-              }
-            : undefined),
-        exemplars: summary.exemplars ?? exemplarsObservability ?? undefined,
-        grounding:
-          summary.grounding ??
-          (groundingTotals.entitiesUngroundedTotal > 0 ||
-          groundingTotals.relationsDroppedTotal > 0 ||
-          groundingTotals.mentionsDroppedTotal > 0
-            ? {
-                entitiesUngroundedTotal:
-                  groundingTotals.entitiesUngroundedTotal,
-                relationsDroppedTotal: groundingTotals.relationsDroppedTotal,
-                mentionsDroppedTotal: groundingTotals.mentionsDroppedTotal,
-              }
-            : undefined),
-        relationCritique:
-          summary.relationCritique ??
-          (relationsCritiquedSources > 0 ||
-          relationsDroppedByCritique > 0 ||
-          relationsCritiqueSkippedDueToDeadline > 0 ||
-          relationCritiqueCalls > 0
-            ? {
-                sourcesCritiqued: relationsCritiquedSources,
-                relationsDroppedByCritique,
-                critiqueCalls: relationCritiqueCalls,
-                critiquePromptTokens: llmUsageTotals.critiquePromptTokens,
-                critiqueCompletionTokens:
-                  llmUsageTotals.critiqueCompletionTokens,
-              }
-            : undefined),
-        vocabularyPartitioning:
-          summary.vocabularyPartitioning ??
-          (badEntitiesDropped > 0 ||
-          badRelationsDropped > 0 ||
-          vocabularyRepairCallsAttempted > 0 ||
-          rowsRecoveredByRepair > 0
-            ? {
-                badEntitiesDropped,
-                badRelationsDropped,
-                repairCallsAttempted: vocabularyRepairCallsAttempted,
-                repairCallsSucceeded: vocabularyRepairCallsSucceeded,
-                repairCallsFailed: vocabularyRepairCallsFailed,
-                rowsRecoveredByRepair,
-              }
-            : undefined),
-        sourceQuality:
-          summary.sourceQuality ??
-          (sourceQualityScoredSourceCount > 0
-            ? {
-                tier1Sources: sourceQualityTier1Sources,
-                tier2Sources: sourceQualityTier2Sources,
-                tier3Sources: sourceQualityTier3Sources,
-                unknownHostSources: sourceQualityUnknownHostSources,
-                avgRecencyHours:
-                  sourceQualityRecencyHoursCount > 0
-                    ? sourceQualityRecencyHoursSum /
-                      sourceQualityRecencyHoursCount
-                    : null,
-                avgQualityScore:
-                  sourceQualityScoreSum / sourceQualityScoredSourceCount,
-              }
-            : undefined),
-        selection:
-          summary.selection ??
-          (selectionEligibleRows > 0 ||
-          selectionSuppressedAsDuplicates > 0 ||
-          selectionClustersFormed > 0
-            ? {
-                eligibleRows: selectionEligibleRows,
-                clustersFormed: selectionClustersFormed,
-                selectedAfterDiversification:
-                  selectionSelectedAfterDiversification,
-                suppressedAsDuplicates: selectionSuppressedAsDuplicates,
-                largestClusterSize: selectionLargestClusterSize,
-              }
-            : undefined),
-      }),
+      buildArticleAnalysisRunSummaryPayload(merged),
       ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
     );
+    const yieldSnapshot = getRunYieldSnapshot(merged);
+    log.info(
+      buildYieldSnapshotLogPayload(yieldSnapshot),
+      ARTICLE_ANALYSIS_YIELD_SNAPSHOT_MESSAGE,
+    );
+    const comparison = compareYieldAgainstBaseline(
+      yieldSnapshot,
+      cfg.yieldBaseline,
+    );
+    if (comparison.regression && comparison.deltas !== null) {
+      log.warn(
+        {
+          baseline: comparison.baseline,
+          ...comparison.deltas,
+        },
+        ARTICLE_ANALYSIS_YIELD_REGRESSION_MESSAGE,
+      );
+    }
+    return yieldSnapshot;
   };
 
   const sourceQualityHostTiers: SourceQualityComputeCtx["hostTiers"] = {
@@ -478,6 +508,12 @@ export const run = async ({
   let relationsCreated = 0;
   let articlesScoredTotal = 0;
   let articlesSelectedTotal = 0;
+  let extractionSkippedDueToDeadline = 0;
+  let parallelPeakInFlight = 0;
+  let parallelDeadlineFiredAtMs: number | undefined;
+  const perSourceExtractionLatencyMs: number[] = [];
+  const perSourceBrainstormLatencyMs: number[] = [];
+  const perSourceCritiqueLatencyMs: number[] = [];
 
   const accumulateLlmUsage = (usage: LlmExtractionUsage | null): void => {
     if (!usage) {
@@ -512,12 +548,12 @@ export const run = async ({
   };
 
   try {
-    const effectiveMaxBatchSize = input.maxBatchSize ?? cfg.defaultMaxBatchSize;
+    const effectiveMaxBatchSize = cfg.maxBatchSize;
     const analysisGetLimit = Math.min(
       effectiveMaxBatchSize,
       cfg.analysisGetDataSourceLimitMax,
     );
-    const query = buildAnalysisGetQuery(inputForQuery, {
+    const query = buildAnalysisGetQuery(input.tickerId, {
       limit: analysisGetLimit,
     });
     const ctx = await dataApiClient.analysis.get(query);
@@ -528,7 +564,7 @@ export const run = async ({
       cfg.debounceMinUnanalyzedCount > 0 &&
       unanalyzedBacklogTotal < cfg.debounceMinUnanalyzedCount
     ) {
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
         articlesProcessed: 0,
         extractionSuccessCount: 0,
@@ -552,9 +588,9 @@ export const run = async ({
         success: true,
         message: `debounce: ${unanalyzedBacklogTotal} unanalyzed source(s) below min ${cfg.debounceMinUnanalyzedCount}; skipping run`,
         details: {
+          yieldSnapshot,
           dataSourcesReturned: unanalyzedBacklogTotal,
           dataSourcesSelected: 0,
-          reanalyze,
           runStatus: "success" as const,
           extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
           extractionSuccessCount: 0,
@@ -579,7 +615,7 @@ export const run = async ({
       minutesSinceUtcIso(ctx.lastRelevanceScoredAtIso) <
         cfg.debounceMinMinutesSinceLastScore
     ) {
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
         articlesProcessed: 0,
         extractionSuccessCount: 0,
@@ -603,9 +639,9 @@ export const run = async ({
         success: true,
         message: `debounce: last relevance scored at ${ctx.lastRelevanceScoredAtIso} is within ${cfg.debounceMinMinutesSinceLastScore} minute(s); skipping run`,
         details: {
+          yieldSnapshot,
           dataSourcesReturned: unanalyzedBacklogTotal,
           dataSourcesSelected: 0,
-          reanalyze,
           runStatus: "success" as const,
           extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
           extractionSuccessCount: 0,
@@ -628,7 +664,7 @@ export const run = async ({
     articlesProcessedForSummary = batch.length;
 
     if (batch.length === 0) {
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
         articlesProcessed: 0,
         extractionSuccessCount: 0,
@@ -651,9 +687,9 @@ export const run = async ({
         success: true,
         message: "analysis context loaded (0 source(s)); nothing to process",
         details: {
+          yieldSnapshot,
           dataSourcesReturned: ctx.dataSourceTotalCount,
           dataSourcesSelected: 0,
-          reanalyze,
           runStatus: "success" as const,
           extractionFailures: [] as ArticleAnalysisExtractionFailureRecord[],
           extractionSuccessCount: 0,
@@ -673,7 +709,7 @@ export const run = async ({
     }
 
     if (ctx.entityTypes.length === 0 || ctx.relationTypes.length === 0) {
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "failure",
         articlesProcessed: batch.length,
         extractionSuccessCount: 0,
@@ -697,6 +733,7 @@ export const run = async ({
         message:
           "KG vocabulary from analysis GET is empty (entityTypes or relationTypes); cannot extract",
         details: {
+          yieldSnapshot,
           entityTypeCount: ctx.entityTypes.length,
           relationTypeCount: ctx.relationTypes.length,
           articlesScored: 0,
@@ -706,10 +743,7 @@ export const run = async ({
       };
     }
 
-    const systemContent = resolveArticleAnalysisExtractionSystemContent(
-      cfg.prompts?.systemPrompt,
-      ctx,
-    );
+    const systemContent = buildArticleAnalysisExtractionSystemContent(ctx);
     const resolvedExemplars = resolveExemplarsForContext(
       DEFAULT_EXTRACTION_EXEMPLARS,
       ctx,
@@ -735,513 +769,151 @@ export const run = async ({
       ctx.entityTypes,
       ctx.existingEntities,
     );
-    const runProcessingStartedAt = Date.now();
+    const isRunDeadlineElapsed = (): boolean =>
+      cfg.runDeadlineMs !== undefined &&
+      Date.now() - runStart >= cfg.runDeadlineMs;
 
-    for (const source of batch) {
-      const qualityDecision = runArticleQualityGate(
-        source.url,
-        source.title,
-        source.content,
-      );
-      if (qualityDecision.blocked) {
-        const nonArticleReason: QualityDropReason = qualityDecision.reason;
-        droppedByContentQuality[nonArticleReason] += 1;
-        extractionFailures.push({
-          dataSourceId: source.id,
-          stage: "prefilter",
-          message: nonArticleReason,
-        });
-        log.info(
-          {
-            dataSourceId: source.id,
-            stage: "prefilter",
-            nonArticleReason,
-          },
-          "article-analysis skipped source with non-article prefilter",
-        );
-        if (shouldHardDeleteDataSourceForNonArticleReason(nonArticleReason)) {
-          try {
-            await hardDeleteDataSourceById(source.id, {
-              dataApiClient,
-              tickerId: input.tickerId,
-            });
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "prefilter",
-                nonArticleReason,
-              },
-              "article-analysis hard-deleted data source after non-article prefilter",
-            );
-          } catch (deleteErr) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "prefilter",
-                err: toSafeLogError(deleteErr),
-                nonArticleReason,
-              },
-              "article-analysis failed to hard-delete data source after non-article prefilter",
-            );
-          }
-        }
-        continue;
+    const applySourceProcessingOutcome = (
+      outcome: SourceProcessingOutcome,
+    ): void => {
+      mergedEntities.push(...outcome.mergedEntities);
+      mergedRelations.push(...outcome.mergedRelations);
+      mergedArticleEntityRows.push(...outcome.mergedArticleEntityRows);
+      if (outcome.perSourceSignal !== undefined) {
+        perSourceSignals.push(outcome.perSourceSignal);
       }
-
-      const truncated = cfg.useStructureAwareTruncation
-        ? (() => {
-            const result = truncateArticleForExtraction(source.content, {
-              maxChars: cfg.maxContentChars,
-              tickerSymbols: truncationTickerContext.tickerSymbols,
-              companyAliases: truncationTickerContext.companyAliases,
-              leadParagraphsAlwaysKept: cfg.truncationLeadParagraphsAlwaysKept,
-              financialKeywordsExtra: cfg.truncationFinancialKeywordsExtra,
-            });
-            accumulateTruncationMeta(truncationTotals, result.meta);
-            return result.content;
-          })()
-        : source.content.length > cfg.maxContentChars
-          ? source.content.slice(0, cfg.maxContentChars)
-          : source.content;
-
-      try {
-        const t0 = Date.now();
-        const extractionUserContent =
-          resolveArticleAnalysisExtractionUserContent(
-            cfg.prompts?.userPromptTemplate,
-            {
-              tickerId: input.tickerId,
-              title: source.title,
-              contentTruncated: truncated,
-            },
-          );
-        lastLlmPromptFingerprint = computeLlmPromptFingerprint(
-          systemContent,
-          extractionUserContent,
-        );
-
-        let brainstormText: string | undefined;
-        const runElapsedMs = Date.now() - runProcessingStartedAt;
-        const shouldRunBrainstorm =
-          cfg.useBrainstormPass && runElapsedMs < cfg.runDeadlineMs;
-
-        if (shouldRunBrainstorm) {
-          try {
-            const brainstormResult = await fetchArticleBrainstorm({
-              apiKey: cfg.openaiApiKey,
-              model: cfg.brainstormModel,
-              maxOutputTokens: cfg.brainstormMaxOutputTokens,
-              messages: [
-                {
-                  role: "system",
-                  content: buildBrainstormSystemContent(ctx),
-                },
-                {
-                  role: "user",
-                  content: buildBrainstormUserContent({
-                    tickerId: input.tickerId,
-                    title: source.title,
-                    contentTruncated: truncated,
-                  }),
-                },
-              ],
-            });
-            brainstormCalls += 1;
-            accumulateBrainstormUsage(brainstormResult.usage);
-            if (brainstormResult.text.trim().length > 0) {
-              brainstormText = brainstormResult.text;
-            }
-          } catch (brainstormErr) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "brainstorm",
-                err: toSafeLogError(brainstormErr),
-              },
-              "article-analysis brainstorm pass failed; falling back to single-pass extraction",
-            );
-          }
-        } else if (cfg.useBrainstormPass && runElapsedMs >= cfg.runDeadlineMs) {
-          log.warn(
-            {
-              dataSourceId: source.id,
-              runElapsedMs,
-              runDeadlineMs: cfg.runDeadlineMs,
-            },
-            "article-analysis skipping brainstorm pass due to run deadline",
-          );
+      extractionFailures.push(...outcome.extractionFailures);
+      for (const [reason, count] of Object.entries(
+        outcome.droppedByContentQualityDelta,
+      )) {
+        if (count !== undefined && count > 0) {
+          droppedByContentQuality[reason as QualityDropReason] += count;
         }
+      }
+      if (outcome.truncationMeta !== undefined) {
+        accumulateTruncationMeta(truncationTotals, outcome.truncationMeta);
+      }
+      if (outcome.groundingCounters !== undefined) {
+        accumulateGroundingCounters(groundingTotals, outcome.groundingCounters);
+      }
+      if (outcome.llmPromptFingerprint !== undefined) {
+        lastLlmPromptFingerprint = outcome.llmPromptFingerprint;
+      }
+      if (outcome.extractionUsage !== undefined) {
+        accumulateLlmUsage(outcome.extractionUsage);
+      }
+      if (outcome.repairUsage !== undefined) {
+        accumulateLlmUsage(outcome.repairUsage);
+      }
+      if (outcome.brainstormUsage !== undefined) {
+        accumulateBrainstormUsage(outcome.brainstormUsage);
+      }
+      if (outcome.critiqueUsage !== undefined) {
+        accumulateCritiqueUsage(outcome.critiqueUsage);
+      }
+      extractionLatencyMsTotal += outcome.extractionLatencyMs;
+      extractionCalls += outcome.extractionCalls;
+      if (outcome.extractionCalls > 0) {
+        perSourceExtractionLatencyMs.push(outcome.extractionLatencyMs);
+      }
+      if (outcome.brainstormCalls > 0) {
+        perSourceBrainstormLatencyMs.push(outcome.brainstormLatencyMs);
+      }
+      if (outcome.relationCritiqueCalls > 0) {
+        perSourceCritiqueLatencyMs.push(outcome.critiqueLatencyMs);
+      }
+      brainstormCalls += outcome.brainstormCalls;
+      vocabularyFailures += outcome.vocabularyFailures;
+      badEntitiesDropped += outcome.badEntitiesDropped;
+      badRelationsDropped += outcome.badRelationsDropped;
+      vocabularyRepairCallsAttempted += outcome.vocabularyRepairCallsAttempted;
+      vocabularyRepairCallsSucceeded += outcome.vocabularyRepairCallsSucceeded;
+      vocabularyRepairCallsFailed += outcome.vocabularyRepairCallsFailed;
+      vocabularyRepairFailures += outcome.vocabularyRepairFailures;
+      rowsRecoveredByRepair += outcome.rowsRecoveredByRepair;
+      relationsCritiquedSources += outcome.relationsCritiquedSources;
+      relationsCritiqueSkippedDueToDeadline +=
+        outcome.relationsCritiqueSkippedDueToDeadline;
+      relationsDroppedByCritique += outcome.relationsDroppedByCritique;
+      relationCritiqueCalls += outcome.relationCritiqueCalls;
+      if (outcome.sourceQualityTier !== undefined) {
+        recordSourceQualityTier(outcome.sourceQualityTier);
+      }
+      if (outcome.sourceQualityScore !== undefined) {
+        sourceQualityScoredSourceCount += 1;
+        sourceQualityScoreSum += outcome.sourceQualityScore;
+      }
+      if (outcome.sourceQualityRecencyHours != null) {
+        sourceQualityRecencyHoursSum += outcome.sourceQualityRecencyHours;
+        sourceQualityRecencyHoursCount += 1;
+      }
+    };
 
-        const extractedResult = await extractEntitiesAndRelationsForSource({
-          apiKey: cfg.openaiApiKey,
-          model: cfg.openaiModel,
-          maxOutputTokens: cfg.maxOutputTokens,
-          messages: [
-            { role: "system", content: systemContent },
-            {
-              role: "user",
-              content: extractionUserContent,
-            },
-          ],
-          ...(resolvedExemplars.length > 0
-            ? { exemplars: resolvedExemplars }
-            : {}),
-          ...(brainstormText !== undefined ? { brainstormText } : {}),
-        });
-        extractionLatencyMsTotal += Date.now() - t0;
-        extractionCalls += 1;
-        accumulateLlmUsage(extractedResult.usage);
-        const extracted = extractedResult.object;
+    const processOneSource = createProcessOneSource({
+      cfg,
+      ctx,
+      tickerId: input.tickerId,
+      systemContent,
+      resolvedExemplars,
+      existingLookup,
+      truncationTickerContext,
+      sourceQualityHostTiers,
+      runStart,
+      isRunDeadlineElapsed,
+      resolveAgainstExistingEntities,
+      dataApiClient,
+      log,
+      hardDeleteDataSource: hardDeleteDataSourceById,
+    });
 
-        let entitiesForPipeline: EntityProposal[] = [...extracted.entities];
-        let relationsForPipeline: RelationProposal[] = [...extracted.relations];
+    const extractionDeadlineAtMs =
+      cfg.runDeadlineMs !== undefined && cfg.runDeadlineMs > 0
+        ? runStart + cfg.runDeadlineMs
+        : undefined;
 
-        if (cfg.vocabularyPolicy === "strict") {
-          const vocab = validateExtractionVocabulary(
-            entitiesForPipeline,
-            relationsForPipeline,
-            ctx,
-          );
-          if (!vocab.ok) {
-            vocabularyFailures += 1;
-            extractionFailures.push({
-              dataSourceId: source.id,
-              stage: "vocabulary",
-              message: vocab.message,
-            });
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "vocabulary",
-              },
-              "article-analysis vocabulary validation failed for source; skipping",
-            );
-            continue;
-          }
-        } else {
-          const partitioned = partitionExtractionByVocabulary(
-            entitiesForPipeline,
-            relationsForPipeline,
-            ctx,
-          );
-          badEntitiesDropped += partitioned.badEntities.length;
-          badRelationsDropped += partitioned.badRelations.length;
-          entitiesForPipeline = [...partitioned.okEntities];
-          relationsForPipeline = [...partitioned.okRelations];
-
-          const rejectedCount =
-            partitioned.badEntities.length + partitioned.badRelations.length;
-
-          if (
-            cfg.vocabularyPolicy === "repair" &&
-            rejectedCount > 0 &&
-            rejectedCount <= cfg.vocabularyRepairMaxItems
-          ) {
-            vocabularyRepairCallsAttempted += 1;
-            try {
-              const repairResult = await repairExtractionVocabulary({
-                apiKey: cfg.openaiApiKey,
-                model: cfg.vocabularyRepairModel,
-                maxOutputTokens: cfg.maxOutputTokens,
-                ctx,
-                badEntities: partitioned.badEntities,
-                badRelations: partitioned.badRelations,
-              });
-              accumulateLlmUsage(repairResult.usage);
-
-              const repairedPartition = partitionExtractionByVocabulary(
-                repairResult.entities,
-                repairResult.relations,
-                ctx,
-              );
-              badEntitiesDropped += repairedPartition.badEntities.length;
-              badRelationsDropped += repairedPartition.badRelations.length;
-
-              const recoveredCount =
-                repairedPartition.okEntities.length +
-                repairedPartition.okRelations.length;
-              if (recoveredCount > 0) {
-                vocabularyRepairCallsSucceeded += 1;
-                rowsRecoveredByRepair += recoveredCount;
-                entitiesForPipeline.push(...repairedPartition.okEntities);
-                relationsForPipeline.push(...repairedPartition.okRelations);
-              } else {
-                vocabularyRepairCallsFailed += 1;
-              }
-            } catch (repairErr) {
-              vocabularyRepairFailures += 1;
-              vocabularyRepairCallsFailed += 1;
-              log.warn(
-                {
-                  dataSourceId: source.id,
-                  stage: "vocabulary_repair",
-                  err: toSafeLogError(repairErr),
-                },
-                "article-analysis vocabulary repair failed; keeping partitioned good rows only",
-              );
-            }
-          } else if (
-            cfg.vocabularyPolicy === "repair" &&
-            rejectedCount > cfg.vocabularyRepairMaxItems
-          ) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                rejectedCount,
-                vocabularyRepairMaxItems: cfg.vocabularyRepairMaxItems,
-              },
-              "article-analysis skipping vocabulary repair due to rejected row cap",
-            );
-          }
-
-          if (
-            entitiesForPipeline.length === 0 &&
-            relationsForPipeline.length === 0
-          ) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "vocabulary",
-                vocabularyPolicy: cfg.vocabularyPolicy,
-              },
-              "article-analysis no vocabulary-valid rows remain for source; skipping",
-            );
-            continue;
-          }
-        }
-
-        const groundedExtraction = applyExtractionEntityGrounding({
-          entities: entitiesForPipeline,
-          relations: relationsForPipeline,
-          mentions: extracted.articleMentions,
-          articleText: source.content,
-          title: source.title,
-          policy: cfg.entityGroundingPolicy,
-          entityGroundingMinTitleHits: cfg.entityGroundingMinTitleHits,
-        });
-        accumulateGroundingCounters(
-          groundingTotals,
-          groundedExtraction.counters,
-        );
-        if (cfg.verbose && cfg.entityGroundingPolicy !== "off") {
-          log.info(
-            {
-              dataSourceId: source.id,
-              ungroundedEntityCount:
-                groundedExtraction.counters.ungroundedEntityCount,
-              relationsDroppedDueToUngroundedEndpoint:
-                groundedExtraction.counters
-                  .relationsDroppedDueToUngroundedEndpoint,
-              mentionsDroppedDueToUngroundedEntity:
-                groundedExtraction.counters
-                  .mentionsDroppedDueToUngroundedEntity,
-            },
-            "article-analysis entity grounding applied for source",
-          );
-        }
-
-        const resolved = resolveAgainstExistingEntities(
-          groundedExtraction.entities,
-          groundedExtraction.relations,
-          existingLookup,
-        );
-
-        let relationsAfterCritique = resolved.relations;
-        const critiqueEligible =
-          cfg.useRelationSelfCritique &&
-          resolved.relations.length >= cfg.relationCritiqueMinRelationCount;
-        const critiqueDeadlineElapsed =
-          Date.now() - runProcessingStartedAt >= cfg.runDeadlineMs;
-
-        if (critiqueEligible && critiqueDeadlineElapsed) {
-          relationsCritiqueSkippedDueToDeadline += 1;
-          log.warn(
-            {
-              dataSourceId: source.id,
-              runElapsedMs: Date.now() - runProcessingStartedAt,
-              runDeadlineMs: cfg.runDeadlineMs,
-              relationCount: resolved.relations.length,
-            },
-            "article-analysis skipping relation critique due to run deadline",
-          );
-        } else if (critiqueEligible) {
-          try {
-            const critiqueResult = await critiqueExtractedRelations({
-              apiKey: cfg.openaiApiKey,
-              model: cfg.relationCritiqueModel,
-              maxOutputTokens: cfg.maxOutputTokens,
-              messages: buildRelationCritiqueModelMessages(ctx, {
-                articleTitle: source.title,
-                articleBody: source.content,
-                candidates: resolved.relations,
-              }),
-            });
-            relationCritiqueCalls += 1;
-            relationsCritiquedSources += 1;
-            accumulateCritiqueUsage(critiqueResult.usage);
-            const critiqueApplied = applyRelationCritiqueDrops(
-              resolved.relations,
-              critiqueResult.ratings,
-              cfg.relationCritiqueDropFraction,
-            );
-            relationsDroppedByCritique += critiqueApplied.droppedCount;
-            relationsAfterCritique = critiqueApplied.relations;
-            for (const relation of resolved.relations) {
-              const evidenceSpan = critiqueApplied.evidenceByKey.get(
-                relationCritiqueRowKey(relation),
-              );
-              if (evidenceSpan !== undefined) {
-                log.info(
-                  {
-                    dataSourceId: source.id,
-                    from: relation.fromEntityName,
-                    to: relation.toEntityName,
-                    relationTypeId: relation.relationTypeId,
-                    evidenceSpan,
-                  },
-                  "article-analysis relation critique evidence",
-                );
-              }
-            }
-          } catch (critiqueErr) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "relation_critique",
-                err: toSafeLogError(critiqueErr),
-              },
-              "article-analysis relation critique failed; keeping post-grounding relations",
-            );
-          }
-        }
-
-        const capped = applyPerArticleExtractionCaps(
-          resolved.entities,
-          relationsAfterCritique,
-          cfg.maxEntitiesPerArticle,
-          cfg.maxRelationsPerArticle,
-        );
-        mergedEntities.push(...capped.entities);
-        mergedRelations.push(...capped.relations);
-
-        const allowedCatalog = buildNormalizedEntityCatalogForArticle(
-          capped.entities,
-        );
-        const mentionFiltered = filterMentionsToArticleEntityCatalog(
-          groundedExtraction.mentions,
-          allowedCatalog,
-        );
-        const mentionCapped = applyPerArticleArticleMentionCap(
-          mentionFiltered,
-          cfg.maxArticleEntitiesPerArticle,
-        );
-        mergedArticleEntityRows.push(
-          ...toArticleEntityRowsForSource(source.id, mentionCapped),
-        );
-
-        const avgMentionConfidence =
-          mentionCapped.length === 0
-            ? 0
-            : mentionCapped.reduce((s, m) => s + m.confidence, 0) /
-              mentionCapped.length;
-        const sourceWithOptionalPublishedAt = source as typeof source & {
-          publishedAt?: Date | null;
-        };
-        let sourceQualityScore: number | undefined;
-        if (cfg.useSourceQualityV2) {
-          const qualityMeta = computeSourceQualityWithMeta(
-            {
-              url: source.url,
-              title: source.title,
-              content: source.content,
-              createdAt: source.createdAt,
-              publishedAt: sourceWithOptionalPublishedAt.publishedAt,
-            },
-            {
-              now: new Date(),
-              recencyHalfLifeHours: cfg.sourceQualityRecencyHalfLifeHours,
-              hostTiers: sourceQualityHostTiers,
-            },
-          );
-          sourceQualityScore = qualityMeta.qualityScore;
-          recordSourceQualityTier(qualityMeta.hostTier);
-          sourceQualityScoredSourceCount += 1;
-          sourceQualityScoreSum += qualityMeta.qualityScore;
-          if (qualityMeta.ageHours !== null) {
-            sourceQualityRecencyHoursSum += qualityMeta.ageHours;
-            sourceQualityRecencyHoursCount += 1;
-          }
-          if (cfg.verbose) {
-            log.info(
-              {
-                dataSourceId: source.id,
-                hostTier: qualityMeta.hostTier,
-                hostClassScore: qualityMeta.hostClassScore,
-                recencyScore: qualityMeta.recencyScore,
-                ageHours: qualityMeta.ageHours,
-                structuralScore: qualityMeta.structuralScore,
-                qualityScore: qualityMeta.qualityScore,
-              },
-              "article-analysis source quality breakdown",
-            );
-          }
-        }
-
-        perSourceSignals.push({
-          dataSourceId: source.id,
-          createdAt: source.createdAt,
-          entityCount: capped.entities.length,
-          relationCount: capped.relations.length,
-          mentionCount: mentionCapped.length,
-          avgMentionConfidence,
-          titleLower: source.title.toLowerCase(),
-          textLower: truncated.toLowerCase(),
-          entityNames: buildEntityNamesForDiversification(
-            capped.entities,
-            mentionCapped.map((mention) => mention.entityName),
-          ),
-          ...(sourceQualityScore !== undefined ? { sourceQualityScore } : {}),
-        });
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        extractionFailures.push({
-          dataSourceId: source.id,
-          stage: "llm",
-          message,
-        });
+    const walkResult = await runExtractionsInParallel(batch, processOneSource, {
+      concurrency: cfg.extractionConcurrency,
+      deadlineAtMs: extractionDeadlineAtMs,
+      onDeadlineSkip: (source) => {
         log.warn(
           {
             dataSourceId: source.id,
-            stage: "llm",
-            err: toSafeLogError(err),
+            runDeadlineMs: cfg.runDeadlineMs,
           },
-          "article-analysis LLM extraction failed for source; skipping",
+          "article-analysis skipped source extraction due to run deadline",
         );
-        if (shouldHardDeleteDataSourceForExtractionError(message)) {
-          try {
-            await hardDeleteDataSourceById(source.id, {
-              dataApiClient,
-              tickerId: input.tickerId,
-            });
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "llm",
-              },
-              "article-analysis hard-deleted data source after unrecoverable extraction parse failure",
-            );
-          } catch (deleteErr) {
-            log.warn(
-              {
-                dataSourceId: source.id,
-                stage: "llm",
-                err: toSafeLogError(deleteErr),
-              },
-              "article-analysis failed to hard-delete data source after extraction parse failure",
-            );
-          }
-        }
+      },
+    });
+
+    extractionSkippedDueToDeadline =
+      walkResult.stats.extractionSkippedDueToDeadline;
+    parallelPeakInFlight = walkResult.stats.peakInFlight;
+    parallelDeadlineFiredAtMs = walkResult.stats.deadlineFiredAtMs;
+
+    for (const itemOutcome of walkResult.results) {
+      if (itemOutcome.ok) {
+        applySourceProcessingOutcome(itemOutcome.value);
+        continue;
       }
+
+      const source = batch[itemOutcome.index]!;
+      const message =
+        itemOutcome.error instanceof Error
+          ? itemOutcome.error.message
+          : String(itemOutcome.error);
+      extractionFailures.push({
+        dataSourceId: source.id,
+        stage: "llm",
+        message,
+      });
+      log.warn(
+        {
+          dataSourceId: source.id,
+          stage: "llm",
+          err: toSafeLogError(itemOutcome.error),
+        },
+        "article-analysis unexpected per-source processing failure; skipping",
+      );
     }
 
     extractionSuccessCount = perSourceSignals.length;
@@ -1252,7 +924,7 @@ export const run = async ({
         cfg.runPolicy,
       )
     ) {
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "failure",
         articlesProcessed: batch.length,
         extractionSuccessCount,
@@ -1275,6 +947,7 @@ export const run = async ({
         success: false,
         message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.runPolicy.minSuccessfulSources}.`,
         details: {
+          yieldSnapshot,
           extractionFailures,
           extractionSuccessCount,
           runPolicy: cfg.runPolicy,
@@ -1283,7 +956,6 @@ export const run = async ({
           relevancePostChunks: 0,
           postFailures: [] as ArticleAnalysisPostFailureRecord[],
           dataSourcesProcessed: batch.length,
-          reanalyze,
           vocabularyFailures,
         },
       };
@@ -1309,7 +981,7 @@ export const run = async ({
         extractionFailures.length,
         postFailures.length,
       );
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
         articlesProcessed: batch.length,
         extractionSuccessCount,
@@ -1335,6 +1007,7 @@ export const run = async ({
             ? `no extraction produced (${extractionFailures.length} source(s) failed extraction; check logs)`
             : "extraction produced no entities or relations",
         details: {
+          yieldSnapshot,
           dataSourcesProcessed: batch.length,
           extractionFailures,
           extractionSuccessCount,
@@ -1350,7 +1023,6 @@ export const run = async ({
           articlesScored: 0,
           articlesSelected: 0,
           relevancePostChunks: 0,
-          reanalyze,
           vocabularyFailures,
         },
       };
@@ -1426,7 +1098,7 @@ export const run = async ({
         extractionFailures.length,
         postFailures.length,
       );
-      emitRunSummary({
+      const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
         articlesProcessed: batch.length,
         extractionSuccessCount,
@@ -1450,6 +1122,7 @@ export const run = async ({
         message:
           "no valid POST chunks after extraction (check relation endpoint names vs entity canonicalName)",
         details: {
+          yieldSnapshot,
           dataSourcesProcessed: batch.length,
           relationCountAfterCaps: relations.length,
           droppedRelations,
@@ -1465,7 +1138,6 @@ export const run = async ({
           articlesScored: 0,
           articlesSelected: 0,
           relevancePostChunks: 0,
-          reanalyze,
           vocabularyFailures,
         },
       };
@@ -1600,7 +1272,7 @@ export const run = async ({
         }
       }
       if (relevanceValidationErrors.length > 0) {
-        emitRunSummary({
+        const yieldSnapshot = emitRunSummaryAndYield({
           outcome: "failure",
           articlesProcessed: batch.length,
           extractionSuccessCount,
@@ -1628,6 +1300,7 @@ export const run = async ({
           message:
             "article-analysis relevance row validation failed before selection",
           details: {
+            yieldSnapshot,
             tickerId: input.tickerId,
             validationErrorCount: relevanceValidationErrors.length,
             relevanceValidationErrors: relevanceValidationErrors.slice(0, 20),
@@ -1688,7 +1361,7 @@ export const run = async ({
           },
           "article-analysis relevance chunk build reported parse issues",
         );
-        emitRunSummary({
+        const yieldSnapshot = emitRunSummaryAndYield({
           outcome: "failure",
           articlesProcessed: batch.length,
           extractionSuccessCount,
@@ -1715,6 +1388,7 @@ export const run = async ({
           success: false,
           message: "article-analysis relevance chunk parse failed",
           details: {
+            yieldSnapshot,
             tickerId: input.tickerId,
             parseErrorCount: relevanceParseErrors.length,
             relevanceParseErrors: relevanceParseErrors.slice(0, 20),
@@ -1772,7 +1446,7 @@ export const run = async ({
         ? aggregateRelevanceObservability(relevanceRowsForObservability)
         : null;
 
-    emitRunSummary({
+    const yieldSnapshot = emitRunSummaryAndYield({
       outcome: "success",
       articlesProcessed: batch.length,
       extractionSuccessCount,
@@ -1800,6 +1474,7 @@ export const run = async ({
       success: true,
       message: `complete (${runStatus}): ${erPostChunksCompleted}/${chunks.length} ER chunk(s), ${mentionPostChunksCompleted} articleEntity chunk(s), ${relevancePostChunksCompleted} relevance chunk(s); entitiesCreated=${entitiesCreated} entitiesReused=${entitiesReused} relationsCreated=${relationsCreated} articleEntityRowsPosted=${articleEntityRowsPosted} articlesScored=${articlesScoredTotal} articlesSelected=${articlesSelectedTotal}`,
       details: {
+        yieldSnapshot,
         dataSourcesProcessed: batch.length,
         dataSourcesReturned: ctx.dataSourceTotalCount,
         extractionFailures,
@@ -1824,7 +1499,6 @@ export const run = async ({
         ),
         droppedRelations,
         articleEntityParseErrors: articleEntityParseErrors.slice(0, 20),
-        reanalyze,
         vocabularyFailures,
         ...(lastLlmPromptFingerprint !== undefined
           ? { llmPromptFingerprint: lastLlmPromptFingerprint }
@@ -1837,7 +1511,7 @@ export const run = async ({
         ? error.message
         : "agent-data-api article-analysis run failed";
     log.error({ err: toSafeLogError(error) }, message);
-    emitRunSummary({
+    const yieldSnapshot = emitRunSummaryAndYield({
       outcome: "failure",
       articlesProcessed: articlesProcessedForSummary,
       extractionSuccessCount,
@@ -1859,6 +1533,6 @@ export const run = async ({
         ? { llmPromptFingerprint: lastLlmPromptFingerprint }
         : {}),
     });
-    return { success: false, message };
+    return { success: false, message, details: { yieldSnapshot } };
   }
 };

--- a/apps/mediapulse/agents/article-analysis/src/schemas/article-analysis-input-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/schemas/article-analysis-input-schema.test.ts
@@ -4,34 +4,46 @@ import { describe, expect, it } from "vitest";
 import { articleAnalysisInputSchema } from "./article-analysis-input-schema.js";
 
 describe("articleAnalysisInputSchema", () => {
-  it("rejects reanalyze without maxBatchSize or timeWindow bounds", () => {
+  it("accepts tickerId only", () => {
+    const result = articleAnalysisInputSchema.safeParse({
+      tickerId: "t1",
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data).toEqual({ tickerId: "t1" });
+    }
+  });
+
+  it("rejects reanalyze as an unknown field", () => {
     const result = articleAnalysisInputSchema.safeParse({
       tickerId: "t1",
       reanalyze: true,
     });
     expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
+    }
   });
 
-  it("accepts reanalyze with maxBatchSize only", () => {
+  it("rejects timeWindow as an unknown field", () => {
     const result = articleAnalysisInputSchema.safeParse({
       tickerId: "t1",
-      reanalyze: true,
-      maxBatchSize: 10,
-    });
-    expect(result.success).toBe(true);
-  });
-
-  it("accepts reanalyze with timeWindow start only", () => {
-    const result = articleAnalysisInputSchema.safeParse({
-      tickerId: "t1",
-      reanalyze: true,
       timeWindow: { start: "2026-01-01T00:00:00.000Z" },
     });
-    expect(result.success).toBe(true);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
+    }
   });
 
-  it("allows omitted reanalyze", () => {
-    const result = articleAnalysisInputSchema.parse({ tickerId: "t1" });
-    expect(result.reanalyze).toBeUndefined();
+  it("rejects maxBatchSize as an unknown field", () => {
+    const result = articleAnalysisInputSchema.safeParse({
+      tickerId: "t1",
+      maxBatchSize: 5,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
+    }
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/schemas/article-analysis-input-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/schemas/article-analysis-input-schema.ts
@@ -1,42 +1,16 @@
 import { hermesTickerIdSchema } from "@workspace/agent-runtime";
 import { z } from "zod";
 
-const timeWindowSchema = z
-  .object({
-    start: z.string().datetime().optional(),
-    end: z.string().datetime().optional(),
-  })
-  .optional();
-
 /**
- * Hermes run input for the article-analysis agent (Phase A: context load and batch bounds only).
+ * Hermes run input for the article-analysis agent.
  *
- * When `reanalyze` is true, callers must supply `maxBatchSize` and/or a `timeWindow` with at least
- * one of `start` or `end` (ISO 8601), matching MP-ART-ANALYSIS-003 / FR1.
+ * Runs are always incremental (`unanalyzed: true` on analysis GET). Batch size and
+ * extraction tuning live in Hermes agent config, not per-run input.
  */
 export const articleAnalysisInputSchema = z
   .object({
     tickerId: hermesTickerIdSchema,
-    reanalyze: z.boolean().optional(),
-    timeWindow: timeWindowSchema,
-    maxBatchSize: z.number().int().positive().optional(),
   })
-  .superRefine((data, ctx) => {
-    if (data.reanalyze !== true) {
-      return;
-    }
-    const hasWindow =
-      data.timeWindow?.start !== undefined ||
-      data.timeWindow?.end !== undefined;
-    const hasCap = data.maxBatchSize !== undefined;
-    if (!hasWindow && !hasCap) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          "reanalyze requires maxBatchSize and/or timeWindow with start or end",
-        path: ["reanalyze"],
-      });
-    }
-  });
+  .strict();
 
 export type ArticleAnalysisInput = z.infer<typeof articleAnalysisInputSchema>;

--- a/apps/mediapulse/agents/article-analysis/src/utilities/parallel-extraction.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/parallel-extraction.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runExtractionsInParallel } from "./parallel-extraction.js";
+
+const sleepMs = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("runExtractionsInParallel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("respects concurrency and records peak in-flight", async () => {
+    // Setup
+    const items = Array.from({ length: 10 }, (_, index) => index);
+    let inFlight = 0;
+    let peakInFlight = 0;
+
+    // Act
+    const startedAt = Date.now();
+    const { results, stats } = await runExtractionsInParallel(
+      items,
+      async () => {
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+        await sleepMs(100);
+        inFlight -= 1;
+        return "ok";
+      },
+      { concurrency: 3 },
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    // Assert
+    expect(results).toHaveLength(10);
+    expect(results.every((result) => result.ok && result.value === "ok")).toBe(
+      true,
+    );
+    expect(stats.peakInFlight).toBe(3);
+    expect(peakInFlight).toBe(3);
+    expect(stats.extractionSkippedDueToDeadline).toBe(0);
+    expect(elapsedMs).toBeGreaterThanOrEqual(300);
+    expect(elapsedMs).toBeLessThan(700);
+  });
+
+  it("skips undispatched items after deadline without cancelling in-flight work", async () => {
+    // Setup
+    const items = Array.from({ length: 10 }, (_, index) => index);
+    const onDeadlineSkip = vi.fn();
+    const startedIndices: number[] = [];
+    const completedIndices: number[] = [];
+
+    // Act
+    const { results, stats } = await runExtractionsInParallel(
+      items,
+      async (item) => {
+        startedIndices.push(item);
+        await sleepMs(100);
+        completedIndices.push(item);
+        return item;
+      },
+      {
+        concurrency: 1,
+        deadlineAtMs: Date.now() + 200,
+        onDeadlineSkip: (item) => {
+          onDeadlineSkip(item);
+        },
+      },
+    );
+
+    // Assert
+    expect(results).toHaveLength(2);
+    expect(results.map((result) => (result.ok ? result.value : null))).toEqual([
+      0, 1,
+    ]);
+    expect(onDeadlineSkip).toHaveBeenCalledTimes(8);
+    expect(stats.extractionSkippedDueToDeadline).toBe(8);
+    expect(stats.deadlineFiredAtMs).toEqual(expect.any(Number));
+    expect(startedIndices).toEqual([0, 1]);
+    expect(completedIndices).toEqual([0, 1]);
+  });
+
+  it("isolates worker errors without aborting remaining items", async () => {
+    // Setup
+    const items = ["a", "b", "c"];
+
+    // Act
+    const { results } = await runExtractionsInParallel(
+      items,
+      async (item) => {
+        if (item === "b") {
+          throw new Error("boom");
+        }
+        return item.toUpperCase();
+      },
+      { concurrency: 2 },
+    );
+
+    // Assert
+    expect(results).toHaveLength(3);
+    expect(results[0]).toEqual({ ok: true, index: 0, value: "A" });
+    expect(results[1]).toEqual({
+      ok: false,
+      index: 1,
+      error: expect.objectContaining({ message: "boom" }),
+    });
+    expect(results[2]).toEqual({ ok: true, index: 2, value: "C" });
+  });
+
+  it("returns results sorted by original batch index", async () => {
+    // Setup
+    const items = [1, 2, 3, 4, 5];
+
+    // Act
+    const { results } = await runExtractionsInParallel(
+      items,
+      async (item) => {
+        await sleepMs((5 - item) * 10);
+        return item * 10;
+      },
+      { concurrency: 5 },
+    );
+
+    // Assert
+    expect(results.map((result) => (result.ok ? result.index : -1))).toEqual([
+      0, 1, 2, 3, 4,
+    ]);
+    expect(results.map((result) => (result.ok ? result.value : null))).toEqual([
+      10, 20, 30, 40, 50,
+    ]);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/utilities/parallel-extraction.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/parallel-extraction.ts
@@ -1,0 +1,130 @@
+/** Outcome for one item processed by {@link runExtractionsInParallel}. */
+export type ParallelExtractionItemOutcome<R> =
+  | { ok: true; index: number; value: R }
+  | { ok: false; index: number; error: unknown };
+
+/** Runtime stats collected while walking items with a concurrency cap. */
+export type ParallelExtractionWalkStats = {
+  peakInFlight: number;
+  extractionSkippedDueToDeadline: number;
+  deadlineFiredAtMs?: number;
+};
+
+/** Options for bounded parallel extraction with an optional dispatch deadline. */
+export type RunExtractionsInParallelOptions<T> = {
+  /** Max in-flight worker calls at once (minimum 1). */
+  concurrency: number;
+  /** When `Date.now() >= deadlineAtMs`, no new items are dispatched. */
+  deadlineAtMs?: number;
+  /** Invoked once per item not started because the deadline already passed. */
+  onDeadlineSkip?: (item: T, index: number) => void;
+};
+
+/** Result of {@link runExtractionsInParallel}. */
+export type ParallelExtractionWalkResult<R> = {
+  results: ParallelExtractionItemOutcome<R>[];
+  stats: ParallelExtractionWalkStats;
+};
+
+/**
+ * Runs an async worker over items with bounded concurrency and an optional deadline.
+ * Items past `deadlineAtMs` are not started; in-flight work is awaited to completion.
+ * Worker rejections are captured as `{ ok: false, error }` and do not abort the walk.
+ *
+ * @param items - Inputs in deterministic batch order.
+ * @param worker - Per-item async processor.
+ * @param options - Concurrency limit, optional deadline, and skip callback.
+ * @returns Fulfilled/rejected outcomes plus walk stats (`peakInFlight`, deadline skips).
+ */
+export const runExtractionsInParallel = async <T, R>(
+  items: readonly T[],
+  worker: (item: T, index: number) => Promise<R>,
+  options: RunExtractionsInParallelOptions<T>,
+): Promise<ParallelExtractionWalkResult<R>> => {
+  const concurrency = Math.max(1, options.concurrency);
+  const results: ParallelExtractionItemOutcome<R>[] = [];
+  let peakInFlight = 0;
+  let inFlight = 0;
+  let extractionSkippedDueToDeadline = 0;
+  let deadlineFiredAtMs: number | undefined;
+  let nextDispatchIndex = 0;
+
+  const isPastDeadline = (): boolean =>
+    options.deadlineAtMs !== undefined && Date.now() >= options.deadlineAtMs;
+
+  const wrapWorker = async (
+    item: T,
+    index: number,
+  ): Promise<ParallelExtractionItemOutcome<R>> => {
+    try {
+      const value = await worker(item, index);
+      return { ok: true, index, value };
+    } catch (error) {
+      return { ok: false, index, error };
+    }
+  };
+
+  if (items.length === 0) {
+    return {
+      results: [],
+      stats: {
+        peakInFlight: 0,
+        extractionSkippedDueToDeadline: 0,
+      },
+    };
+  }
+
+  await new Promise<void>((resolve) => {
+    const maybeFinish = (): void => {
+      const allDispatchedOrSkipped = nextDispatchIndex >= items.length;
+      if (allDispatchedOrSkipped && inFlight === 0) {
+        resolve();
+      }
+    };
+
+    const dispatchWhileCapacity = (): void => {
+      while (inFlight < concurrency && nextDispatchIndex < items.length) {
+        if (isPastDeadline()) {
+          if (deadlineFiredAtMs === undefined) {
+            deadlineFiredAtMs = Date.now();
+          }
+          while (nextDispatchIndex < items.length) {
+            const skippedIndex = nextDispatchIndex;
+            options.onDeadlineSkip?.(items[skippedIndex]!, skippedIndex);
+            extractionSkippedDueToDeadline += 1;
+            nextDispatchIndex += 1;
+          }
+          break;
+        }
+
+        const index = nextDispatchIndex;
+        const item = items[index]!;
+        nextDispatchIndex += 1;
+        inFlight += 1;
+        peakInFlight = Math.max(peakInFlight, inFlight);
+
+        void wrapWorker(item, index).then((outcome) => {
+          results.push(outcome);
+          inFlight -= 1;
+          dispatchWhileCapacity();
+          maybeFinish();
+        });
+      }
+
+      maybeFinish();
+    };
+
+    dispatchWhileCapacity();
+  });
+
+  results.sort((a, b) => a.index - b.index);
+
+  return {
+    results,
+    stats: {
+      peakInFlight,
+      extractionSkippedDueToDeadline,
+      ...(deadlineFiredAtMs !== undefined ? { deadlineFiredAtMs } : {}),
+    },
+  };
+};

--- a/dev-docs/docs/mediapulse/apps/agents/article-analysis.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/article-analysis.mdx
@@ -4,6 +4,24 @@ description: LLM extraction, relevance scoring, and source-quality v2 for articl
 icon: FileSearch
 ---
 
+## Hermes input
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `tickerId` | yes | Ticker whose unanalyzed data sources this run processes |
+
+Runs are **always incremental**: `analysis.get` uses `unanalyzed: true`. Batch size, debounce, and extraction tuning are Hermes **agent config** fields (see the analysis agent doc for `maxBatchSize` and related knobs).
+
+### Reanalysis is out-of-band
+
+Re-extracting articles across an arbitrary time window is not an agent run mode. To re-process specific sources, reset their analyzed marker (for example clear `articleAnalysis.scoredAt` on selected `data_source` rows via a one-shot data-fix script). The next normal incremental run picks them up as unanalyzed.
+
+Do not send `reanalyze`, `timeWindow`, or `maxBatchSize` on run input — the schema is strict and rejects unknown keys.
+
+## Extraction prompts
+
+Extraction prompts live in source. To change them, open a PR. Query-analysis uses the same approach (see [Query Analysis](./query-analysis)).
+
 ## Source quality v2
 
 Relevance scoring stores five subscores in `article_relevance.score_breakdown`. Before source quality v2, `sourceQuality` was always **0.5**, so the weighted aggregate only used four live dimensions.
@@ -80,7 +98,7 @@ Two eligible rows (`score >= relevanceMinScore`) merge into the same cluster whe
 | Entity overlap | `selectionEntityOverlapThreshold` **0.5** | Jaccard over normalized canonical names, aliases, and mention names |
 | Title similarity | `selectionTitleSimilarityThreshold` **0.4** | Jaccard over 4-word lowercase title shingles |
 
-Clustering is O(n²) on the batch (n ≤ `maxBatchSize`). No embeddings or LLM calls.
+Clustering is O(n²) on the batch (n ≤ config `maxBatchSize`). No embeddings or LLM calls.
 
 ### Selection walk
 
@@ -103,6 +121,78 @@ With **`useSelectionDiversification`: `false`**, `applyRelevanceSelection` runs 
 Run summary field **`selection`** reports `eligibleRows`, `clustersFormed`, `selectedAfterDiversification`, `suppressedAsDuplicates` (rows classic top-K would have taken but diversification skipped because they were not cluster representatives), and `largestClusterSize`.
 
 Pair with **source quality v2**: the cluster representative is usually the highest-scored row, which tends to be the best outlet when `useSourceQualityV2` is on.
+
+## Yield feedback
+
+Each run emits two structured log lines: the existing **`article_analysis.run.summary`** and a separate **`article_analysis.yield.snapshot`**. The snapshot rolls up where sources and rows were dropped across pipeline stages so you can tune gates without parsing per-source noise.
+
+The same snapshot is returned on the agent result as **`details.yieldSnapshot`** for Hermes and downstream consumers.
+
+### Ratios
+
+| Ratio | Meaning |
+| ----- | ------- |
+| `extractionYield` | Sources that produced at least one grounded entity (`extractionSuccessCount / batchSize`) |
+| `groundingYield` | Sources that passed quality gate and LLM/vocab failures, before row-level grounding drops |
+| `vocabularyYield` | Same as extraction yield (sources with vocabulary-valid output) |
+| `selectionYield` | Sources selected for the daily relevance budget (`articlesSelected / batchSize`) |
+
+### Sample snapshot
+
+```json
+{
+  "event": "article_analysis.yield.snapshot",
+  "batchSize": 10,
+  "passed": {
+    "qualityGate": 8,
+    "grounding": 7,
+    "vocabulary": 6,
+    "scoring": 6,
+    "selection": 2
+  },
+  "dropped": {
+    "byContentQuality": { "content_soft_404": 2 },
+    "byGrounding": { "entities": 1, "relations": 0, "mentions": 0 },
+    "byVocabulary": { "entities": 1, "relations": 0, "repaired": 0 },
+    "bySelectionDiversification": 1,
+    "byDeadline": 0,
+    "byCritique": 0
+  },
+  "ratios": {
+    "extractionYield": 0.6,
+    "groundingYield": 0.7,
+    "vocabularyYield": 0.6,
+    "selectionYield": 0.2
+  },
+  "latency": {
+    "extractionMsP50": 4200,
+    "extractionMsP95": 9100,
+    "brainstormMsP50": 800,
+    "critiqueMsP50": null
+  }
+}
+```
+
+### Baseline regression warnings
+
+Optional Hermes config **`yieldBaseline`** supplies operator-measured P50 ratios (not auto-computed from history):
+
+| Key | Meaning |
+| --- | ------- |
+| `extractionYieldP50` | Expected median extraction yield |
+| `groundingYieldP50` | Expected median grounding yield |
+| `vocabularyYieldP50` | Expected median vocabulary yield |
+
+When any configured dimension drops **more than 15 points** below its baseline, the run logs **`article_analysis.yield.regression`** once with deltas. When `yieldBaseline` is unset, comparison is silent (no false positives on new deployments).
+
+### Recommended workflow
+
+1. Export `article_analysis.yield.snapshot` lines for a ticker over ~7 days.
+2. Compute P50 per ratio from those exports.
+3. Set `yieldBaseline` in Hermes agent config to those P50s.
+4. Watch for regression warnings; when they fire, inspect `dropped.*` buckets and adjust gate thresholds (content quality, grounding, diversification) rather than chasing raw `entitiesCreated` alone.
+
+When enabling **entity grounding** for the first time, expect extraction yield to drop until hallucinated entities are removed. Observe the new normal for a week, then update `yieldBaseline` — otherwise regression alerts will fire on every run.
 
 ## Related docs
 


### PR DESCRIPTION
## Summary

Article-analysis runs can now extract sources in parallel with an optional wall-clock deadline, emit a per-run yield snapshot for debugging drop-offs, and use a slimmer Hermes contract. Run input is `{ tickerId }` only; batch size and extraction prompts are config/code knobs, not per-run overrides.

## Related issues

Closes #558

## Important changes

- Added `runExtractionsInParallel` with configurable `extractionConcurrency` and optional `runDeadlineMs`; results merge in original batch order so dedupe stays deterministic.
- Added `YieldSnapshot` on run summary logs and `details.yieldSnapshot`, with optional `yieldBaseline` regression warnings (15-point threshold).
- Input schema is strict `{ tickerId }`; removed `reanalyze`, `timeWindow`, and input `maxBatchSize`.
- Config: `defaultMaxBatchSize` renamed to `maxBatchSize`; removed Hermes `prompts` overrides; extraction prompts built from in-code templates only.

## Other changes

- Extracted per-source logic into `run-process-one-source.ts`.
- Updated Hermes SchemaForm dev fixture and capture script for agents without `prompts` config.
- Expanded `article-analysis.mdx` (input contract, yield workflow, in-code prompts).

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/utilities/parallel-extraction.ts` — concurrency cap and deadline dispatch.
- `apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts` — per-source extraction pipeline.
- `apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts` — yield snapshot and baseline comparison.
- `apps/mediapulse/agents/article-analysis/src/run.ts` — parallel walker integration and yield emission.
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` / `schemas/article-analysis-input-schema.ts` — strict contract cleanup.

## How to test

1. From repo root: `export ASDF_NODEJS_VERSION=22.18.0 && pnpm code-quality` (or `pnpm --filter @mediapulse/article-analysis test`).
2. Confirm 225+ article-analysis tests pass, including parallel order, deadline partial success, and yield snapshot integration tests.
3. Parse sample config with legacy keys (`prompts`, `defaultMaxBatchSize`) and input with `reanalyze` — each should fail strict validation.
4. Optional: run with `extractionConcurrency: 4` and `runDeadlineMs` on a ticker with many unanalyzed sources; check run summary for `parallelism` and `yieldSnapshot` fields.
