### PR TITLE
Add multi-provider web fetch with ordered provider fallback

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -107,8 +107,7 @@ const defaultSearchSuccess = [
 
 const defaultFetchSuccess = [
   {
-    success: true,
-    data: {
+    success: {
       url: "http://example.com",
       title: validArticleTitle,
       content: validArticleContent,
@@ -116,7 +115,9 @@ const defaultFetchSuccess = [
       searchQueryId: "sq-1",
       searchQueryText: "test query",
       serpIndex: 0,
+      provider: "jina" as const,
     },
+    failures: [],
   },
 ];
 
@@ -175,9 +176,14 @@ describe("data-collection agent (HTTP)", () => {
               rateLimit: { requests: 1, perSeconds: 1 },
             },
             webFetch: {
-              baseUrl: "https://fetch.example",
-              authentication: { type: "bearer" },
-              rateLimit: { requests: 1, perSeconds: 1 },
+              providers: [
+                {
+                  type: "jina",
+                  baseUrl: "https://fetch.example",
+                  authentication: { type: "bearer" },
+                  rateLimit: { requests: 1, perSeconds: 1 },
+                },
+              ],
             },
           },
         }),
@@ -249,9 +255,14 @@ describe("data-collection agent (HTTP)", () => {
               rateLimit: { requests: 1, perSeconds: 1 },
             },
             webFetch: {
-              baseUrl: "https://fetch.example",
-              authentication: { type: "bearer" },
-              rateLimit: { requests: 1, perSeconds: 1 },
+              providers: [
+                {
+                  type: "jina",
+                  baseUrl: "https://fetch.example",
+                  authentication: { type: "bearer" },
+                  rateLimit: { requests: 1, perSeconds: 1 },
+                },
+              ],
             },
           },
         }),

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -5,6 +5,11 @@ import type { AgentRunContext } from "@workspace/agent-runtime";
 
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
+import type {
+  FetchedWebSearchResult,
+  WebFetchFailure,
+  WebFetchOutcome,
+} from "./utilities/web-fetch";
 
 const TICKER_ID = "11111111-1111-4111-a111-111111111111";
 
@@ -40,10 +45,15 @@ const baseConfig = {
     concurrency: 4,
   },
   webFetch: {
-    baseUrl: "https://fetch.example",
-    authentication: { type: "bearer" as const },
-    rateLimit: { requests: 1, perSeconds: 1 },
-    concurrency: 4,
+    providers: [
+      {
+        type: "jina",
+        baseUrl: "https://fetch.example",
+        authentication: { type: "bearer" as const },
+        rateLimit: { requests: 1, perSeconds: 1 },
+        concurrency: 4,
+      },
+    ],
   },
   targetDailySuccessfulSources: 1,
   maxRefillRounds: 3,
@@ -60,6 +70,32 @@ const searchSuccessPage = {
   searchQueryText: "test query",
   serpIndex: 0,
 };
+
+/**
+ * Builds a successful web-fetch outcome for run-level mocks.
+ *
+ * @param data - Fetched page fields returned by the mock provider chain.
+ */
+const mockFetchSuccess = (
+  data: Omit<FetchedWebSearchResult, "provider"> &
+    Partial<Pick<FetchedWebSearchResult, "provider">>,
+): WebFetchOutcome => ({
+  success: { provider: "jina", ...data },
+  failures: [],
+});
+
+/**
+ * Builds a failed web-fetch outcome for run-level mocks.
+ *
+ * @param failure - Failure fields for the mocked provider attempt.
+ */
+const mockFetchFailure = (
+  failure: Omit<WebFetchFailure, "provider"> &
+    Partial<Pick<WebFetchFailure, "provider">>,
+): WebFetchOutcome => ({
+  success: null,
+  failures: [{ provider: "jina", ...failure }],
+});
 
 vi.mock("@mediapulse/env/agents-data-collection", () => ({
   env: {
@@ -172,13 +208,10 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValue([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          content: validArticleContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        content: validArticleContent,
+      }),
     ]);
     getMock.mockResolvedValue({
       data: [{ id: "sq-1", text: "test query", tickerId: TICKER_ID }],
@@ -354,8 +387,7 @@ describe("runDataCollection", () => {
 
   it("records 404 fetch failures to the dead-url cache", async () => {
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: false,
+      mockFetchFailure({
         url: "http://failed.com",
         queryId: "sq-1",
         tickerId: TICKER_ID,
@@ -363,7 +395,7 @@ describe("runDataCollection", () => {
         message: "404 Not Found",
         retryable: false,
         httpStatus: 404,
-      },
+      }),
     ]);
 
     await runDataCollection(
@@ -419,41 +451,29 @@ describe("runDataCollection", () => {
       ]);
 
       vi.mocked(performWebFetch).mockResolvedValueOnce([
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            url: "http://example.com/fresh",
-            content: validArticleContent,
-            jinaMetadata: { publishedTime: isoDaysAgo(2) },
-          },
-        },
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            url: "http://example.com/stale",
-            content: validArticleContent,
-            jinaMetadata: { publishedTime: isoDaysAgo(30) },
-          },
-        },
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            url: "http://example.com/unknown",
-            content: validArticleContent,
-          },
-        },
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            url: "http://example.com/future",
-            content: validArticleContent,
-            jinaMetadata: { publishedTime: isoDaysAhead(5) },
-          },
-        },
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "http://example.com/fresh",
+          content: validArticleContent,
+          fetchMetadata: { publishedTime: isoDaysAgo(2) },
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "http://example.com/stale",
+          content: validArticleContent,
+          fetchMetadata: { publishedTime: isoDaysAgo(30) },
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "http://example.com/unknown",
+          content: validArticleContent,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "http://example.com/future",
+          content: validArticleContent,
+          fetchMetadata: { publishedTime: isoDaysAhead(5) },
+        }),
       ]);
 
       const result = await runDataCollection(
@@ -597,24 +617,18 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "http://example.com/earnings",
-          title: "Apple Q2 earnings beat estimates",
-          content: earningsContent,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "http://example.com/vision",
-          title: "Apple unveils new Vision Pro",
-          content: visionContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "http://example.com/earnings",
+        title: "Apple Q2 earnings beat estimates",
+        content: earningsContent,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "http://example.com/vision",
+        title: "Apple unveils new Vision Pro",
+        content: visionContent,
+      }),
     ]);
 
     const result = await runDataCollection(
@@ -680,8 +694,7 @@ describe("runDataCollection", () => {
   it("records partial_success and persists fetch failures", async () => {
     // Setup
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: false,
+      mockFetchFailure({
         url: "http://failed.com",
         queryId: "sq-1",
         tickerId: TICKER_ID,
@@ -689,7 +702,7 @@ describe("runDataCollection", () => {
         message: "404 Not Found",
         retryable: false,
         httpStatus: 404,
-      },
+      }),
     ]);
 
     // Act
@@ -772,13 +785,10 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          content: validArticleContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        content: validArticleContent,
+      }),
     ]);
 
     // Act
@@ -870,33 +880,24 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/clean",
-          title: validArticleTitle,
-          content: validArticleContent,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/off-topic",
-          title: "Microsoft earnings headline here",
-          content: offTopicContent,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/paywall",
-          title: "Premium article headline here",
-          content: paywallContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/clean",
+        title: validArticleTitle,
+        content: validArticleContent,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/off-topic",
+        title: "Microsoft earnings headline here",
+        content: offTopicContent,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/paywall",
+        title: "Premium article headline here",
+        content: paywallContent,
+      }),
     ]);
 
     // Act
@@ -975,42 +976,30 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/clean",
-          title: validArticleTitle,
-          content: validArticleContent,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/paywall",
-          title: "Premium article headline here",
-          content: paywallContent,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/soft-404",
-          title: "Missing article headline here",
-          content: soft404Content,
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "https://example.com/short",
-          title: "Valid headline for short body",
-          content: shortContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/clean",
+        title: validArticleTitle,
+        content: validArticleContent,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/paywall",
+        title: "Premium article headline here",
+        content: paywallContent,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/soft-404",
+        title: "Missing article headline here",
+        content: soft404Content,
+      }),
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        url: "https://example.com/short",
+        title: "Valid headline for short body",
+        content: shortContent,
+      }),
     ]);
 
     // Act
@@ -1061,15 +1050,12 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          title: "Company profile and key statistics",
-          url: "https://example.com/stocks",
-          content: `Financial summary and key statistics with market cap details. ${Array.from({ length: 120 }, (_, index) => `Detail paragraph ${index} covers regional lending trends.`).join(" ")}`,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        title: "Company profile and key statistics",
+        url: "https://example.com/stocks",
+        content: `Financial summary and key statistics with market cap details. ${Array.from({ length: 120 }, (_, index) => `Detail paragraph ${index} covers regional lending trends.`).join(" ")}`,
+      }),
     ]);
 
     // Act
@@ -1131,22 +1117,16 @@ describe("runDataCollection", () => {
       ]);
     vi.mocked(performWebFetch)
       .mockResolvedValueOnce([
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            content: validArticleContent,
-          },
-        },
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          content: validArticleContent,
+        }),
       ])
       .mockResolvedValueOnce([
-        {
-          success: true,
-          data: {
-            ...searchSuccessPage,
-            content: validArticleContent,
-          },
-        },
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          content: validArticleContent,
+        }),
       ]);
 
     // Act
@@ -1204,13 +1184,10 @@ describe("runDataCollection", () => {
       },
     ]);
     vi.mocked(performWebFetch).mockResolvedValue([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          content: validArticleContent,
-        },
-      },
+      mockFetchSuccess({
+        ...searchSuccessPage,
+        content: validArticleContent,
+      }),
     ]);
 
     // Act
