### PR TITLE
Fix Hermes worker batch stall on invoke_agent jobs

### DIFF
--- a/apps/hermes/worker/src/cleanup-orphaned-executions.test.ts
+++ b/apps/hermes/worker/src/cleanup-orphaned-executions.test.ts
@@ -90,7 +90,7 @@ describe("cleanupOrphanedExecutions", () => {
     expect(cutoff.getTime()).toBeLessThanOrEqual(after - 30 * 60 * 1_000 + 100);
   });
 
-  it("uses DEFAULT_ORPHAN_THRESHOLD_MINUTES (60) when thresholdMinutes is omitted", async () => {
+  it("uses DEFAULT_ORPHAN_THRESHOLD_MINUTES (35) when thresholdMinutes is omitted", async () => {
     // Setup
     const before = Date.now();
     mockFindMany.mockResolvedValue([]);
@@ -281,7 +281,7 @@ describe("cleanupOrphanedExecutions", () => {
 
     // Assert
     expect(deps.logger.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ count: 1, thresholdMinutes: 60 }),
+      expect.objectContaining({ count: 1, thresholdMinutes: 35 }),
       "cleanup_orphaned_executions: found stuck running rows",
     );
   });

--- a/apps/hermes/worker/src/cleanup-orphaned-executions.ts
+++ b/apps/hermes/worker/src/cleanup-orphaned-executions.ts
@@ -8,7 +8,7 @@ import {
 } from "@hermes/scheduler";
 
 /** Minimum orphan age in minutes before a record is eligible for cleanup. */
-export const DEFAULT_ORPHAN_THRESHOLD_MINUTES = 60;
+export const DEFAULT_ORPHAN_THRESHOLD_MINUTES = 35;
 
 /**
  * Dependencies for {@link cleanupOrphanedExecutions}.

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -11,7 +11,12 @@ import {
 } from "@hermes/scheduler";
 import { logger } from "@workspace/logger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
-import { jobHandlers } from "./job-handlers";
+import {
+  DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+  jobHandlers,
+  resolveDataQueueJob,
+  resolveInvokeAgentJobTimeoutMs,
+} from "./job-handlers";
 
 const mockPrisma = vi.hoisted(() => ({
   agentJobExecution: {
@@ -63,6 +68,7 @@ vi.mock("@hermes/env/hermes-worker", () => ({
     HERMES_INVOKE_AGENT_RETRY_DELAY: undefined as string | undefined,
     HERMES_INVOKE_AGENT_RETRY_BACKOFF: undefined as string | undefined,
     HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: undefined as string | undefined,
+    HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS: undefined as string | undefined,
   },
 }));
 
@@ -93,8 +99,7 @@ vi.mock("@hermes/scheduler", async (importOriginal) => {
 });
 
 const mockAddJobs = vi.fn().mockResolvedValue([1]);
-const mockEditJob = vi.fn().mockResolvedValue(undefined);
-const mockGetJob = vi.fn();
+const mockPoolQuery = vi.fn();
 
 vi.mock("./cleanup-orphaned-executions", () => ({
   cleanupOrphanedExecutions: vi.fn().mockResolvedValue(0),
@@ -103,8 +108,9 @@ vi.mock("./cleanup-orphaned-executions", () => ({
 vi.mock("./queue", () => ({
   getJobQueue: () => ({
     addJobs: mockAddJobs,
-    editJob: mockEditJob,
-    getJob: mockGetJob,
+    getPool: () => ({
+      query: mockPoolQuery,
+    }),
   }),
 }));
 
@@ -114,9 +120,9 @@ describe("jobHandlers", () => {
     vi.mocked(executeSchedule).mockClear();
     vi.mocked(logger.error).mockClear();
     mockAddJobs.mockClear();
-    mockEditJob.mockClear();
-    mockGetJob.mockClear();
+    mockPoolQuery.mockClear();
     mockAddJobs.mockResolvedValue([1]);
+    mockPoolQuery.mockResolvedValue({ rows: [] });
   });
 
   afterEach(() => {
@@ -224,13 +230,74 @@ describe("jobHandlers", () => {
         idempotencyKey: "j1",
         timeoutMs: 60_000,
       });
-      expect(mockEditJob).toHaveBeenCalledTimes(1);
-      expect(mockEditJob).toHaveBeenCalledWith(1, {
-        payload: expect.objectContaining({
-          jobId: "j1",
-          hermesDataQueueJobId: 1,
-        }),
+    });
+
+    it("caps DataQueue job timeoutMs at DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS when agent timeout is larger", async () => {
+      const { prisma } = await import("@hermes/orchestration-database");
+      const fakeSchedule = {
+        id: "schedule-cap",
+        enabled: true,
+        nextRunAt: new Date(),
+        pipelineId: "pipeline-cap",
+        cronExpression: "0 * * * *",
+        timezone: "UTC",
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        pipeline: {
+          id: "pipeline-cap",
+          name: "Test",
+          domainIntegrationId: "di-1",
+          executionConfig: null,
+          steps: [],
+        },
+      } as unknown as Awaited<ReturnType<typeof getDueSchedules>>[number];
+      vi.mocked(getDueSchedules).mockResolvedValue([fakeSchedule]);
+      vi.mocked(executeSchedule).mockImplementation(async (_schedule, deps) => {
+        await deps.enqueueAgentInvocations([
+          {
+            payload: {
+              jobId: "j-cap",
+              executionId: "e-cap",
+              scheduleExecutionId: "se-cap",
+              scheduleId: "s-cap",
+              pipelineId: "p-cap",
+              pipelineStepId: "st-cap",
+              domainIntegrationId: "di-1",
+              agentId: "a1",
+              agentVersion: "1.0.0",
+              endpointUrl: "https://a.example/",
+              body: { input: {}, config: {} },
+              timeoutMs: 7_200_000,
+              priority: 0,
+            },
+          },
+        ]);
       });
+
+      await jobHandlers.check_schedules(
+        {},
+        new AbortController().signal,
+        {} as Parameters<typeof jobHandlers.check_schedules>[2],
+      );
+
+      expect(executeSchedule).toHaveBeenCalledWith(fakeSchedule, {
+        db: prisma,
+        logger,
+        enqueueAgentInvocations: expect.any(Function),
+        expandStepInputs: expect.any(Function),
+        defaultTimeoutMs: 300_000,
+        variableSecretMasterKey: "test-internal-hermes-key",
+        variableSecretFallbackMasterKey: undefined,
+        requireHttpsAgentEndpoints: false,
+      });
+      const jobOptions = mockAddJobs.mock.calls[0]![0] as Array<{
+        timeoutMs: number;
+        payload: { timeoutMs: number };
+      }>;
+      expect(jobOptions[0]!.timeoutMs).toBe(
+        DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+      );
+      expect(jobOptions[0]!.payload.timeoutMs).toBe(7_200_000);
     });
 
     it("logs error and continues when executeSchedule throws for a schedule", async () => {
@@ -557,10 +624,9 @@ describe("jobHandlers", () => {
       );
     });
 
-    it("syncs DataQueue attempts after claim when hermesDataQueueJobId is set", async () => {
-      mockGetJob.mockResolvedValueOnce({
-        attempts: 2,
-        maxAttempts: 5,
+    it("syncs DataQueue attempts after claim via idempotency key lookup", async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 42, attempts: 2, max_attempts: 5 }],
       });
       vi.mocked(invokeAgentPost).mockResolvedValue({
         kind: "http",
@@ -579,13 +645,12 @@ describe("jobHandlers", () => {
         },
       });
 
-      await jobHandlers.invoke_agent(
-        { ...payload, hermesDataQueueJobId: 42 },
-        signal,
-        jobCtx,
-      );
+      await jobHandlers.invoke_agent(payload, signal, jobCtx);
 
-      expect(mockGetJob).toHaveBeenCalledWith(42);
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("idempotency_key"),
+        [payload.jobId],
+      );
       expect(mockPrisma.agentJobExecution.update).toHaveBeenCalledWith({
         where: { jobId: payload.jobId },
         data: {
@@ -595,7 +660,7 @@ describe("jobHandlers", () => {
       });
     });
 
-    it("updates to failed and rethrows on transport error when hermesDataQueueJobId is absent (legacy)", async () => {
+    it("updates to failed and rethrows on transport error when DataQueue row is missing", async () => {
       vi.mocked(invokeAgentPost).mockResolvedValue({
         kind: "transport_error",
         error: new Error("Network error"),
@@ -606,7 +671,7 @@ describe("jobHandlers", () => {
       ).rejects.toThrow("Network error");
 
       expect(invokeAgentPost).toHaveBeenCalledTimes(1);
-      expect(mockGetJob).not.toHaveBeenCalled();
+      expect(mockPoolQuery).toHaveBeenCalled();
       expect(mockPrisma.agentJobExecution.update).toHaveBeenCalledWith({
         where: { jobId: payload.jobId },
         data: {
@@ -622,20 +687,18 @@ describe("jobHandlers", () => {
         kind: "transport_error",
         error: new Error("Network error"),
       });
-      mockGetJob.mockResolvedValue({
-        attempts: 1,
-        maxAttempts: 3,
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ id: 42, attempts: 1, max_attempts: 3 }],
       });
 
       await expect(
-        jobHandlers.invoke_agent(
-          { ...payload, hermesDataQueueJobId: 42 },
-          signal,
-          jobCtx,
-        ),
+        jobHandlers.invoke_agent(payload, signal, jobCtx),
       ).rejects.toThrow("Network error");
 
-      expect(mockGetJob).toHaveBeenCalledWith(42);
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("idempotency_key"),
+        [payload.jobId],
+      );
       expect(mockPrisma.agentJobExecution.updateMany).toHaveBeenCalledWith({
         where: {
           jobId: payload.jobId,
@@ -659,17 +722,12 @@ describe("jobHandlers", () => {
         kind: "transport_error",
         error: new Error("Network error"),
       });
-      mockGetJob.mockResolvedValue({
-        attempts: 3,
-        maxAttempts: 3,
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ id: 99, attempts: 3, max_attempts: 3 }],
       });
 
       await expect(
-        jobHandlers.invoke_agent(
-          { ...payload, hermesDataQueueJobId: 99 },
-          signal,
-          jobCtx,
-        ),
+        jobHandlers.invoke_agent(payload, signal, jobCtx),
       ).rejects.toThrow("Network error");
 
       expect(applyInvocationCompletion).toHaveBeenCalledWith(
@@ -694,17 +752,12 @@ describe("jobHandlers", () => {
           isEmptyBody: true,
         },
       });
-      mockGetJob.mockResolvedValue({
-        attempts: 2,
-        maxAttempts: 2,
+      mockPoolQuery.mockResolvedValue({
+        rows: [{ id: 7, attempts: 2, max_attempts: 2 }],
       });
 
       await expect(
-        jobHandlers.invoke_agent(
-          { ...payload, hermesDataQueueJobId: 7 },
-          signal,
-          jobCtx,
-        ),
+        jobHandlers.invoke_agent(payload, signal, jobCtx),
       ).rejects.toThrow("Agent returned HTTP 503");
 
       expect(applyInvocationCompletion).toHaveBeenCalledWith(
@@ -793,6 +846,42 @@ describe("jobHandlers", () => {
           },
         }),
         expect.any(Object),
+      );
+    });
+  });
+
+  describe("resolveDataQueueJob", () => {
+    it("returns null when pool is unavailable", async () => {
+      const result = await resolveDataQueueJob("missing-job", {
+        getPool: () => undefined,
+      } as unknown as ReturnType<typeof import("./queue").getJobQueue>);
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the first row from idempotency key lookup", async () => {
+      mockPoolQuery.mockResolvedValueOnce({
+        rows: [{ id: 5, attempts: 1, max_attempts: 3 }],
+      });
+
+      const result = await resolveDataQueueJob("job-key");
+
+      expect(result).toEqual({ id: 5, attempts: 1, max_attempts: 3 });
+      expect(mockPoolQuery).toHaveBeenCalledWith(
+        expect.stringContaining("idempotency_key"),
+        ["job-key"],
+      );
+    });
+  });
+
+  describe("resolveInvokeAgentJobTimeoutMs", () => {
+    it("returns agent timeout when below default cap", () => {
+      expect(resolveInvokeAgentJobTimeoutMs(60_000)).toBe(60_000);
+    });
+
+    it("returns cap when agent timeout exceeds it", () => {
+      expect(resolveInvokeAgentJobTimeoutMs(7_200_000, 1_800_000)).toBe(
+        1_800_000,
       );
     });
   });

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -30,6 +30,55 @@ import { getJobQueue } from "./queue";
 import { executeHttpTrigger } from "./execute-http-trigger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
 
+/** Default cap for DataQueue `invoke_agent` job timeout (abort + supervisor reclaim). */
+export const DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS = 1_800_000;
+
+type ResolvedDataQueueJob = {
+  id: number;
+  attempts: number;
+  max_attempts: number;
+};
+
+/**
+ * Looks up a DataQueue row by `idempotency_key` (same value as `InvokeAgentJobPayload.jobId`).
+ * Avoids post-enqueue `editJob` payload patches that briefly lock rows and cause batch claim races.
+ *
+ * @param logicalJobId - Hermes agent job id used as DataQueue idempotency key.
+ * @param jobQueue - Optional queue instance for tests.
+ * @returns Row metadata when found; otherwise null.
+ */
+export const resolveDataQueueJob = async (
+  logicalJobId: string,
+  jobQueue = getJobQueue(),
+): Promise<ResolvedDataQueueJob | null> => {
+  const pool = jobQueue.getPool?.();
+  if (pool == null) {
+    return null;
+  }
+  const result = await pool.query<ResolvedDataQueueJob>(
+    `SELECT id, attempts, max_attempts
+     FROM job_queue
+     WHERE idempotency_key = $1
+     LIMIT 1`,
+    [logicalJobId],
+  );
+  return result.rows[0] ?? null;
+};
+
+/**
+ * Caps DataQueue job-level timeout so a hung agent invoke cannot block the processor batch
+ * for the full agent HTTP deadline (which may be hours).
+ *
+ * @param agentTimeoutMs - Agent HTTP timeout from pipeline/schedule config.
+ * @param capMs - Optional override cap in milliseconds.
+ * @returns Min of agent timeout and cap.
+ */
+export const resolveInvokeAgentJobTimeoutMs = (
+  agentTimeoutMs: number,
+  capMs?: number,
+): number =>
+  Math.min(agentTimeoutMs, capMs ?? DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS);
+
 /**
  * Parses optional positive integer env strings (DataQueue retry delay fields are in seconds).
  *
@@ -150,9 +199,9 @@ const handleTransientInvokeFailure = async (params: {
   errorToThrow: Error;
 }): Promise<never> => {
   const { payload, message, errorToThrow } = params;
-  const jobQueue = getJobQueue();
 
-  if (payload.hermesDataQueueJobId == null) {
+  const dqJob = await resolveDataQueueJob(payload.jobId);
+  if (dqJob == null) {
     await orchestrationPrisma.agentJobExecution.update({
       where: { jobId: payload.jobId },
       data: {
@@ -164,11 +213,7 @@ const handleTransientInvokeFailure = async (params: {
     throw errorToThrow;
   }
 
-  const dqJob = await jobQueue.getJob(payload.hermesDataQueueJobId);
-  if (
-    dqJob == null ||
-    !willRetryAfterTransientFailure(dqJob.attempts, dqJob.maxAttempts)
-  ) {
+  if (!willRetryAfterTransientFailure(dqJob.attempts, dqJob.max_attempts)) {
     await applyInvocationCompletion(
       {
         jobId: payload.jobId,
@@ -241,15 +286,20 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
                 : backoffRaw === "false"
                   ? false
                   : undefined;
+            const invokeAgentJobTimeoutCapMs =
+              parsePositiveIntEnv(env.HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS) ??
+              DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS;
             const jobDefs = items.map((item) => ({
               jobType: "invoke_agent" as const,
               payload: item.payload,
               priority: item.payload.priority,
               idempotencyKey: item.payload.jobId,
-              // Mirror the HTTP-request timeout as a DataQueue-level job deadline so
-              // DataQueue's supervisor can force-kill the job if the got timeout fails
-              // to fire (e.g. TCP-level hang where the OS never delivers a close event).
-              timeoutMs: item.payload.timeoutMs,
+              // Cap DataQueue job timeout below agent HTTP deadline so a hung invoke
+              // frees a processor slot and supervisor reclaim runs within minutes, not hours.
+              timeoutMs: resolveInvokeAgentJobTimeoutMs(
+                item.payload.timeoutMs,
+                invokeAgentJobTimeoutCapMs,
+              ),
               maxAttempts,
               deadLetterJobType,
               ...(retryDelaySec !== undefined
@@ -275,20 +325,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
                 `pipelineStep:${item.payload.pipelineStepId}`,
               ],
             }));
-            const insertedIds = await jobQueue.addJobs(jobDefs);
-            for (let i = 0; i < insertedIds.length; i++) {
-              const queueJobId = insertedIds[i];
-              const item = items[i];
-              if (item === undefined || queueJobId === undefined) {
-                continue;
-              }
-              await jobQueue.editJob(queueJobId, {
-                payload: {
-                  ...item.payload,
-                  hermesDataQueueJobId: queueJobId,
-                },
-              });
-            }
+            await jobQueue.addJobs(jobDefs);
           },
           expandStepInputs,
           defaultTimeoutMs: 300_000,
@@ -311,12 +348,18 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
     await executeHttpTrigger(payload.httpTriggerExecutionId, {
       db: orchestrationPrisma,
       enqueueAgentInvocations: async (items) => {
+        const invokeAgentJobTimeoutCapMs =
+          parsePositiveIntEnv(env.HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS) ??
+          DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS;
         const jobDefs = items.map((item) => ({
           jobType: "invoke_agent" as const,
           payload: item.payload,
           priority: item.payload.priority,
           idempotencyKey: item.payload.jobId,
-          timeoutMs: item.payload.timeoutMs,
+          timeoutMs: resolveInvokeAgentJobTimeoutMs(
+            item.payload.timeoutMs,
+            invokeAgentJobTimeoutCapMs,
+          ),
           dependsOn:
             item.dependsOnBatchIndices && item.dependsOnBatchIndices.length > 0
               ? {
@@ -332,15 +375,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             `pipelineStep:${item.payload.pipelineStepId}`,
           ],
         }));
-        const insertedIds = await jobQueue.addJobs(jobDefs);
-        for (let idx = 0; idx < insertedIds.length; idx++) {
-          const queueJobId = insertedIds[idx];
-          const item = items[idx];
-          if (item === undefined || queueJobId === undefined) continue;
-          await jobQueue.editJob(queueJobId, {
-            payload: { ...item.payload, hermesDataQueueJobId: queueJobId },
-          });
-        }
+        await jobQueue.addJobs(jobDefs);
       },
       expandStepInputs,
       defaultTimeoutMs: 300_000,
@@ -385,24 +420,22 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       return;
     }
 
-    if (payload.hermesDataQueueJobId != null) {
-      try {
-        const dqJob = await getJobQueue().getJob(payload.hermesDataQueueJobId);
-        if (dqJob != null) {
-          await orchestrationPrisma.agentJobExecution.update({
-            where: { jobId: payload.jobId },
-            data: {
-              dataQueueAttempts: dqJob.attempts,
-              dataQueueMaxAttempts: dqJob.maxAttempts,
-            },
-          });
-        }
-      } catch (err) {
-        logger.warn(
-          { err, jobId: payload.jobId },
-          "invoke_agent: failed to sync DataQueue attempts to agent_job_execution",
-        );
+    try {
+      const dqJob = await resolveDataQueueJob(payload.jobId);
+      if (dqJob != null) {
+        await orchestrationPrisma.agentJobExecution.update({
+          where: { jobId: payload.jobId },
+          data: {
+            dataQueueAttempts: dqJob.attempts,
+            dataQueueMaxAttempts: dqJob.max_attempts,
+          },
+        });
       }
+    } catch (err) {
+      logger.warn(
+        { err, jobId: payload.jobId },
+        "invoke_agent: failed to sync DataQueue attempts to agent_job_execution",
+      );
     }
 
     const hasParentExecution =

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -46,3 +46,5 @@ HERMES_INVOKE_AGENT_RETRY_DELAY= # optional #number
 HERMES_INVOKE_AGENT_RETRY_BACKOFF= # optional
 # Optional: cap retry delay in seconds (DataQueue retryDelayMax).
 HERMES_INVOKE_AGENT_RETRY_DELAY_MAX= # optional #number
+# Optional: cap DataQueue invoke_agent job timeout in ms (AbortController + supervisor reclaim). Default 1800000 (30 min). Agent HTTP deadline stays on pipeline timeout.
+HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS= # optional #number #default

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -21,6 +21,7 @@ export const env = createEnv({
     HERMES_INVOKE_AGENT_RETRY_DELAY: z.string().optional(),
     HERMES_INVOKE_AGENT_RETRY_BACKOFF: z.string().optional(),
     HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: z.string().optional(),
+    HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS: z.string().optional(),
   },
   client: {
   },


### PR DESCRIPTION
## Summary

When Hermes enqueues several `invoke_agent` jobs at once, the worker could leave one job pending forever and freeze the whole batch if another invoke hung. This change removes the post-enqueue row locks that caused skipped claims, looks up DataQueue retry state by idempotency key at handler time, and caps the DataQueue job timeout at 30 minutes so a stuck HTTP call cannot block the processor for hours.

## Related issues

Closes #590

## Important changes

- Drop `editJob` loops after `addJobs` in schedule and HTTP-trigger enqueue paths.
- Add `resolveDataQueueJob()` to read attempts/max_attempts from `job_queue` via `idempotency_key` (`payload.jobId`).
- Cap DataQueue `timeoutMs` with `HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS` (default 1_800_000 ms); agent HTTP still uses pipeline `timeoutMs` on the payload.
- Lower orphan execution cleanup default from 60 to 35 minutes.

## Other changes

- Unit tests updated for idempotency lookup, timeout cap, and orphan threshold.

## Key files to review

- `apps/hermes/worker/src/job-handlers.ts` — enqueue paths, `resolveDataQueueJob`, timeout cap helpers.
- `apps/hermes/worker/src/job-handlers.test.ts` — coverage for the above.
- `apps/hermes/worker/src/cleanup-orphaned-executions.ts` — 35-minute default threshold.
- `packages/hermes/env/src/hermes-worker.ts` — optional `HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS`.

## How to test

1. `pnpm --filter @hermes/worker test` — expect 37 passing tests.
2. `pnpm --filter @hermes/worker type:check` and `lint` — clean.
3. After deploy: run a manual pipeline with 4+ tickers; confirm all invoke jobs enter `processing` in the same poll window and that a hung agent invoke clears within ~30 minutes without blocking `check_schedules`.
