### PR TITLE
Enable best-quality query-analysis defaults out of the box

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -49,30 +49,30 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
       kgTemplateCap: 6,
     });
     expect(parsed.prompting).toEqual({
-      personas: ["analyst", "retail", "regulator"],
+      personas: ["analyst", "retail", "regulator", "esg", "short_seller"],
       perPersonaQuotaCount: 3,
       fewShotExemplarCount: 3,
     });
     expect(parsed.creativity).toEqual({
       wildcardFraction: 0.1,
       wildcardTemperature: 1.2,
-      useBrainstormPass: false,
+      useBrainstormPass: true,
     });
     expect(parsed.quality.semanticDedupe).toEqual({
-      enabled: false,
+      enabled: true,
       threshold: 0.85,
       embeddingModel: "{{EMBEDDING_MODEL}}",
     });
     expect(parsed.quality.diversityGate).toEqual({
-      enabled: false,
+      enabled: true,
       threshold: 0.6,
       weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
     });
-    expect(parsed.quality.useSelfCritique).toBe(false);
+    expect(parsed.quality.useSelfCritique).toBe(true);
     expect(parsed.quality.critiqueDropFraction).toBe(0.25);
     expect(parsed.dynamics.temporalBias).toEqual({ enabled: true });
     expect(parsed.dynamics.yieldFeedback).toEqual({
-      enabled: false,
+      enabled: true,
       windowDays: 30,
       minTemplateYield: 0.05,
     });
@@ -291,9 +291,9 @@ describe("queryAnalysisConfigSchema sampling", () => {
 });
 
 describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
