### PR TITLE
Group and default query-analysis config for Hermes

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -6,72 +6,165 @@ import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api
 import {
   queryAnalysisConfigSchema,
   resolveIntentWeights,
-  resolveYieldFeedbackConfig,
 } from "./config-schema";
 
-const minimal = { openaiApiKey: "sk-test" } satisfies Parameters<
-  typeof queryAnalysisConfigSchema.parse
->[0];
+/** Parses config with a resolved API key while keeping other schema defaults. */
+const parseWithApiKey = (
+  overrides: Parameters<typeof queryAnalysisConfigSchema.parse>[0] = {},
+) =>
+  queryAnalysisConfigSchema.parse({
+    credentials: { openaiApiKey: "sk-test" },
+    ...overrides,
+  });
 
-describe("queryAnalysisConfigSchema templatePack", () => {
+describe("queryAnalysisConfigSchema grouped layout", () => {
+  it("parses an empty object into the full recommended config", () => {
+    const parsed = queryAnalysisConfigSchema.parse({});
+
+    expect(Object.keys(parsed)).toEqual([
+      "credentials",
+      "output",
+      "sampling",
+      "templates",
+      "prompting",
+      "creativity",
+      "quality",
+      "dynamics",
+    ]);
+    expect(parsed.credentials).toEqual({
+      openaiApiKey: "{{OPENAI_API_KEY}}",
+      chatModel: "{{QUERY_ANALYSIS_MODEL}}",
+    });
+    expect(parsed.output.queryCount).toBe(10);
+    expect(parsed.output.languageQuotas).toBeUndefined();
+    expect(parsed.sampling).toEqual({
+      temperature: 0.9,
+      topP: 0.95,
+      presencePenalty: 0.4,
+      frequencyPenalty: 0.5,
+    });
+    expect(parsed.templates).toEqual({
+      templatePack: "default-v1",
+      kgTemplateCap: 6,
+    });
+    expect(parsed.prompting).toEqual({
+      personas: ["analyst", "retail", "regulator"],
+      perPersonaQuotaCount: 3,
+      fewShotExemplarCount: 3,
+    });
+    expect(parsed.creativity).toEqual({
+      wildcardFraction: 0.1,
+      wildcardTemperature: 1.2,
+      useBrainstormPass: false,
+    });
+    expect(parsed.quality.semanticDedupe).toEqual({
+      enabled: false,
+      threshold: 0.85,
+      embeddingModel: "{{EMBEDDING_MODEL}}",
+    });
+    expect(parsed.quality.diversityGate).toEqual({
+      enabled: false,
+      threshold: 0.6,
+      weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
+    });
+    expect(parsed.quality.useSelfCritique).toBe(false);
+    expect(parsed.quality.critiqueDropFraction).toBe(0.25);
+    expect(parsed.dynamics.temporalBias).toEqual({ enabled: true });
+    expect(parsed.dynamics.yieldFeedback).toEqual({
+      enabled: false,
+      windowDays: 30,
+      minTemplateYield: 0.05,
+    });
+  });
+
+  it("preserves Hermes variable placeholders verbatim", () => {
+    const parsed = queryAnalysisConfigSchema.parse({});
+
+    expect(parsed.credentials.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
+    expect(parsed.credentials.chatModel).toBe("{{QUERY_ANALYSIS_MODEL}}");
+    expect(parsed.quality.semanticDedupe.embeddingModel).toBe(
+      "{{EMBEDDING_MODEL}}",
+    );
+  });
+
+  it("rejects legacy flat top-level keys under strict mode", () => {
+    const flatKeys = [
+      "openaiApiKey",
+      "openaiModel",
+      "queryCount",
+      "temperature",
+      "templatePack",
+      "semanticDedupe",
+      "diversityGate",
+      "temporalBias",
+      "yieldFeedback",
+    ] as const;
+
+    for (const key of flatKeys) {
+      const result = queryAnalysisConfigSchema.safeParse({
+        credentials: { openaiApiKey: "sk-test" },
+        [key]: key === "openaiApiKey" ? "sk-test" : "x",
+      });
+      expect(result.success).toBe(false);
+    }
+  });
+});
+
+describe("queryAnalysisConfigSchema templates", () => {
   it("defaults templatePack to default-v1", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.templatePack).toBe("default-v1");
+    const parsed = parseWithApiKey();
+    expect(parsed.templates.templatePack).toBe("default-v1");
   });
 
   it("accepts rich-v2 template pack", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      templatePack: "rich-v2",
+    const parsed = parseWithApiKey({
+      templates: { templatePack: "rich-v2" },
     });
-    expect(parsed.templatePack).toBe("rich-v2");
+    expect(parsed.templates.templatePack).toBe("rich-v2");
   });
 
   it("accepts rich-v2-extended template pack", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      templatePack: "rich-v2-extended",
+    const parsed = parseWithApiKey({
+      templates: { templatePack: "rich-v2-extended" },
     });
-    expect(parsed.templatePack).toBe("rich-v2-extended");
+    expect(parsed.templates.templatePack).toBe("rich-v2-extended");
   });
 
   it("accepts kg-aware-v1 template pack", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      templatePack: "kg-aware-v1",
+    const parsed = parseWithApiKey({
+      templates: { templatePack: "kg-aware-v1" },
     });
-    expect(parsed.templatePack).toBe("kg-aware-v1");
+    expect(parsed.templates.templatePack).toBe("kg-aware-v1");
   });
 
   it("rejects unknown template pack names", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      templatePack: "unknown",
+      credentials: { openaiApiKey: "sk-test" },
+      templates: { templatePack: "unknown" },
     });
     expect(result.success).toBe(false);
   });
 
   it("defaults kgTemplateCap to 6", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.kgTemplateCap).toBe(6);
