### PR TITLE
Remove Prisma transaction wrapper from analysis POST persistence

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -447,8 +447,9 @@ describe("loadAnalysisContext", () => {
 describe("applyAnalysisPost", () => {
   it("throws when a dataSourceId is not scoped to the ticker", async () => {
     const DS_BAD = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    const tx = {
+    const db = {
       dataSource: {
+        findMany: vi.fn(),
         findUnique: vi
           .fn()
           .mockImplementation(({ where: { id } }: { where: { id: string } }) =>
@@ -456,13 +457,6 @@ describe("applyAnalysisPost", () => {
               id === DS_BAD ? { tickerId: "other-ticker" } : null,
             ),
           ),
-      },
-    };
-
-    const db = {
-      dataSource: {
-        findMany: vi.fn(),
-        findUnique: vi.fn(),
         findFirst: vi.fn(),
       },
       entityType: { findMany: vi.fn() },
@@ -473,7 +467,6 @@ describe("applyAnalysisPost", () => {
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn() },
-      $transaction: vi.fn((fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
     };
 
     await expect(
@@ -499,16 +492,10 @@ describe("applyAnalysisPost", () => {
 
   it("upserts article relevance on repeat POST with the same keys (idempotent)", async () => {
     const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    const tx = {
-      dataSource: {
-        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
-      },
-      articleRelevance: { upsert: vi.fn() },
-    };
     const db = {
       dataSource: {
         findMany: vi.fn(),
-        findUnique: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
         findFirst: vi.fn(),
       },
       entityType: { findMany: vi.fn() },
@@ -519,7 +506,6 @@ describe("applyAnalysisPost", () => {
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn(), count: vi.fn() },
-      $transaction: vi.fn((fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
     };
 
     const body = {
@@ -547,8 +533,8 @@ describe("applyAnalysisPost", () => {
     await applyAnalysisPost(body, { db: db as never });
     await applyAnalysisPost(body, { db: db as never });
 
-    expect(tx.articleRelevance.upsert).toHaveBeenCalledTimes(2);
-    expect(tx.articleRelevance.upsert).toHaveBeenNthCalledWith(
+    expect(db.articleRelevance.upsert).toHaveBeenCalledTimes(2);
+    expect(db.articleRelevance.upsert).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
         where: {
@@ -567,7 +553,7 @@ describe("applyAnalysisPost", () => {
         }),
       }),
     );
-    expect(tx.articleRelevance.upsert).toHaveBeenNthCalledWith(
+    expect(db.articleRelevance.upsert).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         where: {
@@ -583,30 +569,24 @@ describe("applyAnalysisPost", () => {
   it("skips article entity mention when entityName is not in ticker vocabulary", async () => {
     // Setup
     const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
-    const tx = {
-      dataSource: {
-        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
-      },
-      entity: {
-        findFirst: vi.fn().mockResolvedValue(null),
-      },
-      articleEntity: { upsert: vi.fn() },
-    };
     const db = {
       dataSource: {
         findMany: vi.fn(),
-        findUnique: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
         findFirst: vi.fn(),
       },
       entityType: { findMany: vi.fn() },
       relationType: { findMany: vi.fn() },
-      entity: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+      entity: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn(),
+      },
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn(), count: vi.fn() },
-      $transaction: vi.fn((fn: (t: typeof tx) => Promise<unknown>) => fn(tx)),
     };
 
     // Act: mention references an entity name not in the vocab and not in entities list.
@@ -630,7 +610,7 @@ describe("applyAnalysisPost", () => {
 
     // Assert: resolves without throwing; articleEntity.upsert never called; warn logged.
     expect(result.entitiesCreated).toBe(0);
-    expect(tx.articleEntity.upsert).not.toHaveBeenCalled();
+    expect(db.articleEntity.upsert).not.toHaveBeenCalled();
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
         tickerId: "ticker-1",

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -41,6 +41,12 @@ type AnalysisDb = {
   $transaction: typeof prisma.$transaction;
 };
 
+/** Database delegates used by analysis POST persistence (no interactive transaction). */
+type AnalysisWriteDb = Omit<
+  AnalysisDb,
+  "$transaction" | "entityType" | "relationType"
+>;
+
 const defaultDb: AnalysisDb = prisma;
 
 /**
@@ -206,6 +212,7 @@ export const loadAnalysisContext = async (
 
 /**
  * Persists analysis POST payloads: entities, relations, per-article mentions, and relevance rows.
+ * Writes run without a Prisma interactive transaction so large batches are not capped by the 5s default timeout.
  *
  * @param body - Validated POST body.
  * @param deps - Injectable database delegates for tests.
@@ -213,7 +220,7 @@ export const loadAnalysisContext = async (
  */
 export const applyAnalysisPost = async (
   body: PostAnalysisBody,
-  deps: { db?: AnalysisDb } = {},
+  deps: { db?: AnalysisWriteDb } = {},
 ): Promise<PostAnalysisResponse> => {
   const db = deps.db ?? defaultDb;
 
@@ -225,84 +232,40 @@ export const applyAnalysisPost = async (
     dataSourceIds.add(row.dataSourceId);
   }
 
-  return db.$transaction(async (tx) => {
-    for (const dataSourceId of dataSourceIds) {
-      const ds = await tx.dataSource.findUnique({
-        where: { id: dataSourceId },
-        select: { tickerId: true },
-      });
-      if (!ds || ds.tickerId !== body.tickerId) {
-        throw new AnalysisPostValidationError(
-          `dataSourceId ${dataSourceId} is missing or not scoped to tickerId`,
-        );
-      }
-    }
-
-    const nameToEntityId = new Map<string, string>();
-    let entitiesCreated = 0;
-    let entitiesReused = 0;
-
-    for (const ent of body.entities) {
-      const existing = await findReusableEntity(
-        tx,
-        ent.typeId,
-        ent.canonicalName,
-        [ent.canonicalName, ...ent.aliases],
+  for (const dataSourceId of dataSourceIds) {
+    const ds = await db.dataSource.findUnique({
+      where: { id: dataSourceId },
+      select: { tickerId: true },
+    });
+    if (!ds || ds.tickerId !== body.tickerId) {
+      throw new AnalysisPostValidationError(
+        `dataSourceId ${dataSourceId} is missing or not scoped to tickerId`,
       );
+    }
+  }
 
-      let entityId: string;
-      if (existing) {
-        entityId = existing.id;
-        entitiesReused += 1;
-        const linked = await tx.tickerEntity.findFirst({
-          where: { tickerId: body.tickerId, entityId },
-          select: { id: true },
-        });
-        if (!linked) {
-          await tx.tickerEntity.create({
-            data: {
-              tickerId: body.tickerId,
-              entityId,
-              source: "EXTRACTED",
-            },
-          });
-        }
-      } else {
-        const created = await tx.entity.create({
-          data: {
-            typeId: ent.typeId,
-            canonicalName: ent.canonicalName.trim(),
-            description: ent.description?.trim() ?? null,
-          },
-        });
-        entityId = created.id;
-        entitiesCreated += 1;
+  const nameToEntityId = new Map<string, string>();
+  let entitiesCreated = 0;
+  let entitiesReused = 0;
 
-        const aliasRows: Prisma.EntityAliasCreateManyInput[] = [];
-        const seenNorm = new Set<string>();
-        const addAlias = (raw: string) => {
-          const trimmed = raw.trim();
-          const n = normalizeAnalysisName(trimmed);
-          if (seenNorm.has(n)) return;
-          seenNorm.add(n);
-          aliasRows.push({
-            entityId,
-            alias: trimmed,
-            normalizedAlias: n,
-          });
-        };
-        addAlias(ent.canonicalName);
-        for (const a of ent.aliases) {
-          addAlias(a);
-        }
-        if (aliasRows.length > 0) {
-          await tx.entityAlias.createMany({
-            data: aliasRows,
-            skipDuplicates: true,
-          });
-        }
+  for (const ent of body.entities) {
+    const existing = await findReusableEntity(
+      db,
+      ent.typeId,
+      ent.canonicalName,
+      [ent.canonicalName, ...ent.aliases],
+    );
 
-        await tx.tickerEntity.create({
+    let entityId: string;
+    if (existing) {
+      entityId = existing.id;
+      entitiesReused += 1;
+      const linked = await db.tickerEntity.findFirst({
+        where: { tickerId: body.tickerId, entityId },
+        select: { id: true },
+      });
+      if (!linked) {
+        await db.tickerEntity.create({
           data: {
             tickerId: body.tickerId,
             entityId,
@@ -310,136 +273,178 @@ export const applyAnalysisPost = async (
           },
         });
       }
-
-      const registerName = (raw: string) => {
-        nameToEntityId.set(normalizeAnalysisName(raw), entityId);
-      };
-      registerName(ent.canonicalName);
-      for (const a of ent.aliases) {
-        registerName(a);
-      }
-    }
-
-    let relationsCreated = 0;
-    for (const rel of body.relations) {
-      const fromId = nameToEntityId.get(
-        normalizeAnalysisName(rel.fromEntityName),
-      );
-      const toId = nameToEntityId.get(normalizeAnalysisName(rel.toEntityName));
-      if (!fromId || !toId) {
-        throw new AnalysisPostValidationError(
-          `Unknown entity name in relation: ${rel.fromEntityName} -> ${rel.toEntityName}`,
-        );
-      }
-
-      const existingRel = await tx.entityRelation.findUnique({
-        where: {
-          fromEntityId_toEntityId_relationTypeId: {
-            fromEntityId: fromId,
-            toEntityId: toId,
-            relationTypeId: rel.relationTypeId,
-          },
+    } else {
+      const created = await db.entity.create({
+        data: {
+          typeId: ent.typeId,
+          canonicalName: ent.canonicalName.trim(),
+          description: ent.description?.trim() ?? null,
         },
-        select: { id: true },
       });
-      if (!existingRel) {
-        await tx.entityRelation.create({
-          data: {
-            fromEntityId: fromId,
-            toEntityId: toId,
-            relationTypeId: rel.relationTypeId,
-          },
+      entityId = created.id;
+      entitiesCreated += 1;
+
+      const aliasRows: Prisma.EntityAliasCreateManyInput[] = [];
+      const seenNorm = new Set<string>();
+      const addAlias = (raw: string) => {
+        const trimmed = raw.trim();
+        const n = normalizeAnalysisName(trimmed);
+        if (seenNorm.has(n)) return;
+        seenNorm.add(n);
+        aliasRows.push({
+          entityId,
+          alias: trimmed,
+          normalizedAlias: n,
         });
-        relationsCreated += 1;
+      };
+      addAlias(ent.canonicalName);
+      for (const a of ent.aliases) {
+        addAlias(a);
       }
+      if (aliasRows.length > 0) {
+        await db.entityAlias.createMany({
+          data: aliasRows,
+          skipDuplicates: true,
+        });
+      }
+
+      await db.tickerEntity.create({
+        data: {
+          tickerId: body.tickerId,
+          entityId,
+          source: "EXTRACTED",
+        },
+      });
     }
 
-    for (const mention of body.articleEntities) {
-      let entityId: string | undefined = nameToEntityId.get(
-        normalizeAnalysisName(mention.entityName),
-      );
-      if (entityId === undefined) {
-        entityId =
-          (await resolveEntityIdByNameForTicker(
-            tx,
-            body.tickerId,
-            mention.entityName,
-          )) ?? undefined;
-      }
-      if (entityId === undefined) {
-        logger.warn(
-          {
-            tickerId: body.tickerId,
-            entityName: mention.entityName,
-            dataSourceId: mention.dataSourceId,
-          },
-          "article entity mention skipped: entityName not in ticker vocabulary",
-        );
-        continue;
-      }
+    const registerName = (raw: string) => {
+      nameToEntityId.set(normalizeAnalysisName(raw), entityId);
+    };
+    registerName(ent.canonicalName);
+    for (const a of ent.aliases) {
+      registerName(a);
+    }
+  }
 
-      await tx.articleEntity.upsert({
-        where: {
-          dataSourceId_entityId: {
-            dataSourceId: mention.dataSourceId,
-            entityId,
-          },
+  let relationsCreated = 0;
+  for (const rel of body.relations) {
+    const fromId = nameToEntityId.get(
+      normalizeAnalysisName(rel.fromEntityName),
+    );
+    const toId = nameToEntityId.get(normalizeAnalysisName(rel.toEntityName));
+    if (!fromId || !toId) {
+      throw new AnalysisPostValidationError(
+        `Unknown entity name in relation: ${rel.fromEntityName} -> ${rel.toEntityName}`,
+      );
+    }
+
+    const existingRel = await db.entityRelation.findUnique({
+      where: {
+        fromEntityId_toEntityId_relationTypeId: {
+          fromEntityId: fromId,
+          toEntityId: toId,
+          relationTypeId: rel.relationTypeId,
         },
-        create: {
+      },
+      select: { id: true },
+    });
+    if (!existingRel) {
+      await db.entityRelation.create({
+        data: {
+          fromEntityId: fromId,
+          toEntityId: toId,
+          relationTypeId: rel.relationTypeId,
+        },
+      });
+      relationsCreated += 1;
+    }
+  }
+
+  for (const mention of body.articleEntities) {
+    let entityId: string | undefined = nameToEntityId.get(
+      normalizeAnalysisName(mention.entityName),
+    );
+    if (entityId === undefined) {
+      entityId =
+        (await resolveEntityIdByNameForTicker(
+          db,
+          body.tickerId,
+          mention.entityName,
+        )) ?? undefined;
+    }
+    if (entityId === undefined) {
+      logger.warn(
+        {
+          tickerId: body.tickerId,
+          entityName: mention.entityName,
+          dataSourceId: mention.dataSourceId,
+        },
+        "article entity mention skipped: entityName not in ticker vocabulary",
+      );
+      continue;
+    }
+
+    await db.articleEntity.upsert({
+      where: {
+        dataSourceId_entityId: {
           dataSourceId: mention.dataSourceId,
           entityId,
-          mentionCount: mention.mentionCount,
-          confidence: mention.confidence,
-          sentiment: mention.sentiment ?? null,
         },
-        update: {
-          mentionCount: mention.mentionCount,
-          confidence: mention.confidence,
-          sentiment: mention.sentiment ?? null,
-        },
-      });
-    }
+      },
+      create: {
+        dataSourceId: mention.dataSourceId,
+        entityId,
+        mentionCount: mention.mentionCount,
+        confidence: mention.confidence,
+        sentiment: mention.sentiment ?? null,
+      },
+      update: {
+        mentionCount: mention.mentionCount,
+        confidence: mention.confidence,
+        sentiment: mention.sentiment ?? null,
+      },
+    });
+  }
 
-    let articlesScored = 0;
-    for (const relRow of body.articleRelevances) {
-      const scoreBreakdown = relRow.scoreBreakdown as Prisma.InputJsonValue;
-      await tx.articleRelevance.upsert({
-        where: {
-          dataSourceId_tickerId: {
-            dataSourceId: relRow.dataSourceId,
-            tickerId: body.tickerId,
-          },
-        },
-        create: {
+  let articlesScored = 0;
+  for (const relRow of body.articleRelevances) {
+    const scoreBreakdown = relRow.scoreBreakdown as Prisma.InputJsonValue;
+    await db.articleRelevance.upsert({
+      where: {
+        dataSourceId_tickerId: {
           dataSourceId: relRow.dataSourceId,
           tickerId: body.tickerId,
-          score: relRow.score,
-          scoreBreakdown,
-          selected: relRow.selected,
-          scoredAt: new Date(),
         },
-        update: {
-          score: relRow.score,
-          scoreBreakdown,
-          selected: relRow.selected,
-          scoredAt: new Date(),
-        },
-      });
-      articlesScored += 1;
-    }
+      },
+      create: {
+        dataSourceId: relRow.dataSourceId,
+        tickerId: body.tickerId,
+        score: relRow.score,
+        scoreBreakdown,
+        selected: relRow.selected,
+        scoredAt: new Date(),
+      },
+      update: {
+        score: relRow.score,
+        scoreBreakdown,
+        selected: relRow.selected,
+        scoredAt: new Date(),
+      },
+    });
+    articlesScored += 1;
+  }
 
-    const articlesSelected = body.articleRelevances.filter(
-      (r) => r.selected,
-    ).length;
+  const articlesSelected = body.articleRelevances.filter(
+    (r) => r.selected,
+  ).length;
 
-    return {
-      entitiesCreated,
-      entitiesReused,
-      relationsCreated,
-      articlesScored,
-      articlesSelected,
-    };
-  });
+  return {
+    entitiesCreated,
+    entitiesReused,
+    relationsCreated,
+    articlesScored,
+    articlesSelected,
+  };
 };
 
 /**
@@ -468,14 +473,14 @@ export const deleteAnalysisDataSource = async (
 /**
  * Finds an entity that matches canonical name or alias (case-insensitive) for a given type.
  *
- * @param tx - Prisma transaction client.
+ * @param db - Injectable database delegates for entity lookup.
  * @param typeId - Entity type UUID.
  * @param canonicalName - Primary name from the payload.
  * @param nameVariants - Canonical plus alias strings to match.
  * @returns Existing entity id or null.
  */
 async function findReusableEntity(
-  tx: Prisma.TransactionClient,
+  db: Pick<AnalysisWriteDb, "entity">,
   typeId: string,
   canonicalName: string,
   nameVariants: string[],
@@ -485,7 +490,7 @@ async function findReusableEntity(
   );
   const normalizedList = [...normalizedSet];
 
-  return tx.entity.findFirst({
+  return db.entity.findFirst({
     where: {
       typeId,
       OR: [
@@ -511,18 +516,18 @@ async function findReusableEntity(
 /**
  * Resolves an entity id by display name for a ticker when not present in the run-local map.
  *
- * @param tx - Prisma transaction client.
+ * @param db - Injectable database delegates for entity lookup.
  * @param tickerId - Ticker scope.
  * @param entityName - Mention name from the payload.
  * @returns Entity id or null.
  */
 async function resolveEntityIdByNameForTicker(
-  tx: Prisma.TransactionClient,
+  db: Pick<AnalysisWriteDb, "entity">,
   tickerId: string,
   entityName: string,
 ): Promise<string | null> {
   const n = normalizeAnalysisName(entityName);
-  const entity = await tx.entity.findFirst({
+  const entity = await db.entity.findFirst({
     where: {
       tickerEntities: { some: { tickerId } },
       OR: [


### PR DESCRIPTION
## Summary

Large `POST /api/v1/analysis` payloads were hitting Prisma's default 5s interactive transaction limit and returning 500. This removes the `$transaction` wrapper from `applyAnalysisPost` so persistence is no longer capped by that timeout.

## Related issues

Closes #562

## Important changes

- `applyAnalysisPost` writes entities, relations, mentions, and relevances directly on the Prisma client instead of inside an interactive transaction.
- Unit tests no longer mock `$transaction`; mocks target the write delegates on `db`.

## Other changes

- Added `AnalysisWriteDb` for the slimmer injectable type used by the POST path.
- Updated JSDoc on `applyAnalysisPost` and entity lookup helpers.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — main behavior change; confirm the tradeoff (no single atomic rollback) is acceptable for idempotent upserts.
- `apps/mediapulse/agent-data-api/src/services/analysis.test.ts` — updated mocks and expectations.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test`
2. Run article-analysis against agent-data-api with a batch large enough to exceed ~5s of DB work.
3. Confirm `POST /api/v1/analysis` returns 200 and no longer logs `Transaction API error: A query cannot be executed on an expired transaction`.
