### PR TITLE
Seed Hermes config forms from schema defaults and widen config modal

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agent-configs/add-config-modal.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/add-config-modal.tsx
@@ -142,7 +142,7 @@ export const AddConfigModal = ({
       {trigger != null && !initialData ? (
         <DialogTrigger asChild>{trigger}</DialogTrigger>
       ) : null}
-      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>
             {initialData ? "Duplicate config" : "Add config"}

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/add-config-modal.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/add-config-modal.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
-
 import {
   Dialog,
   DialogContent,
@@ -11,12 +8,11 @@ import {
   DialogTrigger,
 } from "@workspace/ui/components/dialog";
 import { Button } from "@workspace/ui/components/button";
-import { useFormAction } from "@/app/dashboard/agent-configs/actions/create/.generated/use-form-action";
 
 import { AgentConfigFormFields } from "./agent-config-form-fields";
 import type { AgentConfigRow } from "./agent-config-row-actions";
 import type { VariableExpansionStringFieldLoaders } from "@workspace/variable-expansion-picker";
-import { useCloseOnSuccessfulSubmit } from "@/app/dashboard/hooks/use-close-on-successful-submit";
+import { useAddConfigModalState } from "./use-add-config-modal-state";
 
 type AgentForDropdown = {
   id: string;
@@ -31,80 +27,6 @@ type AddConfigModalProps = {
   onOpenChange?: (open: boolean) => void;
   initialData?: AgentConfigRow | null;
   trigger?: React.ReactNode;
-};
-
-const emptyForm = {
-  name: "",
-  description: "",
-  agentKey: "",
-  config: {} as Record<string, unknown>,
-};
-
-/**
- * Encapsulates open/form state, form action, and close-on-success for add config modal.
- */
-const useAddConfigModalState = (
-  controlledOpen?: boolean,
-  onOpenChange?: (open: boolean) => void,
-  initialData?: AgentConfigRow | null,
-) => {
-  const router = useRouter();
-  const [internalOpen, setInternalOpen] = useState(false);
-  const [formState, setFormState] = useState(emptyForm);
-  const { FormWithAction, state, pending } = useFormAction();
-
-  const isControlled = controlledOpen !== undefined;
-  const open = isControlled ? controlledOpen : internalOpen;
-  const setOpen = useMemo(
-    () => (isControlled ? (onOpenChange ?? (() => {})) : setInternalOpen),
-    [isControlled, onOpenChange],
-  );
-
-  const errorMessage = useMemo(() => {
-    if (state && state.status === false) return state.message as string;
-    return null;
-  }, [state]);
-
-  useEffect(() => {
-    if (open && initialData) {
-      setFormState({
-        name: `Copy of ${initialData.name}`,
-        description: initialData.description ?? "",
-        agentKey: `${initialData.agentId}@${initialData.agentVersion}`,
-        config:
-          typeof initialData.config === "object" && initialData.config !== null
-            ? { ...(initialData.config as Record<string, unknown>) }
-            : {},
-      });
-    } else if (open && !initialData) {
-      setFormState(emptyForm);
-    }
-  }, [open, initialData]);
-
-  useCloseOnSuccessfulSubmit({
-    open,
-    pending,
-    state,
-    isSuccess: (nextState) =>
-      Boolean(
-        nextState && nextState.status === true && nextState.data?.id != null,
-      ),
-    onSuccess: () => {
-      setOpen(false);
-      setFormState(emptyForm);
-      router.refresh();
-    },
-  });
-
-  return {
-    open,
-    setOpen,
-    formState,
-    setFormState,
-    FormWithAction,
-    pending,
-    errorMessage,
-  };
 };
 
 /**

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/edit-config-modal.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/edit-config-modal.tsx
@@ -1,8 +1,5 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
-
 import {
   Dialog,
   DialogContent,
@@ -10,12 +7,11 @@ import {
   DialogTitle,
 } from "@workspace/ui/components/dialog";
 import { Button } from "@workspace/ui/components/button";
-import { useFormAction } from "@/app/dashboard/agent-configs/actions/update/.generated/use-form-action";
 
 import { AgentConfigFormFields } from "./agent-config-form-fields";
 import type { AgentConfigRow } from "./agent-config-row-actions";
 import type { VariableExpansionStringFieldLoaders } from "@workspace/variable-expansion-picker";
-import { useCloseOnSuccessfulSubmit } from "@/app/dashboard/hooks/use-close-on-successful-submit";
+import { useEditConfigModalState } from "./use-edit-config-modal-state";
 
 type AgentForDropdown = {
   id: string;
@@ -29,58 +25,6 @@ type EditConfigModalProps = {
   pickerLoaders: VariableExpansionStringFieldLoaders;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-};
-
-const initialFormState = {
-  name: "",
-  description: "",
-  agentKey: "",
-  config: {} as Record<string, unknown>,
-};
-
-/**
- * Encapsulates form state synced from config, form action, and close-on-success for edit config modal.
- */
-const useEditConfigModalState = (
-  config: AgentConfigRow | null,
-  open: boolean,
-  onOpenChange: (open: boolean) => void,
-) => {
-  const router = useRouter();
-  const [formState, setFormState] = useState(initialFormState);
-  const { FormWithAction, state, pending } = useFormAction();
-
-  const errorMessage = useMemo(() => {
-    if (state && state.status === false) return state.message as string;
-    return null;
-  }, [state]);
-
-  useEffect(() => {
-    if (config && open) {
-      setFormState({
-        name: config.name,
-        description: config.description ?? "",
-        agentKey: `${config.agentId}@${config.agentVersion}`,
-        config:
-          typeof config.config === "object" && config.config !== null
-            ? { ...(config.config as Record<string, unknown>) }
-            : {},
-      });
-    }
-  }, [config, open]);
-
-  useCloseOnSuccessfulSubmit({
-    open,
-    pending,
-    state,
-    isSuccess: (nextState) => Boolean(nextState && nextState.status === true),
-    onSuccess: () => {
-      onOpenChange(false);
-      router.refresh();
-    },
-  });
-
-  return { formState, setFormState, FormWithAction, pending, errorMessage };
 };
 
 /**

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/edit-config-modal.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/edit-config-modal.tsx
@@ -104,7 +104,7 @@ export const EditConfigModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-lg max-h-[90vh] overflow-y-auto">
+      <DialogContent className="sm:max-w-3xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Edit config: {config.name}</DialogTitle>
         </DialogHeader>

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/use-add-config-modal-state.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/use-add-config-modal-state.ts
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useFormAction } from "@/app/dashboard/agent-configs/actions/create/.generated/use-form-action";
+import { useCloseOnSuccessfulSubmit } from "@/app/dashboard/hooks/use-close-on-successful-submit";
+
+import type { AgentConfigRow } from "./agent-config-row-actions";
+
+const emptyForm = {
+  name: "",
+  description: "",
+  agentKey: "",
+  config: {} as Record<string, unknown>,
+};
+
+/**
+ * Encapsulates open/form state, form action, and close-on-success for add config modal.
+ */
+export const useAddConfigModalState = (
+  controlledOpen?: boolean,
+  onOpenChange?: (open: boolean) => void,
+  initialData?: AgentConfigRow | null,
+) => {
+  const router = useRouter();
+  const [internalOpen, setInternalOpen] = useState(false);
+  const [formState, setFormState] = useState(emptyForm);
+  const { FormWithAction, state, pending } = useFormAction();
+
+  const isControlled = controlledOpen !== undefined;
+  const open = isControlled ? controlledOpen : internalOpen;
+  const setOpen = useMemo(
+    () => (isControlled ? (onOpenChange ?? (() => {})) : setInternalOpen),
+    [isControlled, onOpenChange],
+  );
+
+  const errorMessage = useMemo(() => {
+    if (state && state.status === false) return state.message as string;
+    return null;
+  }, [state]);
+
+  useEffect(() => {
+    if (open && initialData) {
+      setFormState({
+        name: `Copy of ${initialData.name}`,
+        description: initialData.description ?? "",
+        agentKey: `${initialData.agentId}@${initialData.agentVersion}`,
+        config:
+          typeof initialData.config === "object" && initialData.config !== null
+            ? { ...(initialData.config as Record<string, unknown>) }
+            : {},
+      });
+    } else if (open && !initialData) {
+      setFormState(emptyForm);
+    }
+  }, [open, initialData]);
+
+  useCloseOnSuccessfulSubmit({
+    open,
+    pending,
+    state,
+    isSuccess: (nextState) =>
+      Boolean(
+        nextState && nextState.status === true && nextState.data?.id != null,
+      ),
+    onSuccess: () => {
+      setOpen(false);
+      setFormState(emptyForm);
+      router.refresh();
+    },
+  });
+
+  return {
+    open,
+    setOpen,
+    formState,
+    setFormState,
+    FormWithAction,
+    pending,
+    errorMessage,
+  };
+};

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/use-edit-config-modal-state.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/use-edit-config-modal-state.ts
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { useFormAction } from "@/app/dashboard/agent-configs/actions/update/.generated/use-form-action";
+import { useCloseOnSuccessfulSubmit } from "@/app/dashboard/hooks/use-close-on-successful-submit";
+
+import type { AgentConfigRow } from "./agent-config-row-actions";
+
+const initialFormState = {
+  name: "",
+  description: "",
+  agentKey: "",
+  config: {} as Record<string, unknown>,
+};
+
+/**
+ * Encapsulates form state synced from config, form action, and close-on-success for edit config modal.
+ */
+export const useEditConfigModalState = (
+  config: AgentConfigRow | null,
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+) => {
+  const router = useRouter();
+  const [formState, setFormState] = useState(initialFormState);
+  const { FormWithAction, state, pending } = useFormAction();
+
+  const errorMessage = useMemo(() => {
+    if (state && state.status === false) return state.message as string;
+    return null;
+  }, [state]);
+
+  useEffect(() => {
+    if (config && open) {
+      setFormState({
+        name: config.name,
+        description: config.description ?? "",
+        agentKey: `${config.agentId}@${config.agentVersion}`,
+        config:
+          typeof config.config === "object" && config.config !== null
+            ? { ...(config.config as Record<string, unknown>) }
+            : {},
+      });
+    }
+  }, [config, open]);
+
+  useCloseOnSuccessfulSubmit({
+    open,
+    pending,
+    state,
+    isSuccess: (nextState) => Boolean(nextState && nextState.status === true),
+    onSuccess: () => {
+      onOpenChange(false);
+      router.refresh();
+    },
+  });
+
+  return { formState, setFormState, FormWithAction, pending, errorMessage };
+};

--- a/packages/shared/json-schema-form/src/schema-form-utils.test.ts
+++ b/packages/shared/json-schema-form/src/schema-form-utils.test.ts
@@ -2,7 +2,8 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  applyRequiredDefaults,
+  applySchemaDefaults,
+  collectSchemaDefaults,
   defaultForSchema,
   getSchemaFormType,
 } from "./schema-form-utils";
@@ -47,7 +48,61 @@ describe("defaultForSchema", () => {
   });
 });
 
-describe("applyRequiredDefaults", () => {
+describe("collectSchemaDefaults", () => {
+  it("returns undefined when no default is declared", () => {
+    expect(collectSchemaDefaults({ type: "string" })).toBeUndefined();
+  });
+
+  it("returns a primitive default when declared", () => {
+    expect(collectSchemaDefaults({ type: "string", default: "x" })).toBe("x");
+  });
+
+  it("collects optional property defaults on an object", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+        label: { type: "string", default: "hello" },
+      },
+    };
+
+    expect(collectSchemaDefaults(schema)).toEqual({
+      enabled: true,
+      label: "hello",
+    });
+  });
+
+  it("expands a default {} group with nested field defaults", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        grp: {
+          type: "object",
+          default: {},
+          properties: {
+            b: { type: "string", default: "x" },
+          },
+        },
+      },
+    };
+
+    expect(collectSchemaDefaults(schema)).toEqual({ grp: { b: "x" } });
+  });
+
+  it("does not fabricate defaults for optional defaultless fields", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        withDefault: { type: "string", default: "x" },
+        withoutDefault: { type: "string" },
+      },
+    };
+
+    expect(collectSchemaDefaults(schema)).toEqual({ withDefault: "x" });
+  });
+});
+
+describe("applySchemaDefaults", () => {
   it("returns the same reference when nothing changes", () => {
     const schema: JsonSchema = {
       type: "object",
@@ -58,10 +113,10 @@ describe("applyRequiredDefaults", () => {
     };
     const value = { name: "ok" };
 
-    expect(applyRequiredDefaults(schema, value)).toBe(value);
+    expect(applySchemaDefaults(schema, value)).toBe(value);
   });
 
-  it("fills missing required keys", () => {
+  it("fills missing required keys with type-zero defaults", () => {
     const schema: JsonSchema = {
       type: "object",
       required: ["name"],
@@ -70,7 +125,7 @@ describe("applyRequiredDefaults", () => {
       },
     };
 
-    expect(applyRequiredDefaults(schema, {})).toEqual({ name: "" });
+    expect(applySchemaDefaults(schema, {})).toEqual({ name: "" });
   });
 
   it("fills nested required object keys", () => {
@@ -88,8 +143,78 @@ describe("applyRequiredDefaults", () => {
       },
     };
 
-    expect(applyRequiredDefaults(schema, { prompts: {} })).toEqual({
+    expect(applySchemaDefaults(schema, { prompts: {} })).toEqual({
       prompts: { systemPrompt: "" },
     });
+  });
+
+  it("seeds optional fields with declared defaults from an empty object", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+        label: { type: "string", default: "{{NAME}}" },
+      },
+    };
+
+    expect(applySchemaDefaults(schema, {})).toEqual({
+      enabled: true,
+      label: "{{NAME}}",
+    });
+  });
+
+  it("seeds a default {} group with nested field defaults from an empty object", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        grp: {
+          type: "object",
+          default: {},
+          properties: {
+            b: { type: "string", default: "x" },
+            enabled: { type: "boolean", default: true },
+          },
+        },
+      },
+    };
+
+    expect(applySchemaDefaults(schema, {})).toEqual({
+      grp: { b: "x", enabled: true },
+    });
+  });
+
+  it("does not fabricate optional defaultless fields", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        withDefault: { type: "string", default: "x" },
+        withoutDefault: { type: "string" },
+      },
+    };
+
+    expect(applySchemaDefaults(schema, {})).toEqual({ withDefault: "x" });
+  });
+
+  it("seeds when top-level required is empty", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        flag: { type: "boolean", default: false },
+      },
+    };
+
+    expect(applySchemaDefaults(schema, {})).toEqual({ flag: false });
+  });
+
+  it("is idempotent once defaults are applied", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+      },
+    };
+    const seeded = applySchemaDefaults(schema, {});
+
+    expect(applySchemaDefaults(schema, seeded)).toBe(seeded);
   });
 });

