### PR TITLE
Strip stale agent config keys on Hermes save

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
+import { stripConfigToJsonSchema } from "@/lib/strip-config-to-json-schema";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
 const configBody = z
@@ -84,8 +85,12 @@ export const createCreateAgentConfigHandler = ({
       agent.configSchema != null && typeof agent.configSchema === "object"
         ? (agent.configSchema as Record<string, unknown>)
         : null;
+    const configToStore =
+      configSchema != null
+        ? stripConfigToJsonSchema(configSchema, config)
+        : config;
     if (configSchema) {
-      const result = validateWithJsonSchema(configSchema, config);
+      const result = validateWithJsonSchema(configSchema, configToStore);
       if (!result.valid) {
         return errorResponse(
           `Config validation failed: ${result.errors.join("; ")}`,
@@ -101,7 +106,7 @@ export const createCreateAgentConfigHandler = ({
         description: description ?? null,
         agentId,
         agentVersion,
-        config: config as object,
+        config: configToStore as object,
         configSchemaFingerprint: fingerprint || null,
         createdById: userId,
       },

--- a/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 import { requireMutationDashboardPrincipalForRoute } from "@/lib/require-mutation-dashboard-principal-for-route";
 import { configSchemaFingerprint } from "@/lib/config-schema-fingerprint";
+import { stripConfigToJsonSchema } from "@/lib/strip-config-to-json-schema";
 import { validateWithJsonSchema } from "@/lib/validate-json-schema";
 
 const configBody = z
@@ -91,8 +92,12 @@ export const createUpdateAgentConfigHandler = ({
       agent.configSchema != null && typeof agent.configSchema === "object"
         ? (agent.configSchema as Record<string, unknown>)
         : null;
+    const configToStore =
+      configSchema != null
+        ? stripConfigToJsonSchema(configSchema, config)
+        : config;
     if (configSchema) {
-      const result = validateWithJsonSchema(configSchema, config);
+      const result = validateWithJsonSchema(configSchema, configToStore);
       if (!result.valid) {
         return errorResponse(
           `Config validation failed: ${result.errors.join("; ")}`,
@@ -109,7 +114,7 @@ export const createUpdateAgentConfigHandler = ({
         description: description ?? null,
         agentId,
         agentVersion,
-        config: config as object,
+        config: configToStore as object,
         configSchemaFingerprint: fingerprint || null,
       },
     });

--- a/apps/hermes/dashboard/lib/strip-config-to-json-schema.test.ts
+++ b/apps/hermes/dashboard/lib/strip-config-to-json-schema.test.ts
@@ -1,0 +1,78 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { stripConfigToJsonSchema } from "./strip-config-to-json-schema";
+
+describe("stripConfigToJsonSchema", () => {
+  const groupedSchema = {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      providers: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          search: {
+            type: "object",
+            properties: { baseUrl: { type: "string" } },
+          },
+        },
+      },
+      collection: {
+        type: "object",
+        properties: {
+          perRunFetchBudget: { type: "number" },
+        },
+      },
+    },
+  } as const;
+
+  it("removes legacy flat top-level keys so grouped schema validation can pass", () => {
+    const stripped = stripConfigToJsonSchema(groupedSchema, {
+      webSearch: { baseUrl: "https://old.example/search" },
+      webFetch: { providers: [] },
+      collection: { perRunFetchBudget: 20 },
+    });
+
+    expect(stripped).toEqual({
+      collection: { perRunFetchBudget: 20 },
+    });
+    expect(stripped).not.toHaveProperty("webSearch");
+    expect(stripped).not.toHaveProperty("webFetch");
+  });
+
+  it("keeps grouped keys and strips nested unknown fields", () => {
+    const stripped = stripConfigToJsonSchema(groupedSchema, {
+      providers: {
+        search: {
+          baseUrl: "https://google.serper.dev/search",
+          legacyKey: true,
+        },
+      },
+      collection: { perRunFetchBudget: 40 },
+      staleRoot: 1,
+    });
+
+    expect(stripped).toEqual({
+      providers: {
+        search: { baseUrl: "https://google.serper.dev/search" },
+      },
+      collection: { perRunFetchBudget: 40 },
+    });
+  });
+
+  it("preserves dynamic record keys when additionalProperties is an object schema", () => {
+    const recordSchema = {
+      type: "object",
+      properties: {},
+      additionalProperties: { type: "string" },
+    };
+
+    expect(
+      stripConfigToJsonSchema(recordSchema, {
+        customKey: "value",
+        extra: 1,
+      }),
+    ).toEqual({ customKey: "value" });
+  });
+});

--- a/apps/hermes/dashboard/lib/strip-config-to-json-schema.ts
+++ b/apps/hermes/dashboard/lib/strip-config-to-json-schema.ts
@@ -1,0 +1,140 @@
+type JsonSchemaNode = {
+  type?: string | string[];
+  properties?: Record<string, JsonSchemaNode>;
+  additionalProperties?: boolean | JsonSchemaNode;
+  items?: JsonSchemaNode | JsonSchemaNode[];
+};
+
+/**
+ * Resolves the primary JSON Schema type name when `type` is a string or array.
+ *
+ * @param schema - Schema node.
+ * @returns Primary type string, if any.
+ */
+const schemaType = (schema: JsonSchemaNode): string | undefined => {
+  const raw = schema.type;
+  if (Array.isArray(raw)) {
+    return raw[0];
+  }
+  return raw;
+};
+
+/**
+ * Strips a value to the shape described by a JSON Schema node (recursive for objects).
+ *
+ * @param schema - JSON Schema node.
+ * @param value - Raw config fragment.
+ * @returns Coerced value, or `undefined` when the value cannot be placed in the schema.
+ */
+const stripValueToSchema = (
+  schema: JsonSchemaNode,
+  value: unknown,
+): unknown => {
+  const type = schemaType(schema);
+
+  if (type === "object") {
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+      return undefined;
+    }
+    return stripObjectToSchema(schema, value as Record<string, unknown>);
+  }
+
+  if (type === "array") {
+    if (!Array.isArray(value)) {
+      return undefined;
+    }
+    const itemSchema = Array.isArray(schema.items)
+      ? schema.items[0]
+      : schema.items;
+    if (!itemSchema) {
+      return value;
+    }
+    return value
+      .map((entry) => stripValueToSchema(itemSchema, entry))
+      .filter((entry) => entry !== undefined);
+  }
+
+  if (type === "string" && typeof value !== "string") {
+    return undefined;
+  }
+  if (type === "number" && typeof value !== "number") {
+    return undefined;
+  }
+  if (type === "integer" && typeof value !== "number") {
+    return undefined;
+  }
+  if (type === "boolean" && typeof value !== "boolean") {
+    return undefined;
+  }
+
+  return value;
+};
+
+/**
+ * Strips an object to declared `properties`, optionally keeping dynamic keys when allowed.
+ *
+ * @param schema - Object schema node.
+ * @param value - Raw object.
+ * @returns Object containing only schema-allowed keys.
+ */
+const stripObjectToSchema = (
+  schema: JsonSchemaNode,
+  value: Record<string, unknown>,
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  if (schema.properties) {
+    for (const [key, propSchema] of Object.entries(schema.properties)) {
+      if (!Object.hasOwn(value, key)) {
+        continue;
+      }
+      const stripped = stripValueToSchema(propSchema, value[key]);
+      if (stripped !== undefined) {
+        result[key] = stripped;
+      }
+    }
+  }
+
+  const additional = schema.additionalProperties;
+  if (additional === true) {
+    for (const [key, entry] of Object.entries(value)) {
+      if (!Object.hasOwn(result, key)) {
+        result[key] = entry;
+      }
+    }
+    return result;
+  }
+
+  if (additional && typeof additional === "object") {
+    for (const [key, entry] of Object.entries(value)) {
+      if (Object.hasOwn(result, key)) {
+        continue;
+      }
+      const stripped = stripValueToSchema(additional, entry);
+      if (stripped !== undefined) {
+        result[key] = stripped;
+      }
+    }
+  }
+
+  return result;
+};
+
+/**
+ * Drops config keys that are not allowed by the agent config JSON Schema (AJV `additionalProperties: false`).
+ * Aligns Hermes save validation with Zod's strip behavior for regrouped agent configs.
+ *
+ * @param schema - Agent config schema from the registry.
+ * @param config - Config object from the Hermes form or database.
+ * @returns Config object containing only schema-declared properties.
+ */
+export const stripConfigToJsonSchema = (
+  schema: Record<string, unknown>,
+  config: Record<string, unknown>,
+): Record<string, unknown> => {
+  const node = schema as JsonSchemaNode;
+  if (schemaType(node) !== "object") {
+    return config;
+  }
+  return stripObjectToSchema(node, config);
+};

--- a/apps/mediapulse/agents/data-collection/README.md
+++ b/apps/mediapulse/agents/data-collection/README.md
@@ -46,4 +46,4 @@ See `config.example.jsonc` for the full default shape with placeholders.
 
 ### Breaking change
 
-The previous flat config keys (`webSearch`, `webFetch`, top-level gate fields, and so on) are no longer accepted. Stale stored configs with unknown keys are stripped by Zod and fall back to defaults; re-enter any custom tuning in the grouped form.
+The previous flat config keys (`webSearch`, `webFetch`, top-level gate fields, and so on) are no longer accepted. At invoke time, Zod strips unknown keys and applies defaults. When you save in Hermes, unknown keys are dropped to match the grouped JSON Schema (same as the form); re-enter any custom tuning in the grouped form or create a new saved config.

--- a/packages/shared/json-schema-form/src/schema-form-utils.test.ts
+++ b/packages/shared/json-schema-form/src/schema-form-utils.test.ts
@@ -206,6 +206,19 @@ describe("applySchemaDefaults", () => {
     expect(applySchemaDefaults(schema, {})).toEqual({ flag: false });
   });
 
+  it("drops top-level keys not declared in schema.properties", () => {
+    const schema: JsonSchema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+    };
+
+    expect(
+      applySchemaDefaults(schema, { name: "ok", legacyFlatKey: 10 }),
+    ).toEqual({ name: "ok" });
+  });
+
   it("is idempotent once defaults are applied", () => {
     const schema: JsonSchema = {
       type: "object",

--- a/packages/shared/json-schema-form/src/schema-form-utils.ts
+++ b/packages/shared/json-schema-form/src/schema-form-utils.ts
@@ -87,11 +87,14 @@ export const applySchemaDefaults = (
   if (!schema.properties) return value;
 
   const requiredSet = new Set(schema.required ?? []);
-  let changed = false;
-  const result = { ...value };
+  const hasUnknownKeys = Object.keys(value).some(
+    (key) => !Object.hasOwn(schema.properties!, key),
+  );
+  let changed = hasUnknownKeys;
+  const result: Record<string, unknown> = {};
 
   for (const [key, propSchema] of Object.entries(schema.properties)) {
-    const existing = result[key];
+    const existing = value[key];
     const declaredDefault = collectSchemaDefaults(propSchema);
 
     if (existing === undefined) {
@@ -117,12 +120,19 @@ export const applySchemaDefaults = (
         propSchema,
         existing as Record<string, unknown>,
       );
+      result[key] = nested;
       if (nested !== existing) {
-        result[key] = nested;
         changed = true;
       }
+      continue;
     }
+
+    result[key] = existing;
   }
 
-  return changed ? result : value;
+  if (!changed) {
+    return value;
+  }
+
+  return result;
 };


### PR DESCRIPTION
## Summary

Hermes was rejecting agent config saves when the JSON still had flat keys from before the grouped schemas landed. The registry schema only allows section objects now, so AJV reported dozens of "additional properties" errors. This change strips undeclared keys to match the schema before validation and storage, similar to how Zod already strips on invoke for data-collection.

## Related issues

Closes #580

Refs #573

Refs #579

## Important changes

- `stripConfigToJsonSchema` runs on agent config create/update before AJV validation; the stored row matches the schema.
- `applySchemaDefaults` in `@workspace/json-schema-form` no longer keeps top-level keys that are not in `properties`.
- data-collection README notes that Hermes save drops unknown keys (values under removed flat keys are not remapped).

## Other changes

- Unit tests for strip behavior with flat data-collection-shaped payloads and nested unknown fields.

## Key files to review

- `apps/hermes/dashboard/lib/strip-config-to-json-schema.ts` — recursive strip aligned with `additionalProperties: false`.
- `apps/hermes/dashboard/app/dashboard/agent-configs/actions/create/route.post.config.ts` — validate and persist stripped config.
- `apps/hermes/dashboard/app/dashboard/agent-configs/actions/update/route.post.config.ts` — same on update.
- `packages/shared/json-schema-form/src/schema-form-utils.ts` — form state no longer carries stale root keys.

## How to test

1. `cd apps/hermes/dashboard && pnpm test` and `cd packages/shared/json-schema-form && pnpm test` for the touched packages.
2. In Hermes, edit a saved data-collection or query-analysis config that still has flat keys in the DB (or paste flat JSON), save, and confirm validation passes.
3. Confirm the saved config JSON only has grouped section keys; re-enter any tuning that lived only under removed flat fields.
