### PR TITLE
Tune data-collection Hermes defaults for production runs

### DIFF
--- a/apps/mediapulse/agents/data-collection/config.example.jsonc
+++ b/apps/mediapulse/agents/data-collection/config.example.jsonc
@@ -11,7 +11,7 @@
         "headerName": "X-API-KEY",
       },
       "rateLimit": { "requests": 100, "perSeconds": 60 },
-      "concurrency": 4,
+      "concurrency": 2,
       "timeoutMs": 30000,
     },
     "fetch": {
@@ -23,9 +23,14 @@
             "type": "none",
             "apiKey": "{{DIFFBOT_API_KEY}}",
           },
-          "rateLimit": { "requests": 2, "perSeconds": 1 },
-          "concurrency": 2,
-          "timeoutMs": 30000,
+          "rateLimit": { "requests": 1, "perSeconds": 1 },
+          "concurrency": 1,
+          "timeoutMs": 45000,
+          "retry": {
+            "maxAttempts": 4,
+            "baseDelayMs": 2000,
+            "maxDelayMs": 20000,
+          },
         },
         {
           "type": "firecrawl",
@@ -35,9 +40,9 @@
             "apiKey": "{{FIRECRAWL_API_KEY}}",
             "headerName": "Authorization",
           },
-          "rateLimit": { "requests": 2, "perSeconds": 1 },
-          "concurrency": 2,
-          "timeoutMs": 30000,
+          "rateLimit": { "requests": 1, "perSeconds": 1 },
+          "concurrency": 1,
+          "timeoutMs": 45000,
         },
         {
           "type": "jina",
@@ -48,8 +53,8 @@
             "headerName": "Authorization",
           },
           "rateLimit": { "requests": 2, "perSeconds": 1 },
-          "concurrency": 2,
-          "timeoutMs": 30000,
+          "concurrency": 1,
+          "timeoutMs": 45000,
         },
       ],
     },
@@ -57,13 +62,13 @@
   "collection": {
     "targetDailySuccessfulSources": 5,
     "maxRefillRounds": 3,
-    "perQueryFetchBudget": 3,
+    "perQueryFetchBudget": 5,
     "perRunFetchBudget": 40,
   },
   "gates": {
     "relevance": {
       "enabled": true,
-      "headChars": 1500,
+      "headChars": 3000,
       "minMatches": 1,
     },
     "freshness": {
@@ -94,6 +99,6 @@
   },
   "runPolicy": {
     "minSuccessfulSources": 1,
-    "failOnZeroSuccess": true,
+    "failOnZeroSuccess": false,
   },
 }

