### PR TITLE
Group content-generation Hermes config and strip inline article markers

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/compute-config-version.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/compute-config-version.test.ts
@@ -11,7 +11,7 @@ describe("computeConfigVersion", () => {
   it("returns the same hash for the same config called twice", () => {
     // Setup
     const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
+      credentials: { openaiApiKey: "sk-test" },
     });
 
     // Act
@@ -25,7 +25,7 @@ describe("computeConfigVersion", () => {
   it("returns a 16-character hex string", () => {
     // Setup
     const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
+      credentials: { openaiApiKey: "sk-test" },
     });
 
     // Act
@@ -40,13 +40,13 @@ describe("computeConfigVersion", () => {
   // apiKey must produce the same configVersion)
   // -------------------------------------------------------------------------
 
-  it("produces the same hash for two configs differing only in openai.apiKey", () => {
+  it("produces the same hash for two configs differing only in credentials.openaiApiKey", () => {
     // Setup
     const configA = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-key-alpha" },
+      credentials: { openaiApiKey: "sk-key-alpha" },
     });
     const configB = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-key-beta" },
+      credentials: { openaiApiKey: "sk-key-beta" },
     });
 
     // Act
@@ -60,10 +60,13 @@ describe("computeConfigVersion", () => {
   it("produces the same hash regardless of API key presence when all other fields are equal", () => {
     // Setup — two configs with different api keys, same everything else
     const configWithKey = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-some-key", model: "gpt-4o" },
+      credentials: { openaiApiKey: "sk-some-key", chatModel: "gpt-4o" },
     });
     const configWithDifferentKey = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-completely-different-key", model: "gpt-4o" },
+      credentials: {
+        openaiApiKey: "sk-completely-different-key",
+        chatModel: "gpt-4o",
+      },
     });
 
     // Act
@@ -78,13 +81,13 @@ describe("computeConfigVersion", () => {
   // Sensitivity: changing a non-secret field changes the hash
   // -------------------------------------------------------------------------
 
-  it("produces a different hash when openai.model changes", () => {
+  it("produces a different hash when credentials.chatModel changes", () => {
     // Setup
     const configA = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test", model: "gpt-4o-mini" },
+      credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o-mini" },
     });
     const configB = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test", model: "gpt-4o" },
+      credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o" },
     });
 
     // Act
@@ -98,11 +101,11 @@ describe("computeConfigVersion", () => {
   it("produces a different hash when freshness.timezone changes", () => {
     // Setup
     const configA = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
+      credentials: { openaiApiKey: "sk-test" },
       freshness: { timezone: "Asia/Jakarta" },
     });
     const configB = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
+      credentials: { openaiApiKey: "sk-test" },
       freshness: { timezone: "America/New_York" },
     });
 
@@ -121,14 +124,14 @@ describe("computeConfigVersion", () => {
   it("produces the same hash regardless of property insertion order", () => {
     // Setup — two configs that are semantically identical but built in different order
     const configA = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test", model: "gpt-4o-mini" },
+      credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o-mini" },
       freshness: { timezone: "Asia/Jakarta" },
     });
 
     // Rebuild with keys in a different order by spreading
     const configBRaw = {
       freshness: { timezone: "Asia/Jakarta" },
-      openai: { apiKey: "sk-test", model: "gpt-4o-mini" },
+      credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o-mini" },
     };
     const configB = resolveContentGenerationConfig(configBRaw);
 
@@ -147,14 +150,14 @@ describe("computeConfigVersion", () => {
   it("does not mutate the original config object", () => {
     // Setup
     const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-original", model: "gpt-4o" },
+      credentials: { openaiApiKey: "sk-original", chatModel: "gpt-4o" },
     });
-    const originalNestedKey = config.openai.apiKey;
+    const originalNestedKey = config.credentials.openaiApiKey;
 
     // Act
     computeConfigVersion(config);
 
     // Assert
-    expect(config.openai.apiKey).toBe(originalNestedKey);
+    expect(config.credentials.openaiApiKey).toBe(originalNestedKey);
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/compute-config-version.ts
+++ b/apps/mediapulse/agents/content-generation/src/compute-config-version.ts
@@ -29,8 +29,7 @@ function deterministicStringify(value: unknown): string {
  * Algorithm: SHA-256(deterministicJSON(configWithoutSecrets)) → first 16 hex chars.
  *
  * Secret exclusions:
- * - `openaiApiKey` (legacy top-level field)
- * - `openai.apiKey` (nested field)
+ * - `credentials.openaiApiKey`
  *
  * This means two configs that differ only in their API key will produce the
  * same `configVersion`, which is the desired behaviour: the version tracks
@@ -40,19 +39,12 @@ function deterministicStringify(value: unknown): string {
  * @returns 16-character hex string uniquely identifying the non-secret config.
  */
 export function computeConfigVersion(config: ContentGenerationConfig): string {
-  // Clone to avoid mutating the original.
   const clone: Record<string, unknown> = { ...config };
 
-  // Remove the legacy top-level API key.
-  delete clone.openaiApiKey;
-
-  // Remove the nested API key, keeping the rest of the `openai` block.
-  if (clone.openai && typeof clone.openai === "object") {
-    const { apiKey: _apiKey, ...openaiRest } = clone.openai as Record<
-      string,
-      unknown
-    >;
-    clone.openai = openaiRest;
+  if (clone.credentials && typeof clone.credentials === "object") {
+    const { openaiApiKey: _apiKey, ...credentialsRest } =
+      clone.credentials as Record<string, unknown>;
+    clone.credentials = credentialsRest;
   }
 
   const serialized = deterministicStringify(clone);

--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -2,78 +2,80 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { describe, expect, it } from "vitest";
 
 import {
-  contentGenerationConfigDefaults,
   ContentGenerationConfigSchema,
   CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH,
+  CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING,
   resolveContentGenerationConfig,
 } from "./config-schema.js";
 
-describe("ContentGenerationConfigSchema", () => {
-  it("parses minimal config with openai.apiKey and applies all defaults", () => {
-    const parsed = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-    });
+const testCredentials = {
+  credentials: { openaiApiKey: "sk-test" },
+} as const;
 
-    expect(parsed.openai.apiKey).toBe("sk-test");
-    expect(parsed.openai.baseUrl).toBeUndefined();
-    expect(parsed.openai.model).toBe("gpt-4o-mini");
-    expect(parsed.openai.timeoutMs).toBe(120000);
+describe("ContentGenerationConfigSchema", () => {
+  it("parses empty {} into the full grouped recommended config", () => {
+    const parsed = ContentGenerationConfigSchema.parse({});
+
+    expect(parsed.credentials.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
+    expect(parsed.credentials.baseUrl).toBeUndefined();
+    expect(parsed.credentials.chatModel).toBe("{{OPENAI_MODEL}}");
+    expect(parsed.credentials.timeoutMs).toBe(120_000);
     expect(parsed.output.topNewsCount).toBe(10);
-    expect(parsed.context.maxCharsPerSource).toBe(8000);
-    expect(parsed.context.maxTotalContextChars).toBe(100000);
-    expect(parsed.llmRetry.maxAttempts).toBe(3);
-    expect(parsed.llmRetry.baseDelayMs).toBe(500);
-    expect(parsed.llmRetry.maxDelayMs).toBe(8000);
-    expect(parsed.llmRetry.jitter).toBe(true);
+    expect(parsed.inputs.context.maxCharsPerSource).toBe(8000);
+    expect(parsed.inputs.context.maxTotalContextChars).toBe(100_000);
+    expect(parsed.reliability.llmRetry.maxAttempts).toBe(3);
+    expect(parsed.reliability.llmRetry.baseDelayMs).toBe(500);
+    expect(parsed.reliability.llmRetry.maxDelayMs).toBe(8000);
+    expect(parsed.reliability.llmRetry.jitter).toBe(true);
     expect(parsed.freshness.strategy).toBe("calendar_day");
     expect(parsed.freshness.timezone).toBe("Asia/Jakarta");
-    expect(parsed.persistRetry.maxAttempts).toBe(2);
-    expect(parsed.persistRetry.baseDelayMs).toBe(200);
-    expect(parsed.persistRetry.maxDelayMs).toBe(2000);
-    expect(parsed.sourceRanking.enabled).toBe(true);
-    expect(parsed.sourceRanking.maxPerHost).toBe(2);
-    expect(parsed.sourceRanking.recencyHalfLifeHours).toBe(36);
-    expect(parsed.sourceRanking.weights.relevance).toBe(0.45);
-    expect(parsed.sourceRanking.weights.recency).toBe(0.25);
-    expect(parsed.sourceRanking.weights.tier).toBe(0.2);
-    expect(parsed.sourceRanking.weights.length).toBe(0.1);
-    expect(parsed.fewShot.enabled).toBe(false);
-    expect(parsed.fewShot.maxExemplars).toBe(1);
-    expect(parsed.fewShot.sectorTag).toBeUndefined();
-    expect(parsed.useBrainstormPass).toBe(false);
-    expect(parsed.brainstormMaxOutputTokens).toBe(700);
-    expect(parsed.brainstormModel).toBeUndefined();
-    expect(parsed.citationGrounding.enabled).toBe(false);
-    expect(parsed.citationGrounding.policy).toBe("unlink");
-    expect(parsed.citationGrounding.minOverlapScore).toBe(0.18);
-    expect(parsed.citationGrounding.numericBonus).toBe(0.2);
-    expect(parsed.numericAnchors.enabled).toBe(false);
-    expect(parsed.numericAnchors.perArticleCap).toBe(5);
-    expect(parsed.numericAnchors.totalCap).toBe(25);
-    expect(parsed.numericAnchors.unmatchedPolicy).toBe("warn");
-    expect(parsed.crossRunDedup.enabled).toBe(false);
-    expect(parsed.crossRunDedup.windowDays).toBe(14);
-    expect(parsed.crossRunDedup.minSimilarity).toBe(0.55);
-    expect(parsed.crossRunDedup.policy).toBe("warn");
-    expect(parsed.crossRunDedup.lowInfoDayThreshold).toBe(0.5);
-    expect(parsed.subjectLine.enabled).toBe(false);
-    expect(parsed.subjectLine.candidateCount).toBe(5);
-    expect(parsed.subjectLine.weights.lengthFit).toBe(0.2);
-    expect(parsed.subjectLine.weights.curiosityGap).toBe(0.25);
-    expect(parsed.polish.enabled).toBe(false);
-    expect(parsed.polish.tier).toBe("safe");
-    expect(parsed.polish.disabledRuleIds).toEqual([]);
-    expect(parsed.selfCritique.enabled).toBe(false);
-    expect(parsed.selfCritique.dropFraction).toBe(0.2);
-    expect(parsed.selfCritique.minBulletCount).toBe(8);
-    expect(parsed.selfCritique.preferRewriteOverDrop).toBe(true);
+    expect(parsed.reliability.persistRetry.maxAttempts).toBe(2);
+    expect(parsed.reliability.persistRetry.baseDelayMs).toBe(200);
+    expect(parsed.reliability.persistRetry.maxDelayMs).toBe(2000);
+    expect(parsed.inputs.sourceRanking.enabled).toBe(true);
+    expect(parsed.inputs.sourceRanking.maxPerHost).toBe(2);
+    expect(parsed.inputs.sourceRanking.recencyHalfLifeHours).toBe(36);
+    expect(parsed.inputs.sourceRanking.weights.relevance).toBe(0.45);
+    expect(parsed.inputs.sourceRanking.weights.recency).toBe(0.25);
+    expect(parsed.inputs.sourceRanking.weights.tier).toBe(0.2);
+    expect(parsed.inputs.sourceRanking.weights.length).toBe(0.1);
+    expect(parsed.inputs.fewShot.enabled).toBe(true);
+    expect(parsed.inputs.fewShot.maxExemplars).toBe(1);
+    expect(parsed.inputs.fewShot.sectorTag).toBeUndefined();
+    expect(parsed.creativity.brainstorm.enabled).toBe(true);
+    expect(parsed.creativity.brainstorm.maxOutputTokens).toBe(700);
+    expect(parsed.creativity.brainstorm.model).toBeUndefined();
+    expect(parsed.quality.citationGrounding.enabled).toBe(true);
+    expect(parsed.quality.citationGrounding.policy).toBe("unlink");
+    expect(parsed.quality.citationGrounding.minOverlapScore).toBe(0.18);
+    expect(parsed.quality.citationGrounding.numericBonus).toBe(0.2);
+    expect(parsed.inputs.numericAnchors.enabled).toBe(true);
+    expect(parsed.inputs.numericAnchors.perArticleCap).toBe(5);
+    expect(parsed.inputs.numericAnchors.totalCap).toBe(25);
+    expect(parsed.inputs.numericAnchors.unmatchedPolicy).toBe("warn");
+    expect(parsed.quality.crossRunDedup.enabled).toBe(true);
+    expect(parsed.quality.crossRunDedup.windowDays).toBe(14);
+    expect(parsed.quality.crossRunDedup.minSimilarity).toBe(0.55);
+    expect(parsed.quality.crossRunDedup.policy).toBe("warn");
+    expect(parsed.quality.crossRunDedup.lowInfoDayThreshold).toBe(0.5);
+    expect(parsed.delivery.subjectLine.enabled).toBe(true);
+    expect(parsed.delivery.subjectLine.candidateCount).toBe(5);
+    expect(parsed.delivery.subjectLine.weights.lengthFit).toBe(0.2);
+    expect(parsed.delivery.subjectLine.weights.curiosityGap).toBe(0.25);
+    expect(parsed.quality.polish.enabled).toBe(true);
+    expect(parsed.quality.polish.tier).toBe("safe");
+    expect(parsed.quality.polish.disabledRuleIds).toEqual([]);
+    expect(parsed.quality.selfCritique.enabled).toBe(true);
+    expect(parsed.quality.selfCritique.dropFraction).toBe(0.2);
+    expect(parsed.quality.selfCritique.minBulletCount).toBe(8);
+    expect(parsed.quality.selfCritique.preferRewriteOverDrop).toBe(true);
   });
 
-  it("resolveContentGenerationConfig defaults brainstormModel to openai.model", () => {
+  it("resolveContentGenerationConfig defaults brainstormModel to credentials.chatModel", () => {
     const resolved = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test", model: "gpt-4o" },
-        brainstormModel: "gpt-4o-mini",
+        credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o" },
+        creativity: { brainstorm: { model: "gpt-4o-mini" } },
       }),
     );
 
@@ -81,20 +83,20 @@ describe("ContentGenerationConfigSchema", () => {
 
     const defaulted = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test", model: "gpt-4o" },
+        credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o" },
       }),
     );
     expect(defaulted.brainstormModel).toBe("gpt-4o");
   });
 
-  it("parses valid full config", () => {
+  it("parses valid full grouped config", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: {
-        apiKey: "sk-test-new",
+      credentials: {
+        openaiApiKey: "sk-test-new",
         baseUrl: "https://example.com",
-        model: "gpt-4",
+        chatModel: "gpt-4",
         maxTokens: 1000,
-        timeoutMs: 60000,
+        timeoutMs: 60_000,
       },
       prompts: {
         systemPrompt: "You are a bot",
@@ -103,30 +105,34 @@ describe("ContentGenerationConfigSchema", () => {
       output: {
         topNewsCount: 5,
       },
-      context: {
-        maxCharsPerSource: 1000,
-        maxTotalContextChars: 10000,
+      inputs: {
+        context: {
+          maxCharsPerSource: 1000,
+          maxTotalContextChars: 10_000,
+        },
       },
-      llmRetry: {
-        maxAttempts: 1,
-        baseDelayMs: 100,
-        maxDelayMs: 1000,
-        jitter: false,
+      reliability: {
+        llmRetry: {
+          maxAttempts: 1,
+          baseDelayMs: 100,
+          maxDelayMs: 1000,
+          jitter: false,
+        },
+        persistRetry: {
+          maxAttempts: 1,
+          baseDelayMs: 50,
+          maxDelayMs: 500,
+        },
       },
       freshness: {
         strategy: "calendar_day",
         timezone: "America/New_York",
       },
-      persistRetry: {
-        maxAttempts: 1,
-        baseDelayMs: 50,
-        maxDelayMs: 500,
-      },
     });
 
-    expect(parsed.openai.apiKey).toBe("sk-test-new");
-    expect(parsed.openai.baseUrl).toBe("https://example.com");
-    expect(parsed.openai.model).toBe("gpt-4");
+    expect(parsed.credentials.openaiApiKey).toBe("sk-test-new");
+    expect(parsed.credentials.baseUrl).toBe("https://example.com");
+    expect(parsed.credentials.chatModel).toBe("gpt-4");
     expect(parsed.output.topNewsCount).toBe(5);
     expect(parsed.prompts.userPromptTemplate).toBe("Hello {{tickerId}}");
     expect(parsed.freshness.timezone).toBe("America/New_York");
@@ -134,7 +140,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects unknown placeholder in prompts.systemPrompt", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       prompts: {
         systemPrompt: "{{tickerId}} {{notARealToken}}",
       },
@@ -151,7 +157,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects unknown placeholder in prompts.userPromptTemplate", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       prompts: {
         userPromptTemplate: "{{tickerId}} {{bogus}}",
       },
@@ -161,7 +167,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects prompts.systemPrompt longer than max", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       prompts: {
         systemPrompt: "x".repeat(
           CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH + 1,
@@ -173,7 +179,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("accepts systemPrompt at exactly max length", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       prompts: {
         systemPrompt: "y".repeat(
           CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH,
@@ -185,67 +191,59 @@ describe("ContentGenerationConfigSchema", () => {
     );
   });
 
-  it("rejects missing openai object", () => {
-    const result = ContentGenerationConfigSchema.safeParse({});
-
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(result.error.issues.some((i) => i.path[0] === "openai")).toBe(
-        true,
-      );
-    }
-  });
-
-  it("parses config with openai.apiKey only", () => {
+  it("parses config with credentials.openaiApiKey only", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: {
-        apiKey: "sk-new-style",
+      credentials: {
+        openaiApiKey: "sk-new-style",
       },
     });
 
-    expect(parsed.openai.apiKey).toBe("sk-new-style");
+    expect(parsed.credentials.openaiApiKey).toBe("sk-new-style");
   });
 
-  it("rejects missing openai.apiKey", () => {
+  it("rejects empty credentials.openaiApiKey", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: {},
+      credentials: { openaiApiKey: "" },
     });
     expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some(
-          (i) => i.path[0] === "openai" && i.path[1] === "apiKey",
-        ),
-      ).toBe(true);
+  });
+
+  it("rejects whitespace-only credentials.openaiApiKey", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      credentials: { openaiApiKey: "   " },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects legacy flat top-level keys", () => {
+    for (const legacyKey of [
+      "openai",
+      "sourceRanking",
+      "fewShot",
+      "useBrainstormPass",
+      "brainstormModel",
+      "crossRunDedup",
+      "subjectLine",
+      "polish",
+      "selfCritique",
+      "llmRetry",
+      "persistRetry",
+      "context",
+      "numericAnchors",
+      "citationGrounding",
+      "sampling",
+    ] as const) {
+      const result = ContentGenerationConfigSchema.safeParse({
+        ...testCredentials,
+        [legacyKey]: {},
+      });
+      expect(result.success).toBe(false);
     }
-  });
-
-  it("rejects empty openai.apiKey", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "" },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects whitespace-only openai.apiKey", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "   " },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects unknown top-level legacy openaiApiKey", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      openaiApiKey: "sk-test",
-      openai: { apiKey: "sk-test" },
-    });
-
-    expect(result.success).toBe(false);
   });
 
   it("rejects topNewsCount of 0", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       output: { topNewsCount: 0 },
     });
 
@@ -254,7 +252,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects negative topNewsCount", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       output: { topNewsCount: -1 },
     });
 
@@ -263,7 +261,7 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects invalid freshness timezone", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       freshness: { timezone: "Not/ATimezone" },
     });
 
@@ -272,143 +270,243 @@ describe("ContentGenerationConfigSchema", () => {
 
   it("rejects wrong type for topNewsCount", () => {
     const result = ContentGenerationConfigSchema.safeParse({
-      openai: { apiKey: "sk-test" },
+      ...testCredentials,
       output: { topNewsCount: "three" },
     });
 
     expect(result.success).toBe(false);
   });
 
-  it("JSON schema exposes nested openai only (no top-level openaiApiKey)", () => {
+  it("JSON schema exposes grouped config sections", () => {
     const jsonSchema = zodToJsonSchema(ContentGenerationConfigSchema, {
       $refStrategy: "none",
     });
 
     const schemaStr = JSON.stringify(jsonSchema);
-    expect(schemaStr).toContain('"openai"');
-    expect(schemaStr).toContain("apiKey");
-    expect(schemaStr).not.toContain("openaiApiKey");
-    expect(schemaStr).not.toContain("openaiModel");
+    expect(schemaStr).toContain('"credentials"');
+    expect(schemaStr).toContain("openaiApiKey");
+    expect(schemaStr).toContain("chatModel");
+    expect(schemaStr).toContain("inputs");
+    expect(schemaStr).toContain("creativity");
+    expect(schemaStr).toContain("quality");
+    expect(schemaStr).toContain("delivery");
+    expect(schemaStr).toContain("reliability");
     expect(schemaStr).toContain("topNewsCount");
     expect(schemaStr).toContain("systemPrompt");
     expect(schemaStr).toContain("userPromptTemplate");
     expect(schemaStr).toContain("calendar_day");
     expect(schemaStr).toContain("maxCharsPerSource");
     expect(schemaStr).toContain("maxTotalContextChars");
+    expect(schemaStr).not.toContain('"openai"');
   });
 
-  it("parses llmRetry with all fields provided", () => {
+  it("parses reliability.llmRetry with all fields provided", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-      llmRetry: {
-        maxAttempts: 5,
-        baseDelayMs: 200,
-        maxDelayMs: 5000,
-        jitter: false,
+      ...testCredentials,
+      reliability: {
+        llmRetry: {
+          maxAttempts: 5,
+          baseDelayMs: 200,
+          maxDelayMs: 5000,
+          jitter: false,
+        },
       },
     });
 
-    expect(parsed.llmRetry?.maxAttempts).toBe(5);
-    expect(parsed.llmRetry?.baseDelayMs).toBe(200);
-    expect(parsed.llmRetry?.maxDelayMs).toBe(5000);
-    expect(parsed.llmRetry?.jitter).toBe(false);
+    expect(parsed.reliability.llmRetry.maxAttempts).toBe(5);
+    expect(parsed.reliability.llmRetry.baseDelayMs).toBe(200);
+    expect(parsed.reliability.llmRetry.maxDelayMs).toBe(5000);
+    expect(parsed.reliability.llmRetry.jitter).toBe(false);
   });
 
-  it("accepts partial llmRetry with only maxAttempts set", () => {
+  it("accepts partial reliability.llmRetry with only maxAttempts set", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-      llmRetry: { maxAttempts: 5 },
+      ...testCredentials,
+      reliability: {
+        llmRetry: { maxAttempts: 5 },
+      },
     });
 
-    expect(parsed.llmRetry?.maxAttempts).toBe(5);
-    expect(parsed.llmRetry?.baseDelayMs).toBeUndefined();
+    expect(parsed.reliability.llmRetry.maxAttempts).toBe(5);
+    expect(parsed.reliability.llmRetry.baseDelayMs).toBe(500);
   });
 
-  it("accepts openai.timeoutMs", () => {
+  it("accepts credentials.timeoutMs", () => {
     const parsed = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test", timeoutMs: 5000 },
+      credentials: { openaiApiKey: "sk-test", timeoutMs: 5000 },
     });
 
-    expect(parsed.openai?.timeoutMs).toBe(5000);
+    expect(parsed.credentials.timeoutMs).toBe(5000);
   });
 
   it("rejects non-integer or non-positive timeoutMs", () => {
     expect(() =>
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test", timeoutMs: -1 },
+        credentials: { openaiApiKey: "sk-test", timeoutMs: -1 },
       }),
     ).toThrow();
+  });
+
+  it("rejects llmRetry when maxDelayMs is below baseDelayMs", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      ...testCredentials,
+      reliability: {
+        llmRetry: { baseDelayMs: 250, maxDelayMs: 4 },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path[0] === "reliability" &&
+            issue.path[1] === "llmRetry" &&
+            issue.path[2] === "maxDelayMs",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects persistRetry when maxDelayMs is below baseDelayMs", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      ...testCredentials,
+      reliability: {
+        persistRetry: { baseDelayMs: 500, maxDelayMs: 100 },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path[0] === "reliability" &&
+            issue.path[1] === "persistRetry" &&
+            issue.path[2] === "maxDelayMs",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects llmRetry maxAttempts above the ceiling", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      ...testCredentials,
+      reliability: {
+        llmRetry: {
+          maxAttempts: CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING + 1,
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path[0] === "reliability" &&
+            issue.path[1] === "llmRetry" &&
+            issue.path[2] === "maxAttempts",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("rejects persistRetry maxAttempts above the ceiling", () => {
+    const result = ContentGenerationConfigSchema.safeParse({
+      ...testCredentials,
+      reliability: {
+        persistRetry: {
+          maxAttempts: CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING + 1,
+        },
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some(
+          (issue) =>
+            issue.path[0] === "reliability" &&
+            issue.path[1] === "persistRetry" &&
+            issue.path[2] === "maxAttempts",
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("accepts default and valid explicit retry overrides", () => {
+    const defaulted = ContentGenerationConfigSchema.parse({});
+    expect(defaulted.reliability.llmRetry.maxAttempts).toBe(3);
+    expect(defaulted.reliability.llmRetry.maxDelayMs).toBe(8000);
+
+    const explicit = ContentGenerationConfigSchema.parse({
+      ...testCredentials,
+      reliability: {
+        llmRetry: {
+          maxAttempts: 3,
+          baseDelayMs: 250,
+          maxDelayMs: 8000,
+          jitter: true,
+        },
+        persistRetry: {
+          maxAttempts: 2,
+          baseDelayMs: 200,
+          maxDelayMs: 2000,
+        },
+      },
+    });
+    expect(explicit.reliability.llmRetry.maxAttempts).toBe(3);
+    expect(explicit.reliability.persistRetry.maxAttempts).toBe(2);
   });
 });
 
 describe("resolveContentGenerationConfig", () => {
-  it("fills llmRetry defaults when llmRetry is omitted", () => {
+  it("preserves explicit reliability.llmRetry values when supplied", () => {
     const config = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-    });
-
-    const resolved = resolveContentGenerationConfig(config);
-
-    expect(resolved.llmRetry.maxAttempts).toBe(
-      contentGenerationConfigDefaults.llmRetry.maxAttempts,
-    );
-    expect(resolved.llmRetry.baseDelayMs).toBe(
-      contentGenerationConfigDefaults.llmRetry.baseDelayMs,
-    );
-    expect(resolved.llmRetry.maxDelayMs).toBe(
-      contentGenerationConfigDefaults.llmRetry.maxDelayMs,
-    );
-    expect(resolved.llmRetry.jitter).toBe(
-      contentGenerationConfigDefaults.llmRetry.jitter,
-    );
-  });
-
-  it("preserves explicit llmRetry values when supplied", () => {
-    const config = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-      llmRetry: {
-        maxAttempts: 5,
-        baseDelayMs: 200,
-        maxDelayMs: 5000,
-        jitter: false,
+      ...testCredentials,
+      reliability: {
+        llmRetry: {
+          maxAttempts: 5,
+          baseDelayMs: 200,
+          maxDelayMs: 5000,
+          jitter: false,
+        },
       },
     });
 
     const resolved = resolveContentGenerationConfig(config);
 
-    expect(resolved.llmRetry.maxAttempts).toBe(5);
-    expect(resolved.llmRetry.baseDelayMs).toBe(200);
-    expect(resolved.llmRetry.maxDelayMs).toBe(5000);
-    expect(resolved.llmRetry.jitter).toBe(false);
+    expect(resolved.reliability.llmRetry.maxAttempts).toBe(5);
+    expect(resolved.reliability.llmRetry.baseDelayMs).toBe(200);
+    expect(resolved.reliability.llmRetry.maxDelayMs).toBe(5000);
+    expect(resolved.reliability.llmRetry.jitter).toBe(false);
   });
 
-  it("passes through openai config unchanged", () => {
+  it("passes through credentials config unchanged", () => {
     const config = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-key", model: "gpt-4o", timeoutMs: 8000 },
+      credentials: {
+        openaiApiKey: "sk-key",
+        chatModel: "gpt-4o",
+        timeoutMs: 8000,
+      },
     });
 
     const resolved = resolveContentGenerationConfig(config);
 
-    expect(resolved.openai.apiKey).toBe("sk-key");
-    expect(resolved.openai.model).toBe("gpt-4o");
-    expect(resolved.openai.timeoutMs).toBe(8000);
+    expect(resolved.credentials.openaiApiKey).toBe("sk-key");
+    expect(resolved.credentials.chatModel).toBe("gpt-4o");
+    expect(resolved.credentials.timeoutMs).toBe(8000);
   });
 
-  it("fills persistRetry defaults when persistRetry is omitted", () => {
-    const config = ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-    });
+  it("resolves critiqueModel and subjectLineModel from chatModel when omitted", () => {
+    const resolved = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        credentials: { openaiApiKey: "sk-test", chatModel: "gpt-4o" },
+      }),
+    );
 
-    const resolved = resolveContentGenerationConfig(config);
-
-    expect(resolved.persistRetry.maxAttempts).toBe(
-      contentGenerationConfigDefaults.persistRetry.maxAttempts,
-    );
-    expect(resolved.persistRetry.baseDelayMs).toBe(
-      contentGenerationConfigDefaults.persistRetry.baseDelayMs,
-    );
-    expect(resolved.persistRetry.maxDelayMs).toBe(
-      contentGenerationConfigDefaults.persistRetry.maxDelayMs,
-    );
+    expect(resolved.critiqueModel).toBe("gpt-4o");
+    expect(resolved.subjectLineModel).toBe("gpt-4o");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -5,6 +5,9 @@ import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prom
 /** Maximum length for each optional `prompts.*` string (Hermes JSON config). */
 export const CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
 
+/** Rejects runaway `maxAttempts` overrides that would hammer upstream APIs. */
+export const CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING = 10;
+
 const contentGenerationSystemPromptPlaceholders = new Set([
   "topNewsCount",
   "tickerId",
@@ -21,100 +24,59 @@ const contentGenerationUserPromptPlaceholders = new Set([
   "topNewsCount",
 ]);
 
-const llmRetrySchema = z.object({
-  /** Maximum total attempts (including the first). */
-  maxAttempts: z.number().int().nonnegative().optional(),
-  /** Base delay in milliseconds before the first retry. */
-  baseDelayMs: z.number().int().nonnegative().optional(),
-  /** Maximum delay cap in milliseconds. */
-  maxDelayMs: z.number().int().nonnegative().optional(),
-  /** When true, applies ±50% random jitter to each computed backoff delay. */
-  jitter: z.boolean().optional(),
-});
-
-const openaiOptionsSchema = z.object({
-  /**
-   * OpenAI API key for newsletter generation. Required if legacy `openaiApiKey` is omitted.
-   * The agent reads the API key exclusively from Hermes config — do not fall back to
-   * process.env.OPENAI_API_KEY at runtime. For local development, set the key in the
-   * Hermes agent config or use the legacy `openaiApiKey` top-level field.
-   * See FR2 and MP-CGA-011 for full local-dev documentation.
-   */
-  apiKey: z.string().min(1).optional(),
-  /** Base URL for the OpenAI-compatible HTTP API (e.g. Azure OpenAI or a proxy). */
-  baseUrl: z.string().url().optional(),
-  /** Chat completions model id (e.g. `gpt-4o-mini`). */
-  model: z.string().min(1).optional(),
-  /** Maximum tokens to generate. */
-  maxTokens: z.number().int().positive().optional(),
-  /** Per-request timeout in milliseconds passed to the AI SDK `generateObject` call. */
-  timeoutMs: z.number().int().positive().optional(),
-});
-
-const outputSchema = z.object({
-  /** Number of top news items to include in the output. */
-  topNewsCount: z.number().int().positive().optional(),
-});
-
-const contextSchema = z.object({
-  /** Maximum characters to keep per source. */
-  maxCharsPerSource: z.number().int().positive().optional(),
-  /** Maximum total characters across all sources. */
-  maxTotalContextChars: z.number().int().positive().optional(),
-});
-
-const freshnessSchema = z.object({
-  /** Strategy to use for determining freshness. */
-  strategy: z.literal("calendar_day").optional(),
-  /**
-   * Timezone to use for freshness calculations (IANA, e.g. "Asia/Jakarta").
-   * Validated against the IANA database at config-parse time.
-   */
-  timezone: z
-    .string()
-    .refine(
-      (tz) => {
-        try {
-          Intl.DateTimeFormat(undefined, { timeZone: tz });
-          return true;
-        } catch {
-          return false;
-        }
-      },
-      { message: "Invalid IANA timezone" },
-    )
-    .optional(),
-});
-
-const persistRetrySchema = z.object({
-  /** Maximum number of retry attempts for persisting data. */
-  maxAttempts: z.number().int().nonnegative().optional(),
-  /** Base delay in milliseconds between retries. */
-  baseDelayMs: z.number().int().nonnegative().optional(),
-  /** Maximum delay in milliseconds between retries. */
-  maxDelayMs: z.number().int().nonnegative().optional(),
-});
-
 const sourceRankingWeightsSchema = z
   .object({
-    relevance: z.number().min(0).max(1).default(0.45),
-    recency: z.number().min(0).max(1).default(0.25),
-    tier: z.number().min(0).max(1).default(0.2),
-    length: z.number().min(0).max(1).default(0.1),
+    relevance: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.45)
+      .describe("Weight for relevance score in the composite ranking."),
+    recency: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.25)
+      .describe("Weight for recency decay in the composite ranking."),
+    tier: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.2)
+      .describe("Weight for publisher tier in the composite ranking."),
+    length: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.1)
+      .describe("Weight for article length in the composite ranking."),
   })
-  .default({});
+  .default({})
+  .describe("Composite score weights (should sum to 1.0).");
 
 const sourceRankingSchema = z
   .object({
-    /** When false, sources keep relevance-only order (pre-ranking behavior). */
-    enabled: z.boolean().default(true),
-    /** Maximum articles from the same host in the final prompt. */
-    maxPerHost: z.number().int().positive().default(2),
-    /** Recency decay half-life in hours for the composite score. */
-    recencyHalfLifeHours: z.number().positive().default(36),
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, rank and diversify sources before the structured LLM pass.",
+      ),
+    maxPerHost: z
+      .number()
+      .int()
+      .positive()
+      .default(2)
+      .describe("Maximum articles from the same host in the final prompt."),
+    recencyHalfLifeHours: z
+      .number()
+      .positive()
+      .default(36)
+      .describe("Recency decay half-life in hours for the composite score."),
     weights: sourceRankingWeightsSchema,
   })
-  .default({});
+  .default({})
+  .describe("Pre-LLM source ranking and host diversification.");
 
 const fewShotSectorTagSchema = z.enum([
   "industrial",
@@ -126,14 +88,508 @@ const fewShotSectorTagSchema = z.enum([
 
 const fewShotSchema = z
   .object({
-    /** When true, inject curated newsletter exemplars before source summaries. */
-    enabled: z.boolean().default(false),
-    /** Maximum exemplars to include in the user prompt (1–2). */
-    maxExemplars: z.number().int().min(1).max(2).default(1),
-    /** When set, always use exemplars for this sector instead of keyword selection. */
-    sectorTag: fewShotSectorTagSchema.optional(),
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, inject curated newsletter exemplars before source summaries.",
+      ),
+    maxExemplars: z
+      .number()
+      .int()
+      .min(1)
+      .max(2)
+      .default(1)
+      .describe(
+        "Maximum exemplars to include in the user prompt (1–2; more causes over-imitation).",
+      ),
+    sectorTag: fewShotSectorTagSchema
+      .optional()
+      .describe(
+        "When set, always use exemplars for this sector instead of keyword selection.",
+      ),
   })
-  .default({});
+  .default({})
+  .describe("Few-shot exemplar anchors for format and voice calibration.");
+
+const contextSchema = z
+  .object({
+    maxCharsPerSource: z
+      .number()
+      .int()
+      .positive()
+      .default(8000)
+      .describe("Maximum characters to keep per source before truncation."),
+    maxTotalContextChars: z
+      .number()
+      .int()
+      .positive()
+      .default(100_000)
+      .describe("Maximum total characters across all sources in the prompt."),
+  })
+  .default({})
+  .describe("Source truncation budgets for the LLM context window.");
+
+const numericAnchorsSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, extract verbatim figures for the prompt and audit the briefing.",
+      ),
+    perArticleCap: z
+      .number()
+      .int()
+      .positive()
+      .default(5)
+      .describe("Maximum anchors per article in the prompt sidecar."),
+    totalCap: z
+      .number()
+      .int()
+      .positive()
+      .default(25)
+      .describe("Maximum anchors overall in the prompt sidecar."),
+    unmatchedPolicy: z
+      .enum(["warn", "strip"])
+      .default("warn")
+      .describe(
+        "warn = log only; strip = replace figures missing from sources.",
+      ),
+  })
+  .default({})
+  .describe("Verbatim numeric anchor extraction and coverage audit.");
+
+const inputsSchema = z
+  .object({
+    sourceRanking: sourceRankingSchema,
+    context: contextSchema,
+    fewShot: fewShotSchema,
+    numericAnchors: numericAnchorsSchema,
+  })
+  .default({})
+  .describe(
+    "Prompt-shaping inputs: source selection, truncation, exemplars, and figures.",
+  );
+
+const brainstormSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, run a free-form editor's memo pass before structured JSON generation.",
+      ),
+    model: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for the brainstorm pass. If omitted, uses credentials.chatModel.",
+      ),
+    maxOutputTokens: z
+      .number()
+      .int()
+      .positive()
+      .default(700)
+      .describe("Max output tokens for the brainstorm generateText call."),
+  })
+  .default({})
+  .describe("Two-pass generation: free-form memo before structured JSON.");
+
+const creativitySchema = z
+  .object({
+    brainstorm: brainstormSchema,
+  })
+  .default({})
+  .describe("Creative widening passes before structured generation.");
+
+const selfCritiqueSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, run a bounded self-critique pass before polish and grounding.",
+      ),
+    dropFraction: z
+      .number()
+      .min(0)
+      .max(0.4)
+      .default(0.2)
+      .describe(
+        "Maximum fraction of bullets that may be rewritten or dropped.",
+      ),
+    minBulletCount: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(8)
+      .describe(
+        "Skip critique when the briefing has fewer than this many bullets.",
+      ),
+    critiqueModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for the critique pass. If omitted, uses credentials.chatModel.",
+      ),
+    critiqueMaxOutputTokens: z
+      .number()
+      .int()
+      .positive()
+      .default(1500)
+      .describe("Max output tokens for the critique generateObject call."),
+    preferRewriteOverDrop: z
+      .boolean()
+      .default(true)
+      .describe(
+        "Prefer suggestedRewrite over dropping a bullet when both apply.",
+      ),
+  })
+  .default({})
+  .describe("Bounded self-critique pass to repair the weakest bullets.");
+
+const citationGroundingSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, verify each articleIndex against source overlap after generation.",
+      ),
+    policy: z
+      .enum(["warn", "unlink", "drop"])
+      .default("unlink")
+      .describe(
+        "warn = log only; unlink = strip bad links; drop = remove rows (with schema floors).",
+      ),
+    minOverlapScore: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.18)
+      .describe("Minimum Jaccard overlap required to keep a citation link."),
+    numericBonus: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0.2)
+      .describe(
+        "Bonus added when bullet numbers appear in the cited article body.",
+      ),
+  })
+  .default({})
+  .describe("Post-generation citation overlap verification.");
+
+const polishSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, run deterministic filler/hedge/register polish before grounding.",
+      ),
+    tier: z
+      .enum(["safe", "aggressive"])
+      .default("safe")
+      .describe(
+        "safe = filler, hedge, register; aggressive adds overused-word replacement.",
+      ),
+    disabledRuleIds: z
+      .array(z.string())
+      .default([])
+      .describe("Rule ids to skip without disabling the whole pass."),
+  })
+  .default({})
+  .describe("Deterministic vocabulary and register cleanup.");
+
+const crossRunDedupSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, inject recent-bullet avoidance and post-walk dedup.",
+      ),
+    windowDays: z
+      .number()
+      .int()
+      .positive()
+      .default(14)
+      .describe("Lookback window in days for the recent bullet corpus."),
+    minSimilarity: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.55)
+      .describe("Minimum Jaccard similarity to flag a near-duplicate."),
+    policy: z
+      .enum(["warn", "mark", "drop"])
+      .default("warn")
+      .describe(
+        "warn = log only; mark = prepend [follow-up]; drop = remove rows.",
+      ),
+    lowInfoDayThreshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.5)
+      .describe(
+        "Fraction of near-duplicate bullets that sets lowInformationDay.",
+      ),
+  })
+  .default({})
+  .describe("Cross-run semantic dedup against recent newsletter bullets.");
+
+const qualitySchema = z
+  .object({
+    selfCritique: selfCritiqueSchema,
+    citationGrounding: citationGroundingSchema,
+    polish: polishSchema,
+    crossRunDedup: crossRunDedupSchema,
+  })
+  .default({})
+  .describe("Post-generation repair, verification, polish, and dedup passes.");
+
+const subjectLineSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, generate and score subject-line candidates after structured generation.",
+      ),
+    candidateCount: z
+      .number()
+      .int()
+      .min(3)
+      .max(8)
+      .default(5)
+      .describe(
+        "Number of alternative subjects to request from the sidecar LLM call.",
+      ),
+    model: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for subject candidates. If omitted, uses credentials.chatModel.",
+      ),
+    weights: z
+      .object({
+        lengthFit: z
+          .number()
+          .min(0)
+          .max(1)
+          .default(0.2)
+          .describe("Weight for subject length fit scoring."),
+        tickerPresence: z
+          .number()
+          .min(0)
+          .max(1)
+          .default(0.15)
+          .describe("Weight for ticker presence in the subject."),
+        curiosityGap: z
+          .number()
+          .min(0)
+          .max(1)
+          .default(0.25)
+          .describe("Weight for curiosity-gap phrasing."),
+        novelty: z
+          .number()
+          .min(0)
+          .max(1)
+          .default(0.2)
+          .describe("Weight for novelty vs recent subjects."),
+        readability: z
+          .number()
+          .min(0)
+          .max(1)
+          .default(0.2)
+          .describe("Weight for readability scoring."),
+      })
+      .default({})
+      .describe("Scoring weights for subject-line candidate ranking."),
+  })
+  .default({})
+  .describe("Subject-line candidate generation and scoring.");
+
+const deliverySchema = z
+  .object({
+    subjectLine: subjectLineSchema,
+  })
+  .default({})
+  .describe("Delivery-oriented output tuning (subject line, preheader).");
+
+const credentialsSchema = z
+  .object({
+    openaiApiKey: z
+      .string()
+      .min(1, "credentials.openaiApiKey is required")
+      .default("{{OPENAI_API_KEY}}")
+      .refine((k) => k.trim().length > 0, {
+        message: "credentials.openaiApiKey cannot be whitespace only",
+      })
+      .describe(
+        "OpenAI API key or a Hermes variable placeholder such as {{OPENAI_API_KEY}}.",
+      ),
+    baseUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe(
+        "Base URL for the OpenAI-compatible HTTP API (e.g. Azure OpenAI or a proxy).",
+      ),
+    chatModel: z
+      .string()
+      .min(1)
+      .default("{{OPENAI_MODEL}}")
+      .describe(
+        "Chat model id (e.g. gpt-4o-mini) or a Hermes variable placeholder such as {{OPENAI_MODEL}}.",
+      ),
+    maxTokens: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Maximum tokens to generate per LLM call."),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(120_000)
+      .describe("Per-request timeout in milliseconds for LLM calls."),
+  })
+  .default({})
+  .describe("OpenAI credentials resolved from Hermes Variables.");
+
+const outputSchema = z
+  .object({
+    topNewsCount: z
+      .number()
+      .int()
+      .positive()
+      .default(10)
+      .describe("Number of top news items to include in the output."),
+  })
+  .default({})
+  .describe("Newsletter output sizing.");
+
+const promptsSchema = z
+  .object({
+    systemPrompt: z
+      .string()
+      .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
+        message: `prompts.systemPrompt must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
+      })
+      .optional()
+      .describe(
+        "System prompt template. Placeholders: {{topNewsCount}}, {{tickerId}}, {{tickerName}}, {{tickerSymbol}}. Do not put secrets here.",
+      ),
+    userPromptTemplate: z
+      .string()
+      .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
+        message: `prompts.userPromptTemplate must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
+      })
+      .optional()
+      .describe(
+        "User prompt template. Placeholders: {{sourceSummaries}}, {{tickerId}}, {{tickerName}}, {{tickerSymbol}}, {{date}}, {{topNewsCount}}. Do not put secrets here.",
+      ),
+  })
+  .default({})
+  .describe("Optional LLM prompt template overrides.");
+
+const llmRetrySchema = z
+  .object({
+    maxAttempts: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(3)
+      .describe("Maximum total LLM attempts (including the first)."),
+    baseDelayMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(500)
+      .describe("Base delay in milliseconds before the first retry."),
+    maxDelayMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(8000)
+      .describe("Maximum backoff delay cap in milliseconds."),
+    jitter: z
+      .boolean()
+      .default(true)
+      .describe("When true, applies ±50% random jitter to each backoff delay."),
+  })
+  .default({})
+  .describe("Retry policy for LLM calls (429/500 backoff).");
+
+const persistRetrySchema = z
+  .object({
+    maxAttempts: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(2)
+      .describe("Maximum retry attempts for persisting data."),
+    baseDelayMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(200)
+      .describe("Base delay in milliseconds between persist retries."),
+    maxDelayMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(2000)
+      .describe("Maximum delay cap in milliseconds between persist retries."),
+  })
+  .default({})
+  .describe("Retry policy for agent-data-api persist calls (no jitter).");
+
+const reliabilitySchema = z
+  .object({
+    llmRetry: llmRetrySchema,
+    persistRetry: persistRetrySchema,
+  })
+  .default({})
+  .describe("Retry and backoff settings for LLM and persist operations.");
+
+const freshnessSchema = z
+  .object({
+    strategy: z
+      .literal("calendar_day")
+      .default("calendar_day")
+      .describe("Strategy for determining newsletter freshness."),
+    timezone: z
+      .string()
+      .refine(
+        (tz) => {
+          try {
+            Intl.DateTimeFormat(undefined, { timeZone: tz });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        { message: "Invalid IANA timezone" },
+      )
+      .default("Asia/Jakarta")
+      .describe(
+        "IANA timezone for freshness calculations (e.g. Asia/Jakarta).",
+      ),
+  })
+  .default({
+    strategy: "calendar_day",
+    timezone: "Asia/Jakarta",
+  })
+  .describe("Skip-if-fresh precheck window (calendar day in timezone).");
 
 /**
  * Runtime config for the content-generation agent, supplied by Hermes on each invocation
@@ -141,251 +597,17 @@ const fewShotSchema = z
  */
 export const ContentGenerationConfigSchema = z
   .object({
-    /**
-     * OpenAI client settings. The API key is read only from Hermes config (no
-     * `process.env.OPENAI_API_KEY` at runtime). See FR2 and MP-CGA-011 for local-dev notes.
-     */
-    openai: z.object({
-      /** OpenAI API key for newsletter generation (required, non-whitespace). */
-      apiKey: z
-        .string()
-        .min(1, "openai.apiKey is required")
-        .refine((k) => k.trim().length > 0, {
-          message: "openai.apiKey cannot be whitespace only",
-        }),
-      /** Base URL for the OpenAI-compatible HTTP API (e.g. Azure OpenAI or a proxy). */
-      baseUrl: z.string().url().optional(),
-      /** Chat completions model id (e.g. `gpt-4o-mini`). */
-      model: z.string().min(1).default("gpt-4o-mini"),
-      /** Maximum tokens to generate. */
-      maxTokens: z.number().int().positive().optional(),
-      /** Timeout in milliseconds for the OpenAI API call. */
-      timeoutMs: z.number().int().positive().default(120000),
-    }),
-
-    prompts: z
-      .object({
-        /**
-         * System prompt template. Defaults in code apply when omitted.
-         * Supported placeholders: `{{topNewsCount}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`.
-         * Do not put API keys or secrets here — use `openai.apiKey` only.
-         */
-        systemPrompt: z
-          .string()
-          .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
-            message: `prompts.systemPrompt must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-          })
-          .optional(),
-        /**
-         * User prompt template. Supported placeholders: `{{sourceSummaries}}`, `{{tickerId}}`,
-         * `{{tickerName}}`, `{{tickerSymbol}}`, `{{date}}`, `{{topNewsCount}}`.
-         * Do not put API keys or secrets here — use `openai.apiKey` only.
-         */
-        userPromptTemplate: z
-          .string()
-          .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
-            message: `prompts.userPromptTemplate must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-          })
-          .optional(),
-      })
-      .default({}),
-
-    output: z
-      .object({
-        /** Number of top news items to include in the output. */
-        topNewsCount: z.number().int().positive().default(10),
-      })
-      .default({}),
-
-    context: z
-      .object({
-        /** Maximum characters to keep per source. */
-        maxCharsPerSource: z.number().int().positive().default(8000),
-        /** Maximum total characters across all sources. */
-        maxTotalContextChars: z.number().int().positive().default(100000),
-      })
-      .default({}),
-
-    llmRetry: z.preprocess(
-      (value) => (value === undefined ? { __defaultLlmRetry: true } : value),
-      z
-        .object({
-          __defaultLlmRetry: z.literal(true).optional(),
-          /** Maximum number of retry attempts for LLM calls. */
-          maxAttempts: z.number().int().nonnegative().optional(),
-          /** Base delay in milliseconds between retries. */
-          baseDelayMs: z.number().int().nonnegative().optional(),
-          /** Maximum delay in milliseconds between retries. */
-          maxDelayMs: z.number().int().nonnegative().optional(),
-          /** Whether to add jitter to the retry delay. */
-          jitter: z.boolean().optional(),
-        })
-        .transform((parsed) => {
-          if (parsed.__defaultLlmRetry) {
-            return {
-              maxAttempts: 3,
-              baseDelayMs: 500,
-              maxDelayMs: 8000,
-              jitter: true,
-            };
-          }
-          const { __defaultLlmRetry, ...rest } = parsed;
-          return rest;
-        }),
-    ),
-
-    freshness: z
-      .object({
-        /** Strategy to use for determining freshness. */
-        strategy: z.literal("calendar_day").default("calendar_day"),
-        /** Timezone to use for freshness calculations (e.g. "Asia/Jakarta"). */
-        timezone: z
-          .string()
-          .refine(
-            (tz) => {
-              try {
-                Intl.DateTimeFormat(undefined, { timeZone: tz });
-                return true;
-              } catch {
-                return false;
-              }
-            },
-            { message: "Invalid IANA timezone" },
-          )
-          .default("Asia/Jakarta"),
-      })
-      .default({
-        strategy: "calendar_day",
-        timezone: "Asia/Jakarta",
-      }),
-
-    persistRetry: z.preprocess(
-      (value) =>
-        value === undefined ? { __defaultPersistRetry: true } : value,
-      z
-        .object({
-          __defaultPersistRetry: z.literal(true).optional(),
-          /** Maximum number of retry attempts for persisting data. */
-          maxAttempts: z.number().int().nonnegative().optional(),
-          /** Base delay in milliseconds between retries. */
-          baseDelayMs: z.number().int().nonnegative().optional(),
-          /** Maximum delay in milliseconds between retries. */
-          maxDelayMs: z.number().int().nonnegative().optional(),
-        })
-        .transform((parsed) => {
-          if (parsed.__defaultPersistRetry) {
-            return {
-              maxAttempts: 2,
-              baseDelayMs: 200,
-              maxDelayMs: 2000,
-            };
-          }
-          const { __defaultPersistRetry, ...rest } = parsed;
-          return rest;
-        }),
-    ),
-
-    sourceRanking: sourceRankingSchema,
-
-    fewShot: fewShotSchema,
-
-    citationGrounding: z
-      .object({
-        /** When true, verify each articleIndex against source overlap after generation. */
-        enabled: z.boolean().default(false),
-        /** warn = log only; unlink = strip bad links; drop = remove rows (with schema floors). */
-        policy: z.enum(["warn", "unlink", "drop"]).default("unlink"),
-        /** Minimum Jaccard overlap required to keep a citation link. */
-        minOverlapScore: z.number().min(0).max(1).default(0.18),
-        /** Bonus added when bullet numbers appear in the cited article body. */
-        numericBonus: z.number().min(0).max(0.5).default(0.2),
-      })
-      .default({}),
-
-    numericAnchors: z
-      .object({
-        /** When true, extract verbatim figures for the prompt and audit the briefing. */
-        enabled: z.boolean().default(false),
-        /** Maximum anchors per article in the prompt sidecar. */
-        perArticleCap: z.number().int().positive().default(5),
-        /** Maximum anchors overall in the prompt sidecar. */
-        totalCap: z.number().int().positive().default(25),
-        /** warn = log only; strip = replace figures missing from sources. */
-        unmatchedPolicy: z.enum(["warn", "strip"]).default("warn"),
-      })
-      .default({}),
-
-    /** When true, run a free-form editor's memo pass before structured JSON generation. */
-    useBrainstormPass: z.boolean().default(false),
-    /** Chat model for the brainstorm pass (defaults to `openai.model` when omitted). */
-    brainstormModel: z.string().min(1).optional(),
-    /** Max output tokens for the brainstorm `generateText` call. */
-    brainstormMaxOutputTokens: z.number().int().positive().default(700),
-
-    crossRunDedup: z
-      .object({
-        /** When true, inject recent-bullet avoidance and post-walk dedup. */
-        enabled: z.boolean().default(false),
-        /** Lookback window in days for the recent bullet corpus. */
-        windowDays: z.number().int().positive().default(14),
-        /** Minimum Jaccard similarity to flag a near-duplicate. */
-        minSimilarity: z.number().min(0).max(1).default(0.55),
-        /** warn = log only; mark = prepend [follow-up]; drop = remove rows. */
-        policy: z.enum(["warn", "mark", "drop"]).default("warn"),
-        /** Fraction of near-duplicate bullets that sets lowInformationDay. */
-        lowInfoDayThreshold: z.number().min(0).max(1).default(0.5),
-      })
-      .default({}),
-
-    subjectLine: z
-      .object({
-        /** When true, generate and score subject-line candidates after structured generation. */
-        enabled: z.boolean().default(false),
-        /** Number of alternative subjects to request from the sidecar LLM call. */
-        candidateCount: z.number().int().min(3).max(8).default(5),
-        /** Chat model for subject candidates (defaults to `openai.model`). */
-        model: z.string().min(1).optional(),
-        weights: z
-          .object({
-            lengthFit: z.number().min(0).max(1).default(0.2),
-            tickerPresence: z.number().min(0).max(1).default(0.15),
-            curiosityGap: z.number().min(0).max(1).default(0.25),
-            novelty: z.number().min(0).max(1).default(0.2),
-            readability: z.number().min(0).max(1).default(0.2),
-          })
-          .default({}),
-      })
-      .default({}),
-
-    polish: z
-      .object({
-        /** When true, run deterministic filler/hedge/register polish before grounding. */
-        enabled: z.boolean().default(false),
-        /** `safe` = filler, hedge, register; `aggressive` adds overused-word replacement. */
-        tier: z.enum(["safe", "aggressive"]).default("safe"),
-        /** Rule ids to skip without disabling the whole pass. */
-        disabledRuleIds: z.array(z.string()).default([]),
-      })
-      .default({}),
-
-    selfCritique: z
-      .object({
-        /** When true, run a bounded self-critique pass before polish and grounding. */
-        enabled: z.boolean().default(false),
-        /** Maximum fraction of bullets that may be rewritten or dropped. */
-        dropFraction: z.number().min(0).max(0.4).default(0.2),
-        /** Skip critique when the briefing has fewer than this many bullets. */
-        minBulletCount: z.number().int().nonnegative().default(8),
-        /** Chat model for the critique pass (defaults to `openai.model`). */
-        critiqueModel: z.string().min(1).optional(),
-        /** Max output tokens for the critique `generateObject` call. */
-        critiqueMaxOutputTokens: z.number().int().positive().default(1500),
-        /** Prefer `suggestedRewrite` over dropping a bullet when both apply. */
-        preferRewriteOverDrop: z.boolean().default(true),
-      })
-      .default({}),
+    credentials: credentialsSchema,
+    output: outputSchema,
+    prompts: promptsSchema,
+    inputs: inputsSchema,
+    creativity: creativitySchema,
+    quality: qualitySchema,
+    delivery: deliverySchema,
+    freshness: freshnessSchema,
+    reliability: reliabilitySchema,
   })