@@ -1253,13 +1230,12 @@ describe("runDataCollection", () => {
 
     vi.mocked(performWebSearch).mockResolvedValueOnce(searchHits);
     vi.mocked(performWebFetch).mockImplementation(async (results) =>
-      results.map((page) => ({
-        success: true as const,
-        data: {
+      results.map((page) =>
+        mockFetchSuccess({
           ...page,
           content: validArticleContent,
-        },
-      })),
+        }),
+      ),
     );
 
     // Act
@@ -1309,7 +1285,7 @@ describe("parallel fetch wall-clock", () => {
       await new Promise((resolve) => setTimeout(resolve, 50));
       return {
         statusCode: 200,
-        json: async () => ({
+        body: JSON.stringify({
           data: {
             url: "http://example.com/page",
             title: validArticleTitle,
@@ -1324,10 +1300,15 @@ describe("parallel fetch wall-clock", () => {
     const startedAt = Date.now();
     await performWebFetchActual(searchResults, {
       config: {
-        baseUrl: "https://fetch.example",
-        authentication: { type: "bearer" as const },
-        rateLimit: { requests: 12, perSeconds: 1 },
-        concurrency: 4,
+        providers: [
+          {
+            type: "jina",
+            baseUrl: "https://fetch.example",
+            authentication: { type: "bearer" as const },
+            rateLimit: { requests: 12, perSeconds: 1 },
+            concurrency: 4,
+          },
+        ],
       },
       gotClient: fakeGot as never,
       logger: { info: vi.fn(), warn: vi.fn() },

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -204,10 +204,7 @@ export async function runDataCollection(
     >
   > = [];
   const fetchFailures: Array<
-    Extract<
-      Awaited<ReturnType<typeof performWebFetch>>[number],
-      { success: false }
-    >
+    Awaited<ReturnType<typeof performWebFetch>>[number]["failures"][number]
   > = [];
   const droppedByUrlReason: Record<UrlNoiseReason, number> = {
     blocked_host: 0,
@@ -394,10 +391,15 @@ export async function runDataCollection(
       });
       throttleEvents += fetchThrottleStats.throttleEvents;
       const roundFetchSuccesses = fetchAttemptResults
-        .filter((r) => r.success)
-        .map((r) => r.data);
-      const roundFetchFailures = fetchAttemptResults.filter((r) => !r.success);
-      fetchFailedCount += roundFetchFailures.length;
+        .filter((outcome) => outcome.success !== null)
+        .map((outcome) => outcome.success!);
+      const roundFetchFailures = fetchAttemptResults.flatMap(
+        (outcome) => outcome.failures,
+      );
+      const roundFailedUrlCount = fetchAttemptResults.filter(
+        (outcome) => outcome.success === null,
+      ).length;
+      fetchFailedCount += roundFailedUrlCount;
       fetchFailures.push(...roundFetchFailures);
 
       const finalFetchSuccesses: typeof roundFetchSuccesses = [];
@@ -452,7 +454,7 @@ export async function runDataCollection(
 
         if (freshnessGateConfig.enabled) {
           const publishedAt = extractPublishedDate({
-            jinaMetadata: page.jinaMetadata,
+            fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
             content: page.content,
           });
           const freshnessDecision = isFresh(publishedAt, {
@@ -485,7 +487,7 @@ export async function runDataCollection(
         {
           round,
           fetchSuccess: finalFetchSuccesses.length,
-          fetchFailed: roundFetchFailures.length,
+          fetchFailed: roundFailedUrlCount,
           droppedByUrlReason,
           droppedByDuplicateCanonicalUrl,
           droppedByExistingCanonicalUrl,
@@ -503,9 +505,12 @@ export async function runDataCollection(
       );
 
       if (deadUrlCacheConfig.enabled) {
+        const deadUrlFetchFailures = fetchAttemptResults
+          .filter((outcome) => outcome.success === null)
+          .flatMap((outcome) => outcome.failures);
         const deadUrlRecords = buildDeadUrlRecords(
           input.tickerId,
-          roundFetchFailures,
+          deadUrlFetchFailures,
           roundQualityDrops,
         );
         if (deadUrlRecords.length > 0) {
@@ -576,7 +581,7 @@ export async function runDataCollection(
         if (pagesToPersist.length > 0) {
           const sources: DataCollectionInput[] = pagesToPersist.map((page) => {
             const publishedAt = extractPublishedDate({
-              jinaMetadata: page.jinaMetadata,
+              fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
               content: page.content,
             });
             return {
@@ -638,7 +643,7 @@ export async function runDataCollection(
       runId,
       tickerId: input.tickerId,
       stage: "web-fetch" as const,
-      provider: "jina" as const,
+      provider: f.provider,
       searchQueryId: f.queryId,
       url: f.url,
       errorCategory: f.errorCategory,

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -7,6 +7,24 @@ import {
   getConfigSchema,
 } from "./config-schema";
 
+const jinaWebFetchProvider = {
+  type: "jina" as const,
+  baseUrl: "https://r.jina.ai",
+  authentication: {
+    type: "bearer" as const,
+    apiKey: "key",
+    headerName: "Authorization",
+  },
+  rateLimit: {
+    requests: 100,
+    perSeconds: 60,
+  },
+};
+
+const webFetchWithJinaProvider = {
+  providers: [jinaWebFetchProvider],
+};
+
 describe("getConfigSchema", () => {
   it("returns wrapped JSON schema with agentId", () => {
     // Act
@@ -35,18 +53,7 @@ describe("dataCollectionAgentConfigSchema", () => {
           perSeconds: 60,
         },
       },
-      webFetch: {
-        baseUrl: "https://r.jina.ai",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "Authorization",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
+      webFetch: webFetchWithJinaProvider,
       targetDailySuccessfulSources: 5,
       maxRefillRounds: 3,
     };
@@ -56,7 +63,12 @@ describe("dataCollectionAgentConfigSchema", () => {
 
     // Assert
     expect(parsed.webSearch.baseUrl).toBe("https://google.serper.dev");
-    expect(parsed.webFetch.baseUrl).toBe("https://r.jina.ai");
+    expect(parsed.webFetch.providers).toEqual([
+      expect.objectContaining({
+        type: "jina",
+        baseUrl: "https://r.jina.ai",
+      }),
+    ]);
     expect(parsed.targetDailySuccessfulSources).toBe(5);
     expect(parsed.maxRefillRounds).toBe(3);
   });
@@ -76,18 +88,7 @@ describe("dataCollectionAgentConfigSchema", () => {
           perSeconds: 60,
         },
       },
-      webFetch: {
-        baseUrl: "https://r.jina.ai",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "Authorization",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
+      webFetch: webFetchWithJinaProvider,
       relevanceGate: {
         enabled: true,
         headChars: 1500,
@@ -117,15 +118,7 @@ describe("dataCollectionAgentConfigSchema", () => {
         },
         rateLimit: { requests: 0, perSeconds: 60 },
       },
-      webFetch: {
-        baseUrl: "https://r.jina.ai",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "Authorization",
-        },
-        rateLimit: { requests: 10, perSeconds: 60 },
-      },
+      webFetch: webFetchWithJinaProvider,
     };
 
     expect(() => dataCollectionAgentConfigSchema.parse(base)).toThrow();
@@ -139,6 +132,116 @@ describe("dataCollectionAgentConfigSchema", () => {
         },
       }),
     ).toThrow();
+  });
+
+  it("accepts ordered webFetch.providers array", () => {
+    // Setup
+    const config = {
+      webSearch: {
+        baseUrl: "https://google.serper.dev",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "key",
+          headerName: "X-API-KEY",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+      webFetch: {
+        providers: [
+          {
+            type: "jina",
+            baseUrl: "https://r.jina.ai",
+            authentication: {
+              type: "bearer" as const,
+              apiKey: "jina-key",
+              headerName: "Authorization",
+            },
+            rateLimit: {
+              requests: 100,
+              perSeconds: 60,
+            },
+          },
+          {
+            type: "firecrawl",
+            baseUrl: "https://api.firecrawl.dev",
+            authentication: {
+              type: "bearer" as const,
+              apiKey: "fc-key",
+              headerName: "Authorization",
+            },
+            rateLimit: {
+              requests: 50,
+              perSeconds: 60,
+            },
+          },
+        ],
+      },
+    };
+
+    // Act
+    const parsed = dataCollectionAgentConfigSchema.parse(config);
+
+    // Assert
+    expect(parsed.webFetch.providers.map((provider) => provider.type)).toEqual([
+      "jina",
+      "firecrawl",
+    ]);
+  });
+
+  it("rejects legacy single-object webFetch shape", () => {
+    const config = {
+      webSearch: {
+        baseUrl: "https://google.serper.dev",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "key",
+          headerName: "X-API-KEY",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+      webFetch: {
+        baseUrl: "https://r.jina.ai",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "legacy-key",
+          headerName: "Authorization",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+    };
+
+    expect(() => dataCollectionAgentConfigSchema.parse(config)).toThrow();
+  });
+
+  it("rejects empty webFetch.providers arrays", () => {
+    const config = {
+      webSearch: {
+        baseUrl: "https://google.serper.dev",
+        authentication: {
+          type: "bearer" as const,
+          apiKey: "key",
+          headerName: "X-API-KEY",
+        },
+        rateLimit: {
+          requests: 100,
+          perSeconds: 60,
+        },
+      },
+      webFetch: {
+        providers: [],
+      },
+    };
+
+    expect(() => dataCollectionAgentConfigSchema.parse(config)).toThrow();
   });
 
   it("rejects invalid refill configuration values", () => {
@@ -156,18 +259,7 @@ describe("dataCollectionAgentConfigSchema", () => {
           perSeconds: 60,
         },
       },
-      webFetch: {
-        baseUrl: "https://r.jina.ai",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "Authorization",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
+      webFetch: webFetchWithJinaProvider,
     };
 
     // Act + Assert

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -25,26 +25,37 @@ const webSearchSchema = z.object({
     .optional(),
 });
 
-const webFetchSchema = z.object({
+const fetchProviderAuthenticationSchema = z.object({
+  type: z.enum(["bearer", "none"]),
+  apiKey: z.string().optional(),
+  headerName: z.string().optional(),
+});
+
+const fetchProviderRateLimitSchema = z.object({
+  requests: z.number().int().positive(),
+  perSeconds: z.number().positive(),
+});
+
+const fetchProviderRetrySchema = z
+  .object({
+    maxAttempts: z.number().int().nonnegative(),
+    baseDelayMs: z.number().int().positive(),
+    maxDelayMs: z.number().int().positive(),
+  })
+  .optional();
+
+export const fetchProviderConfigSchema = z.object({
+  type: z.string(),
   baseUrl: z.string(),
-  authentication: z.object({
-    type: z.enum(["bearer", "none"]),
-    apiKey: z.string().optional(),
-    headerName: z.string().optional(),
-  }),
-  rateLimit: z.object({
-    requests: z.number().int().positive(),
-    perSeconds: z.number().positive(),
-  }),
+  authentication: fetchProviderAuthenticationSchema,
+  rateLimit: fetchProviderRateLimitSchema,
   concurrency: concurrencySchema,
   timeoutMs: z.number().int().positive().optional(),
-  retry: z
-    .object({
-      maxAttempts: z.number().int().nonnegative(),
-      baseDelayMs: z.number().int().positive(),
-      maxDelayMs: z.number().int().positive(),
-    })
-    .optional(),
+  retry: fetchProviderRetrySchema,
+});
+
+const webFetchSchema = z.object({
+  providers: z.array(fetchProviderConfigSchema).min(1),
 });
 
 const relevanceGateSchema = z.object({

--- a/apps/mediapulse/agents/data-collection/src/utilities/date-extractor.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/date-extractor.ts
@@ -1,12 +1,17 @@
-/** Metadata fields from a Jina Reader response used for publication-date extraction. */
-export type JinaFetchMetadata = {
+/** Metadata fields from a fetch provider response used for publication-date extraction. */
+export type FetchMetadata = {
   publishedTime?: string;
   published_at?: string;
   usage?: { tokens?: number };
 };
 
+/** @deprecated Use {@link FetchMetadata} instead. */
+export type JinaFetchMetadata = FetchMetadata;
+
 export type ExtractPublishedDateInput = {
-  jinaMetadata?: JinaFetchMetadata;
+  fetchMetadata?: FetchMetadata;
+  /** @deprecated Use {@link ExtractPublishedDateInput.fetchMetadata} instead. */
+  jinaMetadata?: FetchMetadata;
   content: string;
 };
 
@@ -50,13 +55,13 @@ const parseInSanityRange = (value: string, now: Date): Date | null => {
 };
 
 /**
- * Reads explicit publication timestamps from Jina Reader metadata.
+ * Reads explicit publication timestamps from fetch provider metadata.
  *
- * @param metadata - Optional Jina metadata object.
+ * @param metadata - Optional fetch metadata object.
  * @param now - Reference time for range validation.
  */
-const extractFromJinaMetadata = (
-  metadata: JinaFetchMetadata | undefined,
+const extractFromFetchMetadata = (
+  metadata: FetchMetadata | undefined,
   now: Date,
 ): Date | null => {
   if (!metadata) {
@@ -113,9 +118,9 @@ const extractFromContent = (content: string, now: Date): Date | null => {
 };
 
 /**
- * Extracts the best-effort publication date from Jina metadata and page content.
+ * Extracts the best-effort publication date from fetch metadata and page content.
  *
- * @param input - Jina metadata and fetched content.
+ * @param input - Fetch metadata and fetched content.
  * @param now - Reference time for sanity-range validation.
  * @returns Parsed publication date, or `null` when no reliable signal is found.
  */
@@ -123,7 +128,8 @@ export const extractPublishedDate = (
   input: ExtractPublishedDateInput,
   now: Date = new Date(),
 ): Date | null => {
-  const fromMetadata = extractFromJinaMetadata(input.jinaMetadata, now);
+  const metadata = input.fetchMetadata ?? input.jinaMetadata;
+  const fromMetadata = extractFromFetchMetadata(metadata, now);
   if (fromMetadata) {
     return fromMetadata;
   }

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.test.ts
@@ -1,0 +1,137 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type got from "got";
+
+import { createDiffbotFetchProvider } from "./diffbot";
+import type { FetchProviderConfig } from "./types";
+
+const defaultConfig: FetchProviderConfig = {
+  type: "diffbot",
+  baseUrl: "https://api.diffbot.com",
+  authentication: {
+    type: "none",
+    apiKey: "diffbot-token",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
+/** Builds a got GET response stub with HTTP status metadata. */
+const mockGotGetResponse = (jsonValue: unknown, statusCode = 200) => ({
+  statusCode,
+  body: JSON.stringify(jsonValue),
+});
+
+describe("createDiffbotFetchProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses and normalizes a successful Diffbot response", async () => {
+    // Setup
+    const getMock = vi.fn().mockReturnValue(
+      mockGotGetResponse({
+        objects: [
+          {
+            text: "Article body",
+            title: "Article title",
+            date: "2026-04-12T08:00:00.000Z",
+          },
+        ],
+      }),
+    );
+    const provider = createDiffbotFetchProvider(defaultConfig);
+
+    // Act
+    const result = await provider.fetchOne("http://example.com/page", {
+      gotClient: { get: getMock } as unknown as typeof got,
+      rateLimiter: {
+        acquire: vi.fn().mockResolvedValue(undefined),
+        recordResponse: vi.fn(),
+      },
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(getMock).toHaveBeenCalledWith(
+      "https://api.diffbot.com/v3/article?token=diffbot-token&url=http%3A%2F%2Fexample.com%2Fpage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: "application/json",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      content: "Article body",
+      title: "Article title",
+      publishedTime: "2026-04-12T08:00:00.000Z",
+    });
+  });
+
+  it("throws when objects is empty", async () => {
+    // Setup
+    const getMock = vi.fn().mockReturnValue(
+      mockGotGetResponse({
+        objects: [],
+      }),
+    );
+    const provider = createDiffbotFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { get: getMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+
+  it("throws on schema mismatch", async () => {
+    // Setup
+    const getMock = vi.fn().mockReturnValue(
+      mockGotGetResponse({
+        items: [],
+      }),
+    );
+    const provider = createDiffbotFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { get: getMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when the first object has no text", async () => {
+    // Setup
+    const getMock = vi.fn().mockReturnValue(
+      mockGotGetResponse({
+        objects: [{ title: "Only title" }],
+      }),
+    );
+    const provider = createDiffbotFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { get: getMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.test.ts
@@ -5,6 +5,7 @@ import type got from "got";
 
 import { createDiffbotFetchProvider } from "./diffbot";
 import type { FetchProviderConfig } from "./types";
+import { mockRateLimiter } from "./test-fixtures";
 
 const defaultConfig: FetchProviderConfig = {
   type: "diffbot",
@@ -46,10 +47,7 @@ describe("createDiffbotFetchProvider", () => {
     // Act
     const result = await provider.fetchOne("http://example.com/page", {
       gotClient: { get: getMock } as unknown as typeof got,
-      rateLimiter: {
-        acquire: vi.fn().mockResolvedValue(undefined),
-        recordResponse: vi.fn(),
-      },
+      rateLimiter: mockRateLimiter(),
       logger: { info: vi.fn(), warn: vi.fn() },
     });
 
@@ -82,10 +80,7 @@ describe("createDiffbotFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { get: getMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow("Semantic validation failed");
@@ -104,10 +99,7 @@ describe("createDiffbotFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { get: getMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow();
@@ -126,10 +118,7 @@ describe("createDiffbotFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { get: getMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow("Semantic validation failed");

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/diffbot.ts
@@ -1,0 +1,112 @@
+import { z } from "zod";
+
+import { withRetry } from "../resilience";
+import { isRetryableError } from "../error-classification";
+
+import type {
+  FetchProvider,
+  FetchProviderConfig,
+  NormalizedFetchData,
+  ProviderRequestContext,
+} from "./types";
+
+/** Zod schema for Diffbot article API response. */
+const diffbotResponseSchema = z.object({
+  objects: z
+    .array(
+      z.object({
+        text: z.string().optional(),
+        title: z.string().optional(),
+        date: z.string().optional(),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Parses and validates a Diffbot article response body.
+ *
+ * @param raw - Parsed JSON body from the HTTP response.
+ */
+const parseDiffbotResponse = (raw: unknown): NormalizedFetchData => {
+  const parsed = diffbotResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  const firstObject = parsed.data.objects?.[0];
+  if (!firstObject?.text || firstObject.text.trim() === "") {
+    throw new Error("Semantic validation failed");
+  }
+
+  return {
+    content: firstObject.text,
+    ...(firstObject.title ? { title: firstObject.title } : {}),
+    ...(firstObject.date ? { publishedTime: firstObject.date } : {}),
+  };
+};
+
+/**
+ * Builds the Diffbot article endpoint with token query parameter auth.
+ *
+ * @param config - Diffbot provider configuration.
+ * @param url - Target page URL.
+ */
+const buildDiffbotEndpoint = (
+  config: FetchProviderConfig,
+  url: string,
+): string => {
+  const baseUrl = config.baseUrl.replace(/\/$/, "");
+  const endpoint = new URL(`${baseUrl}/v3/article`);
+  if (config.authentication.apiKey) {
+    endpoint.searchParams.set("token", config.authentication.apiKey);
+  }
+  endpoint.searchParams.set("url", url);
+  return endpoint.toString();
+};
+
+/**
+ * Executes one Diffbot article fetch for a URL.
+ *
+ * @param url - Target page URL.
+ * @param config - Diffbot provider configuration.
+ * @param ctx - Shared request context.
+ */
+const fetchOneDiffbot = async (
+  url: string,
+  config: FetchProviderConfig,
+  ctx: ProviderRequestContext,
+): Promise<NormalizedFetchData> => {
+  await ctx.rateLimiter.acquire();
+
+  const fetchTask = async () => {
+    const response = await ctx.gotClient.get(
+      buildDiffbotEndpoint(config, url),
+      {
+        headers: {
+          Accept: "application/json",
+        },
+        timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      },
+    );
+    ctx.rateLimiter.recordResponse(response.statusCode);
+    const raw = JSON.parse(response.body) as unknown;
+    return parseDiffbotResponse(raw);
+  };
+
+  return config.retry
+    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    : await fetchTask();
+};
+
+/**
+ * Creates a Diffbot fetch provider adapter.
+ *
+ * @param config - Diffbot provider configuration.
+ */
+export const createDiffbotFetchProvider = (
+  config: FetchProviderConfig,
+): FetchProvider => ({
+  type: "diffbot",
+  fetchOne: (url, ctx) => fetchOneDiffbot(url, config, ctx),
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.test.ts
@@ -1,0 +1,142 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type got from "got";
+
+import { createFirecrawlFetchProvider } from "./firecrawl";
+import type { FetchProviderConfig } from "./types";
+
+const defaultConfig: FetchProviderConfig = {
+  type: "firecrawl",
+  baseUrl: "https://api.firecrawl.dev",
+  authentication: {
+    type: "bearer",
+    apiKey: "fc-key",
+    headerName: "Authorization",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
+/** Builds a got POST response stub with HTTP status metadata. */
+const mockGotPostResponse = (jsonValue: unknown, statusCode = 200) => ({
+  statusCode,
+  body: JSON.stringify(jsonValue),
+});
+
+describe("createFirecrawlFetchProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses and normalizes a successful Firecrawl response", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        success: true,
+        data: {
+          markdown: "# Article body",
+          metadata: {
+            title: "Article title",
+            publishedTime: "2026-04-12T08:00:00.000Z",
+          },
+        },
+      }),
+    );
+    const provider = createFirecrawlFetchProvider(defaultConfig);
+
+    // Act
+    const result = await provider.fetchOne("http://example.com", {
+      gotClient: { post: postMock } as unknown as typeof got,
+      rateLimiter: {
+        acquire: vi.fn().mockResolvedValue(undefined),
+        recordResponse: vi.fn(),
+      },
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(postMock).toHaveBeenCalledWith(
+      "https://api.firecrawl.dev/v1/scrape",
+      expect.objectContaining({
+        json: { url: "http://example.com", formats: ["markdown"] },
+        headers: expect.objectContaining({
+          Authorization: "Bearer fc-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      content: "# Article body",
+      title: "Article title",
+      publishedTime: "2026-04-12T08:00:00.000Z",
+    });
+  });
+
+  it("throws when success is false", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        success: false,
+        data: { markdown: "ignored" },
+      }),
+    );
+    const provider = createFirecrawlFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+
+  it("throws on schema mismatch", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        ok: true,
+      }),
+    );
+    const provider = createFirecrawlFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when markdown is empty", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        success: true,
+        data: { markdown: "  " },
+      }),
+    );
+    const provider = createFirecrawlFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.test.ts
@@ -5,6 +5,7 @@ import type got from "got";
 
 import { createFirecrawlFetchProvider } from "./firecrawl";
 import type { FetchProviderConfig } from "./types";
+import { mockRateLimiter } from "./test-fixtures";
 
 const defaultConfig: FetchProviderConfig = {
   type: "firecrawl",
@@ -48,10 +49,7 @@ describe("createFirecrawlFetchProvider", () => {
     // Act
     const result = await provider.fetchOne("http://example.com", {
       gotClient: { post: postMock } as unknown as typeof got,
-      rateLimiter: {
-        acquire: vi.fn().mockResolvedValue(undefined),
-        recordResponse: vi.fn(),
-      },
+      rateLimiter: mockRateLimiter(),
       logger: { info: vi.fn(), warn: vi.fn() },
     });
 
@@ -86,10 +84,7 @@ describe("createFirecrawlFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { post: postMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow("Semantic validation failed");
@@ -108,10 +103,7 @@ describe("createFirecrawlFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { post: postMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow();
@@ -131,10 +123,7 @@ describe("createFirecrawlFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { post: postMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow("Semantic validation failed");

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/firecrawl.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import { withRetry } from "../resilience";
+import { isRetryableError } from "../error-classification";
+
+import type {
+  FetchProvider,
+  FetchProviderConfig,
+  NormalizedFetchData,
+  ProviderRequestContext,
+} from "./types";
+
+/** Zod schema for Firecrawl scrape API response. */
+const firecrawlResponseSchema = z.object({
+  success: z.boolean(),
+  data: z
+    .object({
+      markdown: z.string().optional(),
+      metadata: z
+        .object({
+          title: z.string().optional(),
+          publishedTime: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
+});
+
+/**
+ * Builds bearer auth headers for Firecrawl requests.
+ *
+ * @param config - Firecrawl provider configuration.
+ */
+const buildAuthHeaders = (
+  config: FetchProviderConfig,
+): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  if (config.authentication.apiKey) {
+    headers.Authorization = `Bearer ${config.authentication.apiKey}`;
+  }
+  return headers;
+};
+
+/**
+ * Parses and validates a Firecrawl scrape response body.
+ *
+ * @param raw - Parsed JSON body from the HTTP response.
+ */
+const parseFirecrawlResponse = (raw: unknown): NormalizedFetchData => {
+  const parsed = firecrawlResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  if (!parsed.data.success) {
+    throw new Error("Semantic validation failed");
+  }
+
+  const markdown = parsed.data.data?.markdown;
+  if (!markdown || markdown.trim() === "") {
+    throw new Error("Semantic validation failed");
+  }
+
+  const metadata = parsed.data.data?.metadata;
+  return {
+    content: markdown,
+    ...(metadata?.title ? { title: metadata.title } : {}),
+    ...(metadata?.publishedTime
+      ? { publishedTime: metadata.publishedTime }
+      : {}),
+  };
+};
+
+/**
+ * Executes one Firecrawl scrape for a URL.
+ *
+ * @param url - Target page URL.
+ * @param config - Firecrawl provider configuration.
+ * @param ctx - Shared request context.
+ */
+const fetchOneFirecrawl = async (
+  url: string,
+  config: FetchProviderConfig,
+  ctx: ProviderRequestContext,
+): Promise<NormalizedFetchData> => {
+  await ctx.rateLimiter.acquire();
+
+  const endpoint = `${config.baseUrl.replace(/\/$/, "")}/v1/scrape`;
+  const fetchTask = async () => {
+    const response = await ctx.gotClient.post(endpoint, {
+      json: { url, formats: ["markdown"] },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...buildAuthHeaders(config),
+      },
+      timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+    });
+    ctx.rateLimiter.recordResponse(response.statusCode);
+    const raw = JSON.parse(response.body) as unknown;
+    return parseFirecrawlResponse(raw);
+  };
+
+  return config.retry
+    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    : await fetchTask();
+};
+
+/**
+ * Creates a Firecrawl fetch provider adapter.
+ *
+ * @param config - Firecrawl provider configuration.
+ */
+export const createFirecrawlFetchProvider = (
+  config: FetchProviderConfig,
+): FetchProvider => ({
+  type: "firecrawl",
+  fetchOne: (url, ctx) => fetchOneFirecrawl(url, config, ctx),
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.test.ts
@@ -5,6 +5,7 @@ import type got from "got";
 
 import { createJinaFetchProvider } from "./jina";
 import type { FetchProviderConfig } from "./types";
+import { mockRateLimiter } from "./test-fixtures";
 
 const defaultConfig: FetchProviderConfig = {
   type: "jina",
@@ -48,10 +49,7 @@ describe("createJinaFetchProvider", () => {
     // Act
     const result = await provider.fetchOne("http://example.com", {
       gotClient: { post: postMock } as unknown as typeof got,
-      rateLimiter: {
-        acquire: vi.fn().mockResolvedValue(undefined),
-        recordResponse: vi.fn(),
-      },
+      rateLimiter: mockRateLimiter(),
       logger: { info: vi.fn(), warn: vi.fn() },
     });
 
@@ -88,10 +86,7 @@ describe("createJinaFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { post: postMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow();
@@ -114,10 +109,7 @@ describe("createJinaFetchProvider", () => {
     await expect(
       provider.fetchOne("http://example.com", {
         gotClient: { post: postMock } as unknown as typeof got,
-        rateLimiter: {
-          acquire: vi.fn().mockResolvedValue(undefined),
-          recordResponse: vi.fn(),
-        },
+        rateLimiter: mockRateLimiter(),
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow("Semantic validation failed");

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.test.ts
@@ -1,0 +1,125 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type got from "got";
+
+import { createJinaFetchProvider } from "./jina";
+import type { FetchProviderConfig } from "./types";
+
+const defaultConfig: FetchProviderConfig = {
+  type: "jina",
+  baseUrl: "https://r.jina.ai/",
+  authentication: {
+    type: "bearer",
+    apiKey: "jina-key",
+    headerName: "Authorization",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
+/** Builds a got POST response stub with HTTP status metadata. */
+const mockGotPostResponse = (jsonValue: unknown, statusCode = 200) => ({
+  statusCode,
+  body: JSON.stringify(jsonValue),
+});
+
+describe("createJinaFetchProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses and normalizes a successful Jina response", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        data: {
+          url: "http://example.com",
+          title: "Title",
+          content: "Full content",
+          publishedTime: "2026-04-12T08:00:00.000Z",
+          published_at: "2026-04-12T09:00:00.000Z",
+          usage: { tokens: 42 },
+        },
+      }),
+    );
+    const provider = createJinaFetchProvider(defaultConfig);
+
+    // Act
+    const result = await provider.fetchOne("http://example.com", {
+      gotClient: { post: postMock } as unknown as typeof got,
+      rateLimiter: {
+        acquire: vi.fn().mockResolvedValue(undefined),
+        recordResponse: vi.fn(),
+      },
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(postMock).toHaveBeenCalledWith(
+      "https://r.jina.ai/",
+      expect.objectContaining({
+        json: { url: "http://example.com" },
+        headers: expect.objectContaining({
+          Authorization: "Bearer jina-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      url: "http://example.com",
+      title: "Title",
+      content: "Full content",
+      publishedTime: "2026-04-12T08:00:00.000Z",
+      published_at: "2026-04-12T09:00:00.000Z",
+      usage: { tokens: 42 },
+    });
+  });
+
+  it("throws on schema mismatch", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        data: "not-an-object",
+      }),
+    );
+    const provider = createJinaFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when content is empty", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        data: {
+          url: "http://example.com",
+          title: "Title",
+          content: "   ",
+        },
+      }),
+    );
+    const provider = createJinaFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: {
+          acquire: vi.fn().mockResolvedValue(undefined),
+          recordResponse: vi.fn(),
+        },
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/jina.ts
@@ -1,0 +1,119 @@
+import { z } from "zod";
+
+import { withRetry } from "../resilience";
+import { isRetryableError } from "../error-classification";
+
+import type {
+  FetchProvider,
+  FetchProviderConfig,
+  NormalizedFetchData,
+  ProviderRequestContext,
+} from "./types";
+
+/** Zod schema for Jina AI Reader API response data object. */
+const jinaDataSchema = z.object({
+  url: z.string().url().optional(),
+  title: z.string().optional(),
+  content: z.string().optional(),
+  publishedTime: z.string().optional(),
+  published_at: z.string().optional(),
+  usage: z
+    .object({
+      tokens: z.number().optional(),
+    })
+    .optional(),
+});
+
+/** Zod schema for Jina AI Reader API response. */
+export const jinaResponseSchema = z.object({
+  data: jinaDataSchema.optional(),
+});
+
+/**
+ * Builds bearer or custom auth headers from provider authentication config.
+ *
+ * @param config - Provider authentication settings.
+ */
+const buildAuthHeaders = (
+  config: FetchProviderConfig,
+): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  if (config.authentication.apiKey && config.authentication.headerName) {
+    const prefix = config.authentication.type === "bearer" ? "Bearer " : "";
+    headers[config.authentication.headerName] =
+      `${prefix}${config.authentication.apiKey}`;
+  }
+  return headers;
+};
+
+/**
+ * Parses and validates a Jina Reader response body.
+ *
+ * @param raw - Parsed JSON body from the HTTP response.
+ */
+const parseJinaResponse = (raw: unknown): NormalizedFetchData => {
+  const parsed = jinaResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  const data = parsed.data.data;
+  if (!data || !data.content || data.content.trim() === "") {
+    throw new Error("Semantic validation failed");
+  }
+
+  return {
+    ...(data.url ? { url: data.url } : {}),
+    ...(data.title ? { title: data.title } : {}),
+    content: data.content,
+    ...(data.publishedTime ? { publishedTime: data.publishedTime } : {}),
+    ...(data.published_at ? { published_at: data.published_at } : {}),
+    ...(data.usage ? { usage: data.usage } : {}),
+  };
+};
+
+/**
+ * Executes one Jina Reader fetch for a URL.
+ *
+ * @param url - Target page URL.
+ * @param config - Jina provider configuration.
+ * @param ctx - Shared request context.
+ */
+const fetchOneJina = async (
+  url: string,
+  config: FetchProviderConfig,
+  ctx: ProviderRequestContext,
+): Promise<NormalizedFetchData> => {
+  await ctx.rateLimiter.acquire();
+
+  const fetchTask = async () => {
+    const response = await ctx.gotClient.post(config.baseUrl, {
+      json: { url },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...buildAuthHeaders(config),
+      },
+      timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+    });
+    ctx.rateLimiter.recordResponse(response.statusCode);
+    const raw = JSON.parse(response.body) as unknown;
+    return parseJinaResponse(raw);
+  };
+
+  return config.retry
+    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    : await fetchTask();
+};
+
+/**
+ * Creates a Jina Reader fetch provider adapter.
+ *
+ * @param config - Jina provider configuration.
+ */
+export const createJinaFetchProvider = (
+  config: FetchProviderConfig,
+): FetchProvider => ({
+  type: "jina",
+  fetchOne: (url, ctx) => fetchOneJina(url, config, ctx),
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/registry.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/registry.ts
@@ -1,0 +1,36 @@
+import { createDiffbotFetchProvider } from "./diffbot";
+import { createFirecrawlFetchProvider } from "./firecrawl";
+import { createJinaFetchProvider } from "./jina";
+
+import type { FetchProvider, FetchProviderConfig } from "./types";
+
+export type { FetchProviderConfig } from "./types";
+
+/**
+ * Instantiates a fetch provider adapter from runtime configuration.
+ *
+ * @param config - Provider configuration including the `type` discriminator.
+ */
+export const createFetchProvider = (
+  config: FetchProviderConfig,
+): FetchProvider => {
+  switch (config.type) {
+    case "jina":
+      return createJinaFetchProvider(config);
+    case "firecrawl":
+      return createFirecrawlFetchProvider(config);
+    case "diffbot":
+      return createDiffbotFetchProvider(config);
+    default:
+      throw new Error(`Unknown fetch provider type: ${config.type}`);
+  }
+};
+
+/**
+ * Builds an ordered provider chain from configuration entries.
+ *
+ * @param configs - Ordered provider configs; index 0 is the primary provider.
+ */
+export const createFetchProviderChain = (
+  configs: FetchProviderConfig[],
+): FetchProvider[] => configs.map(createFetchProvider);

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/test-fixtures.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/test-fixtures.ts
@@ -1,0 +1,12 @@
+import { vi } from "vitest";
+
+import type { RateLimiter } from "../resilience";
+
+/**
+ * Builds a minimal {@link RateLimiter} stub for fetch-provider unit tests.
+ */
+export const mockRateLimiter = (): RateLimiter =>
+  ({
+    acquire: vi.fn().mockResolvedValue(undefined),
+    recordResponse: vi.fn(),
+  }) as unknown as RateLimiter;

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/types.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/types.ts
@@ -1,0 +1,57 @@
+import type got from "got";
+
+import type { RateLimiter } from "../resilience";
+
+/** Normalized page payload returned by every fetch provider adapter on success. */
+export type NormalizedFetchData = {
+  url?: string;
+  title?: string;
+  content: string;
+  publishedTime?: string;
+  published_at?: string;
+  usage?: { tokens?: number };
+};
+
+/** Generic runtime configuration for one fetch provider in the chain. */
+export type FetchProviderConfig = {
+  type: string;
+  baseUrl: string;
+  authentication: {
+    type: "bearer" | "none";
+    apiKey?: string;
+    headerName?: string;
+  };
+  rateLimit: {
+    requests: number;
+    perSeconds: number;
+  };
+  concurrency?: number;
+  timeoutMs?: number;
+  retry?: {
+    maxAttempts: number;
+    baseDelayMs: number;
+    maxDelayMs: number;
+  };
+};
+
+/** Minimal structured logger passed into provider adapters. */
+export type FetchProviderLogger = {
+  info: (obj: object, msg?: string) => void;
+  warn: (obj: object, msg?: string) => void;
+};
+
+/** Shared per-request context for fetch provider adapters. */
+export type ProviderRequestContext = {
+  gotClient: typeof got;
+  rateLimiter: RateLimiter;
+  logger: FetchProviderLogger;
+};
+
+/** Contract implemented by every web-fetch provider adapter. */
+export type FetchProvider = {
+  readonly type: string;
+  fetchOne: (
+    url: string,
+    ctx: ProviderRequestContext,
+  ) => Promise<NormalizedFetchData>;
+};

--- a/apps/mediapulse/agents/data-collection/src/utilities/semantic-dedupe.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/semantic-dedupe.test.ts
@@ -27,6 +27,7 @@ const earningsCandidate = (
   searchQueryId: "22222222-2222-4222-a222-222222222222",
   searchQueryText: "Apple earnings",
   serpIndex: 0,
+  provider: "jina",
 });
 
 /** Deterministic embedder for syndicated earnings headline pairs. */

--- a/apps/mediapulse/agents/data-collection/src/utilities/semantic-dedupe.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/semantic-dedupe.ts
@@ -4,10 +4,10 @@ import {
 } from "@workspace/agent-data-api-contract";
 
 import { cosineSimilarity } from "./embeddings";
-import type { WebSearchResult } from "./web-search";
+import type { FetchedWebSearchResult } from "./web-fetch";
 
 /** Candidate page that survived pre-persistence gates. */
-export type SemanticDedupeCandidate = WebSearchResult;
+export type SemanticDedupeCandidate = FetchedWebSearchResult;
 
 export type SemanticDedupeDrop = {
   candidate: SemanticDedupeCandidate;

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.test.ts
@@ -13,7 +13,8 @@ vi.mock("@workspace/logger", () => ({
 import type { WebSearchResult } from "./web-search";
 import { performWebFetch } from "./web-fetch";
 
-const defaultConfig = {
+const jinaProviderConfig = {
+  type: "jina" as const,
   baseUrl: "https://r.jina.ai/",
   authentication: {
     type: "bearer" as const,
@@ -24,12 +25,50 @@ const defaultConfig = {
   concurrency: 4,
 };
 
+const firecrawlProviderConfig = {
+  type: "firecrawl" as const,
+  baseUrl: "https://api.firecrawl.dev",
+  authentication: {
+    type: "bearer" as const,
+    apiKey: "fc-key",
+    headerName: "Authorization",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
+const diffbotProviderConfig = {
+  type: "diffbot" as const,
+  baseUrl: "https://api.diffbot.com",
+  authentication: {
+    type: "none" as const,
+    apiKey: "diffbot-token",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
 /** Builds a got POST response stub with HTTP status metadata. */
 const mockGotPostResponse = (jsonValue: unknown, statusCode = 200) => ({
   statusCode,
   body: JSON.stringify(jsonValue),
-  json: vi.fn().mockResolvedValue(jsonValue),
 });
+
+/** Builds a got GET response stub with HTTP status metadata. */
+const mockGotGetResponse = (jsonValue: unknown, statusCode = 200) => ({
+  statusCode,
+  body: JSON.stringify(jsonValue),
+});
+
+const baseSearchResult: WebSearchResult = {
+  url: "http://example.com",
+  title: "Snippet title",
+  content: "Snippet",
+  tickerId: "ticker-1",
+  searchQueryId: "q1",
+  searchQueryText: "query",
+  serpIndex: 0,
+};
 
 describe("performWebFetch", () => {
   afterEach(() => {
@@ -50,21 +89,9 @@ describe("performWebFetch", () => {
 
     const fakeGot = { post: postMock } as unknown as typeof got;
 
-    const searchResults: WebSearchResult[] = [
-      {
-        url: "http://example.com",
-        title: "Snippet title",
-        content: "Snippet",
-        tickerId: "ticker-1",
-        searchQueryId: "q1",
-        searchQueryText: "query",
-        serpIndex: 0,
-      },
-    ];
-
     // Act
-    const result = await performWebFetch(searchResults, {
-      config: defaultConfig,
+    const result = await performWebFetch([baseSearchResult], {
+      config: { providers: [jinaProviderConfig] },
       gotClient: fakeGot,
     });
 
@@ -79,56 +106,199 @@ describe("performWebFetch", () => {
       }),
     );
     expect(result).toHaveLength(1);
-
-    expect(result[0]).toMatchObject({
-      success: true,
-      data: {
-        url: "http://example.com",
-        title: "Title",
-        content: "Full content",
-        tickerId: "ticker-1",
-        searchQueryId: "q1",
-        searchQueryText: "query",
-      },
+    expect(result[0]?.success).toMatchObject({
+      url: "http://example.com",
+      title: "Title",
+      content: "Full content",
+      tickerId: "ticker-1",
+      searchQueryId: "q1",
+      searchQueryText: "query",
+      provider: "jina",
     });
+    expect(result[0]?.failures).toEqual([]);
   });
 
-  it("returns failure when Jina returns invalid response shape", async () => {
+  it("returns failures when Jina returns invalid response shape", async () => {
     // Setup
     const postMock = vi.fn().mockReturnValue(
       mockGotPostResponse({
         data: "not-an-object",
       }),
     );
-
     const fakeGot = { post: postMock } as unknown as typeof got;
-    const searchResults: WebSearchResult[] = [
-      {
-        url: "http://example.com",
-        title: "Snippet",
-        content: "Snippet",
-        tickerId: "ticker-1",
-        searchQueryId: "q1",
-        searchQueryText: "query",
-        serpIndex: 0,
-      },
-    ];
 
     // Act
-    const result = await performWebFetch(searchResults, {
-      config: defaultConfig,
+    const result = await performWebFetch([baseSearchResult], {
+      config: { providers: [jinaProviderConfig] },
       gotClient: fakeGot,
     });
 
     // Assert
     expect(result).toHaveLength(1);
-    expect(result[0]).toMatchObject({
-      success: false,
-      url: "http://example.com",
-      queryId: "q1",
-      tickerId: "ticker-1",
-      errorCategory: "provider_schema_error",
+    expect(result[0]?.success).toBeNull();
+    expect(result[0]?.failures).toEqual([
+      expect.objectContaining({
+        url: "http://example.com",
+        queryId: "q1",
+        tickerId: "ticker-1",
+        provider: "jina",
+        errorCategory: "provider_schema_error",
+      }),
+    ]);
+  });
+
+  it("falls back to the next provider when the primary provider fails", async () => {
+    // Setup
+    const postMock = vi
+      .fn()
+      .mockReturnValueOnce(
+        mockGotPostResponse({
+          data: "not-an-object",
+        }),
+      )
+      .mockReturnValueOnce(
+        mockGotPostResponse({
+          success: true,
+          data: {
+            markdown: "Firecrawl body",
+            metadata: { title: "Firecrawl title" },
+          },
+        }),
+      );
+    const fakeGot = { post: postMock } as unknown as typeof got;
+
+    // Act
+    const result = await performWebFetch([baseSearchResult], {
+      config: { providers: [jinaProviderConfig, firecrawlProviderConfig] },
+      gotClient: fakeGot,
     });
+
+    // Assert
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(result[0]?.success).toMatchObject({
+      provider: "firecrawl",
+      title: "Firecrawl title",
+      content: "Firecrawl body",
+    });
+    expect(result[0]?.failures).toEqual([
+      expect.objectContaining({ provider: "jina" }),
+    ]);
+  });
+
+  it("records one failure per provider when the entire chain fails", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        data: "not-an-object",
+      }),
+    );
+    const getMock = vi.fn().mockReturnValue(
+      mockGotGetResponse({
+        objects: [],
+      }),
+    );
+    const fakeGot = {
+      post: postMock,
+      get: getMock,
+    } as unknown as typeof got;
+
+    // Act
+    const result = await performWebFetch([baseSearchResult], {
+      config: {
+        providers: [
+          jinaProviderConfig,
+          firecrawlProviderConfig,
+          diffbotProviderConfig,
+        ],
+      },
+      gotClient: fakeGot,
+    });
+
+    // Assert
+    expect(result[0]?.success).toBeNull();
+    expect(result[0]?.failures).toHaveLength(3);
+    expect(result[0]?.failures.map((failure) => failure.provider)).toEqual([
+      "jina",
+      "firecrawl",
+      "diffbot",
+    ]);
+  });
+
+  it("short-circuits remaining providers after the first success", async () => {
+    // Setup
+    const postMock = vi
+      .fn()
+      .mockReturnValueOnce(
+        mockGotPostResponse({
+          data: {
+            url: "http://example.com",
+            title: "Title",
+            content: "Full content",
+          },
+        }),
+      )
+      .mockReturnValue(
+        mockGotPostResponse({
+          success: true,
+          data: { markdown: "Should not be used" },
+        }),
+      );
+    const getMock = vi.fn();
+    const fakeGot = {
+      post: postMock,
+      get: getMock,
+    } as unknown as typeof got;
+
+    // Act
+    await performWebFetch([baseSearchResult], {
+      config: {
+        providers: [
+          jinaProviderConfig,
+          firecrawlProviderConfig,
+          diffbotProviderConfig,
+        ],
+      },
+      gotClient: fakeGot,
+    });
+
+    // Assert
+    expect(postMock).toHaveBeenCalledTimes(1);
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it("uses separate rate limiters per provider", async () => {
+    // Setup
+    const acquireCounts = { jina: 0, firecrawl: 0 };
+    const postMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes("jina.ai")) {
+        acquireCounts.jina += 1;
+        return mockGotPostResponse({ data: "not-an-object" });
+      }
+      acquireCounts.firecrawl += 1;
+      return mockGotPostResponse({
+        success: true,
+        data: { markdown: "Recovered" },
+      });
+    });
+    const fakeGot = { post: postMock } as unknown as typeof got;
+
+    // Act
+    await performWebFetch([baseSearchResult, baseSearchResult], {
+      config: {
+        providers: [
+          { ...jinaProviderConfig, rateLimit: { requests: 1, perSeconds: 1 } },
+          {
+            ...firecrawlProviderConfig,
+            rateLimit: { requests: 1, perSeconds: 1 },
+          },
+        ],
+      },
+      gotClient: fakeGot,
+    });
+
+    // Assert — both providers were invoked once per URL through their own limiters
+    expect(acquireCounts.jina).toBe(2);
+    expect(acquireCounts.firecrawl).toBe(2);
   });
 
   it("logs a warning with a truncated URL when fetch fails and the URL is very long", async () => {
@@ -140,25 +310,13 @@ describe("performWebFetch", () => {
         data: "not-an-object",
       }),
     );
-
     const fakeGot = { post: postMock } as unknown as typeof got;
     const longPath = "a".repeat(130);
     const longUrl = `https://example.com/${longPath}`;
-    const searchResults: WebSearchResult[] = [
-      {
-        url: longUrl,
-        title: "Snippet",
-        content: "Snippet",
-        tickerId: "ticker-1",
-        searchQueryId: "q1",
-        searchQueryText: "query",
-        serpIndex: 0,
-      },
-    ];
 
     // Act
-    await performWebFetch(searchResults, {
-      config: defaultConfig,
+    await performWebFetch([{ ...baseSearchResult, url: longUrl }], {
+      config: { providers: [jinaProviderConfig] },
       gotClient: fakeGot,
       logger: { info: infoMock, warn: warnMock },
     });
@@ -168,9 +326,10 @@ describe("performWebFetch", () => {
       expect.objectContaining({
         searchQueryId: "q1",
         url: `${longUrl.slice(0, 120)}…`,
+        provider: "jina",
         errorCategory: "provider_schema_error",
       }),
-      "web fetch: URL failed",
+      "web fetch: provider failed",
     );
   });
 });

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
@@ -1,33 +1,45 @@
 import got from "got";
-import { z } from "zod";
+
 import { logger as defaultLogger } from "@workspace/logger";
-import { RateLimiter, type StageThrottleStats, withRetry } from "./resilience";
+import { RateLimiter, type StageThrottleStats } from "./resilience";
 import { classifyError, isRetryableError } from "./error-classification";
 import { pMap } from "./p-map";
+import {
+  createFetchProviderChain,
+  type FetchProviderConfig,
+} from "./fetch-providers/registry";
+import type { FetchProvider } from "./fetch-providers/types";
 
-import type { WebSearchResult } from "./web-search";
+import type { FetchMetadata, WebSearchResult } from "./web-search";
 import type { ConfigSchemaType } from "./config-schema";
 import type { DataCollectionFailure } from "@workspace/agent-data-api-contract";
 import type { HostErrorTracker } from "./host-error-tracker";
 import { hostFromUrl } from "./host-error-tracker";
 
-export interface WebFetchSuccess {
-  success: true;
-  data: WebSearchResult;
-}
+export type WebFetchProviderName = Extract<
+  DataCollectionFailure["provider"],
+  "jina" | "firecrawl" | "diffbot"
+>;
+
+export type FetchedWebSearchResult = WebSearchResult & {
+  provider: WebFetchProviderName;
+};
 
 export interface WebFetchFailure {
-  success: false;
   url: string;
   queryId: string;
   tickerId: string;
+  provider: WebFetchProviderName;
   errorCategory: DataCollectionFailure["errorCategory"];
   message: string;
   retryable: boolean;
   httpStatus?: number;
 }
 
-export type WebFetchAttemptResult = WebFetchSuccess | WebFetchFailure;
+export interface WebFetchOutcome {
+  success: FetchedWebSearchResult | null;
+  failures: WebFetchFailure[];
+}
 
 /** Minimal structured logger for web-fetch (e.g. pino or pino child). */
 export type WebFetchLogger = {
@@ -46,6 +58,18 @@ export interface WebFetchDeps {
   hostErrorTracker?: HostErrorTracker;
 }
 
+type ProviderChainEntry = {
+  provider: FetchProvider;
+  config: FetchProviderConfig;
+  rateLimiter: RateLimiter;
+};
+
+const WEB_FETCH_PROVIDER_NAMES = new Set<WebFetchProviderName>([
+  "jina",
+  "firecrawl",
+  "diffbot",
+]);
+
 /**
  * Truncates a URL for log fields so long query strings do not flood logs.
  *
@@ -60,197 +84,200 @@ function truncateUrlForLog(url: string, maxChars = 120): string {
   return `${url.slice(0, maxChars)}…`;
 }
 
-/** Zod schema for Jina AI Reader API response data object. */
-const jinaDataSchema = z.object({
-  url: z.string().url().optional(),
-  title: z.string().optional(),
-  content: z.string().optional(),
-  publishedTime: z.string().optional(),
-  published_at: z.string().optional(),
-  usage: z
-    .object({
-      tokens: z.number().optional(),
-    })
-    .optional(),
-});
-
-/** Zod schema for Jina AI Reader API response. */
-export const webFetchResponseSchema = z.object({
-  data: jinaDataSchema.optional(),
-});
-
-export type WebFetchResponse = z.infer<typeof webFetchResponseSchema>;
-
 /**
- * Resolves effective mapper concurrency capped by the configured rate limit.
+ * Resolves effective mapper concurrency capped by each provider rate limit.
  *
- * @param config - Web fetch provider configuration.
+ * @param providers - Ordered provider configs for the fetch chain.
  */
-const resolveFetchConcurrency = (
-  config: NonNullable<ConfigSchemaType["webFetch"]>,
-): number => Math.min(config.concurrency ?? 4, config.rateLimit.requests);
+const resolveFetchConcurrency = (providers: FetchProviderConfig[]): number =>
+  Math.max(
+    ...providers.map((provider) =>
+      Math.min(provider.concurrency ?? 4, provider.rateLimit.requests),
+    ),
+  );
 
 /**
- * Fetches one search hit and returns the attempt result.
+ * Builds fetch metadata from normalized provider fields.
+ *
+ * @param data - Normalized provider response fields.
+ */
+const buildFetchMetadata = (data: {
+  publishedTime?: string;
+  published_at?: string;
+  usage?: { tokens?: number };
+}): FetchMetadata | undefined => {
+  const metadata: FetchMetadata = {
+    ...(data.publishedTime ? { publishedTime: data.publishedTime } : {}),
+    ...(data.published_at ? { published_at: data.published_at } : {}),
+    ...(data.usage ? { usage: data.usage } : {}),
+  };
+
+  return Object.keys(metadata).length > 0 ? metadata : undefined;
+};
+
+/**
+ * Narrows a provider type string to a persisted web-fetch provider name.
+ *
+ * @param type - Provider adapter type string.
+ */
+const toWebFetchProviderName = (type: string): WebFetchProviderName => {
+  if (!WEB_FETCH_PROVIDER_NAMES.has(type as WebFetchProviderName)) {
+    throw new Error(`Unsupported web fetch provider: ${type}`);
+  }
+  return type as WebFetchProviderName;
+};
+
+/**
+ * Fetches one search hit through the ordered provider chain.
  *
  * @param result - Search hit to fetch.
+ * @param chain - Ordered provider adapters with per-provider rate limiters.
  * @param deps - Shared dependencies for the fetch stage.
  */
 const fetchOneResult = async (
   result: WebSearchResult,
+  chain: ProviderChainEntry[],
   deps: {
-    config: NonNullable<ConfigSchemaType["webFetch"]>;
     gotClient: typeof got;
     log: WebFetchLogger;
-    rateLimiter: RateLimiter;
-    authHeaders: Record<string, string>;
-    endpoint: string;
     hostErrorTracker?: HostErrorTracker;
   },
-): Promise<WebFetchAttemptResult> => {
-  const {
-    config,
-    gotClient,
-    log,
-    rateLimiter,
-    authHeaders,
-    endpoint,
-    hostErrorTracker,
-  } = deps;
+): Promise<WebFetchOutcome> => {
+  const { gotClient, log, hostErrorTracker } = deps;
+  const failures: WebFetchFailure[] = [];
 
-  try {
-    await rateLimiter.acquire();
+  for (const entry of chain) {
+    const providerName = toWebFetchProviderName(entry.provider.type);
 
-    const fetchTask = async () => {
-      const response = await gotClient.post(endpoint, {
-        json: { url: result.url },
-        headers: {
-          Accept: "application/json",
-          "Content-Type": "application/json",
-          ...authHeaders,
-        },
-        timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+    try {
+      const data = await entry.provider.fetchOne(result.url, {
+        gotClient,
+        rateLimiter: entry.rateLimiter,
+        logger: log,
       });
-      rateLimiter.recordResponse(response.statusCode);
-      const raw = JSON.parse(response.body) as unknown;
 
-      const parsed = webFetchResponseSchema.safeParse(raw);
-      if (!parsed.success) {
-        throw parsed.error;
-      }
+      hostErrorTracker?.record(hostFromUrl(result.url), true);
 
-      const data = parsed.data.data;
-      if (!data || !data.content || data.content.trim() === "") {
-        throw new Error("Semantic validation failed");
-      }
+      const fetchMetadata = buildFetchMetadata(data);
 
-      return data;
-    };
-
-    const data = config.retry
-      ? await withRetry(fetchTask, config.retry, isRetryableError)
-      : await fetchTask();
-
-    hostErrorTracker?.record(hostFromUrl(result.url), true);
-
-    const jinaMetadata = {
-      ...(data.publishedTime ? { publishedTime: data.publishedTime } : {}),
-      ...(data.published_at ? { published_at: data.published_at } : {}),
-      ...(data.usage ? { usage: data.usage } : {}),
-    };
-
-    return {
-      success: true,
-      data: {
-        url: data.url ?? result.url,
-        title: data.title ?? result.title,
-        content: data.content ?? "",
+      return {
+        success: {
+          url: data.url ?? result.url,
+          title: data.title ?? result.title,
+          content: data.content,
+          tickerId: result.tickerId,
+          searchQueryId: result.searchQueryId,
+          searchQueryText: result.searchQueryText,
+          serpIndex: result.serpIndex,
+          provider: providerName,
+          ...(fetchMetadata ? { fetchMetadata } : {}),
+        },
+        failures,
+      };
+    } catch (error) {
+      const classified = classifyError(error);
+      entry.rateLimiter.recordResponse(classified.httpStatus);
+      log.warn(
+        {
+          searchQueryId: result.searchQueryId,
+          url: truncateUrlForLog(result.url),
+          provider: providerName,
+          errorCategory: classified.category,
+          retryable: isRetryableError(error),
+          ...(classified.httpStatus !== undefined
+            ? { httpStatus: classified.httpStatus }
+            : {}),
+        },
+        "web fetch: provider failed",
+      );
+      failures.push({
+        url: result.url,
+        queryId: result.searchQueryId,
         tickerId: result.tickerId,
-        searchQueryId: result.searchQueryId,
-        searchQueryText: result.searchQueryText,
-        serpIndex: result.serpIndex,
-        ...(Object.keys(jinaMetadata).length > 0 ? { jinaMetadata } : {}),
-      },
-    };
-  } catch (error) {
-    const classified = classifyError(error);
-    rateLimiter.recordResponse(classified.httpStatus);
-    hostErrorTracker?.record(hostFromUrl(result.url), false);
-    log.warn(
-      {
-        searchQueryId: result.searchQueryId,
-        url: truncateUrlForLog(result.url),
+        provider: providerName,
         errorCategory: classified.category,
+        message: classified.message,
         retryable: isRetryableError(error),
-        ...(classified.httpStatus !== undefined
-          ? { httpStatus: classified.httpStatus }
-          : {}),
-      },
-      "web fetch: URL failed",
-    );
-    return {
-      success: false,
-      url: result.url,
-      queryId: result.searchQueryId,
-      tickerId: result.tickerId,
-      errorCategory: classified.category,
-      message: classified.message,
-      retryable: isRetryableError(error),
-      httpStatus: classified.httpStatus,
-    };
+        httpStatus: classified.httpStatus,
+      });
+    }
   }
+
+  hostErrorTracker?.record(hostFromUrl(result.url), false);
+
+  return {
+    success: null,
+    failures,
+  };
 };
 
 /**
- * Fetches and enriches web page contents for each search result using the Jina AI API.
- * Uses config-driven limits, retries, and yields partial success items.
+ * Builds the ordered provider chain with one rate limiter per provider.
+ *
+ * @param configs - Ordered provider configs from runtime settings.
+ */
+const buildProviderChain = (
+  configs: FetchProviderConfig[],
+): ProviderChainEntry[] => {
+  const providers = createFetchProviderChain(configs);
+
+  return providers.map((provider, index) => ({
+    provider,
+    config: configs[index]!,
+    rateLimiter: new RateLimiter(
+      configs[index]!.rateLimit.requests,
+      configs[index]!.rateLimit.perSeconds,
+    ),
+  }));
+};
+
+/**
+ * Fetches and enriches web page contents for each search result using an
+ * ordered provider chain with per-provider fallback.
  *
  * @param searchResults - Search results without full content.
  * @param deps - Dependencies including runtime configuration and optional correlated `logger`.
- * @returns A list of web fetch attempt results.
+ * @returns One outcome per URL with optional success and per-provider failures.
  */
 export async function performWebFetch(
   searchResults: WebSearchResult[],
   deps: WebFetchDeps,
-): Promise<WebFetchAttemptResult[]> {
+): Promise<WebFetchOutcome[]> {
   const { config, gotClient = got, logger: logOpt, throttleStats } = deps;
   const log = logOpt ?? defaultLogger;
+  const providerConfigs = config.providers;
 
-  log.info({ urlCount: searchResults.length }, "web fetch: starting");
-
-  const rateLimiter = new RateLimiter(
-    config.rateLimit.requests,
-    config.rateLimit.perSeconds,
+  log.info(
+    {
+      urlCount: searchResults.length,
+      providerChain: providerConfigs.map((provider) => provider.type),
+    },
+    "web fetch: starting",
   );
 
-  const authHeaders: Record<string, string> = {};
-  if (config.authentication.apiKey && config.authentication.headerName) {
-    const prefix = config.authentication.type === "bearer" ? "Bearer " : "";
-    authHeaders[config.authentication.headerName] =
-      `${prefix}${config.authentication.apiKey}`;
-  }
-
-  const endpoint = config.baseUrl;
-  const concurrency = resolveFetchConcurrency(config);
+  const chain = buildProviderChain(providerConfigs);
+  const concurrency = resolveFetchConcurrency(providerConfigs);
   const sharedDeps = {
-    config,
     gotClient,
     log,
-    rateLimiter,
-    authHeaders,
-    endpoint,
     hostErrorTracker: deps.hostErrorTracker,
   };
 
   const results = await pMap(
     searchResults,
-    (result) => fetchOneResult(result, sharedDeps),
+    (result) => fetchOneResult(result, chain, sharedDeps),
     { concurrency },
   );
 
   if (throttleStats) {
-    throttleStats.throttleEvents += rateLimiter.getThrottleEvents();
+    throttleStats.throttleEvents += chain.reduce(
+      (total, entry) => total + entry.rateLimiter.getThrottleEvents(),
+      0,
+    );
   }
 
   return results;
 }
+
+/** @deprecated Use `jinaResponseSchema` from `./fetch-providers/jina` instead. */
+export { jinaResponseSchema as webFetchResponseSchema } from "./fetch-providers/jina";

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
@@ -10,7 +10,8 @@ import {
 } from "./fetch-providers/registry";
 import type { FetchProvider } from "./fetch-providers/types";
 
-import type { FetchMetadata, WebSearchResult } from "./web-search";
+import type { FetchMetadata } from "./date-extractor";
+import type { WebSearchResult } from "./web-search";
 import type { ConfigSchemaType } from "./config-schema";
 import type { DataCollectionFailure } from "@workspace/agent-data-api-contract";
 import type { HostErrorTracker } from "./host-error-tracker";

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
@@ -13,7 +13,7 @@ export interface SearchQuery {
   tickerId: string;
 }
 
-import type { JinaFetchMetadata } from "./date-extractor";
+import type { FetchMetadata } from "./date-extractor";
 
 export interface WebSearchResult {
   url: string;
@@ -23,8 +23,10 @@ export interface WebSearchResult {
   searchQueryId: string;
   searchQueryText: string;
   serpIndex: number;
-  /** Optional Jina Reader metadata captured during web fetch. */
-  jinaMetadata?: JinaFetchMetadata;
+  /** Optional fetch provider metadata captured during web fetch. */
+  fetchMetadata?: FetchMetadata;
+  /** @deprecated Use {@link WebSearchResult.fetchMetadata} instead. */
+  jinaMetadata?: FetchMetadata;
 }
 
 export interface WebSearchSuccess {

--- a/packages/mediapulse/database/prisma/migrations/20260526120000_add_fetch_providers/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260526120000_add_fetch_providers/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum
+ALTER TYPE "DataCollectionProvider" ADD VALUE 'firecrawl';
+ALTER TYPE "DataCollectionProvider" ADD VALUE 'diffbot';

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -441,6 +441,8 @@ enum DataCollectionProviderStage {
 enum DataCollectionProvider {
   serper
   jina
+  firecrawl
+  diffbot
 }
 
 enum DataCollectionErrorCategory {

--- a/packages/shared/agent-data-api-contract/src/data-collection-failure.test.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-failure.test.ts
@@ -1,0 +1,37 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { dataCollectionFailureInputSchema } from "./data-collection-failure";
+
+describe("dataCollectionFailureInputSchema", () => {
+  it("accepts firecrawl and diffbot web-fetch providers", () => {
+    // Setup
+    const base = {
+      id: "11111111-1111-4111-a111-111111111111",
+      runId: "22222222-2222-4222-a222-222222222222",
+      tickerId: "BBCA",
+      stage: "web-fetch" as const,
+      searchQueryId: "33333333-3333-4333-a333-333333333333",
+      url: "https://example.com/article",
+      errorCategory: "provider_http_error" as const,
+      retryable: false,
+      message: "Provider failed",
+      createdAt: "2026-05-21T12:00:00.000Z",
+    };
+
+    // Act + Assert
+    expect(
+      dataCollectionFailureInputSchema.parse({
+        ...base,
+        provider: "firecrawl",
+      }).provider,
+    ).toBe("firecrawl");
+    expect(
+      dataCollectionFailureInputSchema.parse({
+        ...base,
+        provider: "diffbot",
+      }).provider,
+    ).toBe("diffbot");
+  });
+});

--- a/packages/shared/agent-data-api-contract/src/data-collection-failure.test.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-failure.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { dataCollectionFailureInputSchema } from "./data-collection-failure";
+import { dataCollectionFailureInputSchema } from "./data-collection-failure.js";
 
 describe("dataCollectionFailureInputSchema", () => {
   it("accepts firecrawl and diffbot web-fetch providers", () => {

--- a/packages/shared/agent-data-api-contract/src/data-collection-failure.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-failure.ts
@@ -14,7 +14,7 @@ export const dataCollectionFailureInputSchema = z.object({
   runId: z.string().uuid(),
   tickerId: z.string().trim().min(1),
   stage: z.enum(["web-search", "web-fetch"]),
-  provider: z.enum(["serper", "jina"]),
+  provider: z.enum(["serper", "jina", "firecrawl", "diffbot"]),
   searchQueryId: z.string().uuid().optional(),
   url: z.string().url().optional(),
   errorCategory: dataCollectionFailureErrorCategorySchema,


### PR DESCRIPTION
## Summary

Data collection no longer treats a Jina failure as a dead URL. `performWebFetch` walks an ordered provider chain (Jina → Firecrawl → Diffbot by default), records each failed attempt with its provider name, and only marks the URL failed when the whole chain is exhausted. Config is `webFetch.providers[]`; the old flat `webFetch` object is no longer accepted.

## Related issues

Closes #570

## Important changes

- New `FetchProvider` adapters and registry; orchestrator owns the chain with one `RateLimiter` per provider.
- `WebFetchOutcome { success | null; failures[] }` separates failed URLs from failure-row count in run counters and persistence.
- `fetchMetadata` replaces Jina-specific metadata for the freshness gate.
- Contract and Prisma enums extended with `firecrawl` and `diffbot`; migration `20260526120000_add_fetch_providers`.

## Other changes

- Deprecated `jinaMetadata` field kept as a read fallback during transition.
- HTTP and run tests updated for the new outcome shape and `providers[]` config.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts` — chain orchestration and outcome shape.
- `apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/` — Jina, Firecrawl, Diffbot adapters and registry.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — `webFetch.providers[]` only.
- `apps/mediapulse/agents/data-collection/src/run.ts` — failed-URL vs failure-row wiring and dead-url cache guard.
- `packages/mediapulse/database/prisma/migrations/20260526120000_add_fetch_providers/migration.sql` — enum values.

## How to test

1. Run scoped tests:
   ```bash
   pnpm --filter @mediapulse/data-collection exec vitest run src/run.test.ts src/utilities/web-fetch.test.ts src/utilities/fetch-providers src/utilities/config-schema.test.ts
   pnpm --filter @workspace/agent-data-api-contract test
   ```
2. Apply the migration: `pnpm --filter @mediapulse/database db:migrate:dev`
3. Point a data-collection Hermes config at `webFetch.providers[]` with Jina (and optionally Firecrawl/Diffbot). Confirm a URL that fails on the first provider still persists when a later provider succeeds, and that failure rows carry the correct `provider` field.