-  it("defaults useBrainstormPass to false and fewShotExemplarCount to 3", () => {
+  it("defaults useBrainstormPass to true and fewShotExemplarCount to 3", () => {
     const parsed = parseWithApiKey();
-    expect(parsed.creativity.useBrainstormPass).toBe(false);
+    expect(parsed.creativity.useBrainstormPass).toBe(true);
     expect(parsed.prompting.fewShotExemplarCount).toBe(3);
     expect(parsed.creativity.brainstormModel).toBeUndefined();
   });
@@ -318,12 +318,14 @@ describe("queryAnalysisConfigSchema brainstorm and few-shot", () => {
 });
 
 describe("queryAnalysisConfigSchema personas", () => {
-  it("defaults personas and perPersonaQuotaCount", () => {
+  it("defaults personas to all five library voices and perPersonaQuotaCount", () => {
     const parsed = parseWithApiKey();
     expect(parsed.prompting.personas).toEqual([
       "analyst",
       "retail",
       "regulator",
+      "esg",
+      "short_seller",
     ]);
     expect(parsed.prompting.perPersonaQuotaCount).toBe(3);
   });
@@ -338,9 +340,9 @@ describe("queryAnalysisConfigSchema personas", () => {
 });
 
 describe("queryAnalysisConfigSchema self-critique", () => {
-  it("defaults useSelfCritique to false and critiqueDropFraction to 0.25", () => {
+  it("defaults useSelfCritique to true and critiqueDropFraction to 0.25", () => {
     const parsed = parseWithApiKey();
-    expect(parsed.quality.useSelfCritique).toBe(false);
+    expect(parsed.quality.useSelfCritique).toBe(true);
     expect(parsed.quality.critiqueDropFraction).toBe(0.25);
     expect(parsed.quality.critiqueModel).toBeUndefined();
   });
@@ -368,10 +370,10 @@ describe("queryAnalysisConfigSchema self-critique", () => {
 });
 
 describe("queryAnalysisConfigSchema semanticDedupe", () => {
-  it("defaults semantic dedupe to disabled with placeholder embedding model", () => {
+  it("defaults semantic dedupe to enabled with placeholder embedding model", () => {
     const parsed = parseWithApiKey();
     expect(parsed.quality.semanticDedupe).toEqual({
-      enabled: false,
+      enabled: true,
       threshold: 0.85,
       embeddingModel: "{{EMBEDDING_MODEL}}",
     });
@@ -404,10 +406,10 @@ describe("queryAnalysisConfigSchema semanticDedupe", () => {
 });
 
 describe("queryAnalysisConfigSchema diversityGate", () => {
-  it("defaults diversity gate to disabled with recommended weights", () => {
+  it("defaults diversity gate to enabled with recommended weights", () => {
     const parsed = parseWithApiKey();
     expect(parsed.quality.diversityGate).toEqual({
-      enabled: false,
+      enabled: true,
       threshold: 0.6,
       weights: { lexical: 0.4, intent: 0.3, semantic: 0.3 },
     });
@@ -452,10 +454,10 @@ describe("queryAnalysisConfigSchema temporalBias", () => {
 });
 
 describe("queryAnalysisConfigSchema yieldFeedback", () => {
-  it("defaults yield feedback to disabled with a 30-day window", () => {
+  it("defaults yield feedback to enabled with a 30-day window", () => {
     const parsed = parseWithApiKey();
     expect(parsed.dynamics.yieldFeedback).toEqual({
-      enabled: false,
+      enabled: true,
       windowDays: 30,
       minTemplateYield: 0.05,
     });

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -72,7 +72,7 @@ const outputSchema = z
             .min(1)
             .optional()
             .describe(
-              "Optional deterministic pack override for this language; falls back to the global templates.templatePack.",
+              "Optional deterministic pack override for this language. Falls back to the global templates.templatePack.",
             ),
         }),
       )
@@ -84,7 +84,7 @@ const outputSchema = z
       .record(queryAnalysisIntentSchema, z.number().nonnegative())
       .optional()
       .describe(
-        "Relative weights keyed by intent for merge ordering and LLM target counts; omitted keys use contract defaults.",
+        "Relative weights keyed by intent for merge ordering and LLM target counts. Omitted keys use contract defaults.",
       ),
   })
   .default({})
@@ -137,7 +137,7 @@ const templatesSchema = z
       .enum(DETERMINISTIC_PACK_NAMES)
       .default(DEFAULT_DETERMINISTIC_PACK)
       .describe(
-        "Named deterministic template pack for the query floor; switch via Hermes without redeploying.",
+        "Named deterministic template pack for the query floor. Switch via Hermes without redeploying.",
       ),
     kgTemplateCap: z
       .number()
@@ -145,7 +145,7 @@ const templatesSchema = z
       .nonnegative()
       .default(6)
       .describe(
-        "Maximum KG relation rows expanded into deterministic templates per run; 0 disables KG expansion.",
+        "Maximum KG relation rows expanded into deterministic templates per run. Set 0 to disable KG expansion.",
       ),
   })
   .default({})
@@ -155,7 +155,7 @@ const promptingSchema = z
   .object({
     personas: z
       .array(z.string().min(1))
-      .default(["analyst", "retail", "regulator"])
+      .default(["analyst", "retail", "regulator", "esg", "short_seller"])
       .describe(
         "Persona ids from the in-process library to fan out parallel LLM calls.",
       ),
@@ -174,7 +174,7 @@ const promptingSchema = z
       .max(6)
       .default(3)
       .describe(
-        "Number of curated few-shot exemplars to inject; 0 disables exemplars.",
+        "Number of curated few-shot exemplars to inject. Set 0 to disable exemplars.",
       ),
   })
   .default({})
@@ -200,7 +200,7 @@ const creativitySchema = z
       ),
     useBrainstormPass: z
       .boolean()
-      .default(false)
+      .default(true)
       .describe(
         "When true, runs a free-form brainstorm pass before structured query generation.",
       ),
@@ -209,7 +209,7 @@ const creativitySchema = z
       .min(1)
       .optional()
       .describe(
-        "Model id for the brainstorm pass; omitted uses credentials.chatModel.",
+        "Model id for the brainstorm pass. If omitted, uses credentials.chatModel.",
       ),
   })
   .default({})
@@ -219,7 +219,7 @@ const semanticDedupeSchema = z
   .object({
     enabled: z
       .boolean()
-      .default(false)
+      .default(true)
       .describe(
         "When true, deduplicate LLM candidates via embedding cosine similarity before merge.",
       ),
@@ -245,7 +245,7 @@ const diversityGateSchema = z
   .object({
     enabled: z
       .boolean()
-      .default(false)
+      .default(true)
       .describe(
         "When true, run one broaden regenerate pass when the diversity composite is below threshold.",
       ),
@@ -285,7 +285,7 @@ const qualitySchema = z
   .object({
     useSelfCritique: z
       .boolean()
-      .default(false)
+      .default(true)
       .describe(
         "When true, runs a self-critique pass after LLM generation to replace the weakest rows.",
       ),
@@ -302,7 +302,7 @@ const qualitySchema = z
       .min(1)
       .optional()
       .describe(
-        "Model id for the critique pass; omitted uses credentials.chatModel.",
+        "Model id for the critique pass. If omitted, uses credentials.chatModel.",
       ),
     semanticDedupe: semanticDedupeSchema,
     diversityGate: diversityGateSchema,
@@ -326,7 +326,7 @@ const yieldFeedbackSchema = z
   .object({
     enabled: z
       .boolean()
-      .default(false)
+      .default(true)
       .describe(
         "When true, use rolling query-yield feedback in merge ranking, prompts, and template rotation.",
       ),

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -343,7 +343,10 @@ describe("query-analysis run", () => {
       await import("./llm-queries");
     const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
     const applySelfCritiquePassMock = vi.mocked(applySelfCritiquePass);
-    fetchBrainstormBulletsMock.mockResolvedValue(["macro angle", "supply risk"]);
+    fetchBrainstormBulletsMock.mockResolvedValue([
+      "macro angle",
+      "supply risk",
+    ]);
 
     const lowDiversityBatch = Array.from({ length: 10 }, () => ({
       text: "ABC latest news",

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -35,6 +35,7 @@ vi.mock("./llm-queries", async (importOriginal) => {
     fetchLlmQueryCandidatesByPersona: mockFetchQueryLlm,
     fetchWildcardCandidates: mockFetchWildcard,
     fetchBrainstormBullets: vi.fn(),
+    applySelfCritiquePass: vi.fn(),
   };
 });
 
@@ -73,6 +74,18 @@ const baseConfig = queryAnalysisConfigSchema.parse({
   credentials: { openaiApiKey: "sk" },
 });
 
+/** Disables quality passes so unrelated run tests stay focused and fast. */
+const conservativeConfig = queryAnalysisConfigSchema.parse({
+  credentials: { openaiApiKey: "sk" },
+  creativity: { useBrainstormPass: false },
+  quality: {
+    useSelfCritique: false,
+    semanticDedupe: { enabled: false },
+    diversityGate: { enabled: false },
+  },
+  dynamics: { yieldFeedback: { enabled: false } },
+});
+
 describe("query-analysis run", () => {
   beforeEach(async () => {
     mockGet.mockReset();
@@ -82,8 +95,16 @@ describe("query-analysis run", () => {
 
     mockFetchWildcard.mockResolvedValue([]);
 
-    const { fetchBrainstormBullets } = await import("./llm-queries");
+    const { fetchBrainstormBullets, applySelfCritiquePass } =
+      await import("./llm-queries");
     vi.mocked(fetchBrainstormBullets).mockReset();
+    vi.mocked(fetchBrainstormBullets).mockResolvedValue([]);
+    vi.mocked(applySelfCritiquePass).mockReset();
+    vi.mocked(applySelfCritiquePass).mockImplementation(async (params) => ({
+      candidates: params.candidates,
+      replacedCount: 0,
+      skippedDueToDeadline: false,
+    }));
 
     mockGet.mockResolvedValue(ctxResponse);
     mockCreate.mockResolvedValue({
@@ -120,7 +141,7 @@ describe("query-analysis run", () => {
     // Act
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
-      config: baseConfig,
+      config: conservativeConfig,
       token: "Bearer t",
       hermesCorrelation: { jobId: "job-abc" },
     });
@@ -134,7 +155,7 @@ describe("query-analysis run", () => {
   it("returns llmPromptFingerprint on success details", async () => {
     const result = await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
-      config: baseConfig,
+      config: conservativeConfig,
       token: "Bearer t",
     });
 
@@ -155,7 +176,7 @@ describe("query-analysis run", () => {
     // Act
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
-      config: baseConfig,
+      config: conservativeConfig,
       token: "Bearer t",
     });
 
@@ -177,7 +198,7 @@ describe("query-analysis run", () => {
     // Act
     const result = await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
-      config: baseConfig,
+      config: conservativeConfig,
       token: "Bearer t",
     });
 
@@ -204,6 +225,12 @@ describe("query-analysis run", () => {
       config: queryAnalysisConfigSchema.parse({
         credentials: { openaiApiKey: "sk" },
         creativity: { useBrainstormPass: true },
+        quality: {
+          useSelfCritique: false,
+          semanticDedupe: { enabled: false },
+          diversityGate: { enabled: false },
+        },
+        dynamics: { yieldFeedback: { enabled: false } },
       }),
       token: "Bearer t",
     });
@@ -224,14 +251,34 @@ describe("query-analysis run", () => {
     );
   });
 
-  it("defaults useBrainstormPass to false in the LLM orchestrator", async () => {
+  it("defaults useBrainstormPass to true in the LLM orchestrator", async () => {
+    const { fetchBrainstormBullets } = await import("./llm-queries");
+    const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
+    fetchBrainstormBulletsMock.mockResolvedValue(["macro angle"]);
+
+    // Act
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: baseConfig,
+      token: "Bearer t",
+    });
+
+    // Assert
+    expect(fetchBrainstormBulletsMock).toHaveBeenCalledTimes(1);
+    expect(mockFetchQueryLlm).toHaveBeenCalledWith(
+      expect.objectContaining({ brainstormBullets: ["macro angle"] }),
+      expect.anything(),
+    );
+  });
+
+  it("honors useBrainstormPass=false override in the LLM orchestrator", async () => {
     const { fetchBrainstormBullets } = await import("./llm-queries");
     const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
 
     // Act
     await runQueryAnalysis({
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
-      config: baseConfig,
+      config: conservativeConfig,
       token: "Bearer t",
     });
 
@@ -263,7 +310,11 @@ describe("query-analysis run", () => {
       input: { tickerId: "22222222-2222-4222-a222-222222222222" },
       config: queryAnalysisConfigSchema.parse({
         credentials: { openaiApiKey: "sk" },
-        quality: { diversityGate: { enabled: true, threshold: 0.6 } },
+        creativity: { useBrainstormPass: false },
+        quality: {
+          useSelfCritique: false,
+          semanticDedupe: { enabled: false },
+        },
       }),
       token: "Bearer t",
     });
@@ -285,6 +336,61 @@ describe("query-analysis run", () => {
     expect(
       createPayload.strategySnapshot.diversityGate?.diversityRegenerateFired,
     ).toBe(true);
+  });
+
+  it("runs best-quality default profile with brainstorm, critique, and diversity regenerate", async () => {
+    const { fetchBrainstormBullets, applySelfCritiquePass } =
+      await import("./llm-queries");
+    const fetchBrainstormBulletsMock = vi.mocked(fetchBrainstormBullets);
+    const applySelfCritiquePassMock = vi.mocked(applySelfCritiquePass);
+    fetchBrainstormBulletsMock.mockResolvedValue(["macro angle", "supply risk"]);
+
+    const lowDiversityBatch = Array.from({ length: 10 }, () => ({
+      text: "ABC latest news",
+      intent: "breaking" as const,
+      persona: "analyst",
+    }));
+    mockFetchQueryLlm
+      .mockResolvedValueOnce(lowDiversityBatch)
+      .mockResolvedValueOnce([
+        {
+          text: "ABC supply chain risk Q2",
+          intent: "supply_chain" as const,
+          persona: "retail",
+        },
+      ]);
+
+    applySelfCritiquePassMock.mockImplementation(async (params) => ({
+      candidates: params.candidates,
+      replacedCount: 1,
+      skippedDueToDeadline: false,
+    }));
+
+    const result = await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: baseConfig,
+      token: "Bearer t",
+    });
+
+    expect(result.success).toBe(true);
+    expect(fetchBrainstormBulletsMock).toHaveBeenCalledTimes(1);
+    expect(applySelfCritiquePassMock).toHaveBeenCalledTimes(1);
+    expect(mockFetchQueryLlm).toHaveBeenCalledTimes(2);
+
+    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+      strategySnapshot: {
+        useBrainstormPass?: boolean;
+        useSelfCritique?: boolean;
+        diversityGate?: { diversityRegenerateFired: boolean };
+        yieldFeedback?: { enabled: boolean };
+      };
+    };
+    expect(createPayload.strategySnapshot.useBrainstormPass).toBe(true);
+    expect(createPayload.strategySnapshot.useSelfCritique).toBe(true);
+    expect(
+      createPayload.strategySnapshot.diversityGate?.diversityRegenerateFired,
+    ).toBe(true);
+    expect(createPayload.strategySnapshot.yieldFeedback?.enabled).toBe(true);
   });
 
   it("persists wildcardFraction budget as wildcard intent rows", async () => {


### PR DESCRIPTION
## Summary

Empty Hermes config for query-analysis now runs the full quality pipeline: brainstorm, five personas, semantic dedupe, diversity gate, self-critique, and yield feedback. Operators no longer need to enable each pass by hand to get the best query set out of the box.

## Related issues

Closes #582

## Important changes

- Flip default booleans in `config-schema.ts`: `useBrainstormPass`, `useSelfCritique`, `semanticDedupe.enabled`, `diversityGate.enabled`, and `yieldFeedback.enabled` are all `true`.
- Expand default `prompting.personas` from three voices to all five library personas (adds `esg` and `short_seller`).
- Per-run LLM cost and latency go up; sampling and `fewShotExemplarCount` stay unchanged so diversity comes from structured passes, not hotter sampling.

## Other changes

- Add `conservativeConfig` in `run.test.ts` so unrelated run tests stay fast without quality passes firing.
- Add an end-to-end test that verifies brainstorm, critique, and diversity regenerate all run under schema defaults.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — default-value retune only; no generation logic changes.
- `apps/mediapulse/agents/query-analysis/src/config-schema.test.ts` — asserts the new profile from `{}`.
- `apps/mediapulse/agents/query-analysis/src/run.test.ts` — default-behavior and best-quality e2e coverage.

## How to test

1. `cd apps/mediapulse/agents/query-analysis && pnpm test`
2. Confirm `config-schema.test.ts` passes with all quality passes and five personas enabled from `{}`.
3. Confirm `run.test.ts` passes, including `runs best-quality default profile with brainstorm, critique, and diversity regenerate`.
4. In Hermes, open a new query-analysis agent config and confirm the form prefills with the flipped defaults (once schema defaults seed the form).