--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -231,7 +231,12 @@ describe("data-collection agent (HTTP)", () => {
         headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
-          config: {},
+          config: {
+            runPolicy: {
+              minSuccessfulSources: 1,
+              failOnZeroSuccess: true,
+            },
+          },
         }),
       }),
     );

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -66,6 +66,10 @@ const baseConfig = dataCollectionAgentConfigSchema.parse({
     perQueryFetchBudget: 3,
     perRunFetchBudget: 40,
   },
+  runPolicy: {
+    minSuccessfulSources: 1,
+    failOnZeroSuccess: true,
+  },
 });
 
 /**
@@ -593,6 +597,7 @@ describe("runDataCollection", () => {
           deduplication: {
             openaiApiKey: "sk-test",
             semantic: {
+              enabled: true,
               threshold: 0.88,
               windowDays: 7,
               embeddingModel: "text-embedding-3-small",
@@ -705,6 +710,7 @@ describe("runDataCollection", () => {
           deduplication: {
             openaiApiKey: "sk-test",
             semantic: {
+              enabled: true,
               threshold: 0.88,
               windowDays: 7,
               embeddingModel: "text-embedding-3-small",
@@ -735,7 +741,7 @@ describe("runDataCollection", () => {
     });
   });
 
-  it("defaults semantic dedupe to enabled and calls embedTexts when openaiApiKey is resolved", async () => {
+  it("skips semantic dedupe by default when semantic.enabled is false", async () => {
     recentSourceFingerprintsGetMock.mockResolvedValueOnce({
       fingerprints: [
         {
@@ -745,10 +751,6 @@ describe("runDataCollection", () => {
         },
       ],
     });
-    embedTextsMock.mockResolvedValueOnce([
-      [1, 0, 0],
-      [0, 1, 0],
-    ]);
 
     await runDataCollection(
       createContext({
@@ -770,11 +772,8 @@ describe("runDataCollection", () => {
       }),
     );
 
-    expect(embedTextsMock).toHaveBeenCalled();
-    expect(recentSourceFingerprintsGetMock).toHaveBeenCalledWith({
-      tickerId: TICKER_ID,
-      windowDays: 7,
-    });
+    expect(embedTextsMock).not.toHaveBeenCalled();
+    expect(recentSourceFingerprintsGetMock).not.toHaveBeenCalled();
   });
 
   it("does not call dataCollection.create when there are no fetch successes", async () => {

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -73,12 +73,12 @@ describe("dataCollectionAgentConfigSchema", () => {
     expect(parsed.collection).toEqual({
       targetDailySuccessfulSources: 5,
       maxRefillRounds: 3,
-      perQueryFetchBudget: 3,
+      perQueryFetchBudget: 5,
       perRunFetchBudget: 40,
     });
     expect(parsed.gates.relevance).toEqual({
       enabled: true,
-      headChars: 1500,
+      headChars: 3000,
       minMatches: 1,
     });
     expect(parsed.gates.freshness).toEqual({
@@ -96,7 +96,7 @@ describe("dataCollectionAgentConfigSchema", () => {
       errorRateThreshold: 0.5,
     });
     expect(parsed.deduplication.semantic).toEqual({
-      enabled: true,
+      enabled: false,
       threshold: 0.88,
       windowDays: 7,
       embeddingModel: "{{EMBEDDING_MODEL}}",
@@ -104,7 +104,7 @@ describe("dataCollectionAgentConfigSchema", () => {
     expect(parsed.deduplication.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
     expect(parsed.runPolicy).toEqual({
       minSuccessfulSources: 1,
-      failOnZeroSuccess: true,
+      failOnZeroSuccess: false,
     });
   });
 
@@ -137,10 +137,10 @@ describe("dataCollectionAgentConfigSchema", () => {
     });
 
     expect(parsed.collection.perRunFetchBudget).toBe(12);
-    expect(parsed.collection.perQueryFetchBudget).toBe(3);
+    expect(parsed.collection.perQueryFetchBudget).toBe(5);
     expect(parsed.collection.targetDailySuccessfulSources).toBe(5);
     expect(parsed.providers.fetch.providers).toHaveLength(3);
-    expect(parsed.runPolicy.failOnZeroSuccess).toBe(true);
+    expect(parsed.runPolicy.failOnZeroSuccess).toBe(false);
   });
 
   it("accepts ordered fetch providers under providers.fetch.providers", () => {

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -6,7 +6,7 @@ const concurrencySchema = z
   .int()
   .min(1)
   .max(16)
-  .default(4)
+  .default(2)
   .describe("Maximum parallel requests for this stage.");
 
 const retrySchema = z
@@ -33,6 +33,13 @@ const defaultRetry = {
   maxAttempts: 3,
   baseDelayMs: 1000,
   maxDelayMs: 10_000,
+} as const;
+
+/** Extended retry policy for Diffbot when many tickers share one rate-limit budget. */
+const diffbotDefaultRetry = {
+  maxAttempts: 4,
+  baseDelayMs: 2000,
+  maxDelayMs: 20_000,
 } as const;
 
 const authenticationSchema = z.object({
@@ -128,10 +135,10 @@ export const defaultDiffbotFetchProvider = {
     type: "none" as const,
     apiKey: "{{DIFFBOT_API_KEY}}",
   },
-  rateLimit: { requests: 2, perSeconds: 1 },
-  concurrency: 2,
-  timeoutMs: 30_000,
-  retry: defaultRetry,
+  rateLimit: { requests: 1, perSeconds: 1 },
+  concurrency: 1,
+  timeoutMs: 45_000,
+  retry: diffbotDefaultRetry,
 };
 
 /** Recommended Firecrawl provider defaults for the fetch chain. */
@@ -143,9 +150,9 @@ export const defaultFirecrawlFetchProvider = {
     apiKey: "{{FIRECRAWL_API_KEY}}",
     headerName: "Authorization",
   },
-  rateLimit: { requests: 2, perSeconds: 1 },
-  concurrency: 2,
-  timeoutMs: 30_000,
+  rateLimit: { requests: 1, perSeconds: 1 },
+  concurrency: 1,
+  timeoutMs: 45_000,
   retry: defaultRetry,
 };
 
@@ -159,8 +166,8 @@ export const defaultJinaFetchProvider = {
     headerName: "Authorization",
   },
   rateLimit: { requests: 2, perSeconds: 1 },
-  concurrency: 2,
-  timeoutMs: 30_000,
+  concurrency: 1,
+  timeoutMs: 45_000,
   retry: defaultRetry,
 };
 
@@ -215,7 +222,7 @@ const collectionSchema = z
       .number()
       .int()
       .positive()
-      .default(3)
+      .default(5)
       .describe("Maximum URLs fetched per search query after ranking."),
     perRunFetchBudget: z
       .number()
@@ -238,7 +245,7 @@ const relevanceGateSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(1500)
+    .default(3000)
     .describe(
       "Number of leading content characters scanned for alias matches.",
     ),
