### PR TITLE
Persist data-collection sources per article immediately

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -191,18 +191,6 @@ const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
 const analysisGetMock = vi.fn();
 const tickerGetMock = vi.fn();
-const recentSourceFingerprintsGetMock = vi.fn();
-
-const embedTextsMock = vi.hoisted(() => vi.fn());
-
-vi.mock("./utilities/embeddings", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("./utilities/embeddings")>();
-  return {
-    ...actual,
-    embedTexts: (...args: unknown[]) => embedTextsMock(...args),
-  };
-});
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
@@ -218,9 +206,6 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     },
     dataCollectionDeadUrlsRecord: {
       create: deadUrlsRecordMock,
-    },
-    dataCollectionRecentSourceFingerprints: {
-      get: recentSourceFingerprintsGetMock,
     },
     dataCollectionRun: {
       create: runCreateMock,
@@ -294,7 +279,6 @@ describe("runDataCollection", () => {
       message: "Dead URLs recorded",
       recordedCount: 0,
     });
-    recentSourceFingerprintsGetMock.mockResolvedValue({ fingerprints: [] });
     analysisGetMock.mockResolvedValue({
       dataSources: [],
       dataSourceTotalCount: 0,
@@ -560,220 +544,19 @@ describe("runDataCollection", () => {
         fetchSuccess: 2,
       });
 
-      const persisted = createMock.mock.calls[0]?.[0] as Array<{
-        url: string;
-        publishedAt?: string;
-      }>;
-      expect(persisted).toHaveLength(2);
-      expect(persisted).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            url: "http://example.com/fresh",
-            publishedAt: isoDaysAgo(2),
-          }),
-          expect.objectContaining({ url: "http://example.com/unknown" }),
-        ]),
-      );
+      expect(createMock).toHaveBeenCalledTimes(2);
+      expect(createMock).toHaveBeenCalledWith([
+        expect.objectContaining({
+          url: "http://example.com/fresh",
+          publishedAt: isoDaysAgo(2),
+        }),
+      ]);
+      expect(createMock).toHaveBeenCalledWith([
+        expect.objectContaining({ url: "http://example.com/unknown" }),
+      ]);
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("falls back to URL-only dedupe when embedding fails", async () => {
-    embedTextsMock.mockRejectedValueOnce(new Error("quota exceeded"));
-    recentSourceFingerprintsGetMock.mockResolvedValueOnce({
-      fingerprints: [
-        {
-          id: "11111111-1111-4111-a111-111111111111",
-          title: "Apple Q2 earnings beat",
-          headSnippet: "Apple reported record Q2 earnings.",
-        },
-      ],
-    });
-
-    const result = await runDataCollection(
-      createContext({
-        config: withTestConfig({
-          deduplication: {
-            openaiApiKey: "sk-test",
-            semantic: {
-              enabled: true,
-              threshold: 0.88,
-              windowDays: 7,
-              embeddingModel: "text-embedding-3-small",
-            },
-          },
-          gates: {
-            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
-          },
-          runPolicy: {
-            minSuccessfulSources: 0,
-            failOnZeroSuccess: false,
-          },
-        }),
-      }),
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.details?.summary).toMatchObject({
-      droppedBySemanticDedupe: 0,
-      totalSources: 1,
-    });
-    expect(createMock).toHaveBeenCalledWith([
-      expect.objectContaining({ url: "http://example.com" }),
-    ]);
-    expect(mockRunLog.warn).toHaveBeenCalledWith(
-      expect.objectContaining({ round: 1 }),
-      "semantic dedupe failed; continuing with URL-only dedupe",
-    );
-  });
-
-  it("drops semantically duplicate candidates against the existing corpus", async () => {
-    const earningsContent = [
-      "Apple Q2 earnings beat analyst expectations across every segment.",
-      ...Array.from(
-        { length: 90 },
-        (_, index) =>
-          `Earnings detail ${index} covers revenue and margin trends.`,
-      ),
-    ].join(" ");
-    const visionContent = [
-      "Apple unveils new Vision Pro features for enterprise customers worldwide.",
-      ...Array.from(
-        { length: 90 },
-        (_, index) =>
-          `Vision Pro detail ${index} covers hardware and software.`,
-      ),
-    ].join(" ");
-
-    recentSourceFingerprintsGetMock.mockResolvedValueOnce({
-      fingerprints: [
-        {
-          id: "11111111-1111-4111-a111-111111111111",
-          title: "Apple Q2 earnings beat",
-          headSnippet: "Apple reported record Q2 earnings.",
-        },
-      ],
-    });
-    embedTextsMock.mockImplementation((texts: string[]) =>
-      Promise.resolve(
-        texts.map((text) => {
-          if (text.includes("Vision Pro")) {
-            return [0, 1, 0];
-          }
-          if (text.includes("estimates")) {
-            return [0.89, 0.45, 0];
-          }
-          return [1, 0, 0];
-        }),
-      ),
-    );
-
-    vi.mocked(performWebSearch).mockResolvedValueOnce([
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "http://example.com/earnings",
-        },
-      },
-      {
-        success: true,
-        data: {
-          ...searchSuccessPage,
-          url: "http://example.com/vision",
-        },
-      },
-    ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "http://example.com/earnings",
-        title: "Apple Q2 earnings beat estimates",
-        content: earningsContent,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "http://example.com/vision",
-        title: "Apple unveils new Vision Pro",
-        content: visionContent,
-      }),
-    ]);
-
-    const result = await runDataCollection(
-      createContext({
-        config: withTestConfig({
-          collection: {
-            perQueryFetchBudget: 20,
-            perRunFetchBudget: 100,
-          },
-          deduplication: {
-            openaiApiKey: "sk-test",
-            semantic: {
-              enabled: true,
-              threshold: 0.88,
-              windowDays: 7,
-              embeddingModel: "text-embedding-3-small",
-            },
-          },
-          gates: {
-            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
-          },
-          runPolicy: {
-            minSuccessfulSources: 0,
-            failOnZeroSuccess: false,
-          },
-        }),
-      }),
-    );
-
-    expect(result.success).toBe(true);
-    expect(result.details?.summary).toMatchObject({
-      droppedBySemanticDedupe: 1,
-      totalSources: 1,
-    });
-    expect(createMock).toHaveBeenCalledWith([
-      expect.objectContaining({ url: "http://example.com/vision" }),
-    ]);
-    expect(recentSourceFingerprintsGetMock).toHaveBeenCalledWith({
-      tickerId: TICKER_ID,
-      windowDays: 7,
-    });
-  });
-
-  it("skips semantic dedupe by default when semantic.enabled is false", async () => {
-    recentSourceFingerprintsGetMock.mockResolvedValueOnce({
-      fingerprints: [
-        {
-          id: "11111111-1111-4111-a111-111111111111",
-          title: "Bank Central Asia prior coverage",
-          headSnippet: "Earlier reporting on regional lending trends.",
-        },
-      ],
-    });
-
-    await runDataCollection(
-      createContext({
-        config: withTestConfig({
-          deduplication: {
-            openaiApiKey: "sk-test",
-            semantic: {
-              embeddingModel: "text-embedding-3-small",
-            },
-          },
-          gates: {
-            relevance: { enabled: false, headChars: 1500, minMatches: 1 },
-          },
-          runPolicy: {
-            minSuccessfulSources: 0,
-            failOnZeroSuccess: false,
-          },
-        }),
-      }),
-    );
-
-    expect(embedTextsMock).not.toHaveBeenCalled();
-    expect(recentSourceFingerprintsGetMock).not.toHaveBeenCalled();
   });
 
   it("does not call dataCollection.create when there are no fetch successes", async () => {

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -7,7 +7,6 @@ import crypto from "node:crypto";
 
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
-import { isUnresolvedVariablePlaceholder } from "./utilities/config-schema";
 import { performWebFetch } from "./utilities/web-fetch";
 import { performWebSearch } from "./utilities/web-search";
 import {
@@ -32,8 +31,6 @@ import {
 import { deriveRunStatus, type RunCounters } from "./utilities/run-status";
 import { extractPublishedDate } from "./utilities/date-extractor";
 import { isFresh } from "./utilities/freshness-gate";
-import { embedTexts } from "./utilities/embeddings";
-import { dedupeAgainstCorpus } from "./utilities/semantic-dedupe";
 
 /**
  * Executes the data-collection pipeline: load search queries, run web search and fetch,
@@ -92,16 +89,6 @@ export async function runDataCollection(
   const deadUrlCacheConfig = config.resilience.deadUrlCache;
   const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
   const freshnessGateConfig = config.gates.freshness;
-  const semanticDedupeConfig = config.deduplication.semantic;
-  const openaiApiKey = config.deduplication.openaiApiKey;
-  let semanticDedupeActive = semanticDedupeConfig.enabled;
-  if (semanticDedupeActive && isUnresolvedVariablePlaceholder(openaiApiKey)) {
-    log.warn(
-      {},
-      "semantic dedupe enabled in config but openaiApiKey is an unresolved Hermes variable placeholder; falling back to URL-only dedupe",
-    );
-    semanticDedupeActive = false;
-  }
   const hostErrorTracker = new HostErrorTracker(hostErrorBreakerConfig);
 
   const tickerRecord = await dataApiClient.ticker.get({
@@ -197,7 +184,6 @@ export async function runDataCollection(
   let droppedByDeadUrlCache = 0;
   let droppedByHostErrorRate = 0;
   let droppedByFreshness = 0;
-  let droppedBySemanticDedupe = 0;
   let throttleEvents = 0;
 
   if (queries.length === 0) {
@@ -378,7 +364,7 @@ export async function runDataCollection(
       fetchFailedCount += roundFailedUrlCount;
       fetchFailures.push(...roundFetchFailures);
 
-      const finalFetchSuccesses: typeof roundFetchSuccesses = [];
+      let persistedThisRoundCount = 0;
       const roundQualityDrops: QualityDropForDeadUrl[] = [];
       for (const page of roundFetchSuccesses) {
         const urlDecision = classifyNoisyUrl(page.url);
@@ -428,11 +414,12 @@ export async function runDataCollection(
           }
         }
 
+        const publishedAt = extractPublishedDate({
+          fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
+          content: page.content,
+        });
+
         if (freshnessGateConfig.enabled) {
-          const publishedAt = extractPublishedDate({
-            fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
-            content: page.content,
-          });
           const freshnessDecision = isFresh(publishedAt, {
             maxAgeDays: freshnessGateConfig.maxAgeDays,
             allowUnknown: freshnessGateConfig.allowUnknown,
@@ -452,17 +439,28 @@ export async function runDataCollection(
           }
         }
 
-        finalFetchSuccesses.push({
-          ...page,
+        const source: DataCollectionInput = {
           url: urlDecision.canonicalUrl,
-        });
+          title: page.title,
+          content: page.content,
+          tickerId: input.tickerId,
+          searchQueryId: page.searchQueryId,
+          ...(publishedAt ? { publishedAt: publishedAt.toISOString() } : {}),
+        };
+        log.info(
+          { round, url: urlDecision.canonicalUrl.slice(0, 120) },
+          "persisting collected source to Agent Data API",
+        );
+        await dataApiClient.dataCollection.create([source]);
+        persistedThisRunCount += 1;
+        persistedThisRoundCount += 1;
+        fetchSuccessCount += 1;
       }
-      fetchSuccessCount += finalFetchSuccesses.length;
 
       log.info(
         {
           round,
-          fetchSuccess: finalFetchSuccesses.length,
+          fetchSuccess: persistedThisRoundCount,
           fetchFailed: roundFailedUrlCount,
           droppedByUrlReason,
           droppedByDuplicateCanonicalUrl,
@@ -474,7 +472,6 @@ export async function runDataCollection(
           droppedByDeadUrlCache,
           droppedByHostErrorRate,
           droppedByFreshness,
-          droppedBySemanticDedupe,
           throttleEvents,
         },
         "web fetch stage finished",
@@ -511,86 +508,13 @@ export async function runDataCollection(
         }
       }
 
-      if (finalFetchSuccesses.length > 0) {
-        let pagesToPersist = finalFetchSuccesses;
-
-        if (semanticDedupeActive) {
-          try {
-            const { fingerprints } =
-              await dataApiClient.dataCollectionRecentSourceFingerprints.get({
-                tickerId: input.tickerId,
-                windowDays: semanticDedupeConfig.windowDays,
-              });
-            const dedupeResult = await dedupeAgainstCorpus(
-              pagesToPersist,
-              fingerprints,
-              {
-                threshold: semanticDedupeConfig.threshold,
-                embedder: (texts) =>
-                  embedTexts(texts, {
-                    apiKey: openaiApiKey,
-                    model: semanticDedupeConfig.embeddingModel,
-                  }),
-              },
-            );
-            droppedBySemanticDedupe += dedupeResult.dropped.length;
-            for (const drop of dedupeResult.dropped) {
-              log.info(
-                {
-                  round,
-                  url: drop.candidate.url.slice(0, 120),
-                  matchedExistingId: drop.matchedExistingId,
-                  similarity: Number(drop.similarity.toFixed(3)),
-                },
-                "dropped semantically duplicate page against existing corpus",
-              );
-            }
-            pagesToPersist = dedupeResult.kept;
-          } catch (dedupeError) {
-            log.warn(
-              { round, err: dedupeError },
-              "semantic dedupe failed; continuing with URL-only dedupe",
-            );
-          }
-        }
-
-        if (pagesToPersist.length > 0) {
-          const sources: DataCollectionInput[] = pagesToPersist.map((page) => {
-            const publishedAt = extractPublishedDate({
-              fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
-              content: page.content,
-            });
-            return {
-              url: page.url,
-              title: page.title,
-              content: page.content,
-              tickerId: input.tickerId,
-              searchQueryId: page.searchQueryId,
-              ...(publishedAt
-                ? { publishedAt: publishedAt.toISOString() }
-                : {}),
-            };
-          });
-          log.info(
-            { round, sourcesToPersist: sources.length },
-            "persisting collected sources to Agent Data API",
-          );
-          await dataApiClient.dataCollection.create(sources);
-          persistedThisRunCount += sources.length;
-        } else {
-          log.info({ round }, "no sources to persist after semantic dedupe");
-        }
-      } else {
-        log.info({ round }, "no sources to persist after fetch stage");
-      }
-
       const effectiveTodayCount =
         existingTodaySourceCount + persistedThisRunCount;
       if (effectiveTodayCount >= targetDailySuccessfulSources) {
         refillStopReason = "daily_target_met";
         break;
       }
-      if (finalFetchSuccesses.length === 0) {
+      if (persistedThisRoundCount === 0) {
         refillStopReason = "no_progress";
         break;
       }
@@ -683,7 +607,6 @@ export async function runDataCollection(
     droppedByDeadUrlCache,
     droppedByHostErrorRate,
     droppedByFreshness,
-    droppedBySemanticDedupe,
     throttleEvents,
     refill: {
       roundsExecuted,


### PR DESCRIPTION
## Summary

The data-collection agent used to wait until every fetch in a refill round finished before writing anything to the Agent Data API. An article that passed all gates early still sat in memory until the slowest URL in the round settled. This PR persists each source as soon as it clears quality, relevance, and freshness, and drops semantic dedupe from the run path.

## Related issues

Closes #598

## Important changes

- Call `dataCollection.create([source])` inside the per-article gate loop instead of batching at the end of the round
- Use `persistedThisRoundCount` for refill stop checks (`no_progress`, daily target)
- Remove semantic dedupe, corpus fingerprint fetch, and embedding calls from `runDataCollection`

## Other changes

- Update run tests: freshness gate now asserts two separate create calls; remove semantic-dedupe test cases and related mocks

## Key files to review

- `apps/mediapulse/agents/data-collection/src/run.ts` — per-article persist loop and removed batch/semantic-dedupe block
- `apps/mediapulse/agents/data-collection/src/run.test.ts` — expectations for immediate create calls

## How to test

1. From repo root: `pnpm --filter @mediapulse/data-collection type:check && pnpm --filter @mediapulse/data-collection test --run`
2. Confirm all 138 tests pass, including freshness gate and refill-round cases
3. Optional: run a data-collection invoke against a ticker with multiple fetch hits and confirm sources appear in agent-data-api one at a time during the round