+    const parsed = parseWithApiKey();
+    expect(parsed.templates.kgTemplateCap).toBe(6);
   });
 });
 
 describe("resolveIntentWeights", () => {
   it("returns defaults when intentWeights is omitted", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(resolveIntentWeights(parsed)).toEqual(
+    const parsed = parseWithApiKey();
+    expect(resolveIntentWeights(parsed.output)).toEqual(
       DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
     );
   });
 
-  it("parses nested intentWeights from modern Hermes config", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      intentWeights: { breaking: 2, kg_change: 1.1 },
+  it("parses nested intentWeights from the output group", () => {
+    const parsed = parseWithApiKey({
+      output: { intentWeights: { breaking: 2, kg_change: 1.1 } },
     });
 
-    expect(resolveIntentWeights(parsed)).toMatchObject({
+    expect(resolveIntentWeights(parsed.output)).toMatchObject({
       breaking: 2,
       kg_change: 1.1,
     });
@@ -81,7 +174,7 @@ describe("resolveIntentWeights", () => {
 describe("queryAnalysisConfigSchema strict mode", () => {
   it("rejects legacy prompts overrides with an unrecognized key error", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
+      credentials: { openaiApiKey: "sk-test" },
       prompts: {
         systemPrompt: "Custom system prompt",
         userPromptTemplate: "{{queryContextBlock}}",
@@ -99,7 +192,7 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 
   it("rejects removed maxTokens config key under strict mode", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
+      credentials: { openaiApiKey: "sk-test" },
       maxTokens: 1200,
     });
     expect(result.success).toBe(false);
@@ -114,7 +207,7 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 
   it("rejects removed minDeterministicCount config key under strict mode", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
+      credentials: { openaiApiKey: "sk-test" },
       minDeterministicCount: 4,
     });
     expect(result.success).toBe(false);
@@ -129,7 +222,7 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 
   it("rejects legacy weightBreaking config key under strict mode", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
+      credentials: { openaiApiKey: "sk-test" },
       weightBreaking: 2,
     });
     expect(result.success).toBe(false);
@@ -137,7 +230,7 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 
   it("rejects legacy allowedLanguages config key under strict mode", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
+      credentials: { openaiApiKey: "sk-test" },
       allowedLanguages: ["en", "id"],
     });
     expect(result.success).toBe(false);
@@ -146,18 +239,18 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 
 describe("queryAnalysisConfigSchema sampling", () => {
   it("defaults creativity sampling fields", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.temperature).toBe(0.9);
-    expect(parsed.topP).toBe(0.95);
-    expect(parsed.presencePenalty).toBe(0.4);
-    expect(parsed.frequencyPenalty).toBe(0.5);
-    expect(parsed.seed).toBeUndefined();
+    const parsed = parseWithApiKey();
+    expect(parsed.sampling.temperature).toBe(0.9);
+    expect(parsed.sampling.topP).toBe(0.95);
+    expect(parsed.sampling.presencePenalty).toBe(0.4);
+    expect(parsed.sampling.frequencyPenalty).toBe(0.5);
+    expect(parsed.sampling.seed).toBeUndefined();
   });
 
   it("rejects temperature above 2", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      temperature: 2.1,
+      credentials: { openaiApiKey: "sk-test" },
+      sampling: { temperature: 2.1 },
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -169,8 +262,8 @@ describe("queryAnalysisConfigSchema sampling", () => {
 
   it("rejects presencePenalty above 2", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      presencePenalty: 3,
+      credentials: { openaiApiKey: "sk-test" },
+      sampling: { presencePenalty: 3 },
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -184,8 +277,8 @@ describe("queryAnalysisConfigSchema sampling", () => {
 
   it("rejects non-integer seed values", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      seed: 1.5,
+      credentials: { openaiApiKey: "sk-test" },
+      sampling: { seed: 1.5 },
     });
     expect(result.success).toBe(false);
     if (!result.success) {
@@ -198,28 +291,26 @@ describe("queryAnalysisConfigSchema sampling", () => {
 
 describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
   it("defaults useBrainstormPass to false and fewShotExemplarCount to 3", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.useBrainstormPass).toBe(false);
-    expect(parsed.fewShotExemplarCount).toBe(3);
-    expect(parsed.brainstormModel).toBeUndefined();
+    const parsed = parseWithApiKey();
+    expect(parsed.creativity.useBrainstormPass).toBe(false);
+    expect(parsed.prompting.fewShotExemplarCount).toBe(3);
+    expect(parsed.creativity.brainstormModel).toBeUndefined();
   });
 
   it("accepts brainstorm and few-shot overrides", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      useBrainstormPass: true,
-      brainstormModel: "gpt-4o",
-      fewShotExemplarCount: 0,
+    const parsed = parseWithApiKey({
+      creativity: { useBrainstormPass: true, brainstormModel: "gpt-4o" },
+      prompting: { fewShotExemplarCount: 0 },
     });
-    expect(parsed.useBrainstormPass).toBe(true);
-    expect(parsed.brainstormModel).toBe("gpt-4o");
-    expect(parsed.fewShotExemplarCount).toBe(0);
+    expect(parsed.creativity.useBrainstormPass).toBe(true);
+    expect(parsed.creativity.brainstormModel).toBe("gpt-4o");
+    expect(parsed.prompting.fewShotExemplarCount).toBe(0);
   });
 
   it("rejects fewShotExemplarCount above 6", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      fewShotExemplarCount: 7,
+      credentials: { openaiApiKey: "sk-test" },
+      prompting: { fewShotExemplarCount: 7 },
     });
     expect(result.success).toBe(false);
   });
@@ -227,201 +318,142 @@ describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
 
 describe("queryAnalysisConfigSchema personas", () => {
   it("defaults personas and perPersonaQuotaCount", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.personas).toEqual(["analyst", "retail", "regulator"]);
-    expect(parsed.perPersonaQuotaCount).toBe(3);
+    const parsed = parseWithApiKey();
+    expect(parsed.prompting.personas).toEqual([
+      "analyst",
+      "retail",
+      "regulator",
+    ]);
+    expect(parsed.prompting.perPersonaQuotaCount).toBe(3);
   });
 
   it("accepts persona overrides", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      personas: ["esg", "short_seller"],
-      perPersonaQuotaCount: 2,
+    const parsed = parseWithApiKey({
+      prompting: { personas: ["esg", "short_seller"], perPersonaQuotaCount: 2 },
     });
-    expect(parsed.personas).toEqual(["esg", "short_seller"]);
-    expect(parsed.perPersonaQuotaCount).toBe(2);
+    expect(parsed.prompting.personas).toEqual(["esg", "short_seller"]);
+    expect(parsed.prompting.perPersonaQuotaCount).toBe(2);
   });
 });
 
 describe("queryAnalysisConfigSchema self-critique", () => {
   it("defaults useSelfCritique to false and critiqueDropFraction to 0.25", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.useSelfCritique).toBe(false);
-    expect(parsed.critiqueDropFraction).toBe(0.25);
-    expect(parsed.critiqueModel).toBeUndefined();
+    const parsed = parseWithApiKey();
+    expect(parsed.quality.useSelfCritique).toBe(false);
+    expect(parsed.quality.critiqueDropFraction).toBe(0.25);
+    expect(parsed.quality.critiqueModel).toBeUndefined();
   });
 
   it("accepts self-critique overrides", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      useSelfCritique: true,
-      critiqueDropFraction: 0.2,
-      critiqueModel: "gpt-4o",
+    const parsed = parseWithApiKey({
+      quality: {
+        useSelfCritique: true,
+        critiqueDropFraction: 0.2,
+        critiqueModel: "gpt-4o",
+      },
     });
-    expect(parsed.useSelfCritique).toBe(true);
-    expect(parsed.critiqueDropFraction).toBe(0.2);
-    expect(parsed.critiqueModel).toBe("gpt-4o");
+    expect(parsed.quality.useSelfCritique).toBe(true);
+    expect(parsed.quality.critiqueDropFraction).toBe(0.2);
+    expect(parsed.quality.critiqueModel).toBe("gpt-4o");
   });
 
   it("rejects critiqueDropFraction above 0.5", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      critiqueDropFraction: 0.6,
+      credentials: { openaiApiKey: "sk-test" },
+      quality: { critiqueDropFraction: 0.6 },
     });
     expect(result.success).toBe(false);
   });
 });
 
 describe("queryAnalysisConfigSchema semanticDedupe", () => {
-  it("defaults semantic dedupe to disabled when omitted", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.semanticDedupe).toBeUndefined();
+  it("defaults semantic dedupe to disabled with placeholder embedding model", () => {
+    const parsed = parseWithApiKey();
+    expect(parsed.quality.semanticDedupe).toEqual({
+      enabled: false,
+      threshold: 0.85,
+      embeddingModel: "{{EMBEDDING_MODEL}}",
+    });
   });
 
   it("accepts semantic dedupe overrides", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      semanticDedupe: {
-        enabled: true,
-        threshold: 0.9,
-        embeddingModel: "text-embedding-3-large",
+    const parsed = parseWithApiKey({
+      quality: {
+        semanticDedupe: {
+          enabled: true,
+          threshold: 0.9,
+          embeddingModel: "text-embedding-3-large",
+        },
       },
     });
-    expect(parsed.semanticDedupe?.enabled).toBe(true);
-    expect(parsed.semanticDedupe?.threshold).toBe(0.9);
-    expect(parsed.semanticDedupe?.embeddingModel).toBe(
+    expect(parsed.quality.semanticDedupe.enabled).toBe(true);
+    expect(parsed.quality.semanticDedupe.threshold).toBe(0.9);
+    expect(parsed.quality.semanticDedupe.embeddingModel).toBe(
       "text-embedding-3-large",
     );
   });
 
   it("rejects semantic dedupe threshold above 1", () => {
     const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      semanticDedupe: { enabled: true, threshold: 1.1 },
+      credentials: { openaiApiKey: "sk-test" },
+      quality: { semanticDedupe: { enabled: true, threshold: 1.1 } },
     });
     expect(result.success).toBe(false);
   });
 });
 
 describe("queryAnalysisConfigSchema diversityGate", () => {
-  it("defaults diversity gate to disabled when omitted", () => {
-    const parsed = queryAnalysisConfigSchema.parse(minimal);
-    expect(parsed.diversityGate).toBeUndefined();
-  });
-
-  it("accepts diversity gate overrides", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      diversityGate: {
-        enabled: true,
-        threshold: 0.75,
-        weights: { lexical: 0.5, intent: 0.25, semantic: 0.25 },
-      },
-    });
-    expect(parsed.diversityGate?.enabled).toBe(true);
-    expect(parsed.diversityGate?.threshold).toBe(0.75);
-    expect(parsed.diversityGate?.weights?.lexical).toBe(0.5);
-  });
-
-  it("rejects diversity gate threshold above 1", () => {
-    const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      diversityGate: { enabled: true, threshold: 1.2 },
-    });
-    expect(result.success).toBe(false);
-  });
-});
-
-describe("resolveDiversityGateConfig", () => {
-  it("returns schema defaults when diversityGate is omitted", async () => {
-    const { resolveDiversityGateConfig } = await import("./config-schema");
-    expect(resolveDiversityGateConfig({})).toEqual({
+  it("defaults diversity gate to disabled with recommended weights", () => {
+    const parsed = parseWithApiKey();
+    expect(parsed.quality.diversityGate).toEqual({
       enabled: false,
       threshold: 0.6,
       weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
     });
   });
-});
 
-describe("resolveTemporalBiasConfig", () => {
-  it("defaults temporal bias to enabled", async () => {
-    const { resolveTemporalBiasConfig } = await import("./config-schema");
-    expect(resolveTemporalBiasConfig({})).toEqual({ enabled: true });
+  it("accepts diversity gate overrides", () => {
+    const parsed = parseWithApiKey({
+      quality: {
+        diversityGate: {
+          enabled: true,
+          threshold: 0.75,
+          weights: { lexical: 0.5, intent: 0.25, semantic: 0.25 },
+        },
+      },
+    });
+    expect(parsed.quality.diversityGate.enabled).toBe(true);
+    expect(parsed.quality.diversityGate.threshold).toBe(0.75);
+    expect(parsed.quality.diversityGate.weights.lexical).toBe(0.5);
   });
 
-  it("honors temporalBias.enabled=false", async () => {
-    const { resolveTemporalBiasConfig } = await import("./config-schema");
-    expect(
-      resolveTemporalBiasConfig({ temporalBias: { enabled: false } }),
-    ).toEqual({ enabled: false });
+  it("rejects diversity gate threshold above 1", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      credentials: { openaiApiKey: "sk-test" },
+      quality: { diversityGate: { enabled: true, threshold: 1.2 } },
+    });
+    expect(result.success).toBe(false);
   });
 });
 
 describe("queryAnalysisConfigSchema temporalBias", () => {
-  it("defaults temporalBias.enabled to true when the object is present", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      temporalBias: {},
+  it("defaults temporalBias.enabled to true", () => {
+    const parsed = parseWithApiKey();
+    expect(parsed.dynamics.temporalBias.enabled).toBe(true);
+  });
+
+  it("honors temporalBias.enabled=false", () => {
+    const parsed = parseWithApiKey({
+      dynamics: { temporalBias: { enabled: false } },
     });
-    expect(parsed.temporalBias?.enabled).toBe(true);
+    expect(parsed.dynamics.temporalBias.enabled).toBe(false);
   });
 });
 
-describe("queryAnalysisConfigSchema languageQuotas", () => {
-  it("accepts valid languageQuotas whose shares sum to 1.0", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      languageQuotas: [
-        { language: "en", share: 0.6 },
-        { language: "id", share: 0.4 },
-      ],
-    });
-    expect(parsed.languageQuotas).toEqual([
-      { language: "en", share: 0.6 },
-      { language: "id", share: 0.4 },
-    ]);
-  });
-
-  it("rejects languageQuotas shares summing to 0.99", () => {
-    const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      languageQuotas: [
-        { language: "en", share: 0.59 },
-        { language: "id", share: 0.4 },
-      ],
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) =>
-          issue.message.includes("languageQuotas shares must sum to 1.0"),
-        ),
-      ).toBe(true);
-    }
-  });
-
-  it("rejects languageQuotas shares summing to 1.01", () => {
-    const result = queryAnalysisConfigSchema.safeParse({
-      ...minimal,
-      languageQuotas: [
-        { language: "en", share: 0.61 },
-        { language: "id", share: 0.4 },
-      ],
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) =>
-          issue.message.includes("languageQuotas shares must sum to 1.0"),
-        ),
-      ).toBe(true);
-    }
-  });
-});
-
-describe("resolveYieldFeedbackConfig", () => {
+describe("queryAnalysisConfigSchema yieldFeedback", () => {
   it("defaults yield feedback to disabled with a 30-day window", () => {
-    expect(resolveYieldFeedbackConfig({})).toEqual({
+    const parsed = parseWithApiKey();
+    expect(parsed.dynamics.yieldFeedback).toEqual({
       enabled: false,
       windowDays: 30,
       minTemplateYield: 0.05,
@@ -429,18 +461,83 @@ describe("resolveYieldFeedbackConfig", () => {
   });
 
   it("parses enabled yield feedback overrides from Hermes config", () => {
-    const parsed = queryAnalysisConfigSchema.parse({
-      ...minimal,
-      yieldFeedback: {
-        enabled: true,
-        windowDays: 14,
-        minTemplateYield: 0.1,
+    const parsed = parseWithApiKey({
+      dynamics: {
+        yieldFeedback: {
+          enabled: true,
+          windowDays: 14,
+          minTemplateYield: 0.1,
+        },
       },
     });
-    expect(resolveYieldFeedbackConfig(parsed)).toEqual({
+    expect(parsed.dynamics.yieldFeedback).toEqual({
       enabled: true,
       windowDays: 14,
       minTemplateYield: 0.1,
     });
+  });
+});
+
+describe("queryAnalysisConfigSchema languageQuotas", () => {
+  it("accepts valid languageQuotas whose shares sum to 1.0", () => {
+    const parsed = parseWithApiKey({
+      output: {
+        languageQuotas: [
+          { language: "en", share: 0.6 },
+          { language: "id", share: 0.4 },
+        ],
+      },
+    });
+    expect(parsed.output.languageQuotas).toEqual([
+      { language: "en", share: 0.6 },
+      { language: "id", share: 0.4 },
+    ]);
+  });
+
+  it("rejects languageQuotas shares summing to 0.99", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      credentials: { openaiApiKey: "sk-test" },
+      output: {
+        languageQuotas: [
+          { language: "en", share: 0.59 },
+          { language: "id", share: 0.4 },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("languageQuotas shares must sum to 1.0"),
+        ),
+      ).toBe(true);
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path.includes("output") &&
+            issue.path.includes("languageQuotas"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects languageQuotas shares summing to 1.01", () => {
+    const result = queryAnalysisConfigSchema.safeParse({
+      credentials: { openaiApiKey: "sk-test" },
+      output: {
+        languageQuotas: [
+          { language: "en", share: 0.61 },
+          { language: "id", share: 0.4 },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((issue) =>
+          issue.message.includes("languageQuotas shares must sum to 1.0"),
+        ),
+      ).toBe(true);
+    }
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment node */
 import { describe, expect, it } from "vitest";
+import { z } from "zod";
 
 import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api-contract";
 
@@ -10,7 +11,7 @@ import {
 
 /** Parses config with a resolved API key while keeping other schema defaults. */
 const parseWithApiKey = (
-  overrides: Parameters<typeof queryAnalysisConfigSchema.parse>[0] = {},
+  overrides: z.input<typeof queryAnalysisConfigSchema> = {},
 ) =>
   queryAnalysisConfigSchema.parse({
     credentials: { openaiApiKey: "sk-test" },

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -13,99 +13,347 @@ import {
 /**
  * Resolves intent weights from parsed Hermes config with contract defaults applied.
  *
- * @param config - Parsed invoke config fields related to intent weighting.
+ * @param output - Parsed `output` group fields related to intent weighting.
  * @returns Full intent weight record for merge math, prompts, and snapshots.
  */
-export const resolveIntentWeights = (config: {
+export const resolveIntentWeights = (output: {
   intentWeights?: Partial<QueryAnalysisIntentWeights>;
 }): QueryAnalysisIntentWeights => ({
   ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
-  ...config.intentWeights,
+  ...output.intentWeights,
 });
 
-/** Resolved diversity gate settings with defaults applied. */
-export type ResolvedDiversityGateConfig = {
-  enabled: boolean;
-  threshold: number;
-  weights: {
-    lexical: number;
-    intent: number;
-    semantic: number;
-  };
-};
+const credentialsSchema = z
+  .object({
+    openaiApiKey: z
+      .string()
+      .min(1)
+      .default("{{OPENAI_API_KEY}}")
+      .describe(
+        "OpenAI API key or a Hermes variable placeholder such as {{OPENAI_API_KEY}}.",
+      ),
+    chatModel: z
+      .string()
+      .min(1)
+      .default("{{QUERY_ANALYSIS_MODEL}}")
+      .describe(
+        "Chat model id for query generation (e.g. gpt-4o-mini) or a Hermes variable placeholder such as {{QUERY_ANALYSIS_MODEL}}.",
+      ),
+  })
+  .default({})
+  .describe("OpenAI credentials resolved from Hermes Variables.");
 
-/** Resolved temporal event-bias settings with defaults applied. */
-export type ResolvedTemporalBiasConfig = {
-  enabled: boolean;
-};
+const outputSchema = z
+  .object({
+    queryCount: z
+      .number()
+      .int()
+      .positive()
+      .default(10)
+      .describe(
+        "Total number of query rows to persist in the active query set.",
+      ),
+    languageQuotas: z
+      .array(
+        z.object({
+          language: z
+            .string()
+            .min(1)
+            .describe("BCP-47 language tag for this budget slice."),
+          share: z
+            .number()
+            .min(0)
+            .max(1)
+            .describe(
+              "Fraction of queryCount assigned to this language (shares must sum to 1).",
+            ),
+          templatePack: z
+            .string()
+            .min(1)
+            .optional()
+            .describe(
+              "Optional deterministic pack override for this language; falls back to the global templates.templatePack.",
+            ),
+        }),
+      )
+      .optional()
+      .describe(
+        "Per-language query budget shares. Omit for English-only (100% en). When set, shares must sum to 1.0.",
+      ),
+    intentWeights: z
+      .record(queryAnalysisIntentSchema, z.number().nonnegative())
+      .optional()
+      .describe(
+        "Relative weights keyed by intent for merge ordering and LLM target counts; omitted keys use contract defaults.",
+      ),
+  })
+  .default({})
+  .describe("Query set size, language mix, and intent weighting.");
 
-/** Resolved yield feedback settings with defaults applied. */
-export type ResolvedYieldFeedbackConfig = {
-  enabled: boolean;
-  windowDays: number;
-  minTemplateYield: number;
-};
+const samplingSchema = z
+  .object({
+    temperature: z
+      .number()
+      .min(0)
+      .max(2)
+      .default(0.9)
+      .describe("LLM sampling temperature (higher = more varied phrasing)."),
+    topP: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.95)
+      .describe("Nucleus sampling top-p cutoff."),
+    presencePenalty: z
+      .number()
+      .min(-2)
+      .max(2)
+      .default(0.4)
+      .describe(
+        "Penalizes tokens already present in the output (encourages new topics).",
+      ),
+    frequencyPenalty: z
+      .number()
+      .min(-2)
+      .max(2)
+      .default(0.5)
+      .describe(
+        "Penalizes tokens by prior frequency in the output (reduces repetition).",
+      ),
+    seed: z
+      .number()
+      .int()
+      .optional()
+      .describe(
+        "Optional fixed seed for reproducible LLM output during regression hunts.",
+      ),
+  })
+  .default({})
+  .describe("OpenAI sampling knobs shared by standard and wildcard LLM calls.");
 
-/**
- * Resolves yield feedback config with schema defaults when fields are omitted.
- *
- * @param config - Parsed or raw Hermes invoke config.
- * @returns Effective yield feedback settings for merge, prompts, and template rotation.
- */
-export const resolveYieldFeedbackConfig = (config: {
-  yieldFeedback?: {
-    enabled?: boolean;
-    windowDays?: number;
-    minTemplateYield?: number;
-  };
-}): ResolvedYieldFeedbackConfig => ({
-  enabled: config.yieldFeedback?.enabled ?? false,
-  windowDays: config.yieldFeedback?.windowDays ?? 30,
-  minTemplateYield: config.yieldFeedback?.minTemplateYield ?? 0.05,
-});
+const templatesSchema = z
+  .object({
+    templatePack: z
+      .enum(DETERMINISTIC_PACK_NAMES)
+      .default(DEFAULT_DETERMINISTIC_PACK)
+      .describe(
+        "Named deterministic template pack for the query floor; switch via Hermes without redeploying.",
+      ),
+    kgTemplateCap: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(6)
+      .describe(
+        "Maximum KG relation rows expanded into deterministic templates per run; 0 disables KG expansion.",
+      ),
+  })
+  .default({})
+  .describe("Deterministic template pack selection and KG expansion cap.");
 
-/**
- * Resolves temporal event-bias config with schema defaults when fields are omitted.
- *
- * @param config - Parsed or raw Hermes invoke config.
- * @returns Effective temporal bias toggle for the run loop.
- */
-export const resolveTemporalBiasConfig = (config: {
-  temporalBias?: {
-    enabled?: boolean;
-  };
-}): ResolvedTemporalBiasConfig => ({
-  enabled: config.temporalBias?.enabled ?? true,
-});
+const promptingSchema = z
+  .object({
+    personas: z
+      .array(z.string().min(1))
+      .default(["analyst", "retail", "regulator"])
+      .describe(
+        "Persona ids from the in-process library to fan out parallel LLM calls.",
+      ),
+    perPersonaQuotaCount: z
+      .number()
+      .int()
+      .positive()
+      .default(3)
+      .describe(
+        "Maximum structured query rows requested from each persona call.",
+      ),
+    fewShotExemplarCount: z
+      .number()
+      .int()
+      .min(0)
+      .max(6)
+      .default(3)
+      .describe(
+        "Number of curated few-shot exemplars to inject; 0 disables exemplars.",
+      ),
+  })
+  .default({})
+  .describe("Persona fan-out and few-shot prompting.");
 
-/**
- * Resolves diversity gate config with schema defaults when fields are omitted.
- *
- * @param config - Parsed or raw Hermes invoke config.
- * @returns Effective gate settings for scoring and regenerate decisions.
- */
-export const resolveDiversityGateConfig = (config: {
-  diversityGate?: {
-    enabled?: boolean;
-    threshold?: number;
-    weights?: {
-      lexical?: number;
-      intent?: number;
-      semantic?: number;
-    };
-  };
-}): ResolvedDiversityGateConfig => {
-  const gate = config.diversityGate;
-  return {
-    enabled: gate?.enabled ?? false,
-    threshold: gate?.threshold ?? 0.6,
-    weights: {
-      lexical: gate?.weights?.lexical ?? 0.4,
-      intent: gate?.weights?.intent ?? 0.3,
-      semantic: gate?.weights?.semantic ?? 0.3,
-    },
-  };
-};
+const creativitySchema = z
+  .object({
+    wildcardFraction: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0.1)
+      .describe(
+        "Fraction of each query set reserved for stochastic wildcard (lateral) queries.",
+      ),
+    wildcardTemperature: z
+      .number()
+      .min(0)
+      .max(2)
+      .default(1.2)
+      .describe(
+        "Sampling temperature for wildcard generation (defaults higher than sampling.temperature).",
+      ),
+    useBrainstormPass: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, runs a free-form brainstorm pass before structured query generation.",
+      ),
+    brainstormModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Model id for the brainstorm pass; omitted uses credentials.chatModel.",
+      ),
+  })
+  .default({})
+  .describe("Wildcard budget and optional brainstorm pass.");
+
+const semanticDedupeSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, deduplicate LLM candidates via embedding cosine similarity before merge.",
+      ),
+    threshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.85)
+      .describe(
+        "Cosine-similarity threshold above which a candidate is dropped.",
+      ),
+    embeddingModel: z
+      .string()
+      .default("{{EMBEDDING_MODEL}}")
+      .describe(
+        "OpenAI embedding model name or a Hermes variable placeholder such as {{EMBEDDING_MODEL}}.",
+      ),
+  })
+  .default({})
+  .describe("Optional semantic deduplication of LLM candidates.");
+
+const diversityGateSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, run one broaden regenerate pass when the diversity composite is below threshold.",
+      ),
+    threshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.6)
+      .describe(
+        "Minimum composite diversity score before a regenerate pass fires.",
+      ),
+    weights: z
+      .object({
+        lexical: z
+          .number()
+          .nonnegative()
+          .default(0.4)
+          .describe("Weight for lexical diversity in the composite score."),
+        intent: z
+          .number()
+          .nonnegative()
+          .default(0.3)
+          .describe("Weight for intent spread in the composite score."),
+        semantic: z
+          .number()
+          .nonnegative()
+          .default(0.3)
+          .describe("Weight for embedding-based semantic spread."),
+      })
+      .default({ lexical: 0.4, intent: 0.3, semantic: 0.3 })
+      .describe("Axis weights for the diversity composite (should sum to ~1)."),
+  })
+  .default({})
+  .describe("Diversity score gate and optional broaden regenerate pass.");
+
+const qualitySchema = z
+  .object({
+    useSelfCritique: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, runs a self-critique pass after LLM generation to replace the weakest rows.",
+      ),
+    critiqueDropFraction: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0.25)
+      .describe(
+        "Maximum fraction of LLM candidates the critique pass may replace (one-for-one).",
+      ),
+    critiqueModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Model id for the critique pass; omitted uses credentials.chatModel.",
+      ),
+    semanticDedupe: semanticDedupeSchema,
+    diversityGate: diversityGateSchema,
+  })
+  .default({})
+  .describe("Self-critique, semantic dedupe, and diversity gate.");
+
+const temporalBiasSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, apply conservative calendar-driven intent weight boosts from recent events.",
+      ),
+  })
+  .default({})
+  .describe("Calendar-driven intent weight boosts.");
+
+const yieldFeedbackSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, use rolling query-yield feedback in merge ranking, prompts, and template rotation.",
+      ),
+    windowDays: z
+      .number()
+      .int()
+      .positive()
+      .default(30)
+      .describe("Lookback window in days for yield statistics."),
+    minTemplateYield: z
+      .number()
+      .nonnegative()
+      .default(0.05)
+      .describe(
+        "Minimum template yield before rotation deprioritizes a template.",
+      ),
+  })
+  .default({})
+  .describe("Rolling query-yield feedback loop.");
+
+const dynamicsSchema = z
+  .object({
+    temporalBias: temporalBiasSchema,
+    yieldFeedback: yieldFeedbackSchema,
+  })
+  .default({})
+  .describe("Adaptive temporal bias and yield feedback.");
 
 /**
  * Runtime configuration from Hermes invoke `config` (variable substitution).
@@ -116,172 +364,29 @@ export const resolveDiversityGateConfig = (config: {
  */
 export const queryAnalysisConfigSchema = z
   .object({
-    openaiApiKey: z.string().min(1),
-    /**
-     * Chat model id used for query generation (e.g. `gpt-4o-mini`).
-     * When omitted by Hermes, defaults to `gpt-4o-mini`.
-     */
-    openaiModel: z.string().min(1).optional().default("gpt-4o-mini"),
-    /**
-     * Total number of query rows to persist in the active query set.
-     */
-    queryCount: z.number().int().positive().optional().default(10),
-    /**
-     * Per-language query budget shares and optional template pack overrides.
-     */
-    languageQuotas: z
-      .array(
-        z.object({
-          language: z.string().min(1),
-          share: z.number().min(0).max(1),
-          templatePack: z.string().min(1).optional(),
-        }),
-      )
-      .optional(),
-    /**
-     * Relative weights keyed by intent for merge ordering and LLM target counts.
-     */
-    intentWeights: z
-      .record(queryAnalysisIntentSchema, z.number().nonnegative())
-      .optional(),
-    /**
-     * Named deterministic template pack used for the query floor.
-     * Switch via Hermes invoke config without redeploying the agent.
-     */
-    templatePack: z
-      .enum(DETERMINISTIC_PACK_NAMES)
-      .optional()
-      .default(DEFAULT_DETERMINISTIC_PACK),
-    /**
-     * Maximum KG relation rows expanded into deterministic templates per run.
-     * `0` disables KG-template expansion without changing the pack.
-     */
-    kgTemplateCap: z.number().int().nonnegative().optional().default(6),
-    /**
-     * LLM sampling temperature (higher = more varied phrasing).
-     */
-    temperature: z.number().min(0).max(2).optional().default(0.9),
-    /**
-     * Nucleus sampling top-p cutoff.
-     */
-    topP: z.number().min(0).max(1).optional().default(0.95),
-    /**
-     * Penalizes tokens already present in the output (encourages new topics).
-     */
-    presencePenalty: z.number().min(-2).max(2).optional().default(0.4),
-    /**
-     * Penalizes tokens by prior frequency in the output (reduces repetition).
-     */
-    frequencyPenalty: z.number().min(-2).max(2).optional().default(0.5),
-    /**
-     * Optional fixed seed for reproducible LLM output during regression hunts.
-     */
-    seed: z.number().int().optional(),
-    /**
-     * Fraction of each query set reserved for stochastic wildcard (lateral) queries.
-     */
-    wildcardFraction: z.number().min(0).max(0.5).optional().default(0.1),
-    /**
-     * Sampling temperature for wildcard generation (defaults higher than `temperature`).
-     */
-    wildcardTemperature: z.number().min(0).max(2).optional().default(1.2),
-    /**
-     * When true, runs a free-form brainstorm pass before structured query generation.
-     */
-    useBrainstormPass: z.boolean().optional().default(false),
-    /**
-     * Model id for the brainstorm pass (defaults to `openaiModel` in `run.ts` when omitted).
-     */
-    brainstormModel: z.string().min(1).optional(),
-    /**
-     * Number of curated few-shot exemplars to inject (0 disables exemplars).
-     */
-    fewShotExemplarCount: z.number().int().min(0).max(6).optional().default(3),
-    /**
-     * Persona ids from the in-process library to fan out parallel LLM calls.
-     */
-    personas: z
-      .array(z.string().min(1))
-      .optional()
-      .default(["analyst", "retail", "regulator"]),
-    /**
-     * Maximum structured query rows requested from each persona call.
-     */
-    perPersonaQuotaCount: z.number().int().positive().optional().default(3),
-    /**
-     * When true, runs a self-critique pass after LLM generation to replace the weakest rows.
-     */
-    useSelfCritique: z.boolean().optional().default(false),
-    /**
-     * Maximum fraction of LLM candidates the critique pass may replace (one-for-one).
-     */
-    critiqueDropFraction: z.number().min(0).max(0.5).optional().default(0.25),
-    /**
-     * Model id for the critique pass (defaults to `openaiModel` in `run.ts` when omitted).
-     */
-    critiqueModel: z.string().min(1).optional(),
-    /**
-     * Optional semantic deduplication of LLM candidates via embedding cosine similarity.
-     */
-    semanticDedupe: z
-      .object({
-        enabled: z.boolean().default(false),
-        threshold: z.number().min(0).max(1).default(0.85),
-        embeddingModel: z.string().default("text-embedding-3-small"),
-      })
-      .optional(),
-    /**
-     * Optional diversity score gate: one broaden regenerate pass when composite is below threshold.
-     */
-    diversityGate: z
-      .object({
-        enabled: z.boolean().default(false),
-        threshold: z.number().min(0).max(1).default(0.6),
-        weights: z
-          .object({
-            lexical: z.number().nonnegative().default(0.4),
-            intent: z.number().nonnegative().default(0.3),
-            semantic: z.number().nonnegative().default(0.3),
-          })
-          .default({ lexical: 0.4, intent: 0.3, semantic: 0.3 }),
-      })
-      .optional(),
-    /**
-     * Optional calendar-driven intent weight boosts (default on; conservative multipliers).
-     */
-    temporalBias: z
-      .object({
-        enabled: z.boolean().default(true),
-      })
-      .optional(),
-    /**
-     * Optional rolling query-yield feedback loop (merge ranking, prompts, template rotation).
-     */
-    yieldFeedback: z
-      .object({
-        enabled: z.boolean().default(false),
-        windowDays: z.number().int().positive().default(30),
-        minTemplateYield: z.number().nonnegative().default(0.05),
-      })
-      .optional(),
+    credentials: credentialsSchema,
+    output: outputSchema,
+    sampling: samplingSchema,
+    templates: templatesSchema,
+    prompting: promptingSchema,
+    creativity: creativitySchema,
+    quality: qualitySchema,
+    dynamics: dynamicsSchema,
   })
   .strict()
   .superRefine((data, ctx) => {
-    if (data.languageQuotas !== undefined && data.languageQuotas.length > 0) {
-      const sum = data.languageQuotas.reduce(
-        (total, quota) => total + quota.share,
-        0,
-      );
+    const quotas = data.output.languageQuotas;
+    if (quotas !== undefined && quotas.length > 0) {
+      const sum = quotas.reduce((total, quota) => total + quota.share, 0);
       if (Math.abs(sum - 1) > 0.001) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: `languageQuotas shares must sum to 1.0 (received ${String(sum)})`,
-          path: ["languageQuotas"],
+          path: ["output", "languageQuotas"],
         });
       }
     }
   });
 
-// Use Zod *input* type so `createAgentApp`'s Zod generic constraints match.
-// The agent runtime always parses with this schema, so defaults are guaranteed at runtime.
-export type QueryAnalysisConfig = z.input<typeof queryAnalysisConfigSchema>;
+/** Parsed invoke config with all group and field defaults applied. */
+export type QueryAnalysisConfig = z.output<typeof queryAnalysisConfigSchema>;

--- a/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
+++ b/apps/mediapulse/agents/query-analysis/src/language-quotas.ts
@@ -36,16 +36,16 @@ export const languageQuotaSharesAreValid = (
 };
 
 /**
- * Resolves effective language quotas from Hermes config.
+ * Resolves effective language quotas from the parsed `output` config group.
  *
- * @param config - Parsed invoke config language fields.
+ * @param output - Parsed invoke config `output` group.
  * @returns Normalized quota list defaulting to English-only when omitted.
  */
-export const resolveLanguageQuotas = (config: {
+export const resolveLanguageQuotas = (output: {
   languageQuotas?: LanguageQuota[];
 }): LanguageQuota[] => {
-  if (config.languageQuotas !== undefined && config.languageQuotas.length > 0) {
-    return config.languageQuotas;
+  if (output.languageQuotas !== undefined && output.languageQuotas.length > 0) {
+    return output.languageQuotas;
   }
   return [{ language: "en", share: 1 }];
 };

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -69,7 +69,9 @@ const ctxResponse = {
   kgNeighborhood: [] as [],
 };
 
-const baseConfig = queryAnalysisConfigSchema.parse({ openaiApiKey: "sk" });
+const baseConfig = queryAnalysisConfigSchema.parse({
+  credentials: { openaiApiKey: "sk" },
+});
 
 describe("query-analysis run", () => {
   beforeEach(async () => {
@@ -200,8 +202,8 @@ describe("query-analysis run", () => {
     const result = await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        useBrainstormPass: true,
+        credentials: { openaiApiKey: "sk" },
+        creativity: { useBrainstormPass: true },
       }),
       token: "Bearer t",
     });
@@ -260,8 +262,8 @@ describe("query-analysis run", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        diversityGate: { enabled: true, threshold: 0.6 },
+        credentials: { openaiApiKey: "sk" },
+        quality: { diversityGate: { enabled: true, threshold: 0.6 } },
       }),
       token: "Bearer t",
     });
@@ -301,9 +303,9 @@ describe("query-analysis run", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        queryCount: 10,
-        wildcardFraction: 0.2,
+        credentials: { openaiApiKey: "sk" },
+        output: { queryCount: 10 },
+        creativity: { wildcardFraction: 0.2 },
       }),
       token: "Bearer t",
     });
@@ -325,14 +327,16 @@ describe("query-analysis run", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        queryCount: 10,
-        wildcardFraction: 0,
-        personas: [],
-        languageQuotas: [
-          { language: "en", share: 0.6 },
-          { language: "id", share: 0.4 },
-        ],
+        credentials: { openaiApiKey: "sk" },
+        output: {
+          queryCount: 10,
+          languageQuotas: [
+            { language: "en", share: 0.6 },
+            { language: "id", share: 0.4 },
+          ],
+        },
+        creativity: { wildcardFraction: 0 },
+        prompting: { personas: [] },
       }),
       token: "Bearer t",
     });
