### PR TITLE
Fix OpenAI strict schema for content-generation newsletter JSON

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
@@ -1,6 +1,46 @@
 import { describe, expect, it } from "vitest";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
-import { industryNewsletterStructureSchema } from "./industry-newsletter-schema.js";
+import {
+  industryNewsletterStructureLlmSchema,
+  industryNewsletterStructureSchema,
+} from "./industry-newsletter-schema.js";
+
+/** Finds JSON-schema objects whose `properties` keys are not all listed in `required`. */
+const findOpenAiStrictSchemaIssues = (
+  value: unknown,
+  path = "root",
+): string[] => {
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+
+  const issues: string[] = [];
+  const record = value as Record<string, unknown>;
+
+  if (
+    record.type === "object" &&
+    record.properties &&
+    typeof record.properties === "object" &&
+    Array.isArray(record.required)
+  ) {
+    const propertyKeys = Object.keys(
+      record.properties as Record<string, unknown>,
+    );
+    const missing = propertyKeys.filter(
+      (key) => !(record.required as string[]).includes(key),
+    );
+    if (missing.length > 0) {
+      issues.push(`${path}: missing in required: ${missing.join(", ")}`);
+    }
+  }
+
+  for (const [key, nested] of Object.entries(record)) {
+    issues.push(...findOpenAiStrictSchemaIssues(nested, `${path}.${key}`));
+  }
+
+  return issues;
+};
 
 describe("industryNewsletterStructureSchema", () => {
   it("accepts a minimal valid payload", () => {
@@ -74,5 +114,59 @@ describe("industryNewsletterStructureSchema", () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe("industryNewsletterStructureLlmSchema", () => {
+  it("is compatible with OpenAI strict JSON schema required-key rules", () => {
+    const jsonSchema = zodToJsonSchema(industryNewsletterStructureLlmSchema, {
+      $refStrategy: "none",
+    });
+
+    expect(findOpenAiStrictSchemaIssues(jsonSchema)).toEqual([]);
+  });
+
+  it("normalizes nullable articleIndex and optional blocks to the parsed shape", () => {
+    const parsed = industryNewsletterStructureLlmSchema.parse({
+      subject: "S",
+      industryPulse: { displayHeading: "L", prose: "p" },
+      competitiveLandscape: {
+        displayHeading: "C",
+        bullets: [
+          { text: "b1", articleIndex: 1 },
+          { text: "b2", articleIndex: null },
+        ],
+      },
+      dealsAndMovements: {
+        displayHeading: "D",
+        bullets: [{ text: "d1", articleIndex: null }],
+      },
+      regulatoryPolicyWatch: {
+        displayHeading: "R",
+        bullets: [{ text: "r1", articleIndex: 2 }],
+      },
+      disruptorsOrTech: {
+        format: "prose",
+        displayHeading: "X",
+        prose: "pr",
+      },
+      quickHits: {
+        displayHeading: "Q",
+        items: [
+          { text: "h1", articleIndex: 1 },
+          { text: "h2", articleIndex: 2 },
+          { text: "h3", articleIndex: 1 },
+          { text: "h4", articleIndex: 2 },
+          { text: "h5", articleIndex: 1 },
+        ],
+      },
+      readWatchListen: null,
+      quoteOfTheWeek: null,
+    });
+
+    expect(industryNewsletterStructureSchema.parse(parsed)).toEqual(parsed);
+    expect(parsed.competitiveLandscape.bullets[1]).toEqual({ text: "b2" });
+    expect(parsed.readWatchListen).toBeUndefined();
+    expect(parsed.quoteOfTheWeek).toBeUndefined();
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
@@ -81,3 +81,100 @@ export const industryNewsletterStructureSchema = z.object({
 export type IndustryNewsletterStructure = z.infer<
   typeof industryNewsletterStructureSchema
 >;
+
+/** Maps a nullable LLM article index to the optional parsed shape. */
+const normalizeOptionalArticleIndex = (
+  articleIndex: number | null,
+): number | undefined => (articleIndex === null ? undefined : articleIndex);
+
+/** OpenAI strict JSON schema requires every property key in `required`; bullets use null when uncited. */
+const industryBriefBulletLlmSchema = z
+  .object({
+    text: z.string().min(1),
+    articleIndex: z.union([articleIndexSchema, z.null()]),
+  })
+  .transform(
+    ({ text, articleIndex }): z.infer<typeof industryBriefBulletSchema> => {
+      const normalizedIndex = normalizeOptionalArticleIndex(articleIndex);
+      return normalizedIndex === undefined
+        ? { text }
+        : { text, articleIndex: normalizedIndex };
+    },
+  );
+
+const disruptorsOrTechBulletsLlmSchema = z.object({
+  format: z.literal("bullets"),
+  displayHeading: z.string().min(1),
+  bullets: z.array(industryBriefBulletLlmSchema).min(1).max(3),
+});
+
+const disruptorsOrTechLlmSchema = z.discriminatedUnion("format", [
+  disruptorsOrTechProseSchema,
+  disruptorsOrTechBulletsLlmSchema,
+]);
+
+const quoteOfTheWeekLlmSchema = z
+  .object({
+    displayHeading: z.string().min(1),
+    quote: z.string().min(1),
+    attribution: z.string().min(1),
+    articleIndex: z.union([articleIndexSchema, z.null()]),
+  })
+  .transform(
+    ({
+      displayHeading,
+      quote,
+      attribution,
+      articleIndex,
+    }): z.infer<typeof quoteOfTheWeekSchema> => {
+      const normalizedIndex = normalizeOptionalArticleIndex(articleIndex);
+      return normalizedIndex === undefined
+        ? { displayHeading, quote, attribution }
+        : { displayHeading, quote, attribution, articleIndex: normalizedIndex };
+    },
+  );
+
+/**
+ * OpenAI-compatible schema for structured newsletter generation.
+ *
+ * Nullable fields satisfy strict JSON-schema `required` rules; transforms
+ * normalize output to {@link industryNewsletterStructureSchema}.
+ */
+export const industryNewsletterStructureLlmSchema = z
+  .object({
+    subject: z.string().min(1),
+    industryPulse: z.object({
+      displayHeading: z.string().min(1),
+      prose: z.string().min(1),
+    }),
+    competitiveLandscape: z.object({
+      displayHeading: z.string().min(1),
+      bullets: z.array(industryBriefBulletLlmSchema).min(2).max(3),
+    }),
+    dealsAndMovements: z.object({
+      displayHeading: z.string().min(1),
+      bullets: z.array(industryBriefBulletLlmSchema).min(1).max(3),
+    }),
+    regulatoryPolicyWatch: z.object({
+      displayHeading: z.string().min(1),
+      bullets: z.array(industryBriefBulletLlmSchema).min(1).max(3),
+    }),
+    disruptorsOrTech: disruptorsOrTechLlmSchema,
+    quickHits: z.object({
+      displayHeading: z.string().min(1),
+      items: z.array(industryQuickHitSchema).min(5).max(7),
+    }),
+    readWatchListen: z
+      .union([readWatchListenSchema, z.null()])
+      .transform(
+        (value): z.infer<typeof readWatchListenSchema> | undefined =>
+          value ?? undefined,
+      ),
+    quoteOfTheWeek: z
+      .union([quoteOfTheWeekLlmSchema, z.null()])
+      .transform(
+        (value): z.infer<typeof quoteOfTheWeekSchema> | undefined =>
+          value ?? undefined,
+      ),
+  })
+  .transform((value): IndustryNewsletterStructure => value);

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
@@ -30,9 +30,36 @@ export const newsletterCritiqueRatingSchema = z.object({
   rationale: z.string().max(200),
 });
 
+const newsletterCritiqueRatingLlmSchema = z
+  .object({
+    sectionKey: z.string(),
+    bulletIndex: z.number().int().nonnegative(),
+    specificity: z.number().min(1).max(5),
+    citationStrength: z.number().min(1).max(5),
+    redundancy: z.number().min(1).max(5),
+    readerValue: z.number().min(1).max(5),
+    drop: z.boolean(),
+    suggestedRewrite: z.union([z.string().max(400), z.null()]),
+    rationale: z.string().max(200),
+  })
+  .transform(
+    ({
+      suggestedRewrite,
+      ...rest
+    }): z.infer<typeof newsletterCritiqueRatingSchema> => ({
+      ...rest,
+      ...(suggestedRewrite === null ? {} : { suggestedRewrite }),
+    }),
+  );
+
 /** Self-critique JSON shape from the critic model. */
 export const newsletterCritiqueSchema = z.object({
   ratings: z.array(newsletterCritiqueRatingSchema),
+});
+
+/** OpenAI strict JSON schema for the self-critique `generateObject` pass. */
+export const newsletterCritiqueLlmSchema = z.object({
+  ratings: z.array(newsletterCritiqueRatingLlmSchema),
 });
 
 export type NewsletterCritiqueRating = z.infer<
@@ -210,7 +237,7 @@ export const critiqueCompositeScore = (
 /** Arguments for a newsletter self-critique `generateObject` call. */
 export type GenerateObjectForNewsletterCritiqueArgs = {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
-  schema: typeof newsletterCritiqueSchema;
+  schema: typeof newsletterCritiqueLlmSchema;
   system: string;
   prompt: string;
   maxOutputTokens: number;
@@ -278,7 +305,7 @@ export const critiqueNewsletter = async (
 
   const result = await generateObjectFn({
     model: openai(params.model),
-    schema: newsletterCritiqueSchema,
+    schema: newsletterCritiqueLlmSchema,
     system: params.system,
     prompt: params.prompt,
     maxOutputTokens: params.maxOutputTokens,

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -6,7 +6,10 @@ import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
 import { formatIndustryNewsletterV2Wire } from "./format-industry-newsletter-v2.js";
-import { industryNewsletterStructureSchema } from "./industry-newsletter-schema.js";
+import {
+  industryNewsletterStructureLlmSchema,
+  industryNewsletterStructureSchema,
+} from "./industry-newsletter-schema.js";
 import { attachIndustryNewsletterSourceUrls } from "./industry-newsletter-urls.js";
 import { isRetryableLlmError } from "./llm-classify-error.js";
 import {
@@ -154,7 +157,7 @@ export type NewsletterBrainstorm = {
 /** Minimal arguments for a single `generateObject` call for newsletter generation. */
 export type GenerateNewsletterObjectArgs = {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
-  schema: typeof industryNewsletterStructureSchema;
+  schema: typeof industryNewsletterStructureLlmSchema;
   system: string;
   prompt: string;
   /** Should always be 0 — we manage our own retry loop via retryWithBackoff. */
@@ -466,15 +469,15 @@ You receive exactly {{topNewsCount}} numbered articles (Article 1 … Article {{
 Return JSON matching this shape (camelCase keys):
 - "subject": short email subject (under ~60 chars), sector-relevant, may mention {{tickerName}} or {{tickerSymbol}} once if natural.
 - "industryPulse": { "displayHeading", "prose" } — short lead framing the industry story (no bullet characters in prose).
-- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets; each bullet { "text", optional "articleIndex" }.
-- "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets with optional articleIndex.
-- "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets with optional articleIndex.
-- "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets.
+- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets; each bullet { "text", "articleIndex" } where articleIndex is a 1-based article number or null when uncited.
+- "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
+- "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
+- "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
 - "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "text", "articleIndex" } (index required for every quick hit).
-- Optional "readWatchListen": { "displayHeading", "summary", "articleIndex" } — include only when grounded.
-- Optional "quoteOfTheWeek": { "displayHeading", "quote", "attribution", optional "articleIndex" } — include only when grounded.
+- "readWatchListen": { "displayHeading", "summary", "articleIndex" } or null when unsupported by the articles.
+- "quoteOfTheWeek": { "displayHeading", "quote", "attribution", "articleIndex" } or null when unsupported; articleIndex may be null when uncited.
 
-Headings ("displayHeading") can be personality titles. Keep JSON valid; omit optional blocks entirely when unsupported by the articles.`;
+Headings ("displayHeading") can be personality titles. Keep JSON valid; use null for optional blocks and uncited articleIndex values.`;
 
 /**
  * Default user prompt template used when no template is provided in config.
@@ -485,9 +488,9 @@ Write one JSON industry briefing using the {{topNewsCount}} numbered articles be
 
 Rules reminder:
 - Industry and competitive lens; no trading advice.
-- Use "articleIndex" only to point at Article 1 … Article {{topNewsCount}} from this prompt. Omit articleIndex on a bullet when there is no clear single-article grounding.
+- Use "articleIndex" to point at Article 1 … Article {{topNewsCount}} from this prompt. Set articleIndex to null on a bullet when there is no clear single-article grounding.
 - Quick hits must all include articleIndex.
-- Omit optional blocks when you cannot ground them.
+- Set readWatchListen and quoteOfTheWeek to null when you cannot ground them.
 
 {{sourceSummaries}}`;
 
@@ -849,7 +852,7 @@ export async function generateNewsletterWithLlm(
     async () => {
       return generateFn({
         model,
-        schema: industryNewsletterStructureSchema,
+        schema: industryNewsletterStructureLlmSchema,
         system: systemPrompt,
         prompt,
         maxRetries: 0,


### PR DESCRIPTION
## Summary

Newsletter generation was failing before the model ran: OpenAI strict structured output rejects JSON schemas where optional fields (like `articleIndex` on bullets) appear in `properties` but not in `required`. This adds LLM-facing schemas that use nullable required fields, normalizes the parsed output back to the existing newsletter shape, and updates prompts so the model sends `null` instead of omitting keys.

## Related issues

Closes #564

## Important changes

- Add `industryNewsletterStructureLlmSchema` for the main `generateObject` call; downstream validation still uses the lenient schema.
- Add `newsletterCritiqueLlmSchema` so self-critique does not hit the same failure on optional `suggestedRewrite`.
- Update system and user prompts to document null semantics for uncited bullets and unsupported optional blocks.

## Other changes

- Unit tests assert OpenAI strict-schema compatibility and null-to-undefined normalization.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts` — LLM schema, transforms, and normalization helpers.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — wires LLM schema and prompt wording.
- `apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts` — critique LLM schema.
- `apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts` — strict-schema regression coverage.

## How to test

1. `ASDF_NODEJS_VERSION=22.18.0 pnpm --filter @mediapulse/content-generation test`
2. `ASDF_NODEJS_VERSION=22.18.0 pnpm --filter @mediapulse/content-generation type:check`
3. Run content generation for a ticker and confirm the structured LLM call no longer returns `openai_non_retryable` with `Missing 'articleIndex'`.