-  /** Reject unknown keys (e.g. removed top-level `openaiApiKey`) so configs fail fast. */
+  /** Reject unknown keys (e.g. legacy flat `openai`, `sourceRanking`) so configs fail fast. */
   .strict()
   .superRefine((data, ctx) => {
     const prompts = data.prompts;
@@ -413,103 +635,94 @@ export const ContentGenerationConfigSchema = z
         });
       }
     }
+
+    refineRetryGroupValidity(
+      data.reliability.llmRetry,
+      ["reliability", "llmRetry"],
+      ctx,
+    );
+    refineRetryGroupValidity(
+      data.reliability.persistRetry,
+      ["reliability", "persistRetry"],
+      ctx,
+    );
   });
 
-export type ContentGenerationConfig = z.infer<
+/** Parsed invoke config with all group and field defaults applied. */
+export type ContentGenerationConfig = z.output<
   typeof ContentGenerationConfigSchema
 >;
 
 /** Fully resolved LLM retry settings (all fields guaranteed to be present). */
-export type ResolvedLlmRetryConfig = {
-  maxAttempts: number;
-  baseDelayMs: number;
-  maxDelayMs: number;
-  jitter: boolean;
-};
+export type ResolvedLlmRetryConfig =
+  ContentGenerationConfig["reliability"]["llmRetry"];
 
 /** Fully resolved persistence retry settings. */
