### PR TITLE
Enable semantic dedupe by default for data-collection

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -593,7 +593,6 @@ describe("runDataCollection", () => {
           deduplication: {
             openaiApiKey: "sk-test",
             semantic: {
-              enabled: true,
               threshold: 0.88,
               windowDays: 7,
               embeddingModel: "text-embedding-3-small",
@@ -706,7 +705,6 @@ describe("runDataCollection", () => {
           deduplication: {
             openaiApiKey: "sk-test",
             semantic: {
-              enabled: true,
               threshold: 0.88,
               windowDays: 7,
               embeddingModel: "text-embedding-3-small",
@@ -731,6 +729,48 @@ describe("runDataCollection", () => {
     expect(createMock).toHaveBeenCalledWith([
       expect.objectContaining({ url: "http://example.com/vision" }),
     ]);
+    expect(recentSourceFingerprintsGetMock).toHaveBeenCalledWith({
+      tickerId: TICKER_ID,
+      windowDays: 7,
+    });
+  });
+
+  it("defaults semantic dedupe to enabled and calls embedTexts when openaiApiKey is resolved", async () => {
+    recentSourceFingerprintsGetMock.mockResolvedValueOnce({
+      fingerprints: [
+        {
+          id: "11111111-1111-4111-a111-111111111111",
+          title: "Bank Central Asia prior coverage",
+          headSnippet: "Earlier reporting on regional lending trends.",
+        },
+      ],
+    });
+    embedTextsMock.mockResolvedValueOnce([
+      [1, 0, 0],
+      [0, 1, 0],
+    ]);
+
+    await runDataCollection(
+      createContext({
+        config: withTestConfig({
+          deduplication: {
+            openaiApiKey: "sk-test",
+            semantic: {
+              embeddingModel: "text-embedding-3-small",
+            },
+          },
+          gates: {
+            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
+          },
+          runPolicy: {
+            minSuccessfulSources: 0,
+            failOnZeroSuccess: false,
+          },
+        }),
+      }),
+    );
+
+    expect(embedTextsMock).toHaveBeenCalled();
     expect(recentSourceFingerprintsGetMock).toHaveBeenCalledWith({
       tickerId: TICKER_ID,
       windowDays: 7,

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -95,7 +95,7 @@ describe("dataCollectionAgentConfigSchema", () => {
       errorRateThreshold: 0.5,
     });
     expect(parsed.deduplication.semantic).toEqual({
-      enabled: false,
+      enabled: true,
       threshold: 0.88,
       windowDays: 7,
       embeddingModel: "{{EMBEDDING_MODEL}}",

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -328,7 +328,7 @@ const resilienceSchema = z
 const semanticDedupeSchema = z.object({
   enabled: z
     .boolean()
-    .default(false)
+    .default(true)
     .describe(
       "When enabled, drop near-duplicate pages using embedding similarity against recent corpus fingerprints.",
     ),


### PR DESCRIPTION
## Summary

Empty `{}` data-collection config now turns on cross-run semantic deduplication by default. Near-duplicate pages get dropped via embedding similarity when credentials are set, so the corpus stays diverse without an operator flipping a knob. Coverage budgets, relevance/freshness gates, and resilience breakers are unchanged.

## Related issues

Closes #584

## Important changes

- `deduplication.semantic.enabled` defaults to `true` (threshold 0.88, window 7 days, `{{EMBEDDING_MODEL}}` unchanged).
- When `openaiApiKey` is still a Hermes placeholder, the run logs a warning and falls back to URL-only dedupe — same safe degradation as before.

## Other changes

- Config schema test expects semantic dedupe on from `{}`.
- Run test confirms embedding calls fire under the new default when a resolved API key is present.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — the single default flip.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts` — empty-config profile assertions.
- `apps/mediapulse/agents/data-collection/src/run.test.ts` — default-on dedupe behavior and existing semantic dedupe cases.

## How to test

1. `pnpm --filter @mediapulse/data-collection test`
2. Parse `{}` with `dataCollectionAgentConfigSchema` and confirm `deduplication.semantic.enabled === true`.
3. Run data-collection with Variables resolved for `OPENAI_API_KEY` and `EMBEDDING_MODEL`; check logs for semantic dedupe activity (or `droppedBySemanticDedupe` in run summary when duplicates exist).