@@ -377,8 +381,8 @@ describe("query-analysis run", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        wildcardFraction: 0,
+        credentials: { openaiApiKey: "sk" },
+        creativity: { wildcardFraction: 0 },
       }),
       token: "Bearer t",
     });
@@ -437,9 +441,9 @@ describe("runQueryAnalysis derived minDeterministicCount", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        queryCount: 10,
-        wildcardFraction: 0,
+        credentials: { openaiApiKey: "sk" },
+        output: { queryCount: 10 },
+        creativity: { wildcardFraction: 0 },
       }),
       token: "Bearer t",
     });
@@ -459,9 +463,9 @@ describe("runQueryAnalysis derived minDeterministicCount", () => {
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
-        openaiApiKey: "sk",
-        queryCount: 3,
-        wildcardFraction: 0,
+        credentials: { openaiApiKey: "sk" },
+        output: { queryCount: 3 },
+        creativity: { wildcardFraction: 0 },
       }),
       token: "Bearer t",
     });

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -4,12 +4,9 @@ import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import { logger } from "@workspace/logger";
 import { env } from "@mediapulse/env/agents-query-analysis";
-import type { QueryAnalysisConfig } from "./config-schema";
 import {
-  resolveDiversityGateConfig,
   resolveIntentWeights,
-  resolveTemporalBiasConfig,
-  resolveYieldFeedbackConfig,
+  type QueryAnalysisConfig,
 } from "./config-schema";
 import {
   buildQueryAnalysisSystemContent,
@@ -126,7 +123,7 @@ export const buildLlmSamplingFromConfig = (config: {
 export const resolveIntentWeightsWithEventBias = (
   baseIntentWeights: ReturnType<typeof resolveIntentWeights>,
   queryContext: GetQueryAnalysisResponse,
-  temporalBias: ReturnType<typeof resolveTemporalBiasConfig>,
+  temporalBias: QueryAnalysisConfig["dynamics"]["temporalBias"],
   deps: {
     clock?: () => Date;
     rules?: typeof DEFAULT_EVENT_BIAS_RULES;
@@ -229,7 +226,7 @@ export const buildLlmEmbeddingsForDiversity = async (
  */
 export const applyDiversityGatePass = async (params: {
   llmCandidates: LlmCandidate[];
-  diversityGate: ReturnType<typeof resolveDiversityGateConfig>;
+  diversityGate: QueryAnalysisConfig["quality"]["diversityGate"];
   embeddingsByText?: ReadonlyMap<string, number[]>;
   allowRegenerate?: boolean;
   fetchBroadenBatch: (broadenSystemNudge: string) => Promise<LlmCandidate[]>;
@@ -385,12 +382,12 @@ type LanguageSliceSharedConfig = {
   critiqueDropFraction: number;
   critiqueModel: string;
   perPersonaQuotaCount: number;
-  diversityGate: ReturnType<typeof resolveDiversityGateConfig>;
+  diversityGate: QueryAnalysisConfig["quality"]["diversityGate"];
   semanticDedupeEnabled: boolean;
   embeddingModel: string;
   runStartMs: number;
   tickerId: string;
-  yieldFeedback: ReturnType<typeof resolveYieldFeedbackConfig>;
+  yieldFeedback: QueryAnalysisConfig["dynamics"]["yieldFeedback"];
   priorYield?: GetQueryAnalysisResponse["priorYield"];
 };
 
@@ -659,19 +656,28 @@ export const runQueryAnalysis = async (
   const queryContext = await client.queryAnalysis.get({
     tickerId: input.tickerId,
   });
-  const templatePack = config.templatePack!;
-  const kgTemplateCap = config.kgTemplateCap!;
+  const {
+    credentials,
+    output,
+    sampling,
+    templates,
+    prompting,
+    creativity,
+    quality,
+    dynamics,
+  } = config;
 
-  // Zod applies defaults in `createAgentApp` before calling `run`.
-  const queryCount = config.queryCount!;
-  const wildcardFraction = config.wildcardFraction!;
-  const wildcardTemperature = config.wildcardTemperature!;
+  const templatePack = templates.templatePack;
+  const kgTemplateCap = templates.kgTemplateCap;
+  const queryCount = output.queryCount;
+  const wildcardFraction = creativity.wildcardFraction;
+  const wildcardTemperature = creativity.wildcardTemperature;
   const wildcardCount = computeWildcardCount(queryCount, wildcardFraction);
   const standardQueryCount = queryCount - wildcardCount;
-  const languageQuotas = resolveLanguageQuotas(config);
+  const languageQuotas = resolveLanguageQuotas(output);
   const minDeterministicCount = deriveMinDeterministicCount(queryCount);
-  const baseIntentWeights = resolveIntentWeights(config);
-  const temporalBias = resolveTemporalBiasConfig(config);
+  const baseIntentWeights = resolveIntentWeights(output);
+  const temporalBias = dynamics.temporalBias;
   const { intentWeights, appliedEventBias } = resolveIntentWeightsWithEventBias(
     baseIntentWeights,
     queryContext,
@@ -687,20 +693,17 @@ export const runQueryAnalysis = async (
       "query-analysis temporal event bias applied",
     );
   }
-  const openaiModel = config.openaiModel!;
-  const temperature = config.temperature!;
-  const topP = config.topP!;
-  const presencePenalty = config.presencePenalty!;
-  const frequencyPenalty = config.frequencyPenalty!;
-  const seed = config.seed;
-  const useBrainstormPass = config.useBrainstormPass!;
-  const fewShotExemplarCount = config.fewShotExemplarCount!;
-  const brainstormModel = config.brainstormModel ?? openaiModel;
-  const useSelfCritique = config.useSelfCritique!;
-  const critiqueDropFraction = config.critiqueDropFraction!;
-  const critiqueModel = config.critiqueModel ?? openaiModel;
-  const personaIds = config.personas!;
-  let perPersonaQuotaCount = config.perPersonaQuotaCount!;
+  const openaiModel = credentials.chatModel;
+  const { temperature, topP, presencePenalty, frequencyPenalty, seed } =
+    sampling;
+  const useBrainstormPass = creativity.useBrainstormPass;
+  const fewShotExemplarCount = prompting.fewShotExemplarCount;
+  const brainstormModel = creativity.brainstormModel ?? openaiModel;
+  const useSelfCritique = quality.useSelfCritique;
+  const critiqueDropFraction = quality.critiqueDropFraction;
+  const critiqueModel = quality.critiqueModel ?? openaiModel;
+  const personaIds = prompting.personas;
+  let perPersonaQuotaCount = prompting.perPersonaQuotaCount;
   const resolvedPersonas = resolveQueryPersonas(personaIds, {
     warn: (_message, meta) => {
       logger.warn(
@@ -744,19 +747,12 @@ export const runQueryAnalysis = async (
     languageQuotas,
   );
 
-  const llmSampling = buildLlmSamplingFromConfig({
-    temperature,
-    topP,
-    presencePenalty,
-    frequencyPenalty,
-    ...(seed !== undefined ? { seed } : {}),
-  });
+  const llmSampling = buildLlmSamplingFromConfig(sampling);
 
-  const diversityGate = resolveDiversityGateConfig(config);
-  const yieldFeedback = resolveYieldFeedbackConfig(config);
-  const semanticDedupeConfig = config.semanticDedupe;
-  const embeddingModel =
-    semanticDedupeConfig?.embeddingModel ?? "text-embedding-3-small";
+  const diversityGate = quality.diversityGate;
+  const yieldFeedback = dynamics.yieldFeedback;
+  const semanticDedupeConfig = quality.semanticDedupe;
+  const embeddingModel = semanticDedupeConfig.embeddingModel;
 
   const primaryLanguage = languageQuotas[0]?.language ?? "en";
   const llmPromptFingerprint = computeLlmPromptFingerprint(
@@ -770,7 +766,7 @@ export const runQueryAnalysis = async (
   );
 
   const sharedSliceConfig: LanguageSliceSharedConfig = {
-    openaiApiKey: config.openaiApiKey,
+    openaiApiKey: credentials.openaiApiKey,
     openaiModel,
     globalTemplatePack: templatePack,
     kgTemplateCap,
@@ -784,7 +780,7 @@ export const runQueryAnalysis = async (
     critiqueModel,
     perPersonaQuotaCount,
     diversityGate,
-    semanticDedupeEnabled: semanticDedupeConfig?.enabled ?? false,
+    semanticDedupeEnabled: semanticDedupeConfig.enabled,
     embeddingModel,
     runStartMs,
     tickerId: input.tickerId,
@@ -850,7 +846,7 @@ export const runQueryAnalysis = async (
     let wildcardBatch: LlmCandidate[] = [];
     try {
       wildcardBatch = await fetchWildcardCandidates({
-        apiKey: config.openaiApiKey,
+        apiKey: credentials.openaiApiKey,
         model: openaiModel,
         count: wildcardCount,
         context: queryContext,
@@ -874,7 +870,7 @@ export const runQueryAnalysis = async (
           ? async (avoidTexts) => {
               try {
                 return await fetchWildcardCandidates({
-                  apiKey: config.openaiApiKey,
+                  apiKey: credentials.openaiApiKey,
                   model: openaiModel,
                   count: wildcardCount,
                   context: queryContext,
@@ -937,11 +933,11 @@ export const runQueryAnalysis = async (
       : {}),
     ...(useBrainstormPass ? { brainstormModel } : {}),
     ...(seed !== undefined ? { seed } : {}),
-    ...(semanticDedupeConfig?.enabled
+    ...(semanticDedupeConfig.enabled
       ? {
           semanticDedupe: {
             enabled: true,
-            threshold: semanticDedupeConfig.threshold ?? 0.85,
+            threshold: semanticDedupeConfig.threshold,
             embeddingModel,
           },
         }


### PR DESCRIPTION
## Summary

Reorganizes the query-analysis agent invoke config into eight Hermes form sections (credentials through dynamics) with full Zod defaults and `{{NAME}}` placeholders. An empty `{}` now parses to the recommended setup, including semantic dedupe, diversity gate, temporal bias, and yield feedback blocks that were previously optional and invisible in the UI.

## Related issues

Closes #578

Refs #576

## Important changes

- Flat configs break on purpose: strict mode rejects legacy top-level keys (`queryCount`, `openaiModel`, etc.) so operators must re-save in the grouped form.
- `openaiModel` becomes `credentials.chatModel` with default `{{QUERY_ANALYSIS_MODEL}}`; API key and embedding model use `{{OPENAI_API_KEY}}` and `{{EMBEDDING_MODEL}}`.
- Removed `resolveDiversityGateConfig`, `resolveYieldFeedbackConfig`, and `resolveTemporalBiasConfig`; `run.ts` reads parsed grouped paths directly.
- `QueryAnalysisConfig` is now `z.output` so defaults are guaranteed after parse.

## Other changes

- `resolveIntentWeights` reads `output.intentWeights`; `languageQuotas` refine path is `output.languageQuotas`.
- `brainstormModel` and `critiqueModel` stay optional (fallback to chat model unchanged).

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — grouped schema, defaults, descriptions, strict + refine.
- `apps/mediapulse/agents/query-analysis/src/run.ts` — grouped config reads, removed non-null asserts.
- `apps/mediapulse/agents/query-analysis/src/config-schema.test.ts` — empty `{}`, flat-key rejection, placeholder preservation.

## How to test

1. From repo root: `cd apps/mediapulse/agents/query-analysis && npx vitest run` (185 tests should pass).
2. `queryAnalysisConfigSchema.parse({})` and confirm all eight groups and feature-block defaults match the plan.
3. `queryAnalysisConfigSchema.safeParse({ queryCount: 10 })` should fail (unrecognized key).
4. After #576 merges, open the query-analysis step in Hermes and confirm sections prefill; until then, runtime defaults still apply on invoke.
