### PR TITLE
Group and default data-collection config for Hermes

### DIFF
--- a/apps/mediapulse/agents/data-collection/README.md
+++ b/apps/mediapulse/agents/data-collection/README.md
@@ -1,0 +1,49 @@
+# Data collection agent
+
+Collects web sources for a ticker by running Serper search, fetching pages through an ordered provider chain, applying quality and relevance gates, and persisting results to the Agent Data API.
+
+## Configuration
+
+The agent config is grouped for the Hermes step form. An empty `{}` validates into the recommended end-to-end setup; override only the sections you need.
+
+### Hermes variables
+
+Create these variables in Hermes so placeholder defaults resolve at run time:
+
+| Variable            | Used for                                  |
+| ------------------- | ----------------------------------------- |
+| `SERPER_API_KEY`    | Web search (`providers.search`)           |
+| `DIFFBOT_API_KEY`   | Primary fetch provider                    |
+| `FIRECRAWL_API_KEY` | Secondary fetch provider                  |
+| `JINA_API_KEY`      | Tertiary fetch provider                   |
+| `OPENAI_API_KEY`    | Semantic dedupe embeddings (when enabled) |
+| `EMBEDDING_MODEL`   | Embedding model name for semantic dedupe  |
+
+If a variable is missing, the literal `{{NAME}}` is passed through and the affected stage fails with a clear provider auth error.
+
+### Group overview
+
+1. **providers** — Serper search settings and the ordered fetch chain (`diffbot` → `firecrawl` → `jina` by default).
+2. **collection** — Daily target, refill rounds, and per-query/per-run fetch budgets.
+3. **gates** — Relevance and freshness filters before persistence.
+4. **resilience** — Dead-URL cache and per-host error breaker.
+5. **deduplication** — Optional semantic dedupe against recent corpus fingerprints.
+6. **runPolicy** — Minimum successful sources and zero-success failure behavior.
+
+### Example
+
+Saving `{}` in Hermes runs the recommended pipeline. To tighten only the run budget:
+
+```json
+{
+  "collection": {
+    "perRunFetchBudget": 20
+  }
+}
+```
+
+See `config.example.jsonc` for the full default shape with placeholders.
+
+### Breaking change
+
+The previous flat config keys (`webSearch`, `webFetch`, top-level gate fields, and so on) are no longer accepted. Stale stored configs with unknown keys are stripped by Zod and fall back to defaults; re-enter any custom tuning in the grouped form.

--- a/apps/mediapulse/agents/data-collection/config.example.jsonc
+++ b/apps/mediapulse/agents/data-collection/config.example.jsonc
@@ -1,0 +1,99 @@
+{
+  // Empty config — Hermes resolves {{NAME}} placeholders from Variables.
+  // Override only the groups or fields you want to change.
+
+  "providers": {
+    "search": {
+      "baseUrl": "https://google.serper.dev/search",
+      "authentication": {
+        "type": "bearer",
+        "apiKey": "{{SERPER_API_KEY}}",
+        "headerName": "X-API-KEY"
+      },
+      "rateLimit": { "requests": 100, "perSeconds": 60 },
+      "concurrency": 4,
+      "timeoutMs": 30000
+    },
+    "fetch": {
+      "providers": [
+        {
+          "type": "diffbot",
+          "baseUrl": "https://api.diffbot.com",
+          "authentication": {
+            "type": "none",
+            "apiKey": "{{DIFFBOT_API_KEY}}"
+          },
+          "rateLimit": { "requests": 50, "perSeconds": 60 },
+          "concurrency": 4,
+          "timeoutMs": 30000
+        },
+        {
+          "type": "firecrawl",
+          "baseUrl": "https://api.firecrawl.dev",
+          "authentication": {
+            "type": "bearer",
+            "apiKey": "{{FIRECRAWL_API_KEY}}",
+            "headerName": "Authorization"
+          },
+          "rateLimit": { "requests": 50, "perSeconds": 60 },
+          "concurrency": 4,
+          "timeoutMs": 30000
+        },
+        {
+          "type": "jina",
+          "baseUrl": "https://r.jina.ai/",
+          "authentication": {
+            "type": "bearer",
+            "apiKey": "{{JINA_API_KEY}}",
+            "headerName": "Authorization"
+          },
+          "rateLimit": { "requests": 50, "perSeconds": 60 },
+          "concurrency": 4,
+          "timeoutMs": 30000
+        }
+      ]
+    }
+  },
+  "collection": {
+    "targetDailySuccessfulSources": 5,
+    "maxRefillRounds": 3,
+    "perQueryFetchBudget": 3,
+    "perRunFetchBudget": 40
+  },
+  "gates": {
+    "relevance": {
+      "enabled": true,
+      "headChars": 1500,
+      "minMatches": 1
+    },
+    "freshness": {
+      "enabled": true,
+      "maxAgeDays": 14,
+      "allowUnknown": true
+    }
+  },
+  "resilience": {
+    "deadUrlCache": {
+      "enabled": true,
+      "skipLookupBatchSize": 50
+    },
+    "hostErrorBreaker": {
+      "enabled": true,
+      "minAttempts": 5,
+      "errorRateThreshold": 0.5
+    }
+  },
+  "deduplication": {
+    "semantic": {
+      "enabled": false,
+      "threshold": 0.88,
+      "windowDays": 7,
+      "embeddingModel": "{{EMBEDDING_MODEL}}"
+    },
+    "openaiApiKey": "{{OPENAI_API_KEY}}"
+  },
+  "runPolicy": {
+    "minSuccessfulSources": 1,
+    "failOnZeroSuccess": true
+  }
+}

--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -169,23 +169,7 @@ describe("data-collection agent (HTTP)", () => {
         headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
-          config: {
-            webSearch: {
-              baseUrl: "https://search.example",
-              authentication: { type: "bearer" },
-              rateLimit: { requests: 1, perSeconds: 1 },
-            },
-            webFetch: {
-              providers: [
-                {
-                  type: "jina",
-                  baseUrl: "https://fetch.example",
-                  authentication: { type: "bearer" },
-                  rateLimit: { requests: 1, perSeconds: 1 },
-                },
-              ],
-            },
-          },
+          config: {},
         }),
       }),
     );
@@ -201,7 +185,7 @@ describe("data-collection agent (HTTP)", () => {
     expect(body.status).toBe("success");
   }, 15000);
 