-export type ResolvedPersistRetryConfig = {
-  maxAttempts: number;
-  baseDelayMs: number;
-  maxDelayMs: number;
-};
+export type ResolvedPersistRetryConfig =
+  ContentGenerationConfig["reliability"]["persistRetry"];
 
 /**
- * Content-generation config with optional fields resolved to their production defaults.
- * Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
+ * Content-generation config with per-pass model ids resolved to credentials.chatModel
+ * when omitted. Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
  */
 export type ResolvedContentGenerationConfig = ContentGenerationConfig & {
-  llmRetry: ResolvedLlmRetryConfig;
-  persistRetry: ResolvedPersistRetryConfig;
   brainstormModel: string;
   critiqueModel: string;
   subjectLineModel: string;
 };
 
-/** Production defaults for fields that may be omitted in Hermes config. */
-export const contentGenerationConfigDefaults = {
-  llmRetry: {
-    maxAttempts: 3,
-    baseDelayMs: 500,
-    maxDelayMs: 8000,
-    jitter: true,
-  },
-  persistRetry: {
-    maxAttempts: 2,
-    baseDelayMs: 200,
-    maxDelayMs: 2000,
-  },
-  useBrainstormPass: false,
-  brainstormMaxOutputTokens: 700,
-  selfCritique: {
-    enabled: false,
-    dropFraction: 0.2,
-    minBulletCount: 8,
-    critiqueMaxOutputTokens: 1500,
-    preferRewriteOverDrop: true,
-  },
-} as const;
+type RetryFields = {
+  maxAttempts: number;
+  baseDelayMs: number;
+  maxDelayMs: number;
+};
 
 /**
- * Merges Hermes-supplied config with production defaults for optional fields.
+ * Rejects structurally broken retry overrides (inverted delay cap or runaway attempts).
  *
- * @param config - Parsed and validated Hermes agent config.
+ * @param retry - Parsed retry group from Hermes config.
+ * @param pathPrefix - Zod issue path prefix under `reliability`.
+ * @param ctx - Zod refinement context.
+ */
+function refineRetryGroupValidity(
+  retry: RetryFields,
+  pathPrefix: readonly ["reliability", "llmRetry" | "persistRetry"],
+  ctx: z.RefinementCtx,
+): void {
+  if (retry.maxDelayMs < retry.baseDelayMs) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${pathPrefix[1]}.maxDelayMs (${String(retry.maxDelayMs)}) must be >= ${pathPrefix[1]}.baseDelayMs (${String(retry.baseDelayMs)})`,
+      path: [...pathPrefix, "maxDelayMs"],
+    });
+  }
+
+  if (retry.maxAttempts > CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `${pathPrefix[1]}.maxAttempts must be at most ${String(CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING)}`,
+      path: [...pathPrefix, "maxAttempts"],
+    });
+  }
+}
+
+/**
+ * Merges Hermes-supplied config with production defaults and resolves optional
+ * per-pass model ids to `credentials.chatModel`.
+ *
+ * @param config - Raw Hermes agent config.
  * @returns Config safe to use at runtime.
  */
 export function resolveContentGenerationConfig(
-  config: any,
+  config: unknown,
 ): ResolvedContentGenerationConfig {
   const parsed = ContentGenerationConfigSchema.parse(config);
+  const chatModel = parsed.credentials.chatModel;
 
   return {
     ...parsed,
-    llmRetry: {
-      maxAttempts:
-        parsed.llmRetry?.maxAttempts ??
-        contentGenerationConfigDefaults.llmRetry.maxAttempts,
-      baseDelayMs:
-        parsed.llmRetry?.baseDelayMs ??
-        contentGenerationConfigDefaults.llmRetry.baseDelayMs,
-      maxDelayMs:
-        parsed.llmRetry?.maxDelayMs ??
-        contentGenerationConfigDefaults.llmRetry.maxDelayMs,
-      jitter:
-        parsed.llmRetry?.jitter ??
-        contentGenerationConfigDefaults.llmRetry.jitter,
-    },
-    persistRetry: {
-      maxAttempts:
-        parsed.persistRetry?.maxAttempts ??
-        contentGenerationConfigDefaults.persistRetry.maxAttempts,
-      baseDelayMs:
-        parsed.persistRetry?.baseDelayMs ??
-        contentGenerationConfigDefaults.persistRetry.baseDelayMs,
-      maxDelayMs:
-        parsed.persistRetry?.maxDelayMs ??
-        contentGenerationConfigDefaults.persistRetry.maxDelayMs,
-    },
-    brainstormModel: parsed.brainstormModel ?? parsed.openai.model,
-    critiqueModel: parsed.selfCritique.critiqueModel ?? parsed.openai.model,
-    subjectLineModel: parsed.subjectLine.model ?? parsed.openai.model,
-  } as ResolvedContentGenerationConfig;
+    brainstormModel: parsed.creativity.brainstorm.model ?? chatModel,
+    critiqueModel: parsed.quality.selfCritique.critiqueModel ?? chatModel,
+    subjectLineModel: parsed.delivery.subjectLine.model ?? chatModel,
+  };
 }

--- a/apps/mediapulse/agents/content-generation/src/index.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.test.ts
@@ -258,12 +258,17 @@ describe("GET /schemas", () => {
     const schemaStr = JSON.stringify(body.configSchema);
 
     // Verify all config groups are present
-    expect(schemaStr).toContain("openai");
-    expect(schemaStr).toContain("apiKey");
+    expect(schemaStr).toContain('"credentials"');
+    expect(schemaStr).toContain("openaiApiKey");
+    expect(schemaStr).toContain("chatModel");
     expect(schemaStr).toContain("baseUrl");
-    expect(schemaStr).toContain("model");
     expect(schemaStr).toContain("maxTokens");
     expect(schemaStr).toContain("timeoutMs");
+    expect(schemaStr).toContain("inputs");
+    expect(schemaStr).toContain("creativity");
+    expect(schemaStr).toContain("quality");
+    expect(schemaStr).toContain("delivery");
+    expect(schemaStr).toContain("reliability");
     expect(schemaStr).toContain("systemPrompt");
     expect(schemaStr).toContain("userPromptTemplate");
     expect(schemaStr).toContain("topNewsCount");

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -5,7 +5,6 @@ import { logger } from "@workspace/logger";
 
 import {
   ContentGenerationConfigSchema,
-  contentGenerationConfigDefaults,
   resolveContentGenerationConfig,
 } from "./config-schema.js";
 import {
@@ -31,12 +30,31 @@ afterEach(() => {
 // Helpers
 // ---------------------------------------------------------------------------
 
+/** Disables quality passes so unit tests isolate one pipeline stage. */
+const conservativeTestConfigInput = {
+  credentials: { openaiApiKey: "sk-test" },
+  inputs: {
+    sourceRanking: { enabled: false },
+    fewShot: { enabled: false },
+    numericAnchors: { enabled: false },
+  },
+  creativity: {
+    brainstorm: { enabled: false },
+  },
+  quality: {
+    citationGrounding: { enabled: false },
+    polish: { enabled: false },
+    crossRunDedup: { enabled: false },
+    selfCritique: { enabled: false },
+  },
+  delivery: {
+    subjectLine: { enabled: false },
+  },
+} as const;
+
 /** Minimal resolved config used across tests (ranking off — legacy prompt order). */
 const baseConfig = resolveContentGenerationConfig(
-  ContentGenerationConfigSchema.parse({
-    openai: { apiKey: "sk-test" },
-    sourceRanking: { enabled: false },
-  }),
+  ContentGenerationConfigSchema.parse(conservativeTestConfigInput),
 );
 
 /** A fake sleep that records call count without real delays. */
@@ -158,7 +176,7 @@ describe("generateNewsletterWithLlm — happy path", () => {
     // Setup — only two articles should appear in {{sourceSummaries}}.
     const config = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
+        ...conservativeTestConfigInput,
         output: { topNewsCount: 2 },
       }),
     );
@@ -300,11 +318,31 @@ describe("generateNewsletterWithLlm — happy path", () => {
     expect(result.content).not.toMatch(/\[[^\]]+]\(https?:\/\/[^\s)]+\)/);
   });
 
+  it("omits unsupported sampling fields from generateObjectFn", async () => {
+    // Setup
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    // Act
+    await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+    });
+
+    // Assert
+    const callArgs = (generateObjectFn as ReturnType<typeof vi.fn>).mock
+      .calls[0]![0] as Record<string, unknown>;
+    expect(callArgs).not.toHaveProperty("temperature");
+    expect(callArgs).not.toHaveProperty("topP");
+    expect(callArgs).not.toHaveProperty("presencePenalty");
+    expect(callArgs).not.toHaveProperty("frequencyPenalty");
+  });
+
   it("passes timeout to generateObjectFn when openai.timeoutMs is set", async () => {
     // Setup
     const configWithTimeout = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test", timeoutMs: 5000 },
+        ...conservativeTestConfigInput,
+        credentials: { openaiApiKey: "sk-test", timeoutMs: 5000 },
       }),
     );
     const generateObjectFn = makeSuccessfulGenerateFn();
@@ -442,12 +480,14 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
     });
     const config = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        llmRetry: {
-          maxAttempts: 3,
-          baseDelayMs: 10,
-          maxDelayMs: 100,
-          jitter: false,
+        ...conservativeTestConfigInput,
+        reliability: {
+          llmRetry: {
+            maxAttempts: 3,
+            baseDelayMs: 10,
+            maxDelayMs: 100,
+            jitter: false,
+          },
         },
       }),
     );
@@ -477,12 +517,14 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
     });
     const config = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        llmRetry: {
-          maxAttempts: 3,
-          baseDelayMs: 10,
-          maxDelayMs: 100,
-          jitter: false,
+        ...conservativeTestConfigInput,
+        reliability: {
+          llmRetry: {
+            maxAttempts: 3,
+            baseDelayMs: 10,
+            maxDelayMs: 100,
+            jitter: false,
+          },
         },
       }),
     );
@@ -536,9 +578,7 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
       }),
     ).rejects.toThrow();
 
-    expect(generateObjectFn).toHaveBeenCalledTimes(
-      contentGenerationConfigDefaults.llmRetry.maxAttempts,
-    );
+    expect(generateObjectFn).toHaveBeenCalledTimes(3);
   });
 });
 
@@ -734,10 +774,12 @@ describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
   it("uses systemPrompt from config when provided", async () => {
     // Setup
     const customSystem = "You are a specialized financial analyst.";
-    const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
-      prompts: { systemPrompt: customSystem },
-    });
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        prompts: { systemPrompt: customSystem },
+      }),
+    );
     const generateObjectFn = makeSuccessfulGenerateFn();
 
     // Act
@@ -762,10 +804,12 @@ describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
     // Setup
     const customTemplate =
       "Analysis for {{tickerId}} on {{date}}.\n\n{{sourceSummaries}}";
-    const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
-      prompts: { userPromptTemplate: customTemplate },
-    });
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        prompts: { userPromptTemplate: customTemplate },
+      }),
+    );
     const generateObjectFn = makeSuccessfulGenerateFn();
 
     // Act
@@ -793,10 +837,12 @@ describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
   it("handles multiple occurrences of the same placeholder", async () => {
     // Setup
     const customTemplate = "{{tickerId}} report: {{tickerId}}.";
-    const config = resolveContentGenerationConfig({
-      openai: { apiKey: "sk-test" },
-      prompts: { userPromptTemplate: customTemplate },
-    });
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        prompts: { userPromptTemplate: customTemplate },
+      }),
+    );
     const generateObjectFn = makeSuccessfulGenerateFn();
 
     // Act
@@ -857,8 +903,7 @@ describe("generateNewsletterWithLlm — source ranking", () => {
     // Setup
     const legacyConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
+        ...conservativeTestConfigInput,
         output: { topNewsCount: 6 },
       }),
     );
@@ -890,8 +935,11 @@ describe("generateNewsletterWithLlm — source ranking", () => {
     // Setup
     const rankedConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: true, maxPerHost: 2 },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          sourceRanking: { enabled: true, maxPerHost: 2 },
+        },
         output: { topNewsCount: 6 },
       }),
     );
@@ -925,9 +973,11 @@ describe("generateNewsletterWithLlm — few-shot exemplars", () => {
     // Setup
     const disabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        fewShot: { enabled: false },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          fewShot: { enabled: false },
+        },
       }),
     );
     const generateObjectFn = makeSuccessfulGenerateFn();
@@ -949,9 +999,11 @@ describe("generateNewsletterWithLlm — few-shot exemplars", () => {
     // Setup
     const enabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        fewShot: { enabled: true, maxExemplars: 1 },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          fewShot: { enabled: true, maxExemplars: 1 },
+        },
       }),
     );
     const generateObjectFn = makeSuccessfulGenerateFn();
@@ -974,9 +1026,11 @@ describe("generateNewsletterWithLlm — few-shot exemplars", () => {
     // Setup
     const enabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        fewShot: { enabled: true, maxExemplars: 1, sectorTag: "industrial" },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          fewShot: { enabled: true, maxExemplars: 1, sectorTag: "industrial" },
+        },
       }),
     );
     const warnSpy = vi
@@ -1005,16 +1059,20 @@ describe("generateNewsletterWithLlm — few-shot exemplars", () => {
     // Setup
     const disabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        fewShot: { enabled: false },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          fewShot: { enabled: false },
+        },
       }),
     );
     const enabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        fewShot: { enabled: true },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          fewShot: { enabled: true },
+        },
       }),
     );
     const generateObjectFn = makeSuccessfulGenerateFn();
@@ -1056,9 +1114,10 @@ describe("generateNewsletterWithLlm — two-pass brainstorm", () => {
 
   const brainstormEnabledConfig = resolveContentGenerationConfig(
     ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test" },
-      sourceRanking: { enabled: false },
-      useBrainstormPass: true,
+      ...conservativeTestConfigInput,
+      creativity: {
+        brainstorm: { enabled: true },
+      },
     }),
   );
 
@@ -1093,9 +1152,10 @@ describe("generateNewsletterWithLlm — two-pass brainstorm", () => {
     // Setup
     const singlePassConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        useBrainstormPass: false,
+        ...conservativeTestConfigInput,
+        creativity: {
+          brainstorm: { enabled: false },
+        },
       }),
     );
     const generateObjectFn = makeSuccessfulGenerateFn();
@@ -1146,9 +1206,11 @@ describe("generateNewsletterWithLlm — two-pass brainstorm", () => {
     // Setup
     const slowConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test", timeoutMs: 1000 },
-        sourceRanking: { enabled: false },
-        useBrainstormPass: true,
+        ...conservativeTestConfigInput,
+        credentials: { openaiApiKey: "sk-test", timeoutMs: 1000 },
+        creativity: {
+          brainstorm: { enabled: true },
+        },
       }),
     );
     let now = 0;
@@ -1262,12 +1324,14 @@ describe("generateNewsletterWithLlm — citation grounding", () => {
     });
     const groundingConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        citationGrounding: {
-          enabled: true,
-          policy: "drop",
-          minOverlapScore: 0.18,
+        ...conservativeTestConfigInput,
+        quality: {
+          ...conservativeTestConfigInput.quality,
+          citationGrounding: {
+            enabled: true,
+            policy: "drop",
+            minOverlapScore: 0.18,
+          },
         },
       }),
     );
@@ -1302,13 +1366,16 @@ describe("generateNewsletterWithLlm — citation grounding", () => {
 describe("generateNewsletterWithLlm — self-critique", () => {
   const critiqueEnabledConfig = resolveContentGenerationConfig(
     ContentGenerationConfigSchema.parse({
-      openai: { apiKey: "sk-test", timeoutMs: 1000 },
-      sourceRanking: { enabled: false },
-      selfCritique: {
-        enabled: true,
-        dropFraction: 0.2,
-        minBulletCount: 8,
-        preferRewriteOverDrop: true,
+      ...conservativeTestConfigInput,
+      credentials: { openaiApiKey: "sk-test", timeoutMs: 1000 },
+      quality: {
+        ...conservativeTestConfigInput.quality,
+        selfCritique: {
+          enabled: true,
+          dropFraction: 0.2,
+          minBulletCount: 8,
+          preferRewriteOverDrop: true,
+        },
       },
     }),
   );
@@ -1448,11 +1515,13 @@ describe("generateNewsletterWithLlm — self-critique", () => {
     // Setup
     const sparseConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        selfCritique: {
-          enabled: true,
-          minBulletCount: 10,
+        ...conservativeTestConfigInput,
+        quality: {
+          ...conservativeTestConfigInput.quality,
+          selfCritique: {
+            enabled: true,
+            minBulletCount: 10,
+          },
         },
       }),
     );
@@ -1501,6 +1570,76 @@ describe("generateNewsletterWithLlm — self-critique", () => {
     // Assert
     expect(critiqueGenerateObjectFn).not.toHaveBeenCalled();
     expect(result.critiqueSkippedDueToBudget).toBe(true);
+  });
+
+  it("ships un-critiqued bullets and logs self_critique_failed_fallback when the critique throws", async () => {
+    // Setup — mirror the real failure where truncated JSON yields NoObjectGeneratedError
+    const generateObjectFn = makeSuccessfulGenerateFn();
+    const critiqueGenerateObjectFn = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(
+          Object.create(
+            NoObjectGeneratedError.prototype,
+          ) as NoObjectGeneratedError,
+          { message: "No object generated", name: "AI_NoObjectGeneratedError" },
+        ),
+      );
+    const warnSpy = vi
+      .spyOn(logger, "warn")
+      .mockImplementation(() => undefined);
+
+    // Act
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      critiqueEnabledConfig,
+      { ...testContext, runStartedAt: 0 },
+      {
+        generateObjectFn,
+        critiqueGenerateObjectFn,
+        sleepFn: noopSleepFn,
+        nowFn: () => 100,
+      },
+    );
+
+    // Assert — the run still produces a newsletter, critique is marked failed
+    expect(critiqueGenerateObjectFn).toHaveBeenCalledOnce();
+    expect(result.critiqueFailed).toBe(true);
+    expect(result.critiqueSummary).toBeUndefined();
+    expect(result.content.length).toBeGreaterThan(0);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "self_critique_failed_fallback" }),
+      expect.any(String),
+    );
+  });
+
+  it("scales critique maxOutputTokens above the configured floor with candidate count", async () => {
+    // Setup
+    const generateObjectFn = makeSuccessfulGenerateFn();
+    const critiqueGenerateObjectFn = vi.fn().mockResolvedValue({
+      object: { ratings: [] },
+      usage: { promptTokens: 50, completionTokens: 25 },
+    });
+
+    // Act
+    await generateNewsletterWithLlm(
+      testSources,
+      critiqueEnabledConfig,
+      { ...testContext, runStartedAt: 0 },
+      {
+        generateObjectFn,
+        critiqueGenerateObjectFn,
+        sleepFn: noopSleepFn,
+        nowFn: () => 100,
+      },
+    );
+
+    // Assert — nine eligible bullets must push the budget past the 1500 default
+    expect(critiqueGenerateObjectFn).toHaveBeenCalledOnce();
+    const callArgs = critiqueGenerateObjectFn.mock.calls[0]?.[0] as {
+      maxOutputTokens: number;
+    };
+    expect(callArgs.maxOutputTokens).toBeGreaterThan(1500);
   });
 });
 
@@ -1556,9 +1695,11 @@ describe("generateNewsletterWithLlm — numeric anchors", () => {
 
     const anchorsEnabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        numericAnchors: { enabled: true, perArticleCap: 5, totalCap: 25 },
+        ...conservativeTestConfigInput,
+        inputs: {
+          ...conservativeTestConfigInput.inputs,
+          numericAnchors: { enabled: true, perArticleCap: 5, totalCap: 25 },
+        },
       }),
     );
 
@@ -1625,9 +1766,11 @@ describe("generateNewsletterWithLlm — cross-run dedup", () => {
     const generateObjectFn = makeSuccessfulGenerateFn();
     const dedupEnabledConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        crossRunDedup: { enabled: true, windowDays: 14 },
+        ...conservativeTestConfigInput,
+        quality: {
+          ...conservativeTestConfigInput.quality,
+          crossRunDedup: { enabled: true, windowDays: 14 },
+        },
       }),
     );
 
@@ -1704,9 +1847,11 @@ describe("generateNewsletterWithLlm — style polish", () => {
     });
     const polishConfig = resolveContentGenerationConfig(
       ContentGenerationConfigSchema.parse({
-        openai: { apiKey: "sk-test" },
-        sourceRanking: { enabled: false },
-        polish: { enabled: true, tier: "safe" },
+        ...conservativeTestConfigInput,
+        quality: {
+          ...conservativeTestConfigInput.quality,
+          polish: { enabled: true, tier: "safe" },
+        },
       }),
     );
 
@@ -1732,5 +1877,89 @@ describe("generateNewsletterWithLlm — style polish", () => {
     expect(polished.structure.competitiveLandscape.bullets[0]?.text).toBe(
       "BCA grew profit by 12%",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Best-quality default profile (plan 62)
+// ---------------------------------------------------------------------------
+
+describe("generateNewsletterWithLlm — best-quality default profile", () => {
+  it("runs brainstorm, structured, critique, and subject-line LLM calls with default config", async () => {
+    // Setup
+    const bestQualityConfig = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        credentials: { openaiApiKey: "sk-test" },
+      }),
+    );
+    const generateTextFn = vi.fn().mockResolvedValue({
+      text: [
+        "HEADLINE THESIS: Markets in focus",
+        "WHAT CHANGED: Rates held steady",
+      ].join("\n"),
+      usage: { inputTokens: 10, outputTokens: 10 },
+    });
+    const generateObjectFn = makeSuccessfulGenerateFn();
+    const critiqueGenerateObjectFn = vi.fn().mockResolvedValue({
+      object: { ratings: [] },
+      usage: { promptTokens: 5, completionTokens: 5 },
+    });
+    const subjectGenerateObjectFn = vi.fn().mockResolvedValue({
+      object: {
+        candidates: [
+          { subject: "Alt headline A", style: "curiosity", preheader: "p1" },
+          { subject: "Alt headline B", style: "straight", preheader: "p2" },
+          { subject: "Alt headline C", style: "ticker", preheader: "p3" },
+        ],
+      },
+      usage: { promptTokens: 8, completionTokens: 8 },
+    });
+    const recentBullets = [
+      {
+        newsletterId: "nl-1",
+        sectionKey: "quickHits",
+        bulletText: "Prior sector note from last week",
+        createdAt: "2026-04-20T00:00:00.000Z",
+      },
+    ];
+
+    // Act
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      bestQualityConfig,
+      { ...testContext, recentBullets, runStartedAt: 0 },
+      {
+        generateObjectFn,
+        generateTextFn,
+        critiqueGenerateObjectFn,
+        subjectGenerateObjectFn,
+        sleepFn: noopSleepFn,
+        nowFn: () => 100,
+      },
+    );
+
+    // Assert — all quality passes enabled and exercised
+    expect(bestQualityConfig.creativity.brainstorm.enabled).toBe(true);
+    expect(bestQualityConfig.inputs.fewShot.enabled).toBe(true);
+    expect(bestQualityConfig.quality.citationGrounding.enabled).toBe(true);
+    expect(bestQualityConfig.inputs.numericAnchors.enabled).toBe(true);
+    expect(bestQualityConfig.quality.selfCritique.enabled).toBe(true);
+    expect(bestQualityConfig.delivery.subjectLine.enabled).toBe(true);
+    expect(bestQualityConfig.quality.polish.enabled).toBe(true);
+    expect(bestQualityConfig.quality.crossRunDedup.enabled).toBe(true);
+    expect(generateTextFn).toHaveBeenCalledOnce();
+    expect(generateObjectFn).toHaveBeenCalled();
+    expect(critiqueGenerateObjectFn).toHaveBeenCalledOnce();
+    expect(subjectGenerateObjectFn).toHaveBeenCalledOnce();
+    expect(result.brainstormUsed).toBe(true);
+    expect(result.resolvedUserPrompt).toContain("EXEMPLAR");
+    expect(result.resolvedUserPrompt).toContain(
+      "AVOID REPEATING THESE RECENT BULLETS",
+    );
+    expect(result.polishSummary).toBeDefined();
+    expect(result.citationGroundingSummary).toBeDefined();
+    expect(result.numericAnchorSummary).toBeDefined();
+    expect(result.critiqueSummary).toBeDefined();
+    expect(result.subjectLineSummary).toBeDefined();
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -134,6 +134,8 @@ export interface GeneratedContentWithProvenance extends GeneratedContent {
   critiqueSummary?: NewsletterCritiqueSummary;
   /** True when critique was skipped because the run exceeded 70% of timeout budget. */
   critiqueSkippedDueToBudget?: boolean;
+  /** True when the critique pass threw (e.g. truncated JSON) and was skipped. */
+  critiqueFailed?: boolean;
   /** Style polish rule-firing summary when enabled. */
   polishSummary?: Pick<
     PolishNewsletterResult,
@@ -252,6 +254,11 @@ const defaultGenerateTextForNewsletterBrainstorm: GenerateTextForNewsletterBrain
         : null;
     return { text: result.text, usage };
   };
+
+/** Fixed JSON overhead (wrapper object, schema scaffolding) for the critique pass. */
+const CRITIQUE_TOKENS_BASE_OVERHEAD = 256;
+/** Output-token allowance per critique rating row (scores + rationale + optional rewrite). */
+const CRITIQUE_TOKENS_PER_CANDIDATE = 180;
 
 const BRAINSTORM_SYSTEM_PROMPT = [
   "You are an editorial planner for a daily industry briefing.",
@@ -580,7 +587,7 @@ export function buildUserPrompt(
  * plain-text wire format for email parsing.
  *
  * Retries on transient errors (rate limits, server errors, timeouts) up to
- * `config.llmRetry.maxAttempts` times with exponential backoff and optional jitter.
+ * `config.reliability.llmRetry.maxAttempts` times with exponential backoff and optional jitter.
  * Non-retryable errors (auth failure, bad request, schema validation) are thrown immediately.
  *
  * Returns the generated content together with token usage and the exact prompt
@@ -589,7 +596,7 @@ export function buildUserPrompt(
  * needing to reconstruct the prompts.
  *
  * @param sources - Fetched data sources to summarise into a newsletter.
- * @param config - Resolved agent config including `llmRetry` and `openai.timeoutMs`.
+ * @param config - Resolved agent config including `reliability.llmRetry` and `credentials.timeoutMs`.
  * @param context - Dynamic values for prompt placeholder substitution (`tickerId`, `date`, `tickerName`, `tickerSymbol`).
  * @param deps - Injectable dependencies: `generateObjectFn` and `sleepFn` for testing.
  * @returns Generated newsletter content plus provenance metadata.
@@ -624,20 +631,20 @@ export async function generateNewsletterWithLlm(
   const nowFn = deps.nowFn ?? Date.now;
   const generationStartedAt = nowFn();
 
-  const topNewsCount = config.output?.topNewsCount ?? 10;
+  const topNewsCount = config.output.topNewsCount;
 
   // Truncate sources per configurable character limits before building prompts
   // (MP-CGA-004 / FR8). Sources are tail-truncated per-source, then overall
   // total is capped by dropping the least-relevant sources from the end.
-  const maxCharsPerSource = config.context?.maxCharsPerSource ?? 8000;
-  const maxTotalContextChars = config.context?.maxTotalContextChars ?? 100000;
+  const maxCharsPerSource = config.inputs.context.maxCharsPerSource;
+  const maxTotalContextChars = config.inputs.context.maxTotalContextChars;
   const truncatedSources = truncateSources(
     sources,
     maxCharsPerSource,
     maxTotalContextChars,
   );
 
-  const sourceRanking = config.sourceRanking;
+  const sourceRanking = config.inputs.sourceRanking;
   let selectedSources: SourceForGeneration[];
 
   if (sourceRanking.enabled) {
@@ -663,13 +670,15 @@ export async function generateNewsletterWithLlm(
   }
 
   const openai = createOpenAI({
-    apiKey: config.openai.apiKey,
-    ...(config.openai.baseUrl ? { baseURL: config.openai.baseUrl } : {}),
+    apiKey: config.credentials.openaiApiKey,
+    ...(config.credentials.baseUrl
+      ? { baseURL: config.credentials.baseUrl }
+      : {}),
   });
-  const model = openai(config.openai.model);
+  const model = openai(config.credentials.chatModel);
 
   // Wire prompts from config with fallback to defaults (MP-CGA-003 / MP-CGA-008).
-  const fewShot = config.fewShot;
+  const fewShot = config.inputs.fewShot;
   let exemplarSection = "";
   let exemplarsUsed: string[] = [];
   let activeExemplars: ReturnType<typeof pickExemplarsForTicker> = [];
@@ -714,15 +723,15 @@ export async function generateNewsletterWithLlm(
 
   const effectiveTopNewsCount = promptSources.length;
 
-  const timeout = config.openai?.timeoutMs;
-  const maxTokens = config.openai?.maxTokens;
+  const timeout = config.credentials.timeoutMs;
+  const maxTokens = config.credentials.maxTokens;
 
   let brainstormText: string | undefined;
   let brainstormUsed = false;
   let brainstormPromptTokens: number | null = null;
   let brainstormCompletionTokens: number | null = null;
 
-  if (config.useBrainstormPass) {
+  if (config.creativity.brainstorm.enabled) {
     const brainstormSystemPrompt = buildBrainstormSystemPrompt({
       tickerName: context.tickerName,
       tickerSymbol: context.tickerSymbol,
@@ -737,12 +746,12 @@ export async function generateNewsletterWithLlm(
       const brainstormStartedAt = nowFn();
       const brainstormResult = await fetchNewsletterBrainstorm(
         {
-          apiKey: config.openai.apiKey,
-          ...(config.openai.baseUrl !== undefined
-            ? { baseUrl: config.openai.baseUrl }
+          apiKey: config.credentials.openaiApiKey,
+          ...(config.credentials.baseUrl !== undefined
+            ? { baseUrl: config.credentials.baseUrl }
             : {}),
           model: config.brainstormModel,
-          maxOutputTokens: config.brainstormMaxOutputTokens,
+          maxOutputTokens: config.creativity.brainstorm.maxOutputTokens,
           system: brainstormSystemPrompt,
           prompt: brainstormUserPrompt,
           ...(timeout !== undefined ? { timeout } : {}),
@@ -800,7 +809,7 @@ export async function generateNewsletterWithLlm(
     .replaceAll("{{tickerName}}", context.tickerName ?? context.tickerId)
     .replaceAll("{{tickerSymbol}}", context.tickerSymbol ?? context.tickerId);
 
-  const numericAnchors = config.numericAnchors;
+  const numericAnchors = config.inputs.numericAnchors;
   let numericAnchorSection = "";
   let topNumericAnchors: ReturnType<typeof selectTopAnchors> = [];
   let anchorsExtracted = 0;
@@ -816,7 +825,7 @@ export async function generateNewsletterWithLlm(
     numericAnchorSection = formatAnchorsForPrompt(topNumericAnchors);
   }
 
-  const crossRunDedup = config.crossRunDedup;
+  const crossRunDedup = config.quality.crossRunDedup;
   const recentBullets = context.recentBullets ?? [];
   const crossRunDedupAvoidanceSection = crossRunDedup.enabled
     ? formatRecentBulletsAvoidanceBlock(recentBullets, crossRunDedup.windowDays)
@@ -861,7 +870,7 @@ export async function generateNewsletterWithLlm(
         ...(maxTokens !== undefined ? { maxTokens } : {}),
       });
     },
-    config.llmRetry,
+    config.reliability.llmRetry,
     isRetryableLlmError,
     { sleepFn: deps.sleepFn },
   );
@@ -929,8 +938,9 @@ export async function generateNewsletterWithLlm(
   let critiquedStructure = workingStructure;
   let critiqueSummary: NewsletterCritiqueSummary | undefined;
   let critiqueSkippedDueToBudget = false;
+  let critiqueFailed = false;
 
-  const selfCritique = config.selfCritique;
+  const selfCritique = config.quality.selfCritique;
   const runElapsedMs = nowFn() - (context.runStartedAt ?? generationStartedAt);
   const critiqueBudgetExceeded =
     timeout !== undefined && runElapsedMs > timeout * 0.7;
@@ -975,60 +985,86 @@ export async function generateNewsletterWithLlm(
             ? Math.max(1, timeout - (nowFn() - generationStartedAt))
             : undefined;
 
-        const critiqueResult = await critiqueNewsletter(
-          {
-            apiKey: config.openai.apiKey,
-            ...(config.openai.baseUrl !== undefined
-              ? { baseUrl: config.openai.baseUrl }
-              : {}),
-            model: config.critiqueModel,
-            maxOutputTokens: selfCritique.critiqueMaxOutputTokens,
-            system: critiqueSystem,
-            prompt: critiquePrompt,
-            ...(critiqueTimeout !== undefined
-              ? { timeout: critiqueTimeout }
-              : {}),
-          },
-          { generateObjectFn: deps.critiqueGenerateObjectFn },
+        // The critic emits one JSON row per candidate, so a fixed token cap
+        // truncates (and fails to parse) on larger briefings. Scale the budget
+        // with candidate count while honoring the configured value as a floor.
+        const critiqueMaxOutputTokens = Math.max(
+          selfCritique.critiqueMaxOutputTokens,
+          CRITIQUE_TOKENS_BASE_OVERHEAD +
+            candidates.length * CRITIQUE_TOKENS_PER_CANDIDATE,
         );
 
-        const applied = applyNewsletterCritiqueResults(
-          workingStructure,
-          critiqueResult.object.ratings,
-          {
-            dropFraction: selfCritique.dropFraction,
-            preferRewriteOverDrop: selfCritique.preferRewriteOverDrop,
-          },
-        );
+        try {
+          const critiqueResult = await critiqueNewsletter(
+            {
+              apiKey: config.credentials.openaiApiKey,
+              ...(config.credentials.baseUrl !== undefined
+                ? { baseUrl: config.credentials.baseUrl }
+                : {}),
+              model: config.critiqueModel,
+              maxOutputTokens: critiqueMaxOutputTokens,
+              system: critiqueSystem,
+              prompt: critiquePrompt,
+              ...(critiqueTimeout !== undefined
+                ? { timeout: critiqueTimeout }
+                : {}),
+            },
+            { generateObjectFn: deps.critiqueGenerateObjectFn },
+          );
 
-        critiquedStructure = applied.structure;
+          const applied = applyNewsletterCritiqueResults(
+            workingStructure,
+            critiqueResult.object.ratings,
+            {
+              dropFraction: selfCritique.dropFraction,
+              preferRewriteOverDrop: selfCritique.preferRewriteOverDrop,
+            },
+          );
 
-        if (applied.summary.floorPreserved > 0) {
+          critiquedStructure = applied.structure;
+
+          if (applied.summary.floorPreserved > 0) {
+            logger.info(
+              {
+                tickerId: context.tickerId,
+                floorPreserved: applied.summary.floorPreserved,
+                event: "critiqueFloorPreserved",
+              },
+              "Self-critique preserved schema row minimums",
+            );
+          }
+
+          critiqueSummary = {
+            ...applied.summary,
+            promptTokens: critiqueResult.usage.promptTokens,
+            completionTokens: critiqueResult.usage.completionTokens,
+            p50Specificity: applied.p50Specificity,
+            p50ReaderValue: applied.p50ReaderValue,
+          };
+
           logger.info(
             {
               tickerId: context.tickerId,
-              floorPreserved: applied.summary.floorPreserved,
-              event: "critiqueFloorPreserved",
+              critique: critiqueSummary,
             },
-            "Self-critique preserved schema row minimums",
+            "Newsletter self-critique summary",
+          );
+        } catch (critiqueErr) {
+          // The critique pass only drops/rewrites a bounded fraction of an
+          // already-complete newsletter, so a failed critique (e.g. truncated
+          // JSON) must never sink the run. Fall back to the un-critiqued
+          // structure, matching the brainstorm and subject-line passes.
+          critiqueFailed = true;
+          critiquedStructure = workingStructure;
+          logger.warn(
+            {
+              tickerId: context.tickerId,
+              event: "self_critique_failed_fallback",
+              err: critiqueErr,
+            },
+            "Newsletter self-critique pass failed; shipping un-critiqued bullets",
           );
         }
-
-        critiqueSummary = {
-          ...applied.summary,
-          promptTokens: critiqueResult.usage.promptTokens,
-          completionTokens: critiqueResult.usage.completionTokens,
-          p50Specificity: applied.p50Specificity,
-          p50ReaderValue: applied.p50ReaderValue,
-        };
-
-        logger.info(
-          {
-            tickerId: context.tickerId,
-            critique: critiqueSummary,
-          },
-          "Newsletter self-critique summary",
-        );
       }
     }
   }
@@ -1041,7 +1077,7 @@ export async function generateNewsletterWithLlm(
       >
     | undefined;
 
-  const polish = config.polish;
+  const polish = config.quality.polish;
   if (polish.enabled) {
     const polished = polishNewsletter(critiquedStructure, {
       tier: polish.tier,
@@ -1066,7 +1102,7 @@ export async function generateNewsletterWithLlm(
   }
 
   let groundedStructure = polishedStructure;
-  const citationGrounding = config.citationGrounding;
+  const citationGrounding = config.quality.citationGrounding;
   if (citationGrounding.enabled) {
     const grounded = groundNewsletterCitations(
       polishedStructure,
@@ -1122,7 +1158,7 @@ export async function generateNewsletterWithLlm(
   let preheader: string | undefined;
   let subjectLineSummary: SubjectLineSummary | undefined;
 
-  const subjectLine = config.subjectLine;
+  const subjectLine = config.delivery.subjectLine;
   const recentSubjects = context.recentSubjects ?? [];
 
   if (subjectLine.enabled) {
@@ -1150,9 +1186,9 @@ export async function generateNewsletterWithLlm(
 
       const subjectResult = await fetchSubjectCandidates(
         {
-          apiKey: config.openai.apiKey,
-          ...(config.openai.baseUrl !== undefined
-            ? { baseUrl: config.openai.baseUrl }
+          apiKey: config.credentials.openaiApiKey,
+          ...(config.credentials.baseUrl !== undefined
+            ? { baseUrl: config.credentials.baseUrl }
             : {}),
           model: config.subjectLineModel,
           candidateCount: subjectLine.candidateCount,
@@ -1295,6 +1331,7 @@ export async function generateNewsletterWithLlm(
     ...(lowInformationDay !== undefined ? { lowInformationDay } : {}),
     ...(critiqueSummary !== undefined ? { critiqueSummary } : {}),
     ...(critiqueSkippedDueToBudget ? { critiqueSkippedDueToBudget: true } : {}),
+    ...(critiqueFailed ? { critiqueFailed: true } : {}),
     ...(polishSummary !== undefined ? { polishSummary } : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/run.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.test.ts
@@ -68,7 +68,7 @@ const TEST_TICKER_ID = "00000000-0000-4000-8000-000000000001" as const;
 
 const baseConfig: ContentGenerationConfig = ContentGenerationConfigSchema.parse(
   {
-    openai: { apiKey: "sk-test" },
+    credentials: { openaiApiKey: "sk-test" },
   },
 );
 
@@ -552,9 +552,18 @@ describe("run", () => {
     expect(result.success).toBe(true);
     expect(generateSpy).toHaveBeenCalledTimes(1);
     const secondArg = generateSpy.mock.calls[0]![1];
-    expect(secondArg.llmRetry.maxAttempts).toBe(3);
-    expect(secondArg.llmRetry.baseDelayMs).toBe(500);
-    expect(secondArg.llmRetry.jitter).toBe(true);
+    expect(secondArg.reliability.llmRetry.maxAttempts).toBe(3);
+    expect(secondArg.reliability.llmRetry.baseDelayMs).toBe(500);
+    expect(secondArg.reliability.llmRetry.jitter).toBe(true);
+    expect(secondArg.creativity.brainstorm.enabled).toBe(true);
+    expect(secondArg.inputs.fewShot.enabled).toBe(true);
+    expect(secondArg.quality.citationGrounding.enabled).toBe(true);
+    expect(secondArg.inputs.numericAnchors.enabled).toBe(true);
+    expect(secondArg.quality.selfCritique.enabled).toBe(true);
+    expect(secondArg.delivery.subjectLine.enabled).toBe(true);
+    expect(secondArg.quality.polish.enabled).toBe(true);
+    expect(secondArg.quality.crossRunDedup.enabled).toBe(true);
+    expect(secondArg.inputs.sourceRanking.enabled).toBe(true);
   });
 
   it("passes tickerId and current date to generateNewsletterWithLlm", async () => {
@@ -987,6 +996,8 @@ describe("provenance fields in contentGeneration.create", () => {
     contentGenerationGet.mockReset();
     contentGenerationCreate.mockReset();
     contentGenerationNewslettersLatestGet.mockReset();
+    contentGenerationNewslettersRecentGet.mockReset();
+    contentGenerationBulletsRecentGet.mockReset();
     contentGenerationRunsCreate.mockReset();
     vi.spyOn(LlmGenerate, "generateNewsletterWithLlm").mockReset();
   });
@@ -1092,8 +1103,8 @@ describe("provenance fields in contentGeneration.create", () => {
     const result = (await run(
       makeContext({
         config: ContentGenerationConfigSchema.parse({
-          openai: { apiKey: "sk-test" },
-          useBrainstormPass: true,
+          credentials: { openaiApiKey: "sk-test" },
+          creativity: { brainstorm: { enabled: true } },
         }),
       }),
     )) as AgentRunResult & {
@@ -1130,8 +1141,8 @@ describe("provenance fields in contentGeneration.create", () => {
     const result = (await run(
       makeContext({
         config: ContentGenerationConfigSchema.parse({
-          openai: { apiKey: "sk-test" },
-          citationGrounding: { enabled: true },
+          credentials: { openaiApiKey: "sk-test" },
+          quality: { citationGrounding: { enabled: true } },
         }),
       }),
     )) as AgentRunResult & {
@@ -1172,7 +1183,7 @@ describe("provenance fields in contentGeneration.create", () => {
   // model comes from config (AC)
   // -------------------------------------------------------------------------
 
-  it("uses the model from config.openai.model as the provenance model field", async () => {
+  it("uses the model from config.credentials.chatModel as the provenance model field", async () => {
     // Setup
     setupHappyPath();
 
@@ -1180,10 +1191,10 @@ describe("provenance fields in contentGeneration.create", () => {
     await run(
       makeContext({
         config: {
-          openai: {
-            apiKey: "sk-test",
-            model: "gpt-4o",
-            timeoutMs: 120000,
+          credentials: {
+            openaiApiKey: "sk-test",
+            chatModel: "gpt-4o",
+            timeoutMs: 120_000,
           },
         },
       }),
@@ -1214,11 +1225,15 @@ describe("provenance fields in contentGeneration.create", () => {
   // configVersion excludes apiKey (AC)
   // -------------------------------------------------------------------------
 
-  it("produces the same configVersion for two runs differing only in openai.apiKey", async () => {
+  it("produces the same configVersion for two runs differing only in credentials.openaiApiKey", async () => {
     // Setup — run A with key-alpha
     setupHappyPath();
     await run(
-      makeContext({ config: { openai: { apiKey: "sk-key-alpha" } } as any }),
+      makeContext({
+        config: {
+          credentials: { openaiApiKey: "sk-key-alpha" },
+        } as ContentGenerationConfig,
+      }),
     );
     const createArgA = contentGenerationCreate.mock.calls[0]![0];
 
@@ -1232,7 +1247,11 @@ describe("provenance fields in contentGeneration.create", () => {
 
     // Run B with key-beta (everything else is the same)
     await run(
-      makeContext({ config: { openai: { apiKey: "sk-key-beta" } } as any }),
+      makeContext({
+        config: {
+          credentials: { openaiApiKey: "sk-key-beta" },
+        } as ContentGenerationConfig,
+      }),
     );
     const createArgB = contentGenerationCreate.mock.calls[0]![0];
 
@@ -1340,8 +1359,8 @@ describe("provenance fields in contentGeneration.create", () => {
     const result = await run(
       makeContext({
         config: ContentGenerationConfigSchema.parse({
-          openai: { apiKey: "sk-test" },
-          subjectLine: { enabled: true },
+          credentials: { openaiApiKey: "sk-test" },
+          delivery: { subjectLine: { enabled: true } },
         }),
       }),
     );
@@ -1352,7 +1371,9 @@ describe("provenance fields in contentGeneration.create", () => {
     expect(generateSpy).toHaveBeenCalledWith(
       expect.any(Array),
       expect.objectContaining({
-        subjectLine: expect.objectContaining({ enabled: true }),
+        delivery: expect.objectContaining({
+          subjectLine: expect.objectContaining({ enabled: true }),
+        }),
       }),
       expect.objectContaining({
         tickerId: TEST_TICKER_ID,

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -248,8 +248,9 @@ export async function run({
     tickerId: input.tickerId,
   });
 
-  const { apiKey: _apiKey, ...safeOpenai } = resolvedConfig.openai;
-  const safeConfig = { ...resolvedConfig, openai: safeOpenai };
+  const { openaiApiKey: _apiKey, ...safeCredentials } =
+    resolvedConfig.credentials;
+  const safeConfig = { ...resolvedConfig, credentials: safeCredentials };
   logger.info({ sources }, "Data sources for ticker");
   logger.info({ config: safeConfig }, "Config");
 
@@ -293,11 +294,11 @@ export async function run({
     bulletText: string;
     createdAt: string;
   }> = [];
-  if (resolvedConfig.crossRunDedup.enabled) {
+  if (resolvedConfig.quality.crossRunDedup.enabled) {
     try {
       const recent = await dataApiClient.contentGenerationBulletsRecent.get({
         tickerId: input.tickerId,
-        days: resolvedConfig.crossRunDedup.windowDays,
+        days: resolvedConfig.quality.crossRunDedup.windowDays,
       });
       recentBullets = recent.items;
     } catch (recentErr) {
@@ -314,7 +315,7 @@ export async function run({
   }
 
   let recentSubjects: string[] = [];
-  if (resolvedConfig.subjectLine.enabled) {
+  if (resolvedConfig.delivery.subjectLine.enabled) {
     try {
       const recent = await dataApiClient.contentGenerationNewslettersRecent.get(
         {
@@ -399,7 +400,7 @@ export async function run({
   // response model may be an alias or resolved variant (e.g. "gpt-4o-2024-08-06"
   // for an "gpt-4o" alias). Using the config value keeps provenance aligned with
   // the operator-visible setting in Hermes.
-  const provenanceModel = resolvedConfig.openai.model;
+  const provenanceModel = resolvedConfig.credentials.chatModel;
 
   // `configVersion`: deterministic hash of non-secret config fields.
   const configVersion = computeConfigVersion(resolvedConfig);

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation-config-reference.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation-config-reference.mdx
@@ -1,82 +1,102 @@
 ---
 title: Content Generation Agent — Config Reference
-description: Full config schema reference for the content-generation agent, covering all groups, fields, types, defaults, and validation constraints.
+description: Full grouped config schema reference for the content-generation agent, covering all sections, fields, types, defaults, and validation constraints.
 icon: FileText
 ---
 
 ## Overview
 
-The content-generation agent loads its runtime configuration from Hermes on each invocation (Dashboard → Agent configs, select the config for the pipeline step). No configuration is sourced from environment variables — API credentials, model settings, prompts, and retry policies all come from the Hermes config payload. See [Local Dev Credentials](/mediapulse/apps/agents/content-generation-local-dev-credentials) for the local-development env-fallback workflow.
+The content-generation agent loads its runtime configuration from Hermes on each invocation (Dashboard → Agent configs, select the config for the pipeline step). No configuration is sourced from environment variables — API credentials, model settings, prompts, and retry policies all come from the Hermes config payload. The root schema is **strict**: legacy flat keys (`openai`, `sourceRanking`, `useBrainstormPass`, …) are rejected; re-save configs in the grouped form after upgrading.
 
-## Config groups
+Create Hermes Variables: `OPENAI_API_KEY`, `OPENAI_MODEL`.
 
-### OpenAI
+## Config groups (form order)
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `openai.apiKey` | `string` | — | OpenAI API key. Required if `openaiApiKey` (deprecated) is omitted. Must be at least 1 character. |
-| `openai.baseUrl` | `string (url)` | — | OpenAI-compatible API base URL (e.g. Azure OpenAI or proxy). Must be a valid URL. |
-| `openai.model` | `string` | `gpt-4o-mini` | Chat completions model id. Must be at least 1 character. |
-| `openai.maxTokens` | `number` | — | Maximum tokens to generate. Must be a positive integer. |
-| `openai.timeoutMs` | `number` | `120000` | Per-request timeout in milliseconds passed to the AI SDK `generateObject` call. Must be a positive integer. |
-
-**Deprecated top-level fields** (migrate to `openai.*`):
+### Credentials
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `openaiApiKey` | `string` | — | **Deprecated** — use `openai.apiKey`. Must be at least 1 character. |
-| `openaiBaseUrl` | `string (url)` | — | **Deprecated** — use `openai.baseUrl`. Must be a valid URL. |
-| `openaiModel` | `string` | — | **Deprecated** — use `openai.model`. Must be at least 1 character. |
+| `credentials.openaiApiKey` | `string` | `{{OPENAI_API_KEY}}` | OpenAI API key or Hermes variable placeholder. |
+| `credentials.baseUrl` | `string (url)` | — | OpenAI-compatible API base URL. |
+| `credentials.chatModel` | `string` | `{{OPENAI_MODEL}}` | Chat model id or Hermes variable placeholder. |
+| `credentials.maxTokens` | `number` | — | Maximum tokens to generate per LLM call. |
+| `credentials.timeoutMs` | `number` | `120000` | Per-request timeout in milliseconds. |
 
-### Prompts
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `prompts.systemPrompt` | `string` | — | Custom system instructions sent to the LLM. |
-| `prompts.userPromptTemplate` | `string` | — | Template with supported placeholders: `{{sourceSummaries}}`, `{{tickerId}}`, `{{date}}`, `{{topNewsCount}}`. |
+There is no `sampling` group. Reasoning models on the OpenAI Responses API (for example `gpt-5.4-mini`) do not accept `temperature`, `topP`, `presencePenalty`, or `frequencyPenalty`; the agent never forwards those fields to the AI SDK.
 
 ### Output
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `output.topNewsCount` | `number` | `10` | Number of highest-relevance articles passed into the LLM prompt (`Article 1` … `Article N`). Must be a positive integer. |
+| `output.topNewsCount` | `number` | `10` | Articles in the LLM prompt (`Article 1` … `Article N`). |
 
-### Context Limits
-
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `context.maxCharsPerSource` | `number` | `8000` | Maximum characters to keep per source. Must be a positive integer. |
-| `context.maxTotalContextChars` | `number` | `100000` | Maximum total characters across all sources. Must be a positive integer. |
-
-### LLM Retry
+### Prompts
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `llmRetry.maxAttempts` | `number` | `3` | Maximum total attempts (including the first). Must be a non-negative integer. |
-| `llmRetry.baseDelayMs` | `number` | `500` | Base delay in milliseconds before the first retry. Must be a non-negative integer. |
-| `llmRetry.maxDelayMs` | `number` | `8000` | Maximum delay cap in milliseconds. Must be a non-negative integer. |
-| `llmRetry.jitter` | `boolean` | `true` | Applies ±50% random jitter to each computed backoff delay. |
+| `prompts.systemPrompt` | `string` | built-in | Placeholders: `{{topNewsCount}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`. |
+| `prompts.userPromptTemplate` | `string` | built-in | Placeholders: `{{sourceSummaries}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`, `{{date}}`, `{{topNewsCount}}`. |
 
-Retries only for retryable errors: rate limits (429), 5xx server errors, and network timeouts. Non-retryable errors (401, 400, schema validation) short-circuit immediately.
+### Inputs
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `inputs.sourceRanking.enabled` | `boolean` | `true` | Pre-LLM re-rank and host diversification. |
+| `inputs.sourceRanking.maxPerHost` | `number` | `2` | Max articles per host in the prompt. |
+| `inputs.fewShot.enabled` | `boolean` | `true` | Inject curated newsletter exemplars. |
+| `inputs.fewShot.maxExemplars` | `number` | `1` | Exemplar blocks to prepend (1–2). |
+| `inputs.numericAnchors.enabled` | `boolean` | `true` | Verbatim figure sidecar and post-generation audit. |
+| `inputs.context.maxCharsPerSource` | `number` | `8000` | Per-source truncation budget. |
+| `inputs.context.maxTotalContextChars` | `number` | `100000` | Total context budget across sources. |
+
+### Creativity
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `creativity.brainstorm.enabled` | `boolean` | `true` | Free-form editor's memo before structured JSON. |
+| `creativity.brainstorm.model` | `string` | `credentials.chatModel` | Optional brainstorm model override. |
+| `creativity.brainstorm.maxOutputTokens` | `number` | `700` | Memo pass output token cap. |
+
+### Quality
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `quality.selfCritique.enabled` | `boolean` | `true` | Bounded bullet self-critique pass. |
+| `quality.citationGrounding.enabled` | `boolean` | `true` | Citation overlap verification. |
+| `quality.citationGrounding.policy` | enum | `unlink` | `warn`, `unlink`, or `drop`. |
+| `quality.polish.enabled` | `boolean` | `true` | Deterministic filler/hedge/register cleanup. |
+| `quality.polish.tier` | enum | `safe` | `safe` or `aggressive`. |
+| `quality.crossRunDedup.enabled` | `boolean` | `true` | Recent-bullet avoidance and post-walk dedup. |
+| `quality.crossRunDedup.policy` | enum | `warn` | `warn`, `mark`, or `drop`. |
+
+### Delivery
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `delivery.subjectLine.enabled` | `boolean` | `true` | Subject-line candidate generation and scoring. |
+| `delivery.subjectLine.candidateCount` | `number` | `5` | Alternative subjects to request (3–8). |
+| `delivery.subjectLine.model` | `string` | `credentials.chatModel` | Optional subject-line model override. |
 
 ### Freshness
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `freshness.strategy` | `"calendar_day"` | `calendar_day` | Freshness window strategy. Only `calendar_day` is supported in v1. |
-| `freshness.timezone` | `string (IANA)` | `Asia/Jakarta` | IANA timezone for the calendar-day window (e.g. `America/New_York`, `Asia/Jakarta`). Must be a valid IANA timezone identifier. |
+| `freshness.strategy` | `"calendar_day"` | `calendar_day` | Freshness window strategy. |
+| `freshness.timezone` | `string (IANA)` | `Asia/Jakarta` | Calendar-day timezone for skip-if-fresh. |
 
-The freshness window determines whether a newsletter already exists for today's calendar day (midnight-to-midnight in the configured timezone). When a fresh newsletter exists, the agent skips generation. See [Freshness Behavior](/mediapulse/apps/agents/content-generation-freshness) for full semantics.
-
-### Persist Retry
+### Reliability
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `persistRetry.maxAttempts` | `number` | `2` | Maximum total attempts for persisting to agent-data-api. Must be a non-negative integer. |
-| `persistRetry.baseDelayMs` | `number` | `200` | Base delay in milliseconds. Must be a non-negative integer. |
-| `persistRetry.maxDelayMs` | `number` | `2000` | Maximum delay cap in milliseconds. Must be a non-negative integer. |
+| `reliability.llmRetry.maxAttempts` | `number` | `3` | Max LLM attempts (including first). |
+| `reliability.llmRetry.baseDelayMs` | `number` | `500` | Base backoff delay in ms. |
+| `reliability.llmRetry.maxDelayMs` | `number` | `8000` | Max backoff cap in ms. |
+| `reliability.llmRetry.jitter` | `boolean` | `true` | ±50% jitter on backoff delays. |
+| `reliability.persistRetry.maxAttempts` | `number` | `2` | Max persist attempts. |
+| `reliability.persistRetry.baseDelayMs` | `number` | `200` | Base persist backoff in ms. |
+| `reliability.persistRetry.maxDelayMs` | `number` | `2000` | Max persist backoff cap in ms. |
 
-Persist retries use fixed exponential backoff without jitter (unlike LLM retries). Retryable errors: 5xx, 429, and network timeouts. Non-retryable 4xx client errors fail fast.
+Retry validation rejects `maxDelayMs < baseDelayMs` and `maxAttempts` above 10 for either group.
 
 ## Related docs
 

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -14,9 +14,9 @@ The content-generation agent takes **selected data sources** (scored by the anal
 - **Fetches** selected high-relevance sources for the ticker from `GET /api/v1/content-generation` (rows where `article_relevance.selected = true` and scored today).
 - **Calls OpenAI** via the Vercel AI SDK (`generateObject` from `ai` with `@ai-sdk/openai` provider) to generate structured **industry intelligence** newsletter JSON (subject, multi-section briefing, quick hits with `articleIndex` grounding). The API key, optional API base URL, and model id are **not** read from environment variables; they come from the **agent config** selected for the pipeline step in Hermes (Dashboard → Agent configs), so admins can manage credentials centrally (optionally using [variable expansion](/hermes/agent-hermes-contract#variables-in-config-and-params) for secrets).
 - **Serializes** the validated object to plain text with the first-line marker `MP_NEWSLETTER` and deterministic `BEGIN … END` blocks. URLs are **never** taken from model text; they are injected from Hermes-selected sources using each `articleIndex`. Inline `(Article N)` markers that the model sometimes writes into bullet, quick-hit, or prose text are **stripped deterministically** at wire serialization — subscribers see citations only via the rendered `Read the full article: <url>` line. Prompt-side blocks (the brainstorm memo and numeric-anchor sidecar) intentionally keep `(Article N)` tags as LLM input and are not part of the email body. Legacy bodies without the marker (`EXECUTIVE SUMMARY` / `TOP N NEWS`) are unchanged for historical rows. The shared email package parses both shapes (see `@workspace/email-templates` `parseNewsletterBody`).
-- **Retries** transient LLM failures (rate limits, 5xx errors, timeouts) using exponential backoff with optional jitter, up to `llmRetry.maxAttempts` (default 3). Non-retryable errors (auth, bad request, schema validation) short-circuit immediately.
+- **Retries** transient LLM failures (rate limits, 5xx errors, timeouts) using exponential backoff with optional jitter, up to `reliability.llmRetry.maxAttempts` (default 3). Non-retryable errors (auth, bad request, schema validation) short-circuit immediately.
 - **Classifies errors** into structured outcome codes for diagnostics (see [Error taxonomy](#error-taxonomy) below).
-- **Retries persist** errors (agent-data-api 5xx, 429, network timeouts) using exponential backoff up to `persistRetry.maxAttempts` (default 2, no jitter). Non-retryable 4xx client errors fail fast without retrying.
+- **Retries persist** errors (agent-data-api 5xx, 429, network timeouts) using exponential backoff up to `reliability.persistRetry.maxAttempts` (default 2, no jitter). Non-retryable 4xx client errors fail fast without retrying.
 - **Stores** generated content via agent-data-api for the delivery agent.
 - **Skips** with a clear message and outcome code `no_sources` if no data sources are found.
 - **Skip-if-fresh** — Before calling OpenAI, checks whether a newsletter already exists for the ticker within today's freshness window (`freshness.timezone` calendar day). If fresh, the run is skipped with outcome code `skipped_fresh_newsletter_exists`. See [Freshness Behavior](/mediapulse/apps/agents/content-generation-freshness) for full semantics.
@@ -35,43 +35,27 @@ Successful runs include `details.promptHash` (16-character hex, same algorithm a
 
 ## Config schema
 
-| Field                            | Type           | Required | Default          | Description                                                                                                                                                                                                                                                                                               |
-| -------------------------------- | -------------- | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `openai.apiKey`                  | `string`       | ✅       | —                | OpenAI API key. Required if `openaiApiKey` is omitted.                                                                                                                                                                                                                                                    |
-| `openai.model`                   | `string`       | ❌       | `gpt-4o-mini`    | Chat model id.                                                                                                                                                                                                                                                                                            |
-| `openai.baseUrl`                 | `string (url)` | ❌       | official         | OpenAI-compatible API base URL.                                                                                                                                                                                                                                                                           |
-| `openai.timeoutMs`               | `number`       | ❌       | `120000`         | Per-request timeout in milliseconds.                                                                                                                                                                                                                                                                      |
-| `openaiApiKey`                   | `string`       | ❌       | —                | **Deprecated**: Use `openai.apiKey`.                                                                                                                                                                                                                                                                      |
-| `openaiModel`                    | `string`       | ❌       | —                | **Deprecated**: Use `openai.model`.                                                                                                                                                                                                                                                                       |
-| `prompts.systemPrompt`           | `string`       | ❌       | built-in default | Full system template. Allowed placeholders: `{{topNewsCount}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`. Hermes JSON schema lists them for SchemaForm. Max length enforced at parse time (`CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH`). **Not for secrets** — use `openai.apiKey` only. |
-| `prompts.userPromptTemplate`     | `string`       | ❌       | built-in default | User template. Allowed placeholders: `{{sourceSummaries}}`, `{{tickerId}}`, `{{tickerName}}`, `{{tickerSymbol}}`, `{{date}}`, `{{topNewsCount}}`. Same max length and validation as system. **Not for secrets.**                                                                                          |
-| `output.topNewsCount`            | `number`       | ❌       | `10`             | Number of highest-relevance articles included in the LLM prompt (`Article 1` … `Article N`). Also caps how many distinct URLs can be injected from `articleIndex`.                                                                                                                                        |
-| `llmRetry.maxAttempts`           | `number`       | ❌       | `3`              | Max retry attempts (including first).                                                                                                                                                                                                                                                                     |
-| `llmRetry.baseDelayMs`           | `number`       | ❌       | `500`            | Base backoff delay in ms.                                                                                                                                                                                                                                                                                 |
-| `llmRetry.maxDelayMs`            | `number`       | ❌       | `8000`           | Max backoff delay cap in ms.                                                                                                                                                                                                                                                                              |
-| `llmRetry.jitter`                | `boolean`      | ❌       | `true`           | Apply ±50% jitter to delays.                                                                                                                                                                                                                                                                              |
-| `persistRetry.maxAttempts`       | `number`       | ❌       | `2`              | Max persist retry attempts (including first).                                                                                                                                                                                                                                                             |
-| `persistRetry.baseDelayMs`       | `number`       | ❌       | `200`            | Base backoff delay in ms.                                                                                                                                                                                                                                                                                 |
-| `persistRetry.maxDelayMs`        | `number`       | ❌       | `2000`           | Max backoff delay cap in ms. No jitter (unlike llmRetry).                                                                                                                                                                                                                                                 |
-| `sourceRanking.enabled`          | `boolean`      | ❌       | `true`           | Pre-LLM re-rank and host diversification; set `false` for legacy relevance-only order. See [Source ranking](#source-ranking).                                                                                                                                                                             |
-| `fewShot.enabled`                | `boolean`      | ❌       | `false`          | Inject curated newsletter exemplars before source summaries for voice calibration. See [Few-shot exemplars](#few-shot-exemplars).                                                                                                                                                                         |
-| `fewShot.maxExemplars`           | `number` (1–2) | ❌       | `1`              | How many exemplar blocks to prepend when `fewShot.enabled` is true.                                                                                                                                                                                                                                       |
-| `fewShot.sectorTag`              | enum           | ❌       | _(keyword pick)_ | Pin a sector exemplar (`industrial`, `consumer`, `financial`, `tech`, `commodities`); when omitted, keyword heuristics choose.                                                                                                                                                                            |
-| `useBrainstormPass`              | `boolean`      | ❌       | `false`          | Run a free-form editor's memo before structured JSON generation. See [Two-pass generation](#two-pass-generation).                                                                                                                                                                                         |
-| `brainstormModel`                | `string`       | ❌       | `openai.model`   | Model for the brainstorm leg (can be cheaper than the structured pass).                                                                                                                                                                                                                                   |
-| `brainstormMaxOutputTokens`      | `number`       | ❌       | `700`            | Output token cap for the memo pass.                                                                                                                                                                                                                                                                       |
-| `citationGrounding.enabled`      | `boolean`      | ❌       | `false`          | Post-generation citation overlap verification. See [Citation grounding](#citation-grounding).                                                                                                                                                                                                             |
-| `citationGrounding.policy`       | enum           | ❌       | `unlink`         | `warn`, `unlink`, or `drop` for low-overlap citations.                                                                                                                                                                                                                                                    |
-| `numericAnchors.enabled`         | `boolean`      | ❌       | `false`          | Pre-LLM verbatim figure sidecar and post-generation figure audit. See [Numeric anchors](#numeric-anchors).                                                                                                                                                                                                |
-| `numericAnchors.unmatchedPolicy` | enum           | ❌       | `warn`           | `warn` (log only) or `strip` (replace figures missing from sources).                                                                                                                                                                                                                                      |
-| `subjectLine.enabled`            | `boolean`      | ❌       | `false`          | Generate and score subject-line candidates. See [Subject line scoring](#subject-line-scoring).                                                                                                                                                                                                            |
-| `subjectLine.candidateCount`     | `number` (3–8) | ❌       | `5`              | How many alternative subjects the sidecar LLM pass requests.                                                                                                                                                                                                                                              |
-| `crossRunDedup.enabled`          | `boolean`      | ❌       | `false`          | Preventive prompt block + post-generation similarity walker. See [Cross-run dedup](#cross-run-dedup).                                                                                                                                                                                                     |
-| `crossRunDedup.policy`           | enum           | ❌       | `warn`           | `warn`, `mark` (`[follow-up]` prefix), or `drop` for near-duplicates.                                                                                                                                                                                                                                     |
-| `polish.enabled`                 | `boolean`      | ❌       | `false`          | Deterministic filler/hedge/register cleanup before grounding. See [Style polish](#style-polish).                                                                                                                                                                                                          |
-| `polish.tier`                    | enum           | ❌       | `safe`           | `safe` (filler, hedge, register) or `aggressive` (adds overused-word replacement).                                                                                                                                                                                                                        |
-| `selfCritique.enabled`           | `boolean`      | ❌       | `false`          | Bounded bullet self-critique before polish and grounding. See [Self-critique](#self-critique).                                                                                                                                                                                                            |
-| `sourceRanking.maxPerHost`       | `number`       | ❌       | `2`              | Max articles per host in the LLM prompt.                                                                                                                                                                                                                                                                  |
+The Hermes form renders nine top-level sections in this order: **Credentials**, **Output**, **Prompts**, **Inputs**, **Creativity**, **Quality**, **Delivery**, **Freshness**, **Reliability**. An empty `{}` applies the best-quality defaults from plan 62 (all quality passes on). Legacy flat keys are rejected — see [Config Reference](/mediapulse/apps/agents/content-generation-config-reference).
+
+| Field | Type | Default | Description |
+|---|---|---|---|
+| `credentials.openaiApiKey` | `string` | `{{OPENAI_API_KEY}}` | OpenAI API key or Hermes variable placeholder. |
+| `credentials.chatModel` | `string` | `{{OPENAI_MODEL}}` | Chat model id or Hermes variable placeholder. |
+| `credentials.baseUrl` | `string (url)` | official | OpenAI-compatible API base URL. |
+| `credentials.timeoutMs` | `number` | `120000` | Per-request timeout in milliseconds. |
+| `output.topNewsCount` | `number` | `10` | Articles in the LLM prompt. |
+| `creativity.brainstorm.enabled` | `boolean` | `true` | Two-pass editor's memo before structured JSON. |
+| `inputs.fewShot.enabled` | `boolean` | `true` | Few-shot exemplar injection. |
+| `inputs.sourceRanking.enabled` | `boolean` | `true` | Pre-LLM source ranking. |
+| `quality.selfCritique.enabled` | `boolean` | `true` | Self-critique pass. |
+| `quality.citationGrounding.enabled` | `boolean` | `true` | Citation grounding. |
+| `quality.polish.enabled` | `boolean` | `true` | Style polish. |
+| `quality.crossRunDedup.enabled` | `boolean` | `true` | Cross-run dedup. |
+| `delivery.subjectLine.enabled` | `boolean` | `true` | Subject-line scoring. |
+| `reliability.llmRetry.maxAttempts` | `number` | `3` | LLM retry attempts. |
+| `reliability.persistRetry.maxAttempts` | `number` | `2` | Persist retry attempts. |
+
+Full field list: [Config Reference](/mediapulse/apps/agents/content-generation-config-reference).
 
 ## Error taxonomy
 
@@ -97,7 +81,7 @@ The `AgentRunResult` envelope returned to Hermes is unchanged: `{ success: false
 - `@workspace/agent-data-api-client` — Typed API client for content-generation endpoints.
 - `@workspace/agent-types` — `DataSourceRecord` and related types.
 - `@workspace/utils` — `withRetryCustomDelay` used by the retry utility.
-- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config.openai`** from Hermes: required **`apiKey`**, optional **`baseUrl`**, optional **`model`** (defaults to `gpt-4o-mini`), plus **`maxTokens`** and **`timeoutMs`** as defined in the agent config schema.
+- `@workspace/env` — Via `@mediapulse/env/agents-content-generation` (agent-data-api URL, auth URL, port, optional registry). OpenAI settings use **`config.credentials`** from Hermes: **`openaiApiKey`** (defaults to `{{OPENAI_API_KEY}}`), optional **`baseUrl`**, **`chatModel`** (defaults to `{{OPENAI_MODEL}}`), plus **`maxTokens`** and **`timeoutMs`** as defined in the agent config schema.
 - `@workspace/logger` — Logging.
 - `ai` + `@ai-sdk/openai` — Vercel AI SDK for structured LLM calls (`generateObject`).
 
@@ -182,12 +166,12 @@ Fictional tickers and article titles — the live run must ground only in real s
 
 ### Selection heuristic
 
-When `fewShot.sectorTag` is unset, the agent concatenates `tickerName`, `tickerSymbol`, and source titles and keyword-matches:
+When `inputs.fewShot.sectorTag` is unset, the agent concatenates `tickerName`, `tickerSymbol`, and source titles and keyword-matches:
 
 - **Consumer/financial exemplar** when text mentions `bank`, `finance`, `consumer`, `lending`, `deposits`, etc.
 - **Industrial exemplar** otherwise
 
-Set `fewShot.sectorTag` to pin a sector regardless of keywords. Set `fewShot.maxExemplars` to `2` to show both voices (~1500 prompt tokens each).
+Set `inputs.fewShot.sectorTag` to pin a sector regardless of keywords. Set `inputs.fewShot.maxExemplars` to `2` to show both voices (~1500 prompt tokens each).
 
 ### Token budget
 
@@ -205,11 +189,11 @@ After generation, local **Jaccard similarity** compares bullet text to the activ
 4. Document expected token cost in the PR (~1500 tokens per exemplar).
 5. Extend selection tests if the new sector needs distinct keyword routing.
 
-Default rollout: ship with `fewShot.enabled: false`, pilot on one or two tickers, then flip the default once lift is confirmed.
+Default rollout: all quality passes ship **on** in an empty `{}` config; dial individual knobs back in Hermes to trade cost for latency.
 
 ## Two-pass generation
 
-When `useBrainstormPass` is true, the agent runs **two LLM calls** per newsletter:
+When `creativity.brainstorm.enabled` is true, the agent runs **two LLM calls** per newsletter:
 
 1. **Brainstorm pass** (`generateText`) — a free-form editor's memo with six labeled sections: `HEADLINE THESIS`, `THREADS TO WEAVE`, `STANDOUT NUMBERS`, `WHAT CHANGED`, `WHAT TO WATCH`, and `TONE NOTE`. No JSON, no schema — the model commits to thesis, threads, numbers, and tone before formatting.
 2. **Structured pass** (`generateObject`) — the existing industry briefing JSON, conditioned on the memo plus numbered articles (and optional few-shot exemplars on the structured pass only).
@@ -228,13 +212,13 @@ Each label forces a different cognitive mode (synthesis, expansion, concrete fig
 
 | Field                       | Default        | Description                            |
 | --------------------------- | -------------- | -------------------------------------- |
-| `useBrainstormPass`         | `false`        | Enable two-pass generation             |
-| `brainstormModel`           | `openai.model` | Cheaper model for the memo leg is fine |
+| `creativity.brainstorm.enabled` | `true` | Enable two-pass generation |
+| `creativity.brainstorm.model` | `credentials.chatModel` | Cheaper model for the memo leg is fine |
 | `brainstormMaxOutputTokens` | `700`          | Memos are short by design              |
 
 ### Cost and timeout
 
-Expect roughly **2× prompt tokens** and **~1.3× completion tokens** versus single-pass. On brainstorm failure (transport, timeout, empty memo) the run **falls back to single-pass** — consumers still get a newsletter. If the brainstorm consumes more than **half** of `openai.timeoutMs`, the memo is dropped for that run so the structured pass keeps enough budget.
+Expect roughly **2× prompt tokens** and **~1.3× completion tokens** versus single-pass. On brainstorm failure (transport, timeout, empty memo) the run **falls back to single-pass** — consumers still get a newsletter. If the brainstorm consumes more than **half** of `credentials.timeoutMs`, the memo is dropped for that run so the structured pass keeps enough budget.
 
 ### Observability
 
@@ -384,7 +368,7 @@ The subject from the main structured pass competes as **candidate 0** with a pre
 | ---------------------------- | -------------- | ---------------------------------------- |
 | `subjectLine.enabled`        | `false`        | Enable candidate generation and scoring  |
 | `subjectLine.candidateCount` | `5`            | Target number of LLM candidates (3–8)    |
-| `subjectLine.model`          | `openai.model` | Sidecar model (cheaper tier is fine)     |
+| `delivery.subjectLine.model` | `credentials.chatModel` | Sidecar model (cheaper tier is fine) |
 | `subjectLine.weights.*`      | see axes above | Per-axis weights for the composite score |
 
 ### Observability
@@ -505,13 +489,13 @@ Critique **never** emits output that fails `industryNewsletterStructureSchema`. 
 | `selfCritique.enabled`                 | `false`        | Enable the critic pass                       |
 | `selfCritique.dropFraction`            | `0.2`          | Max fraction of bullets rewritten or dropped |
 | `selfCritique.minBulletCount`          | `8`            | Skip critique below this bullet count        |
-| `selfCritique.critiqueModel`           | `openai.model` | Critic model (cheaper tier is fine)          |
+| `quality.selfCritique.critiqueModel` | `credentials.chatModel` | Critic model (cheaper tier is fine) |
 | `selfCritique.critiqueMaxOutputTokens` | `1500`         | Output cap for the critic call               |
 | `selfCritique.preferRewriteOverDrop`   | `true`         | Use `suggestedRewrite` before dropping       |
 
 ### Deadline guard
 
-When wall-clock since run start exceeds **70%** of `openai.timeoutMs` after structured generation, critique is skipped — the briefing continues through polish and grounding without critic scores. Run details include `critiqueSkippedDueToBudget: true`.
+When wall-clock since run start exceeds **70%** of `credentials.timeoutMs` after structured generation, critique is skipped — the briefing continues through polish and grounding without critic scores. Run details include `critiqueSkippedDueToBudget: true`.
 
 ### Pipeline order
 


### PR DESCRIPTION
## Summary

Content-generation gets the same grouped Hermes config treatment as query-analysis and data-collection: nine labeled sections, best-quality defaults prefilled, and shared `{{OPENAI_API_KEY}}` / `{{OPENAI_MODEL}}` placeholders. Stored flat configs fail loudly under `.strict()` so operators re-save in the new shape.

Wire serialization also drops redundant inline `(Article N)` text from bullets and prose. Citations still come from `articleIndex` and the rendered "Read the full article" line.

## Related issues

Closes #594

## Important changes

- **Grouped config schema** — credentials, output, prompts, inputs, creativity, quality, delivery, freshness, reliability; brainstorm trio folded into `creativity.brainstorm`.
- **Best-quality defaults preserved** — quality passes (brainstorm, few-shot, self-critique, grounding, polish, dedup, subject line) stay on by default from plan 62.
- **No unsupported sampling params** — no `temperature` / `topP` / penalties in schema or AI SDK calls; regression test added for reasoning-model compatibility.
- **Inline marker strip** — `stripArticleMarkers` at wire chokepoints; exemplars cleaned; system prompt forbids `(Article N)` in JSON text fields.

## Other changes

- `resolveContentGenerationConfig` collapsed to model-fallback resolution only; retry groups use clean `.default({})` (no preprocess sentinel).
- Dev-docs config reference and agent page updated for grouped fields and Variables checklist.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/config-schema.ts` — grouped schema, strict root, retry validation, `{{OPENAI_MODEL}}` default.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — grouped config reads; critique token budget scaling.
- `apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts` — marker stripping at wire emission.
- `apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.ts` — removed trailing `(Article N)` from exemplar prose.
- `dev-docs/docs/mediapulse/apps/agents/content-generation-config-reference.mdx` — full grouped field reference.

## How to test

1. `ASDF_NODEJS_VERSION=22.18.0 pnpm --filter @mediapulse/content-generation test` — expect 383 tests green.
2. `ASDF_NODEJS_VERSION=22.18.0 pnpm --filter @mediapulse/content-generation type:check` — no TS errors.
3. Parse `{}` through `ContentGenerationConfigSchema` and confirm nine groups, quality passes on, `credentials.chatModel === "{{OPENAI_MODEL}}"`.
4. Run `formatIndustryNewsletterWire` on a briefing whose bullet text includes `(Article 3)` — output must not match `(Article` in prose/bullets; `Read the full article:` lines unchanged.
5. Re-save a content-generation Hermes agent config in the grouped form before deploying (legacy flat keys will fail parse).
