### PR TITLE
Polish industry newsletter layout and drop V2 wire suffix

### DIFF
--- a/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.ts
+++ b/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.ts
@@ -1,4 +1,4 @@
-import { parseIndustryNewsletterWireV2 } from "@workspace/email-templates/parse-industry-newsletter-wire-v2";
+import { parseIndustryNewsletterWire } from "@workspace/email-templates/parse-industry-newsletter-wire";
 
 /** Maps wire machine keys to structured JSON `sectionKey` names. */
 const MACHINE_KEY_TO_SECTION_KEY: Record<string, string> = {
@@ -7,8 +7,6 @@ const MACHINE_KEY_TO_SECTION_KEY: Record<string, string> = {
   "regulatory-policy-watch": "regulatoryPolicyWatch",
   "disruptors-or-tech": "disruptorsOrTech",
   "quick-hits": "quickHits",
-  "read-watch-listen": "readWatchListen",
-  "quote-of-the-week": "quoteOfTheWeek",
 };
 
 export type FlattenedNewsletterBullet = {
@@ -22,7 +20,7 @@ export type FlattenedNewsletterBullet = {
  * Flattens a persisted newsletter wire body into comparable bullet rows.
  *
  * @param newsletterId - Persisted newsletter id.
- * @param content - Wire body text (`MP_NEWSLETTER_V2`).
+ * @param content - Wire body text (`MP_NEWSLETTER`).
  * @param createdAt - ISO timestamp for the newsletter row.
  */
 export const flattenBulletsFromNewsletterWire = (
@@ -30,7 +28,7 @@ export const flattenBulletsFromNewsletterWire = (
   content: string,
   createdAt: string,
 ): FlattenedNewsletterBullet[] => {
-  const parsed = parseIndustryNewsletterWireV2(content);
+  const parsed = parseIndustryNewsletterWire(content);
   if (parsed === undefined) {
     return [];
   }
@@ -86,30 +84,6 @@ export const flattenBulletsFromNewsletterWire = (
           newsletterId,
           sectionKey,
           bulletText: item.text.trim(),
-          createdAt,
-        });
-      }
-      continue;
-    }
-
-    if (section.machineKey === "read-watch-listen") {
-      if (section.summary.trim().length > 0) {
-        bullets.push({
-          newsletterId,
-          sectionKey,
-          bulletText: section.summary.trim(),
-          createdAt,
-        });
-      }
-      continue;
-    }
-
-    if (section.machineKey === "quote-of-the-week") {
-      if (section.quote.trim().length > 0) {
-        bullets.push({
-          newsletterId,
-          sectionKey,
-          bulletText: section.quote.trim(),
           createdAt,
         });
       }

--- a/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
@@ -2,12 +2,12 @@ import { READ_FULL_ARTICLE_LABEL } from "./format-newsletter-content.js";
 import type { IndustryNewsletterResolved } from "./industry-newsletter-urls.js";
 
 /**
- * First line marker for Mediapulse industry newsletter wire format v2.
+ * First line marker for Mediapulse industry newsletter wire format.
  *
- * Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_V2_MARKER` in
- * `packages/shared/email-templates/src/newsletter/parse-newsletter-body.ts`.
+ * Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_MARKER` in
+ * `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts`.
  */
-export const INDUSTRY_NEWSLETTER_WIRE_V2_MARKER = "MP_NEWSLETTER_V2";
+export const INDUSTRY_NEWSLETTER_WIRE_MARKER = "MP_NEWSLETTER";
 
 const BEGIN = "BEGIN";
 const END = "END";
@@ -16,9 +16,6 @@ const PROSE = "PROSE";
 const FORMAT = "FORMAT";
 const BULLET = "BULLET";
 const ITEM = "ITEM";
-const SUMMARY = "SUMMARY";
-const QUOTE = "QUOTE";
-const ATTRIBUTION = "ATTRIBUTION";
 
 /**
  * Collapses internal whitespace so display headings stay a single wire line.
@@ -45,15 +42,15 @@ const withOptionalReadLine = (text: string, url?: string): string => {
 };
 
 /**
- * Serializes a resolved industry briefing into the v2 plain-text wire format.
+ * Serializes a resolved industry briefing into the plain-text wire format.
  *
  * @param briefing - Ground-truth briefing with URLs attached from sources.
- * @returns Wire body whose first line is {@link INDUSTRY_NEWSLETTER_WIRE_V2_MARKER}.
+ * @returns Wire body whose first line is {@link INDUSTRY_NEWSLETTER_WIRE_MARKER}.
  */
-export const formatIndustryNewsletterV2Wire = (
+export const formatIndustryNewsletterWire = (
   briefing: IndustryNewsletterResolved,
 ): string => {
-  const parts: string[] = [INDUSTRY_NEWSLETTER_WIRE_V2_MARKER, ""];
+  const parts: string[] = [INDUSTRY_NEWSLETTER_WIRE_MARKER, ""];
 
   const pushBlock = (block: string): void => {
     parts.push(block.trimEnd(), "");
@@ -142,39 +139,6 @@ export const formatIndustryNewsletterV2Wire = (
   }
   qhLines.push(END);
   pushBlock(qhLines.join("\n"));
-
-  if (briefing.readWatchListen) {
-    const rw = briefing.readWatchListen;
-    pushBlock(
-      [
-        `${BEGIN} read-watch-listen`,
-        DISPLAY_HEADING,
-        collapseHeadingLine(rw.displayHeading),
-        SUMMARY,
-        withOptionalReadLine(rw.summary, rw.url),
-        END,
-      ].join("\n"),
-    );
-  }
-
-  if (briefing.quoteOfTheWeek) {
-    const q = briefing.quoteOfTheWeek;
-    const quoteLines = [
-      `${BEGIN} quote-of-the-week`,
-      DISPLAY_HEADING,
-      collapseHeadingLine(q.displayHeading),
-      QUOTE,
-      q.quote.trim(),
-      ATTRIBUTION,
-      q.attribution.trim(),
-    ];
-    const trimmedUrl = q.url?.trim() ?? "";
-    if (trimmedUrl.length > 0) {
-      quoteLines.push(`${READ_FULL_ARTICLE_LABEL}: ${trimmedUrl}`);
-    }
-    quoteLines.push(END);
-    pushBlock(quoteLines.join("\n"));
-  }
 
   return parts.join("\n").trimEnd() + "\n";
 };

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
@@ -160,13 +160,9 @@ describe("industryNewsletterStructureLlmSchema", () => {
           { text: "h5", articleIndex: 1 },
         ],
       },
-      readWatchListen: null,
-      quoteOfTheWeek: null,
     });
 
     expect(industryNewsletterStructureSchema.parse(parsed)).toEqual(parsed);
     expect(parsed.competitiveLandscape.bullets[1]).toEqual({ text: "b2" });
-    expect(parsed.readWatchListen).toBeUndefined();
-    expect(parsed.quoteOfTheWeek).toBeUndefined();
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
@@ -32,19 +32,6 @@ export const disruptorsOrTechSchema = z.discriminatedUnion("format", [
   disruptorsOrTechBulletsSchema,
 ]);
 
-export const readWatchListenSchema = z.object({
-  displayHeading: z.string().min(1),
-  summary: z.string().min(1),
-  articleIndex: articleIndexSchema,
-});
-
-export const quoteOfTheWeekSchema = z.object({
-  displayHeading: z.string().min(1),
-  quote: z.string().min(1),
-  attribution: z.string().min(1),
-  articleIndex: articleIndexSchema.optional(),
-});
-
 /**
  * Zod schema for the industry-intelligence newsletter JSON returned by the LLM.
  *
@@ -74,8 +61,6 @@ export const industryNewsletterStructureSchema = z.object({
     displayHeading: z.string().min(1),
     items: z.array(industryQuickHitSchema).min(5).max(7),
   }),
-  readWatchListen: readWatchListenSchema.optional(),
-  quoteOfTheWeek: quoteOfTheWeekSchema.optional(),
 });
 
 export type IndustryNewsletterStructure = z.infer<
@@ -113,27 +98,6 @@ const disruptorsOrTechLlmSchema = z.discriminatedUnion("format", [
   disruptorsOrTechBulletsLlmSchema,
 ]);
 
-const quoteOfTheWeekLlmSchema = z
-  .object({
-    displayHeading: z.string().min(1),
-    quote: z.string().min(1),
-    attribution: z.string().min(1),
-    articleIndex: z.union([articleIndexSchema, z.null()]),
-  })
-  .transform(
-    ({
-      displayHeading,
-      quote,
-      attribution,
-      articleIndex,
-    }): z.infer<typeof quoteOfTheWeekSchema> => {
-      const normalizedIndex = normalizeOptionalArticleIndex(articleIndex);
-      return normalizedIndex === undefined
-        ? { displayHeading, quote, attribution }
-        : { displayHeading, quote, attribution, articleIndex: normalizedIndex };
-    },
-  );
-
 /**
  * OpenAI-compatible schema for structured newsletter generation.
  *
@@ -164,17 +128,5 @@ export const industryNewsletterStructureLlmSchema = z
       displayHeading: z.string().min(1),
       items: z.array(industryQuickHitSchema).min(5).max(7),
     }),
-    readWatchListen: z
-      .union([readWatchListenSchema, z.null()])
-      .transform(
-        (value): z.infer<typeof readWatchListenSchema> | undefined =>
-          value ?? undefined,
-      ),
-    quoteOfTheWeek: z
-      .union([quoteOfTheWeekLlmSchema, z.null()])
-      .transform(
-        (value): z.infer<typeof quoteOfTheWeekSchema> | undefined =>
-          value ?? undefined,
-      ),
   })
   .transform((value): IndustryNewsletterStructure => value);

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
@@ -29,7 +29,7 @@ export type IndustryDisruptorsOrTechResolved =
       bullets: IndustryBulletResolved[];
     };
 
-/** Industry briefing ready for V2 wire formatting (all URLs from config, not the LLM). */
+/** Industry briefing ready for wire formatting (all URLs from config, not the LLM). */
 export type IndustryNewsletterResolved = {
   subject: string;
   industryPulse: { displayHeading: string; prose: string };
@@ -49,17 +49,6 @@ export type IndustryNewsletterResolved = {
   quickHits: {
     displayHeading: string;
     items: IndustryQuickHitResolved[];
-  };
-  readWatchListen?: {
-    displayHeading: string;
-    summary: string;
-    url?: string;
-  };
-  quoteOfTheWeek?: {
-    displayHeading: string;
-    quote: string;
-    attribution: string;
-    url?: string;
   };
 };
 
@@ -85,7 +74,7 @@ export const resolveArticleUrlForIndustryNewsletter = (
  *
  * @param briefing - Validated LLM object (no URLs from the model).
  * @param sources - Same ordered slice passed into the prompt (`Article 1` first).
- * @returns A copy safe to pass into the V2 wire serializer.
+ * @returns A copy safe to pass into the wire serializer.
  */
 export const attachIndustryNewsletterSourceUrls = (
   briefing: IndustryNewsletterStructure,
@@ -140,30 +129,5 @@ export const attachIndustryNewsletterSourceUrls = (
       displayHeading: briefing.quickHits.displayHeading,
       items: briefing.quickHits.items.map(mapHit),
     },
-    ...(briefing.readWatchListen
-      ? {
-          readWatchListen: {
-            displayHeading: briefing.readWatchListen.displayHeading,
-            summary: briefing.readWatchListen.summary,
-            url: resolveArticleUrlForIndustryNewsletter(
-              briefing.readWatchListen.articleIndex,
-              sources,
-            ),
-          },
-        }
-      : {}),
-    ...(briefing.quoteOfTheWeek
-      ? {
-          quoteOfTheWeek: {
-            displayHeading: briefing.quoteOfTheWeek.displayHeading,
-            quote: briefing.quoteOfTheWeek.quote,
-            attribution: briefing.quoteOfTheWeek.attribution,
-            url: resolveArticleUrlForIndustryNewsletter(
-              briefing.quoteOfTheWeek.articleIndex,
-              sources,
-            ),
-          },
-        }
-      : {}),
   };
 };

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  formatIndustryNewsletterV2Wire,
-  INDUSTRY_NEWSLETTER_WIRE_V2_MARKER,
-} from "./format-industry-newsletter-v2.js";
+  formatIndustryNewsletterWire,
+  INDUSTRY_NEWSLETTER_WIRE_MARKER,
+} from "./format-industry-newsletter.js";
 import { industryNewsletterStructureSchema } from "./industry-newsletter-schema.js";
 import {
   attachIndustryNewsletterSourceUrls,
@@ -84,8 +84,8 @@ describe("attachIndustryNewsletterSourceUrls", () => {
   });
 });
 
-describe("formatIndustryNewsletterV2Wire", () => {
-  it("starts with the v2 marker and emits read lines", () => {
+describe("formatIndustryNewsletterWire", () => {
+  it("starts with the wire marker and emits read lines", () => {
     const resolved = attachIndustryNewsletterSourceUrls(
       industryNewsletterStructureSchema.parse({
         subject: "S",
@@ -124,11 +124,9 @@ describe("formatIndustryNewsletterV2Wire", () => {
       [{ url: "https://src.example" }],
     );
 
-    const wire = formatIndustryNewsletterV2Wire(resolved);
+    const wire = formatIndustryNewsletterWire(resolved);
 
-    expect(wire.startsWith(`${INDUSTRY_NEWSLETTER_WIRE_V2_MARKER}\n`)).toBe(
-      true,
-    );
+    expect(wire.startsWith(`${INDUSTRY_NEWSLETTER_WIRE_MARKER}\n`)).toBe(true);
     expect(wire).toContain("Read the full article: https://src.example");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.ts
@@ -279,61 +279,6 @@ export const groundNewsletterCitations = (
     }
   });
 
-  if (next.readWatchListen !== undefined) {
-    const article = sources[next.readWatchListen.articleIndex - 1];
-    let overlapScore = 0;
-    let reason: "low_overlap" | "no_source" | null = null;
-    if (article === undefined) {
-      reason = "no_source";
-    } else {
-      overlapScore = scoreBulletAgainstArticle(
-        next.readWatchListen.summary,
-        article,
-        { numericBonus: opts.numericBonus },
-      );
-      if (overlapScore < opts.minOverlapScore) {
-        reason = "low_overlap";
-      }
-    }
-    pending.push({
-      sectionKey: "readWatchListen",
-      bulletIndex: 0,
-      text: next.readWatchListen.summary,
-      articleIndex: next.readWatchListen.articleIndex,
-      overlapScore,
-      reason,
-    });
-  }
-
-  if (
-    next.quoteOfTheWeek !== undefined &&
-    next.quoteOfTheWeek.articleIndex !== undefined
-  ) {
-    const article = sources[next.quoteOfTheWeek.articleIndex - 1];
-    let overlapScore = 0;
-    let reason: "low_overlap" | "no_source" | null = null;
-    if (article === undefined) {
-      reason = "no_source";
-    } else {
-      overlapScore = scoreBulletAgainstArticle(
-        `${next.quoteOfTheWeek.quote} ${next.quoteOfTheWeek.attribution}`,
-        article,
-        { numericBonus: opts.numericBonus },
-      );
-      if (overlapScore < opts.minOverlapScore) {
-        reason = "low_overlap";
-      }
-    }
-    pending.push({
-      sectionKey: "quoteOfTheWeek",
-      bulletIndex: 0,
-      text: next.quoteOfTheWeek.quote,
-      articleIndex: next.quoteOfTheWeek.articleIndex,
-      overlapScore,
-      reason,
-    });
-  }
-
   const decide = (row: PendingCitationRow): GroundingDecision => {
     if (row.reason === null) {
       return { kind: "pass" };
@@ -341,10 +286,7 @@ export const groundNewsletterCitations = (
     if (opts.policy === "warn") {
       return { kind: "pass" };
     }
-    if (
-      row.sectionKey === "quickHits" ||
-      row.sectionKey === "readWatchListen"
-    ) {
+    if (row.sectionKey === "quickHits") {
       return { kind: "drop", reason: row.reason };
     }
     if (opts.policy === "unlink") {
@@ -478,49 +420,6 @@ export const groundNewsletterCitations = (
     }
     return [item];
   }) as IndustryNewsletterStructure["quickHits"]["items"];
-
-  if (next.readWatchListen !== undefined) {
-    const decision = decisions.get("readWatchListen:0") ?? { kind: "pass" };
-    const row = pending.find(
-      (candidate) => candidate.sectionKey === "readWatchListen",
-    );
-    reports.push({
-      sectionKey: "readWatchListen",
-      bulletIndex: 0,
-      articleIndex: next.readWatchListen.articleIndex,
-      overlapScore: row?.overlapScore ?? 0,
-      decision,
-    });
-    if (decision.kind === "drop") {
-      delete next.readWatchListen;
-    }
-  }
-
-  if (
-    next.quoteOfTheWeek !== undefined &&
-    next.quoteOfTheWeek.articleIndex !== undefined
-  ) {
-    const decision = decisions.get("quoteOfTheWeek:0") ?? { kind: "pass" };
-    const row = pending.find(
-      (candidate) => candidate.sectionKey === "quoteOfTheWeek",
-    );
-    reports.push({
-      sectionKey: "quoteOfTheWeek",
-      bulletIndex: 0,
-      articleIndex: next.quoteOfTheWeek.articleIndex,
-      overlapScore: row?.overlapScore ?? 0,
-      decision,
-    });
-    if (decision.kind === "drop") {
-      delete next.quoteOfTheWeek;
-    } else if (decision.kind === "unlink") {
-      next.quoteOfTheWeek = {
-        displayHeading: next.quoteOfTheWeek.displayHeading,
-        quote: next.quoteOfTheWeek.quote,
-        attribution: next.quoteOfTheWeek.attribution,
-      };
-    }
-  }
 
   industryNewsletterStructureSchema.parse(next);
 

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.ts
@@ -41,7 +41,6 @@ const CONSUMER_FINANCIAL_KEYWORDS = [
 
 /**
  * Fictional industrial conglomerate exemplar — mining, infrastructure, and palm oil lens.
- * Omits `quoteOfTheWeek` to show optional blocks can be absent.
  */
 const industrialExemplar: NewsletterExemplar = {
   id: "industrial-INDX",
@@ -149,18 +148,11 @@ const industrialExemplar: NewsletterExemplar = {
         },
       ],
     },
-    readWatchListen: {
-      displayHeading: "Worth a deeper read",
-      summary:
-        "The Batam permit piece is the best map of where civil-work demand may land next — skim it for named estates and contractor shortlists before the next bidding season.",
-      articleIndex: 5,
-    },
   },
 };
 
 /**
  * Fictional consumer and financial mix exemplar — banking, retail, and payments lens.
- * Omits `readWatchListen` to show optional blocks can be absent.
  */
 const consumerFinancialExemplar: NewsletterExemplar = {
   id: "consumer-CONSM",
@@ -259,14 +251,6 @@ const consumerFinancialExemplar: NewsletterExemplar = {
           articleIndex: 6,
         },
       ],
-    },
-    quoteOfTheWeek: {
-      displayHeading: "Quote of the week",
-      quote:
-        "We are not chasing volume for its own sake — we want profitable transactions and cleaner KYC files.",
-      attribution:
-        "Regional wallet CEO quoted in the tier-2 growth slowdown piece",
-      articleIndex: 3,
     },
   },
 };
@@ -402,20 +386,6 @@ export const formatExemplarBlock = (exemplar: NewsletterExemplar): string => {
       formatBulletLine(item.text, item.articleIndex),
     ),
   );
-
-  if (output.readWatchListen !== undefined) {
-    lines.push(
-      `Read, Watch, Listen / ${output.readWatchListen.displayHeading}:`,
-      `${output.readWatchListen.summary} (Article ${String(output.readWatchListen.articleIndex)})`,
-    );
-  }
-
-  if (output.quoteOfTheWeek !== undefined) {
-    lines.push(
-      `Quote of the Week / ${output.quoteOfTheWeek.displayHeading}:`,
-      `"${output.quoteOfTheWeek.quote}" — ${output.quoteOfTheWeek.attribution}`,
-    );
-  }
 
   lines.push("END EXEMPLAR");
   return lines.join("\n");

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-polish.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-polish.ts
@@ -339,26 +339,6 @@ const collectPolishTextRefs = (
     });
   }
 
-  const readWatchListen = structure.readWatchListen;
-  if (readWatchListen !== undefined) {
-    refs.push({
-      get: () => readWatchListen.summary,
-      set: (value) => {
-        readWatchListen.summary = value;
-      },
-    });
-  }
-
-  const quoteOfTheWeek = structure.quoteOfTheWeek;
-  if (quoteOfTheWeek !== undefined) {
-    refs.push({
-      get: () => quoteOfTheWeek.quote,
-      set: (value) => {
-        quoteOfTheWeek.quote = value;
-      },
-    });
-  }
-
   return refs;
 };
 

--- a/apps/mediapulse/agents/content-generation/src/lib/numeric-anchors.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/numeric-anchors.ts
@@ -249,17 +249,6 @@ export const collectBriefingTextSegments = (
     );
   }
 
-  if (structure.readWatchListen !== undefined) {
-    segments.push(structure.readWatchListen.summary);
-  }
-
-  if (structure.quoteOfTheWeek !== undefined) {
-    segments.push(
-      structure.quoteOfTheWeek.quote,
-      structure.quoteOfTheWeek.attribution,
-    );
-  }
-
   return segments;
 };
 
@@ -437,21 +426,6 @@ export const stripUnmatchedFiguresFromStructure = (
         text: strip(bullet.text),
       }),
     );
-  }
-
-  if (next.readWatchListen !== undefined) {
-    next.readWatchListen = {
-      ...next.readWatchListen,
-      summary: strip(next.readWatchListen.summary),
-    };
-  }
-
-  if (next.quoteOfTheWeek !== undefined) {
-    next.quoteOfTheWeek = {
-      ...next.quoteOfTheWeek,
-      quote: strip(next.quoteOfTheWeek.quote),
-      attribution: strip(next.quoteOfTheWeek.attribution),
-    };
   }
 
   return next;

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -127,7 +127,7 @@ describe("generateNewsletterWithLlm — happy path", () => {
 
     // Assert
     expect(result.subject).toBe("Market Rally Continues");
-    expect(result.content).toContain("MP_NEWSLETTER_V2");
+    expect(result.content).toContain("MP_NEWSLETTER");
     expect(result.content).toContain("Stocks rose for the third day.");
     expect(result.content).toContain("BEGIN quick-hits");
     expect(result.description).toBe("Stocks rose for the third day.");

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -5,7 +5,7 @@ import type { z } from "zod";
 import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
-import { formatIndustryNewsletterV2Wire } from "./format-industry-newsletter-v2.js";
+import { formatIndustryNewsletterWire } from "./format-industry-newsletter.js";
 import {
   industryNewsletterStructureLlmSchema,
   industryNewsletterStructureSchema,
@@ -77,7 +77,7 @@ export { newsletterCritiqueSchema };
 export interface GeneratedContent {
   /** Compelling email subject line (under ~60 chars). */
   subject: string;
-  /** Formatted plain-text newsletter body (`MP_NEWSLETTER_V2` industry wire). */
+  /** Formatted plain-text newsletter body (`MP_NEWSLETTER` industry wire). */
   content: string;
   /** Optional executive summary for newsletter preview or listing. */
   description?: string;
@@ -476,8 +476,6 @@ Return JSON matching this shape (camelCase keys):
 - "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
 - "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
 - "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "text", "articleIndex" } (index required for every quick hit).
-- "readWatchListen": { "displayHeading", "summary", "articleIndex" } or null when unsupported by the articles.
-- "quoteOfTheWeek": { "displayHeading", "quote", "attribution", "articleIndex" } or null when unsupported; articleIndex may be null when uncited.
 
 Headings ("displayHeading") can be personality titles. Keep JSON valid; use null for optional blocks and uncited articleIndex values.`;
 
@@ -492,7 +490,6 @@ Rules reminder:
 - Industry and competitive lens; no trading advice.
 - Use "articleIndex" to point at Article 1 … Article {{topNewsCount}} from this prompt. Set articleIndex to null on a bullet when there is no clear single-article grounding.
 - Quick hits must all include articleIndex.
-- Set readWatchListen and quoteOfTheWeek to null when you cannot ground them.
 
 {{sourceSummaries}}`;
 
@@ -579,7 +576,7 @@ export function buildUserPrompt(
  *
  * Selects the top `topNewsCount` sources (by relevance order from the caller) and asks
  * the LLM for an industry briefing JSON object. Source URLs are attached after the call
- * from each optional or required `articleIndex`, then serialized to the `MP_NEWSLETTER_V2`
+ * from each optional or required `articleIndex`, then serialized to the `MP_NEWSLETTER`
  * plain-text wire format for email parsing.
  *
  * Retries on transient errors (rate limits, server errors, timeouts) up to
@@ -1267,7 +1264,7 @@ export async function generateNewsletterWithLlm(
     finalStructure,
     promptSources,
   );
-  const content = formatIndustryNewsletterV2Wire(resolved);
+  const content = formatIndustryNewsletterWire(resolved);
 
   return {
     subject:

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -157,7 +157,7 @@ From agents, use **`contentGenerationNewslettersRecent.get({ tickerId, days })`*
 
 ### Content generation bullets recent (`/api/v1/content-generation-bullets-recent`)
 
-Flattens persisted `MP_NEWSLETTER_V2` wire bodies into bullet rows for cross-run dedup in the content-generation agent.
+Flattens persisted `MP_NEWSLETTER` wire bodies into bullet rows for cross-run dedup in the content-generation agent.
 
 - **GET** — Query (`getContentGenerationBulletsRecentQuerySchema`):
   - `tickerId` (required).

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -13,7 +13,7 @@ The content-generation agent takes **selected data sources** (scored by the anal
 - **Input:** `tickerId` as a non-empty string (UUID or opaque Hermes ticker id). Receives bearer token from Hermes.
 - **Fetches** selected high-relevance sources for the ticker from `GET /api/v1/content-generation` (rows where `article_relevance.selected = true` and scored today).
 - **Calls OpenAI** via the Vercel AI SDK (`generateObject` from `ai` with `@ai-sdk/openai` provider) to generate structured **industry intelligence** newsletter JSON (subject, multi-section briefing, quick hits with `articleIndex` grounding). The API key, optional API base URL, and model id are **not** read from environment variables; they come from the **agent config** selected for the pipeline step in Hermes (Dashboard → Agent configs), so admins can manage credentials centrally (optionally using [variable expansion](/hermes/agent-hermes-contract#variables-in-config-and-params) for secrets).
-- **Serializes** the validated object to plain text with the first-line marker `MP_NEWSLETTER_V2` and deterministic `BEGIN … END` blocks. URLs are **never** taken from model text; they are injected from Hermes-selected sources using each `articleIndex`. Legacy bodies without the marker (`EXECUTIVE SUMMARY` / `TOP N NEWS`) are unchanged for historical rows. The shared email package parses both shapes (see `@workspace/email-templates` `parseNewsletterBody`).
+- **Serializes** the validated object to plain text with the first-line marker `MP_NEWSLETTER` and deterministic `BEGIN … END` blocks. URLs are **never** taken from model text; they are injected from Hermes-selected sources using each `articleIndex`. Legacy bodies without the marker (`EXECUTIVE SUMMARY` / `TOP N NEWS`) are unchanged for historical rows. The shared email package parses both shapes (see `@workspace/email-templates` `parseNewsletterBody`).
 - **Retries** transient LLM failures (rate limits, 5xx errors, timeouts) using exponential backoff with optional jitter, up to `llmRetry.maxAttempts` (default 3). Non-retryable errors (auth, bad request, schema validation) short-circuit immediately.
 - **Classifies errors** into structured outcome codes for diagnostics (see [Error taxonomy](#error-taxonomy) below).
 - **Retries persist** errors (agent-data-api 5xx, 429, network timeouts) using exponential backoff up to `persistRetry.maxAttempts` (default 2, no jitter). Non-retryable 4xx client errors fail fast without retrying.
@@ -175,8 +175,8 @@ Newsletter generation can prepend one or two hand-curated **voice exemplars** be
 
 | Exemplar bank id  | Sector tag   | Teaches                                                                                                     |
 | ----------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
-| `industrial-INDX` | `industrial` | Grounded industrial prose, cited bullets, personality headings; omits `quoteOfTheWeek` when unsupported     |
-| `consumer-CONSM`  | `consumer`   | Consumer/financial voice, quick-hit density, optional quote block; omits `readWatchListen` when unsupported |
+| `industrial-INDX` | `industrial` | Grounded industrial prose, cited bullets, personality headings |
+| `consumer-CONSM`  | `consumer`   | Consumer/financial voice, quick-hit density                    |
 
 Fictional tickers and article titles — the live run must ground only in real sources.
 
@@ -201,7 +201,7 @@ After generation, local **Jaccard similarity** compares bullet text to the activ
 
 1. Open a PR adding a full `IndustryNewsletterStructure` entry to `NEWSLETTER_EXEMPLAR_BANK` in `src/lib/newsletter-exemplars.ts`.
 2. Assign a unique `id`, `sectorTag`, fictional `tickerSymbol`, and `sourceTitles`.
-3. Omit at least one optional block (`readWatchListen` or `quoteOfTheWeek`) so the model learns omission is valid.
+3. Keep every required section grounded in fictional `Article N` references so the model sees complete structure.
 4. Document expected token cost in the PR (~1500 tokens per exemplar).
 5. Extend selection tests if the new sector needs distinct keyword routing.
 

--- a/packages/shared/email-templates/package.json
+++ b/packages/shared/email-templates/package.json
@@ -16,9 +16,9 @@
       "types": "./src/newsletter/parse-newsletter-citations.ts",
       "default": "./src/newsletter/parse-newsletter-citations.ts"
     },
-    "./parse-industry-newsletter-wire-v2": {
-      "types": "./src/newsletter/parse-industry-newsletter-wire-v2.ts",
-      "default": "./src/newsletter/parse-industry-newsletter-wire-v2.ts"
+    "./parse-industry-newsletter-wire": {
+      "types": "./src/newsletter/parse-industry-newsletter-wire.ts",
+      "default": "./src/newsletter/parse-industry-newsletter-wire.ts"
     }
   },
   "scripts": {

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -60,7 +60,9 @@ export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.hyperjump.tech";
 export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
 
 /** Canonical section labels keyed by wire `machineKey`. */
-const SECTION_LABELS: Partial<Record<ParsedIndustrySection["machineKey"], string>> = {
+const SECTION_LABELS: Partial<
+  Record<ParsedIndustrySection["machineKey"], string>
+> = {
   "industry-pulse": "Industry Pulse",
   "competitive-landscape": "Competitive Landscape",
   "deals-and-movements": "Deals & Movements",
@@ -257,7 +259,9 @@ export const DefaultNewsletterEmail = ({
 
   const industryPulseSection =
     parsed?.format === "industry"
-      ? parsed.sections.find((section) => section.machineKey === "industry-pulse")
+      ? parsed.sections.find(
+          (section) => section.machineKey === "industry-pulse",
+        )
       : undefined;
   const industryBodySections =
     parsed?.format === "industry"

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -13,7 +13,7 @@ import {
 import { Fragment, type CSSProperties, type ReactElement } from "react";
 
 import { parseNewsletterBody } from "./parse-newsletter-body.js";
-import type { ParsedIndustryV2Section } from "./parse-industry-newsletter-wire-v2.js";
+import type { ParsedIndustrySection } from "./parse-industry-newsletter-wire.js";
 import { renderInlineMarkdownLinks } from "./render-inline-markdown-links.js";
 
 export interface DefaultNewsletterEmailProps {
@@ -33,9 +33,8 @@ export interface DefaultNewsletterEmailProps {
    */
   unsubscribeUrl?: string;
   /**
-   * Ticker symbol shown directly under the heading (e.g. "AAPL") and reused in
-   * the unsubscribe link text. Falls back to "these" in the unsubscribe link
-   * when omitted, and the ticker line above the body is hidden entirely.
+   * Ticker symbol reused in the subscription footer and unsubscribe link text.
+   * Falls back to "these" in the unsubscribe link when omitted.
    */
   tickerSymbol?: string;
   /**
@@ -60,23 +59,112 @@ export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.hyperjump.tech";
 /** Default Hyperjump marketing site link used for previews and when Hermes config omits the URL. */
 export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
 
+/** Canonical section labels keyed by wire `machineKey`. */
+const SECTION_LABELS: Partial<Record<ParsedIndustrySection["machineKey"], string>> = {
+  "industry-pulse": "Industry Pulse",
+  "competitive-landscape": "Competitive Landscape",
+  "deals-and-movements": "Deals & Movements",
+  "regulatory-policy-watch": "Regulatory & Policy Watch",
+  "disruptors-or-tech": "Disruptors & Tech",
+  "quick-hits": "Quick Hits",
+};
+
+/**
+ * Splits a section display heading into an eyebrow label and subtitle.
+ *
+ * @param machineKey - Wire section key.
+ * @param displayHeading - Model-provided heading text.
+ * @returns Eyebrow and subtitle parts for rendering.
+ */
+export const decomposeSectionHeading = (
+  machineKey: ParsedIndustrySection["machineKey"],
+  displayHeading: string,
+): { eyebrow: string | null; subtitle: string | null } => {
+  const label = SECTION_LABELS[machineKey];
+  if (label === undefined) {
+    return { eyebrow: null, subtitle: displayHeading };
+  }
+
+  const prefix = `${label} / `;
+  if (displayHeading === label) {
+    return { eyebrow: null, subtitle: null };
+  }
+  if (displayHeading.startsWith(prefix)) {
+    const subtitle = displayHeading.slice(prefix.length).trim();
+    return subtitle.length > 0
+      ? { eyebrow: label, subtitle }
+      : { eyebrow: null, subtitle: null };
+  }
+
+  return { eyebrow: label, subtitle: displayHeading };
+};
+
+/**
+ * Renders a section header as an eyebrow kicker plus subtitle, or a plain label.
+ *
+ * @param machineKey - Wire section key.
+ * @param displayHeading - Model-provided heading text.
+ * @returns React Email heading elements for the section.
+ */
+export const renderSectionHeader = (
+  machineKey: ParsedIndustrySection["machineKey"],
+  displayHeading: string,
+): ReactElement => {
+  const { eyebrow, subtitle } = decomposeSectionHeading(
+    machineKey,
+    displayHeading,
+  );
+  const label = SECTION_LABELS[machineKey] ?? displayHeading;
+
+  if (subtitle === null) {
+    return (
+      <Heading as="h2" style={sectionLabel}>
+        {label}
+      </Heading>
+    );
+  }
+
+  return (
+    <>
+      <Text style={sectionEyebrow}>{eyebrow ?? label}</Text>
+      <Heading as="h2" style={sectionLabel}>
+        {subtitle}
+      </Heading>
+    </>
+  );
+};
+
+/**
+ * Builds the default subscription footer when no explicit `footerNote` is passed.
+ *
+ * @param tickerSymbol - Optional ticker symbol for personalized copy.
+ * @returns Footer disclaimer text.
+ */
+export const buildDefaultFooterNote = (tickerSymbol?: string): string => {
+  const trimmed = tickerSymbol?.trim() ?? "";
+  if (trimmed.length > 0) {
+    return `You are receiving this because you subscribed to ${trimmed} updates.`;
+  }
+  return "You are receiving this because you subscribed to updates.";
+};
+
 /**
  * Default HTML newsletter layout for Mediapulse delivery.
  *
  * When `bodyText` follows a structured format (legacy executive summary + top news,
- * or `MP_NEWSLETTER_V2` industry briefing wire), the content is rendered as labelled
+ * or `MP_NEWSLETTER` industry briefing wire), the content is rendered as labelled
  * sections with separated items.
  * Otherwise it falls back to pre-wrapped plain-text rendering.
  *
- * The header includes a short ticker line under the title when `tickerSymbol`
- * is set, and the footer carries a Mediapulse / Hyperjump branding block
- * directly above the subscription disclaimer.
+ * Industry briefings render the Industry Pulse prose as a lead standfirst under the
+ * title. The footer carries a Mediapulse / Hyperjump branding block directly above
+ * the subscription disclaimer.
  *
  * @param props.title - Heading text in the body.
  * @param props.bodyText - Main content; structured plain text or free-form.
  * @param props.footerNote - Optional footer copy.
  * @param props.unsubscribeUrl - Optional URL for the one-click unsubscribe link.
- * @param props.tickerSymbol - Ticker symbol shown under the title and in the unsubscribe link.
+ * @param props.tickerSymbol - Ticker symbol used in the footer and unsubscribe link.
  * @param props.mediapulseSiteUrl - HTTPS URL for the Mediapulse footer link.
  * @param props.hyperjumpSiteUrl - HTTPS URL for the Hyperjump footer link.
  * @returns React Email document tree.
@@ -84,33 +172,19 @@ export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
 export const DefaultNewsletterEmail = ({
   title,
   bodyText,
-  footerNote = "You are receiving this because you subscribed to updates.",
+  footerNote,
   unsubscribeUrl,
   tickerSymbol,
   mediapulseSiteUrl = DEFAULT_MEDIAPULSE_SITE_URL,
   hyperjumpSiteUrl = DEFAULT_HYPERJUMP_SITE_URL,
 }: DefaultNewsletterEmailProps): ReactElement => {
   const parsed = parseNewsletterBody(bodyText);
-  const showTickerLine =
-    tickerSymbol !== undefined && tickerSymbol.trim().length > 0;
+  const resolvedFooterNote = footerNote ?? buildDefaultFooterNote(tickerSymbol);
 
   const renderIndustrySection = (
-    section: ParsedIndustryV2Section,
+    section: ParsedIndustrySection,
     index: number,
   ): ReactElement => {
-    if (section.machineKey === "industry-pulse") {
-      return (
-        <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
-          <Text style={bodyParagraph}>
-            {renderInlineMarkdownLinks(section.prose, link)}
-          </Text>
-        </Section>
-      );
-    }
-
     if (
       section.machineKey === "disruptors-or-tech" &&
       "format" in section &&
@@ -118,9 +192,7 @@ export const DefaultNewsletterEmail = ({
     ) {
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
+          {renderSectionHeader(section.machineKey, section.displayHeading)}
           <Text style={bodyParagraph}>
             {renderInlineMarkdownLinks(section.prose, link)}
           </Text>
@@ -131,9 +203,7 @@ export const DefaultNewsletterEmail = ({
     if ("bullets" in section) {
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
+          {renderSectionHeader(section.machineKey, section.displayHeading)}
           {section.bullets.map((bullet, bulletIndex) => (
             <Section
               key={`${String(section.machineKey)}-b-${String(bulletIndex)}`}
@@ -160,9 +230,7 @@ export const DefaultNewsletterEmail = ({
     if (section.machineKey === "quick-hits") {
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
+          {renderSectionHeader(section.machineKey, section.displayHeading)}
           {section.items.map((item, itemIndex) => (
             <Section key={`qh-${String(itemIndex)}`}>
               <Text style={newsItemTitle}>
@@ -184,49 +252,19 @@ export const DefaultNewsletterEmail = ({
       );
     }
 
-    if (section.machineKey === "read-watch-listen") {
-      return (
-        <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
-          <Text style={bodyParagraph}>
-            {renderInlineMarkdownLinks(section.summary, link)}
-          </Text>
-          {section.url !== undefined && section.url !== "" ? (
-            <Text style={newsItemSourceLink}>
-              <Link href={section.url} style={link}>
-                Read the full article
-              </Link>
-            </Text>
-          ) : null}
-        </Section>
-      );
-    }
-
-    if (section.machineKey === "quote-of-the-week") {
-      return (
-        <Section key={`${section.machineKey}-${String(index)}`}>
-          <Heading as="h2" style={sectionLabel}>
-            {section.displayHeading}
-          </Heading>
-          <Text style={newsItemSummary}>
-            {renderInlineMarkdownLinks(section.quote, link)}
-          </Text>
-          <Text style={newsItemTitle}>— {section.attribution}</Text>
-          {section.url !== undefined && section.url !== "" ? (
-            <Text style={newsItemSourceLink}>
-              <Link href={section.url} style={link}>
-                Read the full article
-              </Link>
-            </Text>
-          ) : null}
-        </Section>
-      );
-    }
-
     return <Fragment key={`unknown-${String(index)}`} />;
   };
+
+  const industryPulseSection =
+    parsed?.format === "industry"
+      ? parsed.sections.find((section) => section.machineKey === "industry-pulse")
+      : undefined;
+  const industryBodySections =
+    parsed?.format === "industry"
+      ? parsed.sections.filter(
+          (section) => section.machineKey !== "industry-pulse",
+        )
+      : [];
 
   return (
     <Html>
@@ -236,17 +274,17 @@ export const DefaultNewsletterEmail = ({
         <Container style={container}>
           <Section style={header}>
             <Heading style={heading}>{title}</Heading>
-            {showTickerLine ? (
-              <Text style={tickerLine}>
-                This digest covers <strong>{tickerSymbol}</strong>.
+            {industryPulseSection !== undefined ? (
+              <Text style={standfirst}>
+                {renderInlineMarkdownLinks(industryPulseSection.prose, link)}
               </Text>
             ) : null}
           </Section>
           <Hr style={hr} />
           {parsed !== undefined ? (
-            parsed.format === "industry-v2" ? (
+            parsed.format === "industry" ? (
               <>
-                {parsed.sections.map((section, index) => (
+                {industryBodySections.map((section, index) => (
                   <Fragment key={`sec-${String(index)}`}>
                     {index > 0 ? <Hr style={hr} /> : null}
                     {renderIndustrySection(section, index)}
@@ -309,7 +347,7 @@ export const DefaultNewsletterEmail = ({
             </Link>
             .
           </Text>
-          <Text style={footer}>{footerNote}</Text>
+          <Text style={footer}>{resolvedFooterNote}</Text>
           {unsubscribeUrl !== undefined && unsubscribeUrl !== "" ? (
             <Text style={footerMuted}>
               <Link href={unsubscribeUrl} style={link}>
@@ -382,6 +420,14 @@ const heading: CSSProperties = {
   margin: "0",
 };
 
+const standfirst: CSSProperties = {
+  color: "#374151",
+  fontSize: "17px",
+  lineHeight: "1.6",
+  margin: "12px 0 0",
+  whiteSpace: "pre-wrap",
+};
+
 const hr: CSSProperties = {
   borderColor: "#e6ebf1",
   margin: "20px 0",
@@ -393,6 +439,16 @@ const bodyParagraph: CSSProperties = {
   lineHeight: "1.6",
   margin: "0",
   whiteSpace: "pre-wrap",
+};
+
+const sectionEyebrow: CSSProperties = {
+  color: "#6b7280",
+  fontSize: "12px",
+  fontWeight: "600",
+  letterSpacing: "0.06em",
+  lineHeight: "1.4",
+  margin: "0 0 4px",
+  textTransform: "uppercase",
 };
 
 const sectionLabel: CSSProperties = {
@@ -428,13 +484,6 @@ const newsItemSourceLink: CSSProperties = {
 const itemSeparator: CSSProperties = {
   borderColor: "#e6ebf1",
   margin: "16px 0",
-};
-
-const tickerLine: CSSProperties = {
-  color: "#4b5563",
-  fontSize: "14px",
-  lineHeight: "1.5",
-  margin: "8px 0 0",
 };
 
 const brandingLine: CSSProperties = {

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
@@ -1,5 +1,5 @@
-/** Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_V2_MARKER` in content-generation `format-industry-newsletter-v2.ts`. */
-export const INDUSTRY_NEWSLETTER_WIRE_V2_MARKER = "MP_NEWSLETTER_V2";
+/** Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_MARKER` in content-generation `format-industry-newsletter.ts`. */
+export const INDUSTRY_NEWSLETTER_WIRE_MARKER = "MP_NEWSLETTER";
 
 const READ_FULL_ARTICLE_LABEL = "Read the full article";
 
@@ -40,32 +40,15 @@ export type ParsedIndustryQuickHitsSection = {
   items: Array<{ text: string; url?: string }>;
 };
 
-export type ParsedIndustryReadWatchListenSection = {
-  machineKey: "read-watch-listen";
-  displayHeading: string;
-  summary: string;
-  url?: string;
-};
-
-export type ParsedIndustryQuoteSection = {
-  machineKey: "quote-of-the-week";
-  displayHeading: string;
-  quote: string;
-  attribution: string;
-  url?: string;
-};
-
-export type ParsedIndustryV2Section =
+export type ParsedIndustrySection =
   | ParsedIndustryPulseSection
   | ParsedIndustryBulletSection
   | ParsedIndustryDisruptorsProseSection
-  | ParsedIndustryQuickHitsSection
-  | ParsedIndustryReadWatchListenSection
-  | ParsedIndustryQuoteSection;
+  | ParsedIndustryQuickHitsSection;
 
-export type IndustryV2ParsedNewsletterBody = {
-  format: "industry-v2";
-  sections: ParsedIndustryV2Section[];
+export type IndustryParsedNewsletterBody = {
+  format: "industry";
+  sections: ParsedIndustrySection[];
 };
 
 /**
@@ -93,24 +76,24 @@ const splitTrailingReadLine = (
 const isBlank = (line: string): boolean => line.trim().length === 0;
 
 /**
- * Parses the industry newsletter v2 wire body (marker + BEGIN/END blocks).
+ * Parses the industry newsletter wire body (marker + BEGIN/END blocks).
  *
  * @param bodyText - Full newsletter body string.
  * @returns Parsed sections, or `undefined` when the marker is present but the body is invalid.
  */
-export const parseIndustryNewsletterWireV2 = (
+export const parseIndustryNewsletterWire = (
   bodyText: string,
-): IndustryV2ParsedNewsletterBody | undefined => {
+): IndustryParsedNewsletterBody | undefined => {
   const trimmed = bodyText.trim();
   const lines = trimmed.split("\n");
   if (
     lines.length === 0 ||
-    lines[0]?.trim() !== INDUSTRY_NEWSLETTER_WIRE_V2_MARKER
+    lines[0]?.trim() !== INDUSTRY_NEWSLETTER_WIRE_MARKER
   ) {
     return undefined;
   }
 
-  const sections: ParsedIndustryV2Section[] = [];
+  const sections: ParsedIndustrySection[] = [];
   let i = 1;
 
   const skipBlanks = (): void => {
@@ -262,55 +245,8 @@ export const parseIndustryNewsletterWireV2 = (
       continue;
     }
 
-    if (machineKey === "read-watch-listen") {
-      if ((lines[i] ?? "").trim() !== "SUMMARY") {
-        return undefined;
-      }
-      i += 1;
-      const summaryBlock = readUntilToken(new Set(["END"]));
-      if ((lines[i] ?? "").trim() !== "END") {
-        return undefined;
-      }
-      i += 1;
-      const { text, url } = splitTrailingReadLine(summaryBlock);
-      sections.push({
-        machineKey: "read-watch-listen",
-        displayHeading,
-        summary: text,
-        ...(url !== undefined ? { url } : {}),
-      });
-      continue;
-    }
-
-    if (machineKey === "quote-of-the-week") {
-      if ((lines[i] ?? "").trim() !== "QUOTE") {
-        return undefined;
-      }
-      i += 1;
-      const quote = readUntilToken(new Set(["ATTRIBUTION"]));
-      if ((lines[i] ?? "").trim() !== "ATTRIBUTION") {
-        return undefined;
-      }
-      i += 1;
-      const attributionBlock = readUntilToken(new Set(["END"]));
-      if ((lines[i] ?? "").trim() !== "END") {
-        return undefined;
-      }
-      i += 1;
-      const { text: attribution, url } =
-        splitTrailingReadLine(attributionBlock);
-      sections.push({
-        machineKey: "quote-of-the-week",
-        displayHeading,
-        quote,
-        attribution,
-        ...(url !== undefined ? { url } : {}),
-      });
-      continue;
-    }
-
     return undefined;
   }
 
-  return { format: "industry-v2", sections };
+  return { format: "industry", sections };
 };

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-body.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-body.test.ts
@@ -427,10 +427,10 @@ describe("parseNewsletterBody", () => {
   });
 });
 
-describe("parseNewsletterBody — industry wire v2", () => {
-  it("parses a minimal v2 wire body with prose disruptors", () => {
+describe("parseNewsletterBody — industry wire", () => {
+  it("parses a minimal wire body with prose disruptors", () => {
     const bodyText = [
-      "MP_NEWSLETTER_V2",
+      "MP_NEWSLETTER",
       "",
       "BEGIN industry-pulse",
       "DISPLAY_HEADING",
@@ -495,9 +495,9 @@ describe("parseNewsletterBody — industry wire v2", () => {
 
     const result = parseNewsletterBody(bodyText);
 
-    expect(result?.format).toBe("industry-v2");
-    if (result?.format !== "industry-v2") {
-      throw new Error("expected v2");
+    expect(result?.format).toBe("industry");
+    if (result?.format !== "industry") {
+      throw new Error("expected industry wire");
     }
     expect(result.sections).toHaveLength(6);
     expect(result.sections[0]?.machineKey).toBe("industry-pulse");

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-body.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-body.ts
@@ -1,7 +1,7 @@
 import {
-  parseIndustryNewsletterWireV2,
-  type IndustryV2ParsedNewsletterBody,
-} from "./parse-industry-newsletter-wire-v2.js";
+  parseIndustryNewsletterWire,
+  type IndustryParsedNewsletterBody,
+} from "./parse-industry-newsletter-wire.js";
 
 /** Visible label used for the per-item source link emitted by the content generator. */
 const READ_FULL_ARTICLE_LABEL = "Read the full article";
@@ -45,7 +45,7 @@ export type LegacyParsedNewsletterBody = {
 /** Union of supported structured newsletter bodies. */
 export type ParsedNewsletterBody =
   | LegacyParsedNewsletterBody
-  | IndustryV2ParsedNewsletterBody;
+  | IndustryParsedNewsletterBody;
 
 const EXECUTIVE_SUMMARY_MARKER = /^\s*EXECUTIVE\s+SUMMARY\s*$/im;
 const TOP_NEWS_MARKER = /^\s*TOP\s+\d+\s+NEWS\s*$/im;
@@ -182,15 +182,15 @@ function parseLegacyNewsletterBodyInner(
  * Returns `undefined` when the body does not follow a supported format,
  * allowing the caller to fall back to plain-text rendering.
  *
- * @param bodyText - Raw newsletter body (legacy or `MP_NEWSLETTER_V2` wire).
+ * @param bodyText - Raw newsletter body (legacy or `MP_NEWSLETTER` wire).
  * @returns Structured sections, or `undefined` when parsing fails.
  */
 export function parseNewsletterBody(
   bodyText: string,
 ): ParsedNewsletterBody | undefined {
   const trimmedStart = bodyText.trimStart();
-  if (trimmedStart.startsWith("MP_NEWSLETTER_V2")) {
-    return parseIndustryNewsletterWireV2(bodyText);
+  if (trimmedStart.startsWith("MP_NEWSLETTER")) {
+    return parseIndustryNewsletterWire(bodyText);
   }
 
   const legacy = parseLegacyNewsletterBodyInner(bodyText);

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.test.ts
@@ -154,9 +154,9 @@ describe("parseNewsletterCitations", () => {
     ]);
   });
 
-  it("pairs read-the-full-article URLs in v2 wire bodies with quick-hit text titles", () => {
+  it("pairs read-the-full-article URLs in wire bodies with quick-hit text titles", () => {
     const body = [
-      "MP_NEWSLETTER_V2",
+      "MP_NEWSLETTER",
       "",
       "BEGIN industry-pulse",
       "DISPLAY_HEADING",

--- a/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-newsletter-citations.ts
@@ -95,21 +95,13 @@ export const parseNewsletterCitations = (
         titleByUrl.set(item.url, item.title);
       }
     }
-  } else if (parsed?.format === "industry-v2") {
+  } else if (parsed?.format === "industry") {
     for (const section of parsed.sections) {
       if (section.machineKey === "quick-hits") {
         for (const hit of section.items) {
           if (hit.url && !titleByUrl.has(hit.url)) {
             titleByUrl.set(hit.url, citationTitleFromPlainText(hit.text));
           }
-        }
-      } else if (section.machineKey === "read-watch-listen") {
-        if (section.url && !titleByUrl.has(section.url)) {
-          titleByUrl.set(section.url, section.displayHeading);
-        }
-      } else if (section.machineKey === "quote-of-the-week") {
-        if (section.url && !titleByUrl.has(section.url)) {
-          titleByUrl.set(section.url, section.displayHeading);
         }
       } else if ("bullets" in section) {
         for (const bullet of section.bullets) {

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -524,10 +524,14 @@ describe("renderNewsletterEmail", () => {
       "The telecom market that is repairing rather than roaring sets the tone for this week.",
     );
     expect(stripped).not.toMatch(/Industry Pulse\s*\/\s*Repairing/i);
-    expect(stripped).not.toContain("Industry Pulse / Repairing rather than roaring");
+    expect(stripped).not.toContain(
+      "Industry Pulse / Repairing rather than roaring",
+    );
     expect(stripped).toContain("Competitive Landscape");
     expect(stripped).toContain("Battle lines redrawn");
-    expect(stripped).not.toContain("Competitive Landscape / Battle lines redrawn");
+    expect(stripped).not.toContain(
+      "Competitive Landscape / Battle lines redrawn",
+    );
     expect(stripped).toContain("A regional acquisition closed.");
     expect(stripped).not.toMatch(/Deals\s*(?:\/|&amp;|&)\s*Movements\s*\//);
     expect(html).not.toMatch(/Quote of the Week/i);

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -178,48 +178,41 @@ describe("renderNewsletterEmail", () => {
     expect(html).not.toContain("Top News");
   });
 
-  it("renders a ticker line under the heading when tickerSymbol is set", async () => {
-    // Act
+  it("does not render a ticker digest line under the heading", async () => {
     const { html, text } = await renderNewsletterEmail({
       title: "Morning Briefing",
       bodyText: "Body content",
       tickerSymbol: "AAPL",
     });
 
-    // Assert
-    const stripped = html.replace(/<!-- -->/g, "");
-    expect(stripped).toContain("This digest covers");
-    expect(stripped).toMatch(/<strong[^>]*>\s*AAPL\s*<\/strong>/i);
-    const tickerLineIndex = stripped.indexOf("This digest covers");
-    const firstHrIndex = stripped.search(/<hr[^>]*>/i);
-    expect(tickerLineIndex).toBeGreaterThan(-1);
-    expect(firstHrIndex).toBeGreaterThan(-1);
-    expect(tickerLineIndex).toBeLessThan(firstHrIndex);
-    expect(text).toMatch(/this digest covers/i);
-    expect(text).toContain("AAPL");
+    expect(html).not.toMatch(/this digest covers/i);
+    expect(text).not.toMatch(/this digest covers/i);
   });
 
-  it("hides the ticker line when tickerSymbol is omitted", async () => {
-    // Act
+  it("uses a ticker-aware default footer when footerNote is omitted", async () => {
+    const { html, text } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      tickerSymbol: "TLKM",
+    });
+
+    expect(html).toContain(
+      "You are receiving this because you subscribed to TLKM updates.",
+    );
+    expect(text).toContain(
+      "You are receiving this because you subscribed to TLKM updates.",
+    );
+  });
+
+  it("uses the generic default footer when tickerSymbol is omitted", async () => {
     const { html } = await renderNewsletterEmail({
       title: "Morning Briefing",
       bodyText: "Body content",
     });
 
-    // Assert
-    expect(html).not.toMatch(/this digest covers/i);
-  });
-
-  it("hides the ticker line when tickerSymbol is blank", async () => {
-    // Act
-    const { html } = await renderNewsletterEmail({
-      title: "Morning Briefing",
-      bodyText: "Body content",
-      tickerSymbol: "   ",
-    });
-
-    // Assert
-    expect(html).not.toMatch(/this digest covers/i);
+    expect(html).toContain(
+      "You are receiving this because you subscribed to updates.",
+    );
   });
 
   it("renders default Mediapulse and Hyperjump branding links in the footer", async () => {
@@ -280,13 +273,11 @@ describe("renderNewsletterEmail", () => {
     expect(text).toContain(hyperjumpSiteUrl);
   });
 
-  it("renders ticker copy and branding link targets together when all props are supplied", async () => {
-    // Setup
+  it("renders branding link targets together when all props are supplied", async () => {
     const mediapulseSiteUrl = "https://staging.mediapulse.example/";
     const hyperjumpSiteUrl = "https://staging.hyperjump.example/";
     const tickerSymbol = "BBCA";
 
-    // Act
     const { html, text } = await renderNewsletterEmail({
       title: "Morning Briefing",
       bodyText: "Body content",
@@ -295,12 +286,7 @@ describe("renderNewsletterEmail", () => {
       hyperjumpSiteUrl,
     });
 
-    // Assert
-    const stripped = html.replace(/<!-- -->/g, "");
-    expect(stripped).toContain("This digest covers");
-    expect(stripped).toMatch(
-      new RegExp(`<strong[^>]*>\\s*${tickerSymbol}\\s*</strong>`, "i"),
-    );
+    expect(html).not.toMatch(/this digest covers/i);
     expect(html).toMatch(
       new RegExp(
         `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
@@ -313,10 +299,11 @@ describe("renderNewsletterEmail", () => {
         "i",
       ),
     );
-    expect(text).toContain(tickerSymbol);
-    expect(text).toMatch(/this digest covers/i);
     expect(text).toContain(mediapulseSiteUrl);
     expect(text).toContain(hyperjumpSiteUrl);
+    expect(text).toContain(
+      "You are receiving this because you subscribed to BBCA updates.",
+    );
   });
 
   it("places the branding block above the subscription footer note", async () => {
@@ -464,5 +451,101 @@ describe("renderNewsletterEmail", () => {
     expect(html).not.toContain("[Bank Central Asia](");
     expect(text).toContain("Bank Central Asia");
     expect(text).toContain(articleUrl);
+  });
+
+  it("renders industry wire bodies with a lead standfirst and eyebrow section headers", async () => {
+    const industryBody = [
+      "MP_NEWSLETTER",
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "Industry Pulse / Repairing rather than roaring",
+      "PROSE",
+      "The telecom market that is repairing rather than roaring sets the tone for this week.",
+      "END",
+      "",
+      "BEGIN competitive-landscape",
+      "DISPLAY_HEADING",
+      "Competitive Landscape / Battle lines redrawn",
+      "BULLET",
+      "First mover extended its lead.",
+      "BULLET",
+      "Second player responded with pricing.",
+      "END",
+      "",
+      "BEGIN deals-and-movements",
+      "DISPLAY_HEADING",
+      "Deals & Movements",
+      "BULLET",
+      "A regional acquisition closed.",
+      "END",
+      "",
+      "BEGIN regulatory-policy-watch",
+      "DISPLAY_HEADING",
+      "Regulatory & Policy Watch / Spectrum watch",
+      "BULLET",
+      "Agencies hinted at tighter oversight.",
+      "END",
+      "",
+      "BEGIN disruptors-or-tech",
+      "DISPLAY_HEADING",
+      "Disruptors & Tech / AI at the edge",
+      "FORMAT",
+      "prose",
+      "PROSE",
+      "Founders keep shipping faster release cycles.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits / Five things worth a skim",
+      "ITEM",
+      "Hit one",
+      "ITEM",
+      "Hit two",
+      "ITEM",
+      "Hit three",
+      "ITEM",
+      "Hit four",
+      "ITEM",
+      "Hit five",
+      "END",
+    ].join("\n");
+
+    const { html, text } = await renderNewsletterEmail({
+      title: "TLKM industry briefing",
+      bodyText: industryBody,
+      tickerSymbol: "TLKM",
+    });
+
+    const stripped = html.replace(/<!-- -->/g, "");
+
+    expect(stripped).toContain(
+      "The telecom market that is repairing rather than roaring sets the tone for this week.",
+    );
+    expect(stripped).not.toMatch(/Industry Pulse\s*\/\s*Repairing/i);
+    expect(stripped).not.toContain("Industry Pulse / Repairing rather than roaring");
+    expect(stripped).toContain("Competitive Landscape");
+    expect(stripped).toContain("Battle lines redrawn");
+    expect(stripped).not.toContain("Competitive Landscape / Battle lines redrawn");
+    expect(stripped).toContain("A regional acquisition closed.");
+    expect(stripped).not.toMatch(/Deals\s*(?:\/|&amp;|&)\s*Movements\s*\//);
+    expect(html).not.toMatch(/Quote of the Week/i);
+    expect(html).not.toMatch(/Read, Watch, Listen/i);
+    expect(html).not.toMatch(/this digest covers/i);
+    expect(html).toContain(
+      "You are receiving this because you subscribed to TLKM updates.",
+    );
+
+    expect(text).toContain(
+      "The telecom market that is repairing rather than roaring sets the tone for this week.",
+    );
+    expect(text).not.toMatch(/Industry Pulse\s*\/\s*Repairing/i);
+    expect(text).not.toContain("Competitive Landscape / Battle lines redrawn");
+    expect(text).not.toMatch(/Quote of the Week/i);
+    expect(text).not.toMatch(/Read, Watch, Listen/i);
+    expect(text).toContain(
+      "You are receiving this because you subscribed to TLKM updates.",
+    );
   });
 });


### PR DESCRIPTION
## Summary

Industry newsletters now lead with the Industry Pulse standfirst, use eyebrow category headers instead of slash-joined labels, and name the subscribed ticker in the default footer. The pipeline drops Quote of the Week and Read / Watch / Listen, and the wire format is de-versioned to `MP_NEWSLETTER`.

## Related issues

Closes #574

## Important changes

- Render: Industry Pulse prose sits under the title as a standfirst; section headers use eyebrow + subtitle; default footer reads "subscribed to {TICKER} updates".
- Pipeline: removed `readWatchListen` and `quoteOfTheWeek` from schema, prompt, formatter, parser, renderer, and grounding helpers.
- Wire format: `MP_NEWSLETTER_V2` → `MP_NEWSLETTER`, `industry-v2` → `industry`; renamed parser/formatter files accordingly.

## Other changes

- Updated dev docs for the new marker and slimmer section set.
- Adjusted agent-data-api wire flattener for the de-versioned parser export.

## Key files to review

- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` — standfirst, eyebrow headers, ticker footer.
- `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts` — de-versioned wire parser without tail sections.
- `apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts` — wire serializer.
- `apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts` — trimmed LLM schema.
- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` — layout assertions for HTML and plain text.

## How to test

1. `cd packages/shared/email-templates && npx vitest run`
2. `cd apps/mediapulse/agents/content-generation && npx vitest run`
3. Render an industry wire body with `tickerSymbol: "TLKM"` and confirm: no "This digest covers" line, standfirst under title, eyebrow headers without ` / `, footer mentions TLKM, no Quote of the Week or Read / Watch / Listen sections.
4. Confirm generated wire bodies start with `MP_NEWSLETTER`, not `MP_NEWSLETTER_V2`.