--- a/packages/shared/json-schema-form/src/schema-form-utils.ts
+++ b/packages/shared/json-schema-form/src/schema-form-utils.ts
@@ -36,34 +36,84 @@ export const defaultForSchema = (schema: JsonSchema): unknown => {
 };
 
 /**
- * Recursively merges value with empty defaults for any required keys that are missing.
+ * Recursively collects only explicitly declared schema defaults.
+ * Returns undefined when no default is declared anywhere in the subtree.
  */
-export const applyRequiredDefaults = (
+export const collectSchemaDefaults = (
+  schema: JsonSchema,
+): unknown | undefined => {
+  const type = getSchemaFormType(schema);
+
+  if (type === "object" && schema.properties) {
+    let obj: Record<string, unknown> | undefined;
+
+    if (schema.default !== undefined) {
+      if (
+        typeof schema.default === "object" &&
+        schema.default !== null &&
+        !Array.isArray(schema.default)
+      ) {
+        obj = { ...(schema.default as Record<string, unknown>) };
+      } else {
+        return schema.default;
+      }
+    }
+
+    for (const [key, propSchema] of Object.entries(schema.properties)) {
+      const propDefault = collectSchemaDefaults(propSchema);
+      if (propDefault !== undefined) {
+        if (!obj) obj = {};
+        obj[key] = propDefault;
+      }
+    }
+
+    return obj;
+  }
+
+  if (schema.default !== undefined) {
+    return schema.default;
+  }
+
+  return undefined;
+};
+
+/**
+ * Recursively merges value with declared schema defaults and required type-zero seeds.
+ */
+export const applySchemaDefaults = (
   schema: JsonSchema,
   value: Record<string, unknown>,
 ): Record<string, unknown> => {
-  if (!schema.properties || !schema.required?.length) return value;
+  if (!schema.properties) return value;
+
+  const requiredSet = new Set(schema.required ?? []);
   let changed = false;
   const result = { ...value };
-  for (const key of schema.required) {
-    const propSchema = schema.properties[key];
-    if (!propSchema) continue;
+
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
     const existing = result[key];
+    const declaredDefault = collectSchemaDefaults(propSchema);
+
     if (existing === undefined) {
-      result[key] = defaultForSchema(propSchema);
-      changed = true;
+      if (declaredDefault !== undefined) {
+        result[key] = declaredDefault;
+        changed = true;
+      } else if (requiredSet.has(key)) {
+        result[key] = defaultForSchema(propSchema);
+        changed = true;
+      }
       continue;
     }
+
     const propType = getSchemaFormType(propSchema);
     if (
       propType === "object" &&
       propSchema.properties != null &&
-      propSchema.required?.length != null &&
       typeof existing === "object" &&
       existing !== null &&
       !Array.isArray(existing)
     ) {
-      const nested = applyRequiredDefaults(
+      const nested = applySchemaDefaults(
         propSchema,
         existing as Record<string, unknown>,
       );
@@ -73,5 +123,6 @@ export const applyRequiredDefaults = (
       }
     }
   }
+
   return changed ? result : value;
 };

--- a/packages/shared/json-schema-form/src/schema-form.tsx
+++ b/packages/shared/json-schema-form/src/schema-form.tsx
@@ -9,7 +9,7 @@ import { cn } from "@workspace/ui/lib/utils";
 
 import { SCHEMA_FORM_NEW_ENTRY_KEY } from "./schema-form-constants";
 import {
-  applyRequiredDefaults,
+  applySchemaDefaults,
   defaultForSchema,
   getSchemaFormType,
 } from "./schema-form-utils";
@@ -556,7 +556,7 @@ export const SchemaForm = ({
   const type = getType(schema);
   const noopOnChange = React.useCallback(() => undefined, []);
   const effectiveValue = React.useMemo(
-    () => (seedRequiredDefaults ? applyRequiredDefaults(schema, value) : value),
+    () => (seedRequiredDefaults ? applySchemaDefaults(schema, value) : value),
     [schema, value, seedRequiredDefaults],
   );
   useSchemaFormSeed(

--- a/packages/shared/json-schema-form/src/use-schema-form-seed.test.ts
+++ b/packages/shared/json-schema-form/src/use-schema-form-seed.test.ts
@@ -35,4 +35,37 @@ describe("useSchemaFormSeed", () => {
 
     expect(onChange).not.toHaveBeenCalled();
   });
+
+  it("calls onChange for optional defaulted fields when top-level required is empty", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+        label: { type: "string", default: "{{NAME}}" },
+      },
+    };
+    const onChange = vi.fn();
+
+    renderHook(() => useSchemaFormSeed(schema, {}, onChange));
+
+    expect(onChange).toHaveBeenCalledWith({
+      enabled: true,
+      label: "{{NAME}}",
+    });
+  });
+
+  it("does not call onChange again once seeding is complete", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean", default: true },
+      },
+    };
+    const onChange = vi.fn();
+    const seeded = { enabled: true };
+
+    renderHook(() => useSchemaFormSeed(schema, seeded, onChange));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/shared/json-schema-form/src/use-schema-form-seed.ts
+++ b/packages/shared/json-schema-form/src/use-schema-form-seed.ts
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 
-import { applyRequiredDefaults, getSchemaFormType } from "./schema-form-utils";
+import { applySchemaDefaults, getSchemaFormType } from "./schema-form-utils";
 import type { JsonSchema } from "./types";
 
 /**
- * Seeds parent value with required schema keys when missing (including nested required keys).
+ * Seeds parent value with schema defaults and required keys when missing (including nested keys).
  */
 export const useSchemaFormSeed = (
   schema: JsonSchema,
@@ -13,10 +13,10 @@ export const useSchemaFormSeed = (
 ): void => {
   const type = getSchemaFormType(schema);
   useEffect(() => {
-    if (type !== "object" || !schema.properties || !schema.required?.length) {
+    if (type !== "object" || !schema.properties) {
       return;
     }
-    const merged = applyRequiredDefaults(schema, value);
+    const merged = applySchemaDefaults(schema, value);
     if (merged !== value) onChange(merged);
   }, [schema, type, value, onChange]);
 };


### PR DESCRIPTION
## Summary

Hermes Add/Edit config modals now prefill values from schema-declared defaults instead of leaving optional fields blank. The json-schema-form seeder only filled required keys before, so Zod `.default()` values (nested groups, `{{NAME}}` placeholders) never appeared in the UI. The modals are wider too, so grouped nested configs are easier to read.

## Related issues

Closes #576

## Important changes

- Add `collectSchemaDefaults` and merge via `applySchemaDefaults` so optional and nested declared defaults seed the form without fabricating empty values for defaultless optionals.
- Drop the `useSchemaFormSeed` early return when top-level `required` is empty (the all-optional-with-defaults case from #573).
- Widen add/edit config modals from `sm:max-w-lg` to `sm:max-w-3xl`.

## Other changes

- Unit tests for declared defaults, nested `default {}` groups, empty `required`, and idempotent seeding.

## Key files to review

- `packages/shared/json-schema-form/src/schema-form-utils.ts` — default collection and merge logic; main behavior change.
- `packages/shared/json-schema-form/src/use-schema-form-seed.ts` — seed runs for optional-only object schemas.
- `apps/hermes/dashboard/app/dashboard/agent-configs/add-config-modal.tsx` — wider modal.
- `apps/hermes/dashboard/app/dashboard/agent-configs/edit-config-modal.tsx` — wider modal.

## How to test

1. `pnpm --filter @workspace/json-schema-form test`
2. Start the Hermes dashboard, go to Agent configs, open Add config for an agent whose schema has optional defaults (e.g. data-collection after #573).
3. Confirm fields show schema defaults, including nested group fields expanded from `default {}`.
4. Confirm optional fields without a declared default stay absent (not zero-filled).
5. Resize to `sm`+ and confirm the modal is wider than before.
