### PR TITLE
Drop unsupported sampling config from query-analysis

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -34,16 +34,11 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
     ]);
     expect(parsed.credentials).toEqual({
       openaiApiKey: "{{OPENAI_API_KEY}}",
-      chatModel: "{{QUERY_ANALYSIS_MODEL}}",
+      chatModel: "{{OPENAI_MODEL}}",
     });
     expect(parsed.output.queryCount).toBe(10);
     expect(parsed.output.languageQuotas).toBeUndefined();
-    expect(parsed.sampling).toEqual({
-      temperature: 0.9,
-      topP: 0.95,
-      presencePenalty: 0.4,
-      frequencyPenalty: 0.5,
-    });
+    expect(parsed.sampling).toEqual({});
     expect(parsed.templates).toEqual({
       templatePack: "default-v1",
       kgTemplateCap: 6,
@@ -55,7 +50,6 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
     });
     expect(parsed.creativity).toEqual({
       wildcardFraction: 0.1,
-      wildcardTemperature: 1.2,
       useBrainstormPass: true,
     });
     expect(parsed.quality.semanticDedupe).toEqual({
@@ -82,7 +76,7 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
     const parsed = queryAnalysisConfigSchema.parse({});
 
     expect(parsed.credentials.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
-    expect(parsed.credentials.chatModel).toBe("{{QUERY_ANALYSIS_MODEL}}");
+    expect(parsed.credentials.chatModel).toBe("{{OPENAI_MODEL}}");
     expect(parsed.quality.semanticDedupe.embeddingModel).toBe(
       "{{EMBEDDING_MODEL}}",
     );
@@ -93,7 +87,6 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
       "openaiApiKey",
       "openaiModel",
       "queryCount",
-      "temperature",
       "templatePack",
       "semanticDedupe",
       "diversityGate",
@@ -239,41 +232,10 @@ describe("queryAnalysisConfigSchema strict mode", () => {
 });
 
 describe("queryAnalysisConfigSchema sampling", () => {
-  it("defaults creativity sampling fields", () => {
+  it("defaults to no sampling overrides", () => {
     const parsed = parseWithApiKey();
-    expect(parsed.sampling.temperature).toBe(0.9);
-    expect(parsed.sampling.topP).toBe(0.95);
-    expect(parsed.sampling.presencePenalty).toBe(0.4);
-    expect(parsed.sampling.frequencyPenalty).toBe(0.5);
+    expect(parsed.sampling).toEqual({});
     expect(parsed.sampling.seed).toBeUndefined();
-  });
-
-  it("rejects temperature above 2", () => {
-    const result = queryAnalysisConfigSchema.safeParse({
-      credentials: { openaiApiKey: "sk-test" },
-      sampling: { temperature: 2.1 },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) => issue.path.includes("temperature")),
-      ).toBe(true);
-    }
-  });
-
-  it("rejects presencePenalty above 2", () => {
-    const result = queryAnalysisConfigSchema.safeParse({
-      credentials: { openaiApiKey: "sk-test" },
-      sampling: { presencePenalty: 3 },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((issue) =>
-          issue.path.includes("presencePenalty"),
-        ),
-      ).toBe(true);
-    }
   });
 
   it("rejects non-integer seed values", () => {

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -35,9 +35,9 @@ const credentialsSchema = z
     chatModel: z
       .string()
       .min(1)
-      .default("{{QUERY_ANALYSIS_MODEL}}")
+      .default("{{OPENAI_MODEL}}")
       .describe(
-        "Chat model id for query generation (e.g. gpt-4o-mini) or a Hermes variable placeholder such as {{QUERY_ANALYSIS_MODEL}}.",
+        "Chat model id for query generation (e.g. gpt-4o-mini) or a Hermes variable placeholder such as {{OPENAI_MODEL}}.",
       ),
   })
   .default({})
@@ -92,44 +92,16 @@ const outputSchema = z
 
 const samplingSchema = z
   .object({
-    temperature: z
-      .number()
-      .min(0)
-      .max(2)
-      .default(0.9)
-      .describe("LLM sampling temperature (higher = more varied phrasing)."),
-    topP: z
-      .number()
-      .min(0)
-      .max(1)
-      .default(0.95)
-      .describe("Nucleus sampling top-p cutoff."),
-    presencePenalty: z
-      .number()
-      .min(-2)
-      .max(2)
-      .default(0.4)
-      .describe(
-        "Penalizes tokens already present in the output (encourages new topics).",
-      ),
-    frequencyPenalty: z
-      .number()
-      .min(-2)
-      .max(2)
-      .default(0.5)
-      .describe(
-        "Penalizes tokens by prior frequency in the output (reduces repetition).",
-      ),
     seed: z
       .number()
       .int()
       .optional()
       .describe(
-        "Optional fixed seed for reproducible LLM output during regression hunts.",
+        "Optional fixed seed for reproducible LLM output when the model supports it.",
       ),
   })
   .default({})
-  .describe("OpenAI sampling knobs shared by standard and wildcard LLM calls.");
+  .describe("Optional LLM reproducibility settings.");
 
 const templatesSchema = z
   .object({
@@ -190,14 +162,6 @@ const creativitySchema = z
       .describe(
         "Fraction of each query set reserved for stochastic wildcard (lateral) queries.",
       ),
-    wildcardTemperature: z
-      .number()
-      .min(0)
-      .max(2)
-      .default(1.2)
-      .describe(
-        "Sampling temperature for wildcard generation (defaults higher than sampling.temperature).",
-      ),
     useBrainstormPass: z
       .boolean()
       .default(true)
@@ -209,7 +173,7 @@ const creativitySchema = z
       .min(1)
       .optional()
       .describe(
-        "Model id for the brainstorm pass. If omitted, uses credentials.chatModel.",
+        "Model id for the brainstorm pass. If omitted, uses credentials.chatModel (default {{OPENAI_MODEL}}).",
       ),
   })
   .default({})
@@ -302,7 +266,7 @@ const qualitySchema = z
       .min(1)
       .optional()
       .describe(
-        "Model id for the critique pass. If omitted, uses credentials.chatModel.",
+        "Model id for the critique pass. If omitted, uses credentials.chatModel (default {{OPENAI_MODEL}}).",
       ),
     semanticDedupe: semanticDedupeSchema,
     diversityGate: diversityGateSchema,

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -100,12 +100,7 @@ describe("QUERY_ANALYSIS_MAX_OUTPUT_TOKENS", () => {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
         messages: [{ role: "user", content: "hi" }],
-        sampling: {
-          temperature: 0.9,
-          topP: 0.95,
-          presencePenalty: 0.4,
-          frequencyPenalty: 0.5,
-        },
+        sampling: {},
       },
       { generateObjectForQueries },
     );
@@ -420,12 +415,7 @@ describe("fetchBrainstormBullets", () => {
           recentThemes: [],
           ...emptyEnrichedContext,
         },
-        sampling: {
-          temperature: 0.9,
-          topP: 0.95,
-          presencePenalty: 0.4,
-          frequencyPenalty: 0.5,
-        },
+        sampling: {},
       },
       { generateTextForBrainstorm },
     );
@@ -463,12 +453,7 @@ describe("fetchQueryAnalysisLlmCandidates", () => {
         fundamental: 0.6,
       },
     },
-    sampling: {
-      temperature: 0.9,
-      topP: 0.95,
-      presencePenalty: 0.4,
-      frequencyPenalty: 0.5,
-    },
+    sampling: {},
     fewShotExemplarCount: 0,
   };
 
@@ -575,12 +560,7 @@ describe("applySelfCritiqueToCandidateBatch", () => {
     },
     dropFraction: 0.3,
     fewShotExemplarCount: 0,
-    sampling: {
-      temperature: 0.9,
-      topP: 0.95,
-      presencePenalty: 0.4,
-      frequencyPenalty: 0.5,
-    },
+    sampling: {},
   };
 
   const tenCandidates = Array.from({ length: 10 }, (_, index) => ({
@@ -691,12 +671,7 @@ describe("regenerateDroppedQueries", () => {
         keptCandidates: [],
         dropCount: 0,
         fewShotExemplarCount: 0,
-        sampling: {
-          temperature: 0.9,
-          topP: 0.95,
-          presencePenalty: 0.4,
-          frequencyPenalty: 0.5,
-        },
+        sampling: {},
       },
       { fetchLlmQueryCandidates: fetchLlmQueryCandidatesSpy },
     );
@@ -715,12 +690,7 @@ describe("fetchLlmQueryCandidatesByPersona", () => {
     personas,
     perPersonaQuota: 3,
     fewShotExemplarCount: 0,
-    sampling: {
-      temperature: 0.9,
-      topP: 0.95,
-      presencePenalty: 0.4,
-      frequencyPenalty: 0.5,
-    },
+    sampling: {},
   };
 
   it("calls generateObject once per persona and tags results", async () => {
@@ -803,12 +773,7 @@ describe("fetchLlmQueryCandidatesByPersona", () => {
 });
 
 describe("fetchLlmQueryCandidates", () => {
-  const defaultSampling = {
-    temperature: 0.9,
-    topP: 0.95,
-    presencePenalty: 0.4,
-    frequencyPenalty: 0.5,
-  };
+  const defaultSampling = {};
 
   afterEach(() => {
     vi.restoreAllMocks();
@@ -841,7 +806,7 @@ describe("fetchLlmQueryCandidates", () => {
     expect(generateObjectForQueries).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards default sampling fields to generateObject", async () => {
+  it("omits unsupported sampling fields from generateObject", async () => {
     // Setup
     const generateObjectForQueries = vi.fn().mockResolvedValue({
       object: { queries: [] },
@@ -859,17 +824,15 @@ describe("fetchLlmQueryCandidates", () => {
     );
 
     // Assert
-    expect(generateObjectForQueries).toHaveBeenCalledWith(
-      expect.objectContaining({
-        temperature: 0.9,
-        topP: 0.95,
-        presencePenalty: 0.4,
-        frequencyPenalty: 0.5,
-      }),
-    );
-    expect(generateObjectForQueries.mock.calls[0]?.[0]).not.toHaveProperty(
-      "seed",
-    );
+    const callArgs = generateObjectForQueries.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs).not.toHaveProperty("temperature");
+    expect(callArgs).not.toHaveProperty("topP");
+    expect(callArgs).not.toHaveProperty("presencePenalty");
+    expect(callArgs).not.toHaveProperty("frequencyPenalty");
+    expect(callArgs).not.toHaveProperty("seed");
   });
 
   it("forwards custom seed to generateObject when set", async () => {
@@ -884,7 +847,7 @@ describe("fetchLlmQueryCandidates", () => {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
         messages: [{ role: "user", content: "hi" }],
-        sampling: { ...defaultSampling, seed: 42 },
+        sampling: { seed: 42 },
       },
       { generateObjectForQueries },
     );
@@ -915,12 +878,7 @@ describe("fetchLlmQueryCandidates", () => {
 });
 
 describe("fetchWildcardCandidates", () => {
-  const defaultSampling = {
-    temperature: 0.9,
-    topP: 0.95,
-    presencePenalty: 0.4,
-    frequencyPenalty: 0.5,
-  };
+  const defaultSampling = {};
 
   const baseContext = {
     ticker: {
@@ -939,7 +897,7 @@ describe("fetchWildcardCandidates", () => {
     vi.restoreAllMocks();
   });
 
-  it("passes wildcardTemperature instead of global temperature to generateObject", async () => {
+  it("omits unsupported sampling fields from wildcard generateObject", async () => {
     const generateObjectForWildcards = vi.fn().mockResolvedValue({
       object: {
         queries: [{ text: "Oblique supply rumor" }],
@@ -954,20 +912,18 @@ describe("fetchWildcardCandidates", () => {
         context: baseContext,
         allowedLanguages: ["en"],
         sampling: defaultSampling,
-        wildcardTemperature: 1.2,
       },
       { generateObjectForWildcards },
     );
 
-    expect(generateObjectForWildcards).toHaveBeenCalledWith(
-      expect.objectContaining({
-        temperature: 1.2,
-        topP: 0.95,
-      }),
-    );
-    expect(generateObjectForWildcards.mock.calls[0]?.[0].temperature).not.toBe(
-      defaultSampling.temperature,
-    );
+    const callArgs = generateObjectForWildcards.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs).not.toHaveProperty("temperature");
+    expect(callArgs).not.toHaveProperty("topP");
+    expect(callArgs).not.toHaveProperty("presencePenalty");
+    expect(callArgs).not.toHaveProperty("frequencyPenalty");
   });
 
   it("tags rows with wildcard intent and respects count cap", async () => {
@@ -989,7 +945,6 @@ describe("fetchWildcardCandidates", () => {
         context: baseContext,
         allowedLanguages: ["en"],
         sampling: defaultSampling,
-        wildcardTemperature: 1.2,
       },
       { generateObjectForWildcards },
     );

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -379,22 +379,19 @@ export const buildStructuredQueryMessages = (options: {
 };
 
 export type LlmQuerySampling = {
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
 };
+
+/** Returns optional seed fields for AI SDK calls when configured. */
+const llmSamplingOptions = (sampling: LlmQuerySampling): { seed?: number } => ({
+  ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+});
 
 export type GenerateObjectForWildcards = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmWildcardOutputSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
 }) => Promise<{ object: z.infer<typeof llmWildcardOutputSchema> }>;
 
@@ -403,10 +400,6 @@ export type GenerateObjectForQueries = (args: {
   schema: typeof llmQueriesOutputSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
 }) => Promise<{ object: z.infer<typeof llmQueriesOutputSchema> }>;
 
@@ -415,10 +408,6 @@ export type GenerateObjectForCritique = (args: {
   schema: typeof llmCritiqueOutputSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
 }) => Promise<{ object: z.infer<typeof llmCritiqueOutputSchema> }>;
 
@@ -426,10 +415,6 @@ export type GenerateTextForBrainstorm = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   messages: ModelMessage[];
   maxOutputTokens: number;
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
 }) => Promise<{ text: string }>;
 
@@ -457,7 +442,6 @@ export const fetchBrainstormBullets = async (
     params.strategy,
     params.context,
   );
-  const { sampling } = params;
   const { text } = await deps.generateTextForBrainstorm({
     model: openai(params.model),
     messages: [
@@ -465,11 +449,7 @@ export const fetchBrainstormBullets = async (
       { role: "user", content: user },
     ],
     maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
-    temperature: sampling.temperature,
-    topP: sampling.topP,
-    presencePenalty: sampling.presencePenalty,
-    frequencyPenalty: sampling.frequencyPenalty,
-    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+    ...llmSamplingOptions(params.sampling),
   });
   return parseBrainstormBullets(text);
 };
@@ -494,17 +474,12 @@ export const fetchLlmQueryCandidates = async (
   },
 ): Promise<Array<{ text: string; intent: QueryAnalysisIntent }>> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
-  const { sampling } = params;
   const { object } = await deps.generateObjectForQueries({
     model: openai(params.model),
     schema: llmQueriesOutputSchema,
     maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
     messages: params.messages,
-    temperature: sampling.temperature,
-    topP: sampling.topP,
-    presencePenalty: sampling.presencePenalty,
-    frequencyPenalty: sampling.frequencyPenalty,
-    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+    ...llmSamplingOptions(params.sampling),
   });
   return (object.queries ?? [])
     .map((q) => ({ text: q.text.trim(), intent: q.intent }))
@@ -569,7 +544,7 @@ export const buildWildcardUserContentWithAvoidNudge = (
 /**
  * Calls the chat model with minimal structured output for wildcard query slots.
  *
- * @param params - API key, model, token budget, count, context, sampling, and wildcard temperature.
+ * @param params - API key, model, token budget, count, context, and optional seed.
  * @param deps - Injectable `generateObject` (default: production `generateObject` from `ai`).
  * @returns Trimmed wildcard candidate rows tagged with `intent: "wildcard"`.
  */
@@ -581,7 +556,6 @@ export const fetchWildcardCandidates = async (
     context: GetQueryAnalysisResponse;
     allowedLanguages: string[];
     sampling: LlmQuerySampling;
-    wildcardTemperature: number;
     avoidTexts?: string[];
   },
   deps: { generateObjectForWildcards: GenerateObjectForWildcards } = {
@@ -589,7 +563,6 @@ export const fetchWildcardCandidates = async (
   },
 ): Promise<Array<{ text: string; intent: "wildcard" }>> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
-  const { sampling } = params;
   const systemContent = resolveWildcardSystemContent(
     params.count,
     params.allowedLanguages,
@@ -606,11 +579,7 @@ export const fetchWildcardCandidates = async (
       { role: "system", content: systemContent },
       { role: "user", content: userContent },
     ],
-    temperature: params.wildcardTemperature,
-    topP: sampling.topP,
-    presencePenalty: sampling.presencePenalty,
-    frequencyPenalty: sampling.frequencyPenalty,
-    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+    ...llmSamplingOptions(params.sampling),
   });
   return (object.queries ?? [])
     .map((q) => ({ text: q.text.trim(), intent: "wildcard" as const }))
@@ -879,7 +848,6 @@ export const critiqueQueryCandidates = async (
     "Queries to critique:",
     formatCandidatesForCritique(params.candidates),
   ].join("\n");
-  const { sampling } = params;
   const { object } = await deps.generateObjectForCritique({
     model: openai(params.model),
     schema: llmCritiqueOutputSchema,
@@ -891,11 +859,7 @@ export const critiqueQueryCandidates = async (
       },
       { role: "user", content: userContent },
     ],
-    temperature: sampling.temperature,
-    topP: sampling.topP,
-    presencePenalty: sampling.presencePenalty,
-    frequencyPenalty: sampling.frequencyPenalty,
-    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+    ...llmSamplingOptions(params.sampling),
   });
   return object.ratings ?? [];
 };

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -86,28 +86,14 @@ export const deriveMinDeterministicCount = (queryCount: number): number =>
   Math.max(2, Math.floor(queryCount * 0.4));
 
 /**
- * Builds the sampling object shared by standard and wildcard LLM calls.
+ * Builds optional LLM reproducibility options from parsed invoke config.
  *
- * @param config - Parsed invoke config with sampling fields.
- * @returns Sampling knobs for LLM calls.
+ * @param config - Parsed `sampling` group (seed only; temperature/top-p/penalties omitted for reasoning models).
+ * @returns Sampling options forwarded to AI SDK calls when supported.
  */
 export const buildLlmSamplingFromConfig = (config: {
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
   seed?: number;
-}): {
-  temperature: number;
-  topP: number;
-  presencePenalty: number;
-  frequencyPenalty: number;
-  seed?: number;
-} => ({
-  temperature: config.temperature,
-  topP: config.topP,
-  presencePenalty: config.presencePenalty,
-  frequencyPenalty: config.frequencyPenalty,
+}): { seed?: number } => ({
   ...(config.seed !== undefined ? { seed: config.seed } : {}),
 });
 
@@ -671,7 +657,6 @@ export const runQueryAnalysis = async (
   const kgTemplateCap = templates.kgTemplateCap;
   const queryCount = output.queryCount;
   const wildcardFraction = creativity.wildcardFraction;
-  const wildcardTemperature = creativity.wildcardTemperature;
   const wildcardCount = computeWildcardCount(queryCount, wildcardFraction);
   const standardQueryCount = queryCount - wildcardCount;
   const languageQuotas = resolveLanguageQuotas(output);
@@ -694,8 +679,7 @@ export const runQueryAnalysis = async (
     );
   }
   const openaiModel = credentials.chatModel;
-  const { temperature, topP, presencePenalty, frequencyPenalty, seed } =
-    sampling;
+  const { seed } = sampling;
   const useBrainstormPass = creativity.useBrainstormPass;
   const fewShotExemplarCount = prompting.fewShotExemplarCount;
   const brainstormModel = creativity.brainstormModel ?? openaiModel;
@@ -852,7 +836,6 @@ export const runQueryAnalysis = async (
         context: queryContext,
         allowedLanguages: wildcardLanguages,
         sampling: llmSampling,
-        wildcardTemperature,
       });
     } catch (error) {
       logger.warn(
@@ -876,7 +859,6 @@ export const runQueryAnalysis = async (
                   context: queryContext,
                   allowedLanguages: wildcardLanguages,
                   sampling: llmSampling,
-                  wildcardTemperature,
                   avoidTexts,
                 });
               } catch (error) {
@@ -899,7 +881,6 @@ export const runQueryAnalysis = async (
   const strategySnapshot = {
     queryCount,
     wildcardFraction,
-    wildcardTemperature,
     wildcardCount,
     kgTemplateCap,
     languageQuotas,
@@ -914,10 +895,6 @@ export const runQueryAnalysis = async (
         }
       : {}),
     model: openaiModel,
-    temperature,
-    topP,
-    presencePenalty,
-    frequencyPenalty,
     useBrainstormPass,
     fewShotExemplarCount,
     personas: personaIds,


### PR DESCRIPTION
## Summary

Query-analysis no longer exposes or forwards sampling knobs that reasoning models reject. Chat model defaults now point at `{{OPENAI_MODEL}}`, and LLM calls only pass an optional seed when configured.

## Related issues

Closes #586

## Important changes

- `credentials.chatModel` defaults to `{{OPENAI_MODEL}}` instead of `{{QUERY_ANALYSIS_MODEL}}`.
- Removed `temperature`, `topP`, `presencePenalty`, `frequencyPenalty`, and `wildcardTemperature` from the Hermes config schema.
- Brainstorm, structured, critique, and wildcard calls no longer send those fields to the AI SDK.

## Other changes

- `sampling` group retains optional `seed` only.
- Strategy snapshots no longer record removed sampling fields.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — schema defaults and removed fields.
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — LLM call sites no longer pass unsupported params.
- `apps/mediapulse/agents/query-analysis/src/run.ts` — strategy snapshot and wildcard wiring.

## How to test

1. `pnpm --filter @mediapulse/query-analysis test`
2. Run query-analysis with a reasoning model (e.g. `gpt-5.4-mini`) and confirm AI SDK no longer warns about temperature, top-p, or penalties.
3. Parse `{}` and verify `credentials.chatModel === "{{OPENAI_MODEL}}"`.