@@ -328,7 +335,7 @@ const resilienceSchema = z
 const semanticDedupeSchema = z.object({
   enabled: z
     .boolean()
-    .default(true)
+    .default(false)
     .describe(
       "When enabled, drop near-duplicate pages using embedding similarity against recent corpus fingerprints.",
     ),
@@ -379,7 +386,7 @@ const runPolicySchema = z
       .describe("Minimum persisted sources required for a successful run."),
     failOnZeroSuccess: z
       .boolean()
-      .default(true)
+      .default(false)
       .describe(
         "When true, a run with zero persisted sources is marked failed even if no HTTP errors occurred.",
       ),

--- a/dev-docs/docs/apps/mediapulse/data-collection-agent.mdx
+++ b/dev-docs/docs/apps/mediapulse/data-collection-agent.mdx
@@ -27,7 +27,7 @@ Each provider (search and fetch) supports:
 Determines how the agent handles success/failure aggregation:
 
 - **`minSuccessfulSources`**: Minimum number of successful items required to mark the run as successful.
-- **`failOnZeroSuccess`**: If true, throws an error (marking the run as failed) if no items were successfully processed.
+- **`failOnZeroSuccess`**: When true (default is false), marks the run as failed if no items were successfully processed in that invocation — useful for strict pipelines; leave false when the schedule runs multiple times per day and the daily source target may already be met.
 
 ## Partial Failure Isolation
 

--- a/dev-docs/docs/mediapulse/apps/agents/data-collection.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/data-collection.mdx
@@ -63,7 +63,7 @@ After the content quality gate, each page is checked for mentions of the target 
 | Setting | Default | Purpose |
 | --- | --- | --- |
 | `relevanceGate.enabled` | `true` | Toggle the gate per pipeline config |
-| `relevanceGate.headChars` | `1500` | Scan window in the page body (title always included) |
+| `relevanceGate.headChars` | `3000` | Scan window in the page body (title always included) |
 | `relevanceGate.minMatches` | `1` | Minimum distinct alias hits required across company or industry aliases |
 
 Pages with no company or industry alias match in the scan window are dropped with reason `no_alias_match`. This lets competitor and sector-wide articles through when they mention the subscribed ticker's industry (e.g. TLKM subscribers can collect XL Axiata news that mentions `Telekomunikasi`). The run summary and persisted run counters include `droppedByRelevance` so operators can spot overly aggressive gates.
@@ -72,7 +72,7 @@ Word-boundary matching prevents short symbols from matching inside unrelated wor
 
 ## Bounded parallelism and adaptive backoff
 
-Web search and web fetch run through `pMap` with configurable concurrency (default `4`, capped at `min(concurrency, rateLimit.requests)`). Each HTTP call still acquires a slot from the sliding-window rate limiter before running.
+Web search and web fetch run through `pMap` with configurable concurrency (default `2`, capped at `min(concurrency, rateLimit.requests)`). Each HTTP call still acquires a slot from the sliding-window rate limiter before running.
 
 When the provider returns `429` or `5xx`, the limiter enlarges its window by 1.5× (up to 4× baseline) for the rest of the run. After ten consecutive successful responses, the window decays back toward baseline. Run counters include `throttleEvents` so operators can see how often adaptive backoff fired.
 
@@ -82,7 +82,7 @@ Before Jina fetch, surviving search hits are ranked by domain reputation, snippe
 
 | Setting | Default | Purpose |
 | --- | --- | --- |
-| `perQueryFetchBudget` | `3` | Maximum fetches contributed by each search query per round |
+| `perQueryFetchBudget` | `5` | Maximum fetches contributed by each search query per round |
 | `perRunFetchBudget` | `40` | Maximum fetches for the entire round after per-query selection |
 
 Skipped hits increment `droppedByPerQueryBudget` and `droppedByPerRunBudget` in the run summary. These are intentional skips, not fetch failures.


### PR DESCRIPTION
## Summary

Production data-collection runs were hitting Diffbot 429s when several tickers fetched in parallel, dropping too many URLs at the per-query budget, and failing scheduled reruns after the daily source target was already met. This PR updates the agent schema defaults so an empty `{}` Hermes config picks up tighter rate limits, a wider relevance scan, and a run policy that does not treat "nothing new to collect today" as a pipeline failure.

## Related issues

Closes #596

## Important changes

- Fetch providers default to concurrency 1; Diffbot and Firecrawl rate limits drop to 1 req/sec with longer timeouts and Diffbot-specific retry backoff.
- `perQueryFetchBudget` rises from 3 to 5; relevance `headChars` from 1500 to 3000.
- `runPolicy.failOnZeroSuccess` defaults to `false` so 4× daily schedules do not fail when the daily target is already satisfied.
- Semantic dedupe defaults to off (was on); enable explicitly when OpenAI embeddings are configured.

## Other changes

- `config.example.jsonc`, config-schema tests, run/index tests, and dev-docs default tables updated to match.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — Zod defaults and exported provider presets.
- `apps/mediapulse/agents/data-collection/config.example.jsonc` — operator reference config.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts` — asserts empty `{}` parses to the new baseline.

## How to test

1. `cd apps/mediapulse/agents/data-collection && npm test` — all 141 tests should pass.
2. `dataCollectionAgentConfigSchema.parse({})` and confirm `runPolicy.failOnZeroSuccess === false`, `collection.perQueryFetchBudget === 5`, and Diffbot `rateLimit.requests === 1`.
3. After deploy, open a Hermes pipeline step with `{}` config and confirm the form/schema reflects the new defaults; pipelines with saved overrides should keep only their explicit keys.