-  it("returns 400 when required provider config is missing", async () => {
+  it("returns 400 when config validation fails", async () => {
     // Setup
     getMock.mockResolvedValue({
       data: [{ id: "sq-1", text: "test query", tickerId: TICKER_ID }],
@@ -216,9 +200,8 @@ describe("data-collection agent (HTTP)", () => {
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
           config: {
-            runPolicy: {
-              minSuccessfulSources: 1,
-              failOnZeroSuccess: true,
+            collection: {
+              targetDailySuccessfulSources: 0,
             },
           },
         }),
@@ -248,23 +231,7 @@ describe("data-collection agent (HTTP)", () => {
         headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
-          config: {
-            webSearch: {
-              baseUrl: "https://search.example",
-              authentication: { type: "bearer" },
-              rateLimit: { requests: 1, perSeconds: 1 },
-            },
-            webFetch: {
-              providers: [
-                {
-                  type: "jina",
-                  baseUrl: "https://fetch.example",
-                  authentication: { type: "bearer" },
-                  rateLimit: { requests: 1, perSeconds: 1 },
-                },
-              ],
-            },
-          },
+          config: {},
         }),
       }),
     );

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -4,7 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentRunContext } from "@workspace/agent-runtime";
 
 import type { BodySchemaType } from "./utilities/body-schema";
-import type { ConfigSchemaType } from "./utilities/config-schema";
+import {
+  dataCollectionAgentConfigSchema,
+  type ConfigSchemaType,
+} from "./utilities/config-schema";
 import type {
   FetchedWebSearchResult,
   WebFetchFailure,
@@ -37,29 +40,90 @@ const longOffTopicArticle = (lead: string): string =>
     ),
   ].join(" ");
 
-const baseConfig = {
-  webSearch: {
-    baseUrl: "https://search.example",
-    authentication: { type: "bearer" as const },
-    rateLimit: { requests: 1, perSeconds: 1 },
-    concurrency: 4,
+const baseConfig = dataCollectionAgentConfigSchema.parse({
+  providers: {
+    search: {
+      baseUrl: "https://search.example",
+      authentication: { type: "bearer" },
+      rateLimit: { requests: 1, perSeconds: 1 },
+      concurrency: 4,
+    },
+    fetch: {
+      providers: [
+        {
+          type: "jina",
+          baseUrl: "https://fetch.example",
+          authentication: { type: "bearer" },
+          rateLimit: { requests: 1, perSeconds: 1 },
+          concurrency: 4,
+        },
+      ],
+    },
   },
-  webFetch: {
-    providers: [
-      {
-        type: "jina",
-        baseUrl: "https://fetch.example",
-        authentication: { type: "bearer" as const },
-        rateLimit: { requests: 1, perSeconds: 1 },
-        concurrency: 4,
+  collection: {
+    targetDailySuccessfulSources: 1,
+    maxRefillRounds: 3,
+    perQueryFetchBudget: 3,
+    perRunFetchBudget: 40,
+  },
+});
+
+/**
+ * Merges grouped config overrides onto the shared run test baseline.
+ *
+ * @param overrides - Partial grouped config fields to override.
+ */
+const withTestConfig = (
+  overrides: {
+    collection?: Partial<ConfigSchemaType["collection"]>;
+    runPolicy?: Partial<ConfigSchemaType["runPolicy"]>;
+    gates?: {
+      relevance?: Partial<ConfigSchemaType["gates"]["relevance"]>;
+      freshness?: Partial<ConfigSchemaType["gates"]["freshness"]>;
+    };
+    deduplication?: {
+      openaiApiKey?: string;
+      semantic?: Partial<ConfigSchemaType["deduplication"]["semantic"]>;
+    };
+    providers?: Partial<ConfigSchemaType["providers"]>;
+  } = {},
+): ConfigSchemaType =>
+  dataCollectionAgentConfigSchema.parse({
+    providers: {
+      ...baseConfig.providers,
+      ...overrides.providers,
+      search: {
+        ...baseConfig.providers.search,
+        ...overrides.providers?.search,
       },
-    ],
-  },
-  targetDailySuccessfulSources: 1,
-  maxRefillRounds: 3,
-  perQueryFetchBudget: 3,
-  perRunFetchBudget: 40,
-} satisfies ConfigSchemaType;
+      fetch: {
+        ...baseConfig.providers.fetch,
+        ...overrides.providers?.fetch,
+      },
+    },
+    collection: { ...baseConfig.collection, ...overrides.collection },
+    gates: {
+      ...baseConfig.gates,
+      relevance: {
+        ...baseConfig.gates.relevance,
+        ...overrides.gates?.relevance,
+      },
+      freshness: {
+        ...baseConfig.gates.freshness,
+        ...overrides.gates?.freshness,
+      },
+    },
+    deduplication: {
+      ...baseConfig.deduplication,
+      ...overrides.deduplication,
+      semantic: {
+        ...baseConfig.deduplication.semantic,
+        ...overrides.deduplication?.semantic,
+      },
+    },
+    runPolicy: { ...baseConfig.runPolicy, ...overrides.runPolicy },
+    resilience: baseConfig.resilience,
+  });
 
 const searchSuccessPage = {
   url: "http://example.com",
@@ -317,13 +381,12 @@ describe("runDataCollection", () => {
 
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -352,15 +415,16 @@ describe("runDataCollection", () => {
 
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          perQueryFetchBudget: 20,
-          perRunFetchBudget: 100,
+        config: withTestConfig({
+          collection: {
+            perQueryFetchBudget: 20,
+            perRunFetchBudget: 100,
+          },
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -400,13 +464,12 @@ describe("runDataCollection", () => {
 
     await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -478,13 +541,12 @@ describe("runDataCollection", () => {
 
       const result = await runDataCollection(
         createContext({
-          config: {
-            ...baseConfig,
+          config: withTestConfig({
             runPolicy: {
               minSuccessfulSources: 0,
               failOnZeroSuccess: false,
             },
-          },
+          }),
         }),
       );
 
@@ -527,21 +589,24 @@ describe("runDataCollection", () => {
 
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          openaiApiKey: "sk-test",
-          relevanceGate: { enabled: false, headChars: 1500, minMatches: 1 },
-          semanticDedupe: {
-            enabled: true,
-            threshold: 0.88,
-            windowDays: 7,
-            embeddingModel: "text-embedding-3-small",
+        config: withTestConfig({
+          deduplication: {
+            openaiApiKey: "sk-test",
+            semantic: {
+              enabled: true,
+              threshold: 0.88,
+              windowDays: 7,
+              embeddingModel: "text-embedding-3-small",
+            },
+          },
+          gates: {
+            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
           },
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -633,23 +698,28 @@ describe("runDataCollection", () => {
 
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          perQueryFetchBudget: 20,
-          perRunFetchBudget: 100,
-          openaiApiKey: "sk-test",
-          relevanceGate: { enabled: false, headChars: 1500, minMatches: 1 },
-          semanticDedupe: {
-            enabled: true,
-            threshold: 0.88,
-            windowDays: 7,
-            embeddingModel: "text-embedding-3-small",
+        config: withTestConfig({
+          collection: {
+            perQueryFetchBudget: 20,
+            perRunFetchBudget: 100,
+          },
+          deduplication: {
+            openaiApiKey: "sk-test",
+            semantic: {
+              enabled: true,
+              threshold: 0.88,
+              windowDays: 7,
+              embeddingModel: "text-embedding-3-small",
+            },
+          },
+          gates: {
+            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
           },
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -674,13 +744,12 @@ describe("runDataCollection", () => {
     // Act
     await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -708,13 +777,12 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
           },
-        },
+        }),
       }),
     );
 
@@ -794,13 +862,12 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: {
             minSuccessfulSources: 2,
             failOnZeroSuccess: true,
           },
-        },
+        }),
       }),
     );
 
@@ -903,10 +970,9 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-        },
+        }),
       }),
     );
 
@@ -1005,10 +1071,9 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-        },
+        }),
       }),
     );
 
@@ -1084,10 +1149,9 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-        },
+        }),
       }),
     );
 
