### PR TITLE
Fix stuck Hermes invoke_agent executions after worker crashes

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -183,6 +183,7 @@ const defaultEnqueueManualAgentInvocations = async (
     payload: item.payload,
     priority: item.payload.priority,
     idempotencyKey: item.payload.jobId,
+    timeoutMs: item.payload.timeoutMs,
     dependsOn:
       item.dependsOnBatchIndices && item.dependsOnBatchIndices.length > 0
         ? {

--- a/apps/hermes/worker/Dockerfile
+++ b/apps/hermes/worker/Dockerfile
@@ -24,4 +24,12 @@ USER bun
 ENV NODE_ENV=production
 
 COPY --from=builder /app/apps/hermes/worker/dist/server.js ./server.js
+
+# The worker writes /tmp/hermes-worker-heartbeat every 60 s.
+# If the file is older than 2 minutes the event loop has hung; mark unhealthy
+# so Docker / Kubernetes restarts the container.
+# --start-period gives the worker time to connect to the DB before checks begin.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=60s --retries=3 \
+  CMD test "$(find /tmp/hermes-worker-heartbeat -mmin -2 2>/dev/null | wc -l)" = "1"
+
 CMD ["bun", "server.js"]

--- a/apps/hermes/worker/src/cleanup-orphaned-executions.test.ts
+++ b/apps/hermes/worker/src/cleanup-orphaned-executions.test.ts
@@ -1,0 +1,288 @@
+/** @vitest-environment node */
+import { AgentJobExecutionStatus } from "@hermes/orchestration-database";
+import { applyInvocationCompletion } from "@hermes/scheduler";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanupOrphanedExecutions,
+  DEFAULT_ORPHAN_THRESHOLD_MINUTES,
+} from "./cleanup-orphaned-executions";
+
+vi.mock("@hermes/orchestration-database", () => ({
+  AgentJobExecutionStatus: {
+    pending: "pending",
+    running: "running",
+    completed: "completed",
+    failed: "failed",
+    cancelled: "cancelled",
+  },
+}));
+
+vi.mock("@hermes/scheduler", () => ({
+  applyInvocationCompletion: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockFindMany = vi.fn();
+const mockUpdate = vi.fn();
+
+const makeDeps = (thresholdMinutes?: number) => ({
+  db: {
+    agentJobExecution: {
+      findMany: mockFindMany,
+      update: mockUpdate,
+    },
+  } as unknown as Parameters<typeof cleanupOrphanedExecutions>[0]["db"],
+  logger: {
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+  thresholdMinutes,
+});
+
+describe("cleanupOrphanedExecutions", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockUpdate.mockReset();
+    vi.mocked(applyInvocationCompletion).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 0 and does not call applyInvocationCompletion when no orphaned rows exist", async () => {
+    // Setup
+    mockFindMany.mockResolvedValue([]);
+    const deps = makeDeps();
+
+    // Act
+    const result = await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    expect(result).toBe(0);
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("queries for running rows older than the threshold cutoff", async () => {
+    // Setup
+    const before = Date.now();
+    mockFindMany.mockResolvedValue([]);
+    const deps = makeDeps(30);
+
+    // Act
+    await cleanupOrphanedExecutions(deps);
+    const after = Date.now();
+
+    // Assert — cutoff should be approximately 30 minutes before call time
+    const findManyCall = mockFindMany.mock.calls[0];
+    expect(findManyCall).toBeDefined();
+    const where = findManyCall![0].where as {
+      status: string;
+      completedAt: null;
+      startedAt: { lt: Date };
+    };
+    expect(where.status).toBe(AgentJobExecutionStatus.running);
+    expect(where.completedAt).toBeNull();
+    const cutoff = where.startedAt.lt;
+    expect(cutoff.getTime()).toBeGreaterThanOrEqual(
+      before - 30 * 60 * 1_000 - 100,
+    );
+    expect(cutoff.getTime()).toBeLessThanOrEqual(after - 30 * 60 * 1_000 + 100);
+  });
+
+  it("uses DEFAULT_ORPHAN_THRESHOLD_MINUTES (60) when thresholdMinutes is omitted", async () => {
+    // Setup
+    const before = Date.now();
+    mockFindMany.mockResolvedValue([]);
+    const deps = makeDeps();
+
+    // Act
+    await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    const where = mockFindMany.mock.calls[0]![0].where as {
+      startedAt: { lt: Date };
+    };
+    const cutoff = where.startedAt.lt.getTime();
+    expect(cutoff).toBeLessThanOrEqual(
+      before - DEFAULT_ORPHAN_THRESHOLD_MINUTES * 60 * 1_000 + 100,
+    );
+  });
+
+  it("calls applyInvocationCompletion with failed terminal for a row that has a schedule execution parent", async () => {
+    // Setup
+    const row = {
+      id: "row-1",
+      jobId: "job-1",
+      scheduleExecutionId: "se-1",
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: "step-1",
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    mockFindMany.mockResolvedValue([row]);
+    const deps = makeDeps();
+
+    // Act
+    const result = await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    expect(result).toBe(1);
+    expect(applyInvocationCompletion).toHaveBeenCalledTimes(1);
+    expect(applyInvocationCompletion).toHaveBeenCalledWith(
+      {
+        jobId: "job-1",
+        scheduleExecutionId: "se-1",
+        httpTriggerExecutionId: undefined,
+        manualExecutionId: undefined,
+        pipelineStepId: "step-1",
+        terminal: {
+          status: AgentJobExecutionStatus.failed,
+          error: expect.objectContaining({
+            message: expect.stringContaining("Orphaned"),
+            retryable: false,
+            orphanCleanup: true,
+          }),
+        },
+      },
+      expect.objectContaining({ db: expect.any(Object) }),
+    );
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("calls applyInvocationCompletion with httpTriggerExecutionId for HTTP trigger rows", async () => {
+    // Setup
+    const row = {
+      id: "row-2",
+      jobId: "job-2",
+      scheduleExecutionId: null,
+      httpTriggerExecutionId: "ht-exec-1",
+      manualExecutionId: null,
+      pipelineStepId: "step-2",
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    mockFindMany.mockResolvedValue([row]);
+    const deps = makeDeps();
+
+    // Act
+    const result = await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    expect(result).toBe(1);
+    expect(applyInvocationCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-2",
+        scheduleExecutionId: undefined,
+        httpTriggerExecutionId: "ht-exec-1",
+        manualExecutionId: undefined,
+        pipelineStepId: "step-2",
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("marks directly as failed (no applyInvocationCompletion) when no parent execution id is set", async () => {
+    // Setup
+    const row = {
+      id: "row-3",
+      jobId: "job-3",
+      scheduleExecutionId: null,
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: "step-3",
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    mockFindMany.mockResolvedValue([row]);
+    mockUpdate.mockResolvedValue(undefined);
+    const deps = makeDeps();
+
+    // Act
+    const result = await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    expect(result).toBe(1);
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { jobId: "job-3" },
+      data: {
+        status: AgentJobExecutionStatus.failed,
+        completedAt: expect.any(Date),
+        error: expect.objectContaining({
+          message: expect.stringContaining("Orphaned"),
+          retryable: false,
+          orphanCleanup: true,
+        }),
+      },
+    });
+  });
+
+  it("continues to next row and logs error when applyInvocationCompletion throws", async () => {
+    // Setup
+    const rowFail = {
+      id: "row-bad",
+      jobId: "job-bad",
+      scheduleExecutionId: "se-fail",
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: "step-fail",
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    const rowOk = {
+      id: "row-ok",
+      jobId: "job-ok",
+      scheduleExecutionId: null,
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: "step-ok",
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    mockFindMany.mockResolvedValue([rowFail, rowOk]);
+    vi.mocked(applyInvocationCompletion).mockRejectedValueOnce(
+      new Error("DB error"),
+    );
+    mockUpdate.mockResolvedValue(undefined);
+    const deps = makeDeps();
+
+    // Act
+    const result = await cleanupOrphanedExecutions(deps);
+
+    // Assert — failed row counted as not resolved; second row processed
+    expect(result).toBe(1);
+    expect(deps.logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-bad" }),
+      expect.stringContaining(
+        "cleanup_orphaned_executions: failed to resolve row",
+      ),
+    );
+    expect(mockUpdate).toHaveBeenCalledTimes(1);
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { jobId: "job-ok" } }),
+    );
+  });
+
+  it("logs a warning when orphaned rows are found", async () => {
+    // Setup
+    const row = {
+      id: "row-x",
+      jobId: "job-x",
+      scheduleExecutionId: null,
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: null,
+      startedAt: new Date(Date.now() - 90 * 60 * 1_000),
+    };
+    mockFindMany.mockResolvedValue([row]);
+    mockUpdate.mockResolvedValue(undefined);
+    const deps = makeDeps();
+
+    // Act
+    await cleanupOrphanedExecutions(deps);
+
+    // Assert
+    expect(deps.logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ count: 1, thresholdMinutes: 60 }),
+      "cleanup_orphaned_executions: found stuck running rows",
+    );
+  });
+});

--- a/apps/hermes/worker/src/cleanup-orphaned-executions.ts
+++ b/apps/hermes/worker/src/cleanup-orphaned-executions.ts
@@ -1,0 +1,139 @@
+import {
+  AgentJobExecutionStatus,
+  type PrismaClient,
+} from "@hermes/orchestration-database";
+import {
+  applyInvocationCompletion,
+  type ApplyInvocationCompletionDeps,
+} from "@hermes/scheduler";
+
+/** Minimum orphan age in minutes before a record is eligible for cleanup. */
+export const DEFAULT_ORPHAN_THRESHOLD_MINUTES = 60;
+
+/**
+ * Dependencies for {@link cleanupOrphanedExecutions}.
+ */
+export type CleanupOrphanedExecutionsDeps = {
+  db: PrismaClient;
+  logger: ApplyInvocationCompletionDeps["logger"];
+  /** Rows running longer than this many minutes are treated as orphaned. Defaults to 60. */
+  thresholdMinutes?: number;
+};
+
+/** Fields read from orphaned agent_job_execution rows. */
+type OrphanedRow = {
+  id: string;
+  jobId: string;
+  scheduleExecutionId: string | null;
+  httpTriggerExecutionId: string | null;
+  manualExecutionId: string | null;
+  pipelineStepId: string | null;
+  startedAt: Date | null;
+};
+
+/**
+ * Finds `agent_job_execution` rows that have been `running` for longer than `thresholdMinutes`
+ * without a `completedAt` timestamp (orphans left behind by worker crashes or DataQueue DLQ
+ * exhaustion) and drives each one to a terminal `failed` state via `applyInvocationCompletion`.
+ * Rows with no parent execution id are marked directly without step-rollup updates.
+ *
+ * @param deps - Injected db client, logger, and optional threshold.
+ * @returns The number of rows that were resolved.
+ */
+export const cleanupOrphanedExecutions = async (
+  deps: CleanupOrphanedExecutionsDeps,
+): Promise<number> => {
+  const {
+    db,
+    logger,
+    thresholdMinutes = DEFAULT_ORPHAN_THRESHOLD_MINUTES,
+  } = deps;
+
+  const cutoff = new Date(Date.now() - thresholdMinutes * 60 * 1_000);
+
+  const rows = await db.agentJobExecution.findMany({
+    where: {
+      status: AgentJobExecutionStatus.running,
+      completedAt: null,
+      startedAt: { lt: cutoff },
+    },
+    select: {
+      id: true,
+      jobId: true,
+      scheduleExecutionId: true,
+      httpTriggerExecutionId: true,
+      manualExecutionId: true,
+      pipelineStepId: true,
+      startedAt: true,
+    },
+  });
+
+  if (rows.length === 0) {
+    return 0;
+  }
+
+  logger.warn(
+    { count: rows.length, thresholdMinutes },
+    "cleanup_orphaned_executions: found stuck running rows",
+  );
+
+  const completionDeps: ApplyInvocationCompletionDeps = { db, logger };
+  let resolved = 0;
+
+  for (const row of rows as OrphanedRow[]) {
+    try {
+      const hasParent = Boolean(
+        row.scheduleExecutionId ??
+        row.httpTriggerExecutionId ??
+        row.manualExecutionId,
+      );
+
+      if (hasParent && row.pipelineStepId) {
+        await applyInvocationCompletion(
+          {
+            jobId: row.jobId,
+            scheduleExecutionId: row.scheduleExecutionId ?? undefined,
+            httpTriggerExecutionId: row.httpTriggerExecutionId ?? undefined,
+            manualExecutionId: row.manualExecutionId ?? undefined,
+            pipelineStepId: row.pipelineStepId,
+            terminal: {
+              status: AgentJobExecutionStatus.failed,
+              error: {
+                message: `Orphaned: still running after ${thresholdMinutes} minutes — worker crash or DataQueue DLQ exhaustion`,
+                retryable: false,
+                orphanCleanup: true,
+              },
+            },
+          },
+          completionDeps,
+        );
+      } else {
+        await db.agentJobExecution.update({
+          where: { jobId: row.jobId },
+          data: {
+            status: AgentJobExecutionStatus.failed,
+            completedAt: new Date(),
+            error: {
+              message: `Orphaned: still running after ${thresholdMinutes} minutes — worker crash or DataQueue DLQ exhaustion (no parent execution)`,
+              retryable: false,
+              orphanCleanup: true,
+            },
+          },
+        });
+      }
+
+      logger.warn(
+        { jobId: row.jobId, startedAt: row.startedAt },
+        "cleanup_orphaned_executions: resolved orphaned row",
+      );
+      resolved++;
+    } catch (err) {
+      logger.error(
+        { err, jobId: row.jobId },
+        "cleanup_orphaned_executions: failed to resolve row — will retry next sweep",
+      );
+    }
+  }
+
+  return resolved;
+};

--- a/apps/hermes/worker/src/index.ts
+++ b/apps/hermes/worker/src/index.ts
@@ -4,9 +4,15 @@
  * Hermes (Next.js) stays stateless and does not run the queue.
  */
 
+import { writeFileSync } from "node:fs";
 import { env } from "@hermes/env/hermes-worker";
 
 const DRAIN_TIMEOUT_MS = 30_000;
+/** Written every minute; Docker HEALTHCHECK reads recency to detect hangs. */
+const HEARTBEAT_PATH = "/tmp/hermes-worker-heartbeat";
+const HEARTBEAT_INTERVAL_MS = 60_000;
+/** Logged every 5 minutes to surface memory growth early. */
+const MEMORY_LOG_INTERVAL_MS = 5 * 60 * 1_000;
 
 const processorBatchSize = Math.max(
   1,
@@ -16,6 +22,57 @@ const processorConcurrency = Math.max(
   1,
   Number.parseInt(env.PROCESSOR_CONCURRENCY ?? "3", 10) || 3,
 );
+
+// ─── Module-level shutdown hook ───────────────────────────────────────────────
+// Set inside main() once the processor/supervisor are running.
+// The global error handlers below reference this so they can drain gracefully
+// even when the error fires outside the main() scope.
+let _shutdown: (() => Promise<void>) | null = null;
+let _fatalHandlerTriggered = false;
+
+/**
+ * Logs a fatal error and initiates a graceful shutdown, falling back to a
+ * forced `process.exit(1)` if shutdown does not complete within 10 seconds.
+ * Guards against being triggered twice (e.g. cascading unhandled rejections).
+ *
+ * @param label - Short label for the error category (e.g. "unhandledRejection").
+ * @param err - The thrown value or rejection reason.
+ */
+const handleFatalError = (label: string, err: unknown): void => {
+  if (_fatalHandlerTriggered) return;
+  _fatalHandlerTriggered = true;
+
+  // Use console.error because the structured logger may not yet be initialised.
+  console.error(`[hermes-worker] ${label}:`, err);
+
+  // Force-exit if graceful shutdown stalls.
+  const forceExitTimer = setTimeout(() => {
+    console.error(
+      "[hermes-worker] Graceful shutdown timed out — force exiting",
+    );
+    process.exit(1);
+  }, 10_000);
+  // .unref() so this timer does not keep the event loop alive on its own.
+  forceExitTimer.unref();
+
+  if (_shutdown) {
+    _shutdown()
+      .catch((shutdownErr) => {
+        console.error("[hermes-worker] Shutdown error:", shutdownErr);
+      })
+      .finally(() => process.exit(1));
+  } else {
+    process.exit(1);
+  }
+};
+
+// Register before main() so errors during startup are also caught.
+process.on("unhandledRejection", (reason) => {
+  handleFatalError("unhandledRejection", reason);
+});
+process.on("uncaughtException", (err) => {
+  handleFatalError("uncaughtException", err);
+});
 
 async function main(): Promise<void> {
   const { getJobQueue } = await import("./queue");
@@ -50,6 +107,19 @@ async function main(): Promise<void> {
       scheduleName: "hermes-check-schedules",
       cronExpression: "* * * * *",
       jobType: "check_schedules",
+      payload: {},
+      timezone: "UTC",
+    });
+  }
+
+  const existingCleanupCron = await jobQueue
+    .getCronJobByName("hermes-cleanup-orphaned-executions")
+    .catch(() => null);
+  if (!existingCleanupCron) {
+    await jobQueue.addCronJob({
+      scheduleName: "hermes-cleanup-orphaned-executions",
+      cronExpression: "*/15 * * * *",
+      jobType: "cleanup_orphaned_executions",
       payload: {},
       timezone: "UTC",
     });
@@ -95,6 +165,9 @@ async function main(): Promise<void> {
     }
   };
 
+  // Expose to the module-level fatal handler so it can drain gracefully.
+  _shutdown = shutdown;
+
   const onShutdownSignal = async (): Promise<void> => {
     let exitCode = 0;
     try {
@@ -112,7 +185,48 @@ async function main(): Promise<void> {
     void onShutdownSignal();
   });
 
-  logger.info("Hermes worker started (processor + supervisor)");
+  // ─── Memory monitoring ─────────────────────────────────────────────────────
+  // Logs heap and RSS every 5 minutes so memory growth is visible in the logs
+  // before the OS kills the process with SIGKILL (OOM). If RSS climbs steadily
+  // across restarts, there is a memory leak that needs profiling.
+  const memTimer = setInterval(() => {
+    const mem = process.memoryUsage();
+    logger.info(
+      {
+        heapUsedMb: Math.round(mem.heapUsed / 1024 / 1024),
+        heapTotalMb: Math.round(mem.heapTotal / 1024 / 1024),
+        rssMb: Math.round(mem.rss / 1024 / 1024),
+        externalMb: Math.round(mem.external / 1024 / 1024),
+      },
+      "worker memory usage",
+    );
+  }, MEMORY_LOG_INTERVAL_MS);
+  memTimer.unref();
+
+  // ─── Heartbeat file ────────────────────────────────────────────────────────
+  // Docker HEALTHCHECK (see Dockerfile) confirms the main loop is alive by
+  // checking that this file was touched within the last 2 minutes. A hung
+  // event loop will stop updating the file and Docker will mark the container
+  // unhealthy, triggering a restart per the deployment restart policy.
+  const writeHeartbeat = (): void => {
+    try {
+      writeFileSync(HEARTBEAT_PATH, Date.now().toString());
+    } catch {
+      // Best-effort — a single failed write should not crash the worker.
+    }
+  };
+  writeHeartbeat();
+  const heartbeatTimer = setInterval(writeHeartbeat, HEARTBEAT_INTERVAL_MS);
+  heartbeatTimer.unref();
+
+  logger.info(
+    {
+      pid: process.pid,
+      concurrency: processorConcurrency,
+      batchSize: processorBatchSize,
+    },
+    "Hermes worker started (processor + supervisor)",
+  );
 }
 
 main().catch((err) => {

--- a/apps/hermes/worker/src/index.ts
+++ b/apps/hermes/worker/src/index.ts
@@ -126,8 +126,7 @@ async function main(): Promise<void> {
   }
 
   processor = jobQueue.createProcessor(jobHandlers, {
-    // eslint-disable-next-line strict-env/no-process-env, turbo/no-undeclared-env-vars
-    verbose: process.env.NODE_ENV === "development",
+    verbose: env.NODE_ENV === "development",
     workerId: `hermes-${process.pid}`,
     batchSize: processorBatchSize,
     concurrency: processorConcurrency,
@@ -139,8 +138,7 @@ async function main(): Promise<void> {
   processor.startInBackground();
 
   supervisor = jobQueue.createSupervisor({
-    // eslint-disable-next-line strict-env/no-process-env, turbo/no-undeclared-env-vars
-    verbose: process.env.NODE_ENV === "development",
+    verbose: env.NODE_ENV === "development",
     intervalMs: 60_000,
     stuckJobsTimeoutMinutes: 10,
     cleanupJobsDaysToKeep: 30,

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -10,6 +10,7 @@ import {
   parseAgentResponseEnvelope,
 } from "@hermes/scheduler";
 import { logger } from "@workspace/logger";
+import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
 import { jobHandlers } from "./job-handlers";
 
 const mockPrisma = vi.hoisted(() => ({
@@ -94,6 +95,10 @@ vi.mock("@hermes/scheduler", async (importOriginal) => {
 const mockAddJobs = vi.fn().mockResolvedValue([1]);
 const mockEditJob = vi.fn().mockResolvedValue(undefined);
 const mockGetJob = vi.fn();
+
+vi.mock("./cleanup-orphaned-executions", () => ({
+  cleanupOrphanedExecutions: vi.fn().mockResolvedValue(0),
+}));
 
 vi.mock("./queue", () => ({
   getJobQueue: () => ({
@@ -217,6 +222,7 @@ describe("jobHandlers", () => {
         payload: expect.objectContaining({ jobId: "j1" }),
         priority: 0,
         idempotencyKey: "j1",
+        timeoutMs: 60_000,
       });
       expect(mockEditJob).toHaveBeenCalledTimes(1);
       expect(mockEditJob).toHaveBeenCalledWith(1, {
@@ -441,7 +447,12 @@ describe("jobHandlers", () => {
       expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledWith({
         where: {
           jobId: payload.jobId,
-          status: AgentJobExecutionStatus.pending,
+          status: {
+            in: [
+              AgentJobExecutionStatus.pending,
+              AgentJobExecutionStatus.running,
+            ],
+          },
         },
         data: {
           status: AgentJobExecutionStatus.running,
@@ -717,6 +728,44 @@ describe("jobHandlers", () => {
       expect(mockPrisma.agentJobExecution.update).not.toHaveBeenCalled();
     });
 
+    it("re-claims an already-running row left by a crashed prior attempt (retry path)", async () => {
+      // Setup — simulate a prior attempt that crashed: the claim Prisma call
+      // must include 'running' so the retry can take over the orphaned row.
+      vi.mocked(invokeAgentPost).mockResolvedValue({
+        kind: "http",
+        response: {
+          statusCode: 200,
+          rawBody: '{"schemaVersion":1,"status":"success"}',
+          isEmptyBody: false,
+        },
+      });
+      vi.mocked(parseAgentResponseEnvelope).mockReturnValue({
+        ok: true,
+        envelope: { schemaVersion: 1, status: "success", truncated: {} },
+      });
+
+      // Act
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
+
+      // Assert — claim where clause must accept both pending AND running
+      expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledWith({
+        where: {
+          jobId: payload.jobId,
+          status: {
+            in: [
+              AgentJobExecutionStatus.pending,
+              AgentJobExecutionStatus.running,
+            ],
+          },
+        },
+        data: {
+          status: AgentJobExecutionStatus.running,
+          startedAt: expect.any(Date),
+        },
+      });
+      expect(invokeAgentPost).toHaveBeenCalledTimes(1);
+    });
+
     it("on 4xx uses JSON body message when present (e.g. agent skipped + message)", async () => {
       vi.mocked(invokeAgentPost).mockResolvedValue({
         kind: "http",
@@ -744,6 +793,30 @@ describe("jobHandlers", () => {
           },
         }),
         expect.any(Object),
+      );
+    });
+  });
+
+  describe("cleanup_orphaned_executions", () => {
+    it("calls cleanupOrphanedExecutions with orchestration prisma and logs resolved count", async () => {
+      // Setup
+      vi.mocked(cleanupOrphanedExecutions).mockResolvedValue(3);
+
+      // Act
+      await jobHandlers.cleanup_orphaned_executions(
+        {},
+        new AbortController().signal,
+        {} as Parameters<typeof jobHandlers.cleanup_orphaned_executions>[2],
+      );
+
+      // Assert
+      expect(cleanupOrphanedExecutions).toHaveBeenCalledTimes(1);
+      expect(cleanupOrphanedExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({ db: expect.any(Object) }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        { resolved: 3 },
+        "cleanup_orphaned_executions: sweep complete",
       );
     });
   });

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -28,6 +28,7 @@ import {
 } from "@hermes/scheduler";
 import { getJobQueue } from "./queue";
 import { executeHttpTrigger } from "./execute-http-trigger";
+import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
 
 /**
  * Parses optional positive integer env strings (DataQueue retry delay fields are in seconds).
@@ -245,6 +246,10 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
               payload: item.payload,
               priority: item.payload.priority,
               idempotencyKey: item.payload.jobId,
+              // Mirror the HTTP-request timeout as a DataQueue-level job deadline so
+              // DataQueue's supervisor can force-kill the job if the got timeout fails
+              // to fire (e.g. TCP-level hang where the OS never delivers a close event).
+              timeoutMs: item.payload.timeoutMs,
               maxAttempts,
               deadLetterJobType,
               ...(retryDelaySec !== undefined
@@ -311,6 +316,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
           payload: item.payload,
           priority: item.payload.priority,
           idempotencyKey: item.payload.jobId,
+          timeoutMs: item.payload.timeoutMs,
           dependsOn:
             item.dependsOnBatchIndices && item.dependsOnBatchIndices.length > 0
               ? {
@@ -354,8 +360,22 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       "invoke_agent started",
     );
 
+    // Claim either a pending record (first attempt) or an already-running record left
+    // behind by a prior attempt whose worker process crashed before completing. When
+    // DataQueue's stuckJobsTimeout recovers the DataQueue job and retries it, the
+    // orchestration row is still "running" because the crash left no cleanup path.
+    // Including "running" here lets the retry re-enter and drive the row to a terminal
+    // state via applyInvocationCompletion or handleTransientInvokeFailure.
     const claimed = await orchestrationPrisma.agentJobExecution.updateMany({
-      where: { jobId: payload.jobId, status: AgentJobExecutionStatus.pending },
+      where: {
+        jobId: payload.jobId,
+        status: {
+          in: [
+            AgentJobExecutionStatus.pending,
+            AgentJobExecutionStatus.running,
+          ],
+        },
+      },
       data: {
         status: AgentJobExecutionStatus.running,
         startedAt: new Date(),
@@ -651,5 +671,13 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
         completionDeps,
       );
     }
+  },
+
+  cleanup_orphaned_executions: async () => {
+    const resolved = await cleanupOrphanedExecutions({
+      db: orchestrationPrisma,
+      logger,
+    });
+    logger.info({ resolved }, "cleanup_orphaned_executions: sweep complete");
   },
 };

--- a/apps/hermes/worker/src/job-payload-map.ts
+++ b/apps/hermes/worker/src/job-payload-map.ts
@@ -4,6 +4,7 @@ import type { InvokeAgentJobPayload } from "@hermes/scheduler";
  * DataQueue job payload map for Hermes. Keys are job types; values are payload shapes.
  * check_schedules: polls due schedules and enqueues invoke_agent jobs.
  * invoke_agent: one job per agent invocation; processor runs with configurable concurrency.
+ * cleanup_orphaned_executions: periodic sweep that marks stuck running agent_job_execution rows as failed.
  */
 export type JobPayloadMap = {
   check_schedules: {
@@ -13,4 +14,5 @@ export type JobPayloadMap = {
     httpTriggerExecutionId: string;
   };
   invoke_agent: InvokeAgentJobPayload;
+  cleanup_orphaned_executions: Record<string, never>;
 };

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -5,6 +5,9 @@
 # for the short-lived token flow set AGENT_AUTH_API_URL as well.
 # =============================================================================
 
+# Node environment (development enables verbose DataQueue processor/supervisor logs).
+NODE_ENV=development #optional
+
 # Orchestration DB URL (pipelines, schedules, agent registry, executions).
 ORCHESTRATION_DATABASE_URL=postgresql://mediapulse:mediapulse@localhost:5432/mediapulse?schema=orchestration # required
 # Max rows per db: expansion (take/limit). Must match Hermes `HERMES_DATA_SOURCE_MAX_TAKE` when validating pipelines.

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
+    NODE_ENV: z.string().optional(),
     ORCHESTRATION_DATABASE_URL: z.string().min(1),
     HERMES_DATA_SOURCE_MAX_TAKE: z.number({ coerce: true }).optional(),
     DATABASE_CERT_BASE64: z.string().optional(),


### PR DESCRIPTION
## Summary

When the Hermes worker crashed during data collection, `agent_job_execution` rows could stay stuck in `running`. DataQueue retried the job, but the handler only claimed `pending` rows, so the retry exited early and the schedule never rolled up. This PR lets retries take over orphaned `running` rows, sets DataQueue job deadlines from the pipeline timeout, sweeps long-stuck rows every 15 minutes, and adds basic worker reliability signals (fatal handlers, memory logs, heartbeat).

## Related issues

Closes #566

## Important changes

- `invoke_agent` claim accepts orchestration rows in `pending` or `running` state
- Pass `timeoutMs` when enqueueing `invoke_agent` jobs from schedules, HTTP triggers, and manual pipeline runs
- New `cleanup_orphaned_executions` DataQueue cron (every 15 minutes; marks rows running longer than 60 minutes)
- Worker registers `unhandledRejection` / `uncaughtException` handlers with graceful drain before exit
- Periodic memory usage logs and a heartbeat file for Docker HEALTHCHECK

## Other changes

- Unit tests for reclaim on retry, timeout propagation, cleanup sweep, and handler wiring

## Key files to review

- `apps/hermes/worker/src/job-handlers.ts` — claim fix, `timeoutMs` on enqueue, cleanup handler
- `apps/hermes/worker/src/cleanup-orphaned-executions.ts` — sweep logic with `applyInvocationCompletion`
- `apps/hermes/worker/src/index.ts` — fatal error handlers, memory logging, heartbeat
- `apps/hermes/worker/Dockerfile` — HEALTHCHECK on heartbeat freshness
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — manual run `timeoutMs`

## How to test

1. From repo root: `pnpm --filter @hermes/worker test` (32 tests)
2. Start the worker and confirm cron job `hermes-cleanup-orphaned-executions` is registered on first boot
3. With a row stuck in `running` and a pending DataQueue retry, verify the handler re-claims it and reaches a terminal state
4. In the container, confirm `/tmp/hermes-worker-heartbeat` updates every minute and `docker inspect` reports healthy after start period