@@ -1132,11 +1196,12 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          targetDailySuccessfulSources: 2,
-          maxRefillRounds: 3,
-        },
+        config: withTestConfig({
+          collection: {
+            targetDailySuccessfulSources: 2,
+            maxRefillRounds: 3,
+          },
+        }),
       }),
     );
 
@@ -1158,11 +1223,10 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          targetDailySuccessfulSources: 5,
+        config: withTestConfig({
+          collection: { targetDailySuccessfulSources: 5 },
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-        },
+        }),
       }),
     );
 
@@ -1193,12 +1257,13 @@ describe("runDataCollection", () => {
     // Act
     const result = await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
+        config: withTestConfig({
+          collection: {
+            targetDailySuccessfulSources: 10,
+            maxRefillRounds: 3,
+          },
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-          targetDailySuccessfulSources: 10,
-          maxRefillRounds: 3,
-        },
+        }),
       }),
     );
 
@@ -1241,12 +1306,13 @@ describe("runDataCollection", () => {
     // Act
     await runDataCollection(
       createContext({
-        config: {
-          ...baseConfig,
-          perQueryFetchBudget: 2,
-          perRunFetchBudget: 6,
+        config: withTestConfig({
+          collection: {
+            perQueryFetchBudget: 2,
+            perRunFetchBudget: 6,
+          },
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
-        },
+        }),
       }),
     );
 

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -7,6 +7,7 @@ import crypto from "node:crypto";
 
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
+import { isUnresolvedVariablePlaceholder } from "./utilities/config-schema";
 import { performWebFetch } from "./utilities/web-fetch";
 import { performWebSearch } from "./utilities/web-search";
 import {
@@ -28,11 +29,7 @@ import {
   buildIndustryAliases,
   isRelevant,
 } from "./utilities/ticker-relevance-gate";
-import {
-  deriveRunStatus,
-  type RunCounters,
-  type RunPolicy,
-} from "./utilities/run-status";
+import { deriveRunStatus, type RunCounters } from "./utilities/run-status";
 import { extractPublishedDate } from "./utilities/date-extractor";
 import { isFresh } from "./utilities/freshness-gate";
 import { embedTexts } from "./utilities/embeddings";
@@ -75,12 +72,10 @@ export async function runDataCollection(
     "data collection run started",
   );
 
-  const runPolicy: RunPolicy = config.runPolicy ?? {
-    minSuccessfulSources: 1,
-    failOnZeroSuccess: true,
-  };
-  const targetDailySuccessfulSources = config.targetDailySuccessfulSources ?? 5;
-  const maxRefillRounds = config.maxRefillRounds ?? 3;
+  const runPolicy = config.runPolicy;
+  const targetDailySuccessfulSources =
+    config.collection.targetDailySuccessfulSources;
+  const maxRefillRounds = config.collection.maxRefillRounds;
   const maxTotalRounds = 1 + maxRefillRounds;
 
   const dataApiClient = createAgentDataApiClient({
@@ -89,40 +84,21 @@ export async function runDataCollection(
     token,
   });
 
-  const webSearchConfig = config.webSearch;
-  const webFetchConfig = config.webFetch;
-  const relevanceGateConfig = config.relevanceGate ?? {
-    enabled: true,
-    headChars: 1500,
-    minMatches: 1,
-  };
-  const perQueryFetchBudget = config.perQueryFetchBudget ?? 3;
-  const perRunFetchBudget = config.perRunFetchBudget ?? 40;
-  const deadUrlCacheConfig = config.deadUrlCache ?? {
-    enabled: true,
-    skipLookupBatchSize: 50,
-  };
-  const hostErrorBreakerConfig = config.hostErrorBreaker ?? {
-    enabled: true,
-    minAttempts: 5,
-    errorRateThreshold: 0.5,
-  };
-  const freshnessGateConfig = config.freshnessGate ?? {
-    enabled: true,
-    maxAgeDays: 14,
-    allowUnknown: true,
-  };
-  const semanticDedupeConfig = config.semanticDedupe ?? {
-    enabled: false,
-    threshold: 0.88,
-    windowDays: 7,
-    embeddingModel: "text-embedding-3-small",
-  };
+  const webSearchConfig = config.providers.search;
+  const webFetchConfig = config.providers.fetch;
+  const relevanceGateConfig = config.gates.relevance;
+  const perQueryFetchBudget = config.collection.perQueryFetchBudget;
+  const perRunFetchBudget = config.collection.perRunFetchBudget;
+  const deadUrlCacheConfig = config.resilience.deadUrlCache;
+  const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
+  const freshnessGateConfig = config.gates.freshness;
+  const semanticDedupeConfig = config.deduplication.semantic;
+  const openaiApiKey = config.deduplication.openaiApiKey;
   let semanticDedupeActive = semanticDedupeConfig.enabled;
-  if (semanticDedupeActive && !config.openaiApiKey) {
+  if (semanticDedupeActive && isUnresolvedVariablePlaceholder(openaiApiKey)) {
     log.warn(
       {},
-      "semantic dedupe enabled in config but openaiApiKey is missing; falling back to URL-only dedupe",
+      "semantic dedupe enabled in config but openaiApiKey is an unresolved Hermes variable placeholder; falling back to URL-only dedupe",
     );
     semanticDedupeActive = false;
   }
@@ -552,7 +528,7 @@ export async function runDataCollection(
                 threshold: semanticDedupeConfig.threshold,
                 embedder: (texts) =>
                   embedTexts(texts, {
-                    apiKey: config.openaiApiKey!,
+                    apiKey: openaiApiKey,
                     model: semanticDedupeConfig.embeddingModel,
                   }),
               },

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -4,26 +4,13 @@ import { describe, expect, it } from "vitest";
 
 import {
   dataCollectionAgentConfigSchema,
+  defaultDiffbotFetchProvider,
+  defaultFetchProviders,
+  defaultFirecrawlFetchProvider,
+  defaultJinaFetchProvider,
   getConfigSchema,
+  isUnresolvedVariablePlaceholder,
 } from "./config-schema";
-
-const jinaWebFetchProvider = {
-  type: "jina" as const,
-  baseUrl: "https://r.jina.ai",
-  authentication: {
-    type: "bearer" as const,
-    apiKey: "key",
-    headerName: "Authorization",
-  },
-  rateLimit: {
-    requests: 100,
-    perSeconds: 60,
-  },
-};
-
-const webFetchWithJinaProvider = {
-  providers: [jinaWebFetchProvider],
-};
 
 describe("getConfigSchema", () => {
   it("returns wrapped JSON schema with agentId", () => {
@@ -34,246 +21,224 @@ describe("getConfigSchema", () => {
     expect(result.agentId).toBe("data-collection");
     expect(result.schema).toHaveProperty("type", "object");
     expect(result.schema).toHaveProperty("properties");
+    const properties = (
+      result.schema as { properties?: Record<string, unknown> }
+    ).properties;
+    expect(Object.keys(properties ?? {})).toEqual([
+      "providers",
+      "collection",
+      "gates",
+      "resilience",
+      "deduplication",
+      "runPolicy",
+    ]);
+  });
+});
+
+describe("isUnresolvedVariablePlaceholder", () => {
+  it("returns true for Hermes placeholder strings", () => {
+    expect(isUnresolvedVariablePlaceholder("{{SERPER_API_KEY}}")).toBe(true);
+  });
+
+  it("returns false for resolved API keys", () => {
+    expect(isUnresolvedVariablePlaceholder("sk-live-key")).toBe(false);
   });
 });
 
 describe("dataCollectionAgentConfigSchema", () => {
-  it("accepts a minimal valid config object", () => {
-    // Setup
-    const config = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: webFetchWithJinaProvider,
+  it("parses an empty object into the full recommended config", () => {
+    // Act
+    const parsed = dataCollectionAgentConfigSchema.parse({});
+
+    // Assert
+    expect(parsed.providers.search.baseUrl).toBe(
+      "https://google.serper.dev/search",
+    );
+    expect(parsed.providers.search.authentication.apiKey).toBe(
+      "{{SERPER_API_KEY}}",
+    );
+    expect(
+      parsed.providers.fetch.providers.map((provider) => provider.type),
+    ).toEqual(["diffbot", "firecrawl", "jina"]);
+    expect(parsed.providers.fetch.providers[0]).toMatchObject(
+      defaultDiffbotFetchProvider,
+    );
+    expect(parsed.providers.fetch.providers[1]).toMatchObject(
+      defaultFirecrawlFetchProvider,
+    );
+    expect(parsed.providers.fetch.providers[2]).toMatchObject(
+      defaultJinaFetchProvider,
+    );
+    expect(parsed.collection).toEqual({
       targetDailySuccessfulSources: 5,
       maxRefillRounds: 3,
-    };
-
-    // Act
-    const parsed = dataCollectionAgentConfigSchema.parse(config);
-
-    // Assert
-    expect(parsed.webSearch.baseUrl).toBe("https://google.serper.dev");
-    expect(parsed.webFetch.providers).toEqual([
-      expect.objectContaining({
-        type: "jina",
-        baseUrl: "https://r.jina.ai",
-      }),
-    ]);
-    expect(parsed.targetDailySuccessfulSources).toBe(5);
-    expect(parsed.maxRefillRounds).toBe(3);
-  });
-
-  it("applies relevance gate defaults when omitted", () => {
-    // Setup
-    const config = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: webFetchWithJinaProvider,
-      relevanceGate: {
-        enabled: true,
-        headChars: 1500,
-        minMatches: 1,
-      },
-    };
-
-    // Act
-    const parsed = dataCollectionAgentConfigSchema.parse(config);
-
-    // Assert
-    expect(parsed.relevanceGate).toEqual({
+      perQueryFetchBudget: 3,
+      perRunFetchBudget: 40,
+    });
+    expect(parsed.gates.relevance).toEqual({
       enabled: true,
       headChars: 1500,
       minMatches: 1,
     });
+    expect(parsed.gates.freshness).toEqual({
+      enabled: true,
+      maxAgeDays: 14,
+      allowUnknown: true,
+    });
+    expect(parsed.resilience.deadUrlCache).toEqual({
+      enabled: true,
+      skipLookupBatchSize: 50,
+    });
+    expect(parsed.resilience.hostErrorBreaker).toEqual({
+      enabled: true,
+      minAttempts: 5,
+      errorRateThreshold: 0.5,
+    });
+    expect(parsed.deduplication.semantic).toEqual({
+      enabled: false,
+      threshold: 0.88,
+      windowDays: 7,
+      embeddingModel: "{{EMBEDDING_MODEL}}",
+    });
+    expect(parsed.deduplication.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
+    expect(parsed.runPolicy).toEqual({
+      minSuccessfulSources: 1,
+      failOnZeroSuccess: true,
+    });
   });
 
-  it("rejects non-positive webSearch rate limits", () => {
-    const base = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: { requests: 0, perSeconds: 60 },
-      },
-      webFetch: webFetchWithJinaProvider,
-    };
+  it("preserves Hermes variable placeholders verbatim", () => {
+    const parsed = dataCollectionAgentConfigSchema.parse({});
 
-    expect(() => dataCollectionAgentConfigSchema.parse(base)).toThrow();
+    expect(parsed.providers.search.authentication.apiKey).toBe(
+      "{{SERPER_API_KEY}}",
+    );
+    expect(parsed.providers.fetch.providers[0]?.authentication.apiKey).toBe(
+      "{{DIFFBOT_API_KEY}}",
+    );
+    expect(parsed.providers.fetch.providers[1]?.authentication.apiKey).toBe(
+      "{{FIRECRAWL_API_KEY}}",
+    );
+    expect(parsed.providers.fetch.providers[2]?.authentication.apiKey).toBe(
+      "{{JINA_API_KEY}}",
+    );
+    expect(parsed.deduplication.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
+    expect(parsed.deduplication.semantic.embeddingModel).toBe(
+      "{{EMBEDDING_MODEL}}",
+    );
+  });
+
+  it("keeps other defaults when only one collection field is overridden", () => {
+    const parsed = dataCollectionAgentConfigSchema.parse({
+      collection: {
+        perRunFetchBudget: 12,
+      },
+    });
+
+    expect(parsed.collection.perRunFetchBudget).toBe(12);
+    expect(parsed.collection.perQueryFetchBudget).toBe(3);
+    expect(parsed.collection.targetDailySuccessfulSources).toBe(5);
+    expect(parsed.providers.fetch.providers).toHaveLength(3);
+    expect(parsed.runPolicy.failOnZeroSuccess).toBe(true);
+  });
+
+  it("accepts ordered fetch providers under providers.fetch.providers", () => {
+    const parsed = dataCollectionAgentConfigSchema.parse({
+      providers: {
+        fetch: {
+          providers: [
+            {
+              type: "jina",
+              baseUrl: "https://r.jina.ai",
+              authentication: {
+                type: "bearer",
+                apiKey: "jina-key",
+                headerName: "Authorization",
+              },
+              rateLimit: {
+                requests: 100,
+                perSeconds: 60,
+              },
+            },
+            {
+              type: "firecrawl",
+              baseUrl: "https://api.firecrawl.dev",
+              authentication: {
+                type: "bearer",
+                apiKey: "fc-key",
+                headerName: "Authorization",
+              },
+              rateLimit: {
+                requests: 50,
+                perSeconds: 60,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(
+      parsed.providers.fetch.providers.map((provider) => provider.type),
+    ).toEqual(["jina", "firecrawl"]);
+  });
+
+  it("rejects non-positive search rate limits", () => {
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        providers: {
+          search: {
+            rateLimit: { requests: 0, perSeconds: 60 },
+          },
+        },
+      }),
+    ).toThrow();
 
     expect(() =>
       dataCollectionAgentConfigSchema.parse({
-        ...base,
-        webSearch: {
-          ...base.webSearch,
-          rateLimit: { requests: 10, perSeconds: 0 },
+        providers: {
+          search: {
+            rateLimit: { requests: 10, perSeconds: 0 },
+          },
         },
       }),
     ).toThrow();
   });
 
-  it("accepts ordered webFetch.providers array", () => {
-    // Setup
-    const config = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: {
-        providers: [
-          {
-            type: "jina",
-            baseUrl: "https://r.jina.ai",
-            authentication: {
-              type: "bearer" as const,
-              apiKey: "jina-key",
-              headerName: "Authorization",
-            },
-            rateLimit: {
-              requests: 100,
-              perSeconds: 60,
-            },
+  it("rejects empty fetch provider arrays", () => {
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        providers: {
+          fetch: {
+            providers: [],
           },
-          {
-            type: "firecrawl",
-            baseUrl: "https://api.firecrawl.dev",
-            authentication: {
-              type: "bearer" as const,
-              apiKey: "fc-key",
-              headerName: "Authorization",
-            },
-            rateLimit: {
-              requests: 50,
-              perSeconds: 60,
-            },
-          },
-        ],
-      },
-    };
+        },
+      }),
+    ).toThrow();
+  });
 
-    // Act
-    const parsed = dataCollectionAgentConfigSchema.parse(config);
+  it("rejects invalid collection refill values", () => {
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        collection: {
+          targetDailySuccessfulSources: 0,
+        },
+      }),
+    ).toThrow();
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        collection: {
+          maxRefillRounds: -1,
+        },
+      }),
+    ).toThrow();
+  });
 
-    // Assert
-    expect(parsed.webFetch.providers.map((provider) => provider.type)).toEqual([
-      "jina",
+  it("exports the default fetch chain in recommended order", () => {
+    expect(defaultFetchProviders.map((provider) => provider.type)).toEqual([
+      "diffbot",
       "firecrawl",
+      "jina",
     ]);
-  });
-
-  it("rejects legacy single-object webFetch shape", () => {
-    const config = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: {
-        baseUrl: "https://r.jina.ai",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "legacy-key",
-          headerName: "Authorization",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-    };
-
-    expect(() => dataCollectionAgentConfigSchema.parse(config)).toThrow();
-  });
-
-  it("rejects empty webFetch.providers arrays", () => {
-    const config = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: {
-        providers: [],
-      },
-    };
-
-    expect(() => dataCollectionAgentConfigSchema.parse(config)).toThrow();
-  });
-
-  it("rejects invalid refill configuration values", () => {
-    // Setup
-    const base = {
-      webSearch: {
-        baseUrl: "https://google.serper.dev",
-        authentication: {
-          type: "bearer" as const,
-          apiKey: "key",
-          headerName: "X-API-KEY",
-        },
-        rateLimit: {
-          requests: 100,
-          perSeconds: 60,
-        },
-      },
-      webFetch: webFetchWithJinaProvider,
-    };
-
-    // Act + Assert
-    expect(() =>
-      dataCollectionAgentConfigSchema.parse({
-        ...base,
-        targetDailySuccessfulSources: 0,
-      }),
-    ).toThrow();
-    expect(() =>
-      dataCollectionAgentConfigSchema.parse({
-        ...base,
-        maxRefillRounds: -1,
-      }),
-    ).toThrow();
   });
 });

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -1,122 +1,408 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-const concurrencySchema = z.number().int().min(1).max(16).default(4);
+const concurrencySchema = z
+  .number()
+  .int()
+  .min(1)
+  .max(16)
+  .default(4)
+  .describe("Maximum parallel requests for this stage.");
 
-const webSearchSchema = z.object({
-  baseUrl: z.string(),
-  authentication: z.object({
-    type: z.enum(["bearer", "none"]),
-    apiKey: z.string().optional(),
-    headerName: z.string().optional(),
-  }),
-  rateLimit: z.object({
-    requests: z.number().int().positive(),
-    perSeconds: z.number().positive(),
-  }),
-  concurrency: concurrencySchema,
-  timeoutMs: z.number().int().positive().optional(),
-  retry: z
-    .object({
-      maxAttempts: z.number().int().nonnegative(),
-      baseDelayMs: z.number().int().positive(),
-      maxDelayMs: z.number().int().positive(),
-    })
-    .optional(),
-});
-
-const fetchProviderAuthenticationSchema = z.object({
-  type: z.enum(["bearer", "none"]),
-  apiKey: z.string().optional(),
-  headerName: z.string().optional(),
-});
-
-const fetchProviderRateLimitSchema = z.object({
-  requests: z.number().int().positive(),
-  perSeconds: z.number().positive(),
-});
-
-const fetchProviderRetrySchema = z
+const retrySchema = z
   .object({
-    maxAttempts: z.number().int().nonnegative(),
-    baseDelayMs: z.number().int().positive(),
-    maxDelayMs: z.number().int().positive(),
+    maxAttempts: z
+      .number()
+      .int()
+      .nonnegative()
+      .describe("Maximum retry attempts after a retryable failure."),
+    baseDelayMs: z
+      .number()
+      .int()
+      .positive()
+      .describe("Initial backoff delay in milliseconds."),
+    maxDelayMs: z
+      .number()
+      .int()
+      .positive()
+      .describe("Maximum backoff delay in milliseconds."),
   })
-  .optional();
+  .describe("Retry policy for transient HTTP failures.");
+
+const defaultRetry = {
+  maxAttempts: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 10_000,
+} as const;
+
+const authenticationSchema = z.object({
+  type: z
+    .enum(["bearer", "none"])
+    .describe("Authentication style for outbound provider requests."),
+  apiKey: z
+    .string()
+    .optional()
+    .describe(
+      "Provider API key or a Hermes variable placeholder such as {{SERPER_API_KEY}}.",
+    ),
+  headerName: z
+    .string()
+    .optional()
+    .describe("HTTP header name when the provider expects a header token."),
+});
+
+const rateLimitSchema = z.object({
+  requests: z
+    .number()
+    .int()
+    .positive()
+    .describe("Maximum requests allowed within the sliding window."),
+  perSeconds: z
+    .number()
+    .positive()
+    .describe("Sliding window length in seconds for rate limiting."),
+});
+
+const searchProviderSchema = z.object({
+  baseUrl: z
+    .string()
+    .default("https://google.serper.dev/search")
+    .describe("Serper search endpoint that accepts POST { q }."),
+  authentication: z
+    .object({
+      type: z.enum(["bearer", "none"]).default("bearer"),
+      apiKey: z.string().default("{{SERPER_API_KEY}}"),
+      headerName: z.string().default("X-API-KEY"),
+    })
+    .default({
+      type: "bearer",
+      apiKey: "{{SERPER_API_KEY}}",
+      headerName: "X-API-KEY",
+    })
+    .describe("Serper credentials resolved from Hermes Variables."),
+  rateLimit: z
+    .object({
+      requests: z.number().int().positive().default(100),
+      perSeconds: z.number().positive().default(60),
+    })
+    .default({ requests: 100, perSeconds: 60 })
+    .describe("Sliding-window request budget for web search."),
+  concurrency: concurrencySchema,
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .default(30_000)
+    .optional()
+    .describe("HTTP request timeout in milliseconds."),
+  retry: retrySchema.default(defaultRetry).optional(),
+});
 
 export const fetchProviderConfigSchema = z.object({
-  type: z.string(),
-  baseUrl: z.string(),
-  authentication: fetchProviderAuthenticationSchema,
-  rateLimit: fetchProviderRateLimitSchema,
+  type: z
+    .string()
+    .describe("Fetch adapter identifier such as diffbot, firecrawl, or jina."),
+  baseUrl: z.string().describe("Provider base URL for this adapter."),
+  authentication: authenticationSchema.describe(
+    "Provider credentials or Hermes variable placeholders.",
+  ),
+  rateLimit: rateLimitSchema.describe(
+    "Sliding-window request budget for this fetch provider.",
+  ),
   concurrency: concurrencySchema,
-  timeoutMs: z.number().int().positive().optional(),
-  retry: fetchProviderRetrySchema,
+  timeoutMs: z
+    .number()
+    .int()
+    .positive()
+    .default(30_000)
+    .optional()
+    .describe("HTTP request timeout in milliseconds."),
+  retry: retrySchema.default(defaultRetry).optional(),
 });
 
-const webFetchSchema = z.object({
-  providers: z.array(fetchProviderConfigSchema).min(1),
+/** Recommended Diffbot provider defaults for the fetch chain. */
+export const defaultDiffbotFetchProvider = {
+  type: "diffbot",
+  baseUrl: "https://api.diffbot.com",
+  authentication: {
+    type: "none" as const,
+    apiKey: "{{DIFFBOT_API_KEY}}",
+  },
+  rateLimit: { requests: 50, perSeconds: 60 },
+  concurrency: 4,
+  timeoutMs: 30_000,
+  retry: defaultRetry,
+};
+
+/** Recommended Firecrawl provider defaults for the fetch chain. */
+export const defaultFirecrawlFetchProvider = {
+  type: "firecrawl",
+  baseUrl: "https://api.firecrawl.dev",
+  authentication: {
+    type: "bearer" as const,
+    apiKey: "{{FIRECRAWL_API_KEY}}",
+    headerName: "Authorization",
+  },
+  rateLimit: { requests: 50, perSeconds: 60 },
+  concurrency: 4,
+  timeoutMs: 30_000,
+  retry: defaultRetry,
+};
+
+/** Recommended Jina provider defaults for the fetch chain. */
+export const defaultJinaFetchProvider = {
+  type: "jina",
+  baseUrl: "https://r.jina.ai/",
+  authentication: {
+    type: "bearer" as const,
+    apiKey: "{{JINA_API_KEY}}",
+    headerName: "Authorization",
+  },
+  rateLimit: { requests: 50, perSeconds: 60 },
+  concurrency: 4,
+  timeoutMs: 30_000,
+  retry: defaultRetry,
+};
+
+/** Default ordered fetch-provider chain: Diffbot, then Firecrawl, then Jina. */
+export const defaultFetchProviders = [
+  defaultDiffbotFetchProvider,
+  defaultFirecrawlFetchProvider,
+  defaultJinaFetchProvider,
+] as const;
+
+const fetchProvidersSchema = z.object({
+  providers: z
+    .array(fetchProviderConfigSchema)
+    .min(1)
+    .default([...defaultFetchProviders])
+    .describe(
+      "Ordered fetch-provider chain. The first provider is tried for each URL; later providers run only after earlier failures.",
+    ),
 });
+
+const providersSchema = z
+  .object({
+    search: searchProviderSchema
+      .default({})
+      .describe("Serper web-search provider settings."),
+    fetch: fetchProvidersSchema
+      .default({})
+      .describe("Ordered web-fetch provider chain settings."),
+  })
+  .default({})
+  .describe("External search and fetch providers used by the pipeline.");
+
+const collectionSchema = z
+  .object({
+    targetDailySuccessfulSources: z
+      .number()
+      .int()
+      .positive()
+      .default(5)
+      .describe(
+        "Stop refill rounds once this many successful sources exist for the ticker today (UTC).",
+      ),
+    maxRefillRounds: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(3)
+      .describe(
+        "Additional search-and-fetch rounds after the initial round when the daily target is not yet met.",
+      ),
+    perQueryFetchBudget: z
+      .number()
+      .int()
+      .positive()
+      .default(3)
+      .describe("Maximum URLs fetched per search query after ranking."),
+    perRunFetchBudget: z
+      .number()
+      .int()
+      .positive()
+      .default(40)
+      .describe("Maximum URLs fetched across all queries in one round."),
+  })
+  .default({})
+  .describe("Collection volume and refill behavior.");
 
 const relevanceGateSchema = z.object({
-  enabled: z.boolean().default(true),
-  headChars: z.number().int().positive().default(1500),
-  minMatches: z.number().int().positive().default(1),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      "When enabled, pages must mention the ticker or industry aliases.",
+    ),
+  headChars: z
+    .number()
+    .int()
+    .positive()
+    .default(1500)
+    .describe(
+      "Number of leading content characters scanned for alias matches.",
+    ),
+  minMatches: z
+    .number()
+    .int()
+    .positive()
+    .default(1)
+    .describe("Minimum alias matches required to keep a page."),
 });
 
 const freshnessGateSchema = z.object({
-  enabled: z.boolean().default(true),
-  maxAgeDays: z.number().int().positive().default(14),
-  allowUnknown: z.boolean().default(true),
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe("When enabled, pages outside the freshness window are dropped."),
+  maxAgeDays: z
+    .number()
+    .int()
+    .positive()
+    .default(14)
+    .describe("Maximum article age in days when a publish date is known."),
+  allowUnknown: z
+    .boolean()
+    .default(true)
+    .describe("Keep pages when no publish date can be extracted."),
 });
 
-/** Zod schema for agent config: web search/fetch providers, optional run policy. */
+const gatesSchema = z
+  .object({
+    relevance: relevanceGateSchema
+      .default({})
+      .describe("Ticker and industry relevance filtering."),
+    freshness: freshnessGateSchema
+      .default({})
+      .describe("Publish-date freshness filtering."),
+  })
+  .default({})
+  .describe("Pre-persistence content gates.");
+
+const deadUrlCacheSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe("Skip URLs previously recorded as dead after fetch failures."),
+  skipLookupBatchSize: z
+    .number()
+    .int()
+    .positive()
+    .default(50)
+    .describe("Batch size for dead-URL negative-cache lookups."),
+});
+
+const hostErrorBreakerSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(true)
+    .describe(
+      "Skip hosts whose recent fetch error rate exceeds the threshold.",
+    ),
+  minAttempts: z
+    .number()
+    .int()
+    .positive()
+    .default(5)
+    .describe("Minimum fetch attempts on a host before the breaker can trip."),
+  errorRateThreshold: z
+    .number()
+    .min(0)
+    .max(1)
+    .default(0.5)
+    .describe("Host error rate above which further fetches are skipped."),
+});
+
+const resilienceSchema = z
+  .object({
+    deadUrlCache: deadUrlCacheSchema
+      .default({})
+      .describe("Negative cache for URLs that repeatedly fail to fetch."),
+    hostErrorBreaker: hostErrorBreakerSchema
+      .default({})
+      .describe("Per-host circuit breaker based on fetch error rate."),
+  })
+  .default({})
+  .describe("Failure-avoidance controls applied before and during fetch.");
+
+const semanticDedupeSchema = z.object({
+  enabled: z
+    .boolean()
+    .default(false)
+    .describe(
+      "When enabled, drop near-duplicate pages using embedding similarity against recent corpus fingerprints.",
+    ),
+  threshold: z
+    .number()
+    .min(0)
+    .max(1)
+    .default(0.88)
+    .describe(
+      "Cosine-similarity threshold above which a candidate is dropped.",
+    ),
+  windowDays: z
+    .number()
+    .int()
+    .positive()
+    .default(7)
+    .describe("Lookback window in days for recent corpus fingerprints."),
+  embeddingModel: z
+    .string()
+    .default("{{EMBEDDING_MODEL}}")
+    .describe(
+      "OpenAI embedding model name or a Hermes variable placeholder such as {{EMBEDDING_MODEL}}.",
+    ),
+});
+
+const deduplicationSchema = z
+  .object({
+    semantic: semanticDedupeSchema
+      .default({})
+      .describe("Semantic deduplication against recently persisted sources."),
+    openaiApiKey: z
+      .string()
+      .default("{{OPENAI_API_KEY}}")
+      .describe(
+        "OpenAI API key for semantic dedupe embeddings or a Hermes variable placeholder.",
+      ),
+  })
+  .default({})
+  .describe("Deduplication settings and credentials.");
+
+const runPolicySchema = z
+  .object({
+    minSuccessfulSources: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(1)
+      .describe("Minimum persisted sources required for a successful run."),
+    failOnZeroSuccess: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, a run with zero persisted sources is marked failed even if no HTTP errors occurred.",
+      ),
+  })
+  .default({})
+  .describe("Run success criteria applied after the pipeline completes.");
+
+/** Zod schema for agent config grouped for Hermes form sections. */
 export const ConfigSchema = z.object({
-  webSearch: webSearchSchema,
-  webFetch: webFetchSchema,
-  targetDailySuccessfulSources: z.number().int().positive().optional(),
-  maxRefillRounds: z.number().int().nonnegative().optional(),
-  relevanceGate: relevanceGateSchema.optional(),
-  freshnessGate: freshnessGateSchema.optional(),
-  perQueryFetchBudget: z.number().int().positive().default(3),
-  perRunFetchBudget: z.number().int().positive().default(40),
-  deadUrlCache: z
-    .object({
-      enabled: z.boolean().default(true),
-      skipLookupBatchSize: z.number().int().positive().default(50),
-    })
-    .optional(),
-  hostErrorBreaker: z
-    .object({
-      enabled: z.boolean().default(true),
-      minAttempts: z.number().int().positive().default(5),
-      errorRateThreshold: z.number().min(0).max(1).default(0.5),
-    })
-    .optional(),
-  semanticDedupe: z
-    .object({
-      enabled: z.boolean().default(false),
-      threshold: z.number().min(0).max(1).default(0.88),
-      windowDays: z.number().int().positive().default(7),
-      embeddingModel: z.string().default("text-embedding-3-small"),
-    })
-    .optional(),
-  /**
-   * OpenAI API key for semantic dedupe embeddings (Hermes config / variable expansion).
-   * Not read from process env — same pattern as query-analysis.
-   */
-  openaiApiKey: z.string().min(1).optional(),
-  runPolicy: z
-    .object({
-      minSuccessfulSources: z.number().int().nonnegative(),
-      failOnZeroSuccess: z.boolean(),
-    })
-    .optional(),
+  providers: providersSchema,
+  collection: collectionSchema,
+  gates: gatesSchema,
+  resilience: resilienceSchema,
+  deduplication: deduplicationSchema,
+  runPolicy: runPolicySchema,
 });
 
 export const dataCollectionAgentConfigSchema = ConfigSchema;
 
 export type ConfigSchemaType = z.infer<typeof ConfigSchema>;
+
+export type SearchProviderConfig = ConfigSchemaType["providers"]["search"];
+export type FetchProvidersConfig = ConfigSchemaType["providers"]["fetch"];
 
 /**
  * Minimal JSON Schema type used for the /config response.
@@ -125,6 +411,14 @@ export type ConfigSchemaType = z.infer<typeof ConfigSchema>;
 export type JsonSchema = {
   [key: string]: unknown;
 };
+
+/**
+ * Returns whether a config value is an unresolved Hermes variable placeholder.
+ *
+ * @param value - Config string that may still contain `{{NAME}}` syntax.
+ */
+export const isUnresolvedVariablePlaceholder = (value: string): boolean =>
+  /^\{\{[A-Z0-9_]+\}\}$/.test(value);
 
 /**
  * Returns the JSON Schema representation of the config schema wrapped with the agent ID.

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
@@ -49,7 +49,7 @@ export type WebFetchLogger = {
 };
 
 export interface WebFetchDeps {
-  config: NonNullable<ConfigSchemaType["webFetch"]>;
+  config: ConfigSchemaType["providers"]["fetch"];
   gotClient?: typeof got;
   /** Logger with run correlation; defaults to workspace logger. */
   logger?: WebFetchLogger;

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.test.ts
@@ -72,7 +72,7 @@ describe("performWebSearch", () => {
     expect(warnMock).toHaveBeenCalledWith(
       expect.objectContaining({
         baseUrl: "https://r.jina.ai/",
-        hint: expect.stringContaining("webFetch"),
+        hint: expect.stringContaining("providers.fetch"),
       }),
       expect.stringContaining("misconfiguration"),
     );

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
@@ -54,7 +54,7 @@ export type WebSearchLogger = {
 };
 
 export interface WebSearchDeps {
-  config: NonNullable<ConfigSchemaType["webSearch"]>;
+  config: ConfigSchemaType["providers"]["search"];
   gotClient?: typeof got;
   /** Logger with run correlation; defaults to workspace logger. */
   logger?: WebSearchLogger;
@@ -82,7 +82,7 @@ export type SerperResponse = z.infer<typeof serperResponseSchema>;
  * @param config - Web search provider configuration.
  */
 const resolveSearchConcurrency = (
-  config: NonNullable<ConfigSchemaType["webSearch"]>,
+  config: ConfigSchemaType["providers"]["search"],
 ): number => Math.min(config.concurrency ?? 4, config.rateLimit.requests);
 
 /**
@@ -94,7 +94,7 @@ const resolveSearchConcurrency = (
 const searchOneQuery = async (
   query: SearchQuery,
   deps: {
-    config: NonNullable<ConfigSchemaType["webSearch"]>;
+    config: ConfigSchemaType["providers"]["search"];
     gotClient: typeof got;
     log: WebSearchLogger;
     rateLimiter: RateLimiter;
@@ -205,9 +205,9 @@ export async function performWebSearch(
       log.warn(
         {
           baseUrl: config.baseUrl,
-          hint: "webSearch uses Serper-shaped POST { q }; Jina Reader belongs on webFetch.baseUrl",
+          hint: "providers.search uses Serper-shaped POST { q }; Jina Reader belongs in providers.fetch.providers",
         },
-        "data-collection webSearch misconfiguration: Jina URL in webSearch.baseUrl",
+        "data-collection search misconfiguration: Jina URL in providers.search.baseUrl",
       );
     }
   } catch {


### PR DESCRIPTION
## Summary

The data-collection step config was a flat list of keys with defaults split between the Zod schema and `run.ts`. Hermes showed one long form, and saving `{}` did not give you a usable pipeline.

This PR groups the config into six sections (providers, collection, gates, resilience, deduplication, run policy), moves every default into the schema, and prefills secrets with `{{NAME}}` placeholders. An empty config now validates into the recommended Serper search plus Diffbot → Firecrawl → Jina fetch chain.

## Related issues

Closes #572

## Important changes

- Replaced flat `webSearch` / `webFetch` / top-level gate keys with grouped paths (`providers.search`, `providers.fetch.providers`, `collection.*`, `gates.*`, etc.).
- Default fetch order is Diffbot, then Firecrawl, then Jina; API keys default to Hermes variable placeholders.
- Removed all inline `??` fallbacks from `run.ts`; the schema is the single source of truth.
- Breaking change: old flat configs strip unknown keys and fall back to all defaults (no coercion).

## Other changes

- Added `README.md` and `config.example.jsonc` documenting the grouped shape and required Hermes Variables.
- Updated `web-search.ts` / `web-fetch.ts` types to read from `providers.search` and `providers.fetch`.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — grouped schema, defaults, descriptions, exported default provider chain.
- `apps/mediapulse/agents/data-collection/src/run.ts` — grouped config reads; semantic dedupe skips unresolved `{{OPENAI_API_KEY}}`.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts` — empty `{}`, placeholders, partial overrides.
- `apps/mediapulse/agents/data-collection/src/run.test.ts` — migrated fixtures via `withTestConfig()`.

## How to test

1. `pnpm exec turbo run lint type:check test:coverage --filter=@mediapulse/data-collection`
2. Confirm `dataCollectionAgentConfigSchema.parse({})` yields the three-provider chain and all gate/resilience defaults.
3. In Hermes, open a data-collection step: form should show grouped sections with prefilled values; saving `{}` should be valid.
4. Re-enter any custom tuning that lived in the old flat config shape (stale stored configs revert to defaults).
