### PR TITLE
Tune data-collection Serper defaults and fetch retries

### DIFF
--- a/apps/mediapulse/agents/data-collection/config.example.jsonc
+++ b/apps/mediapulse/agents/data-collection/config.example.jsonc
@@ -5,6 +5,12 @@
   "providers": {
     "search": {
       "baseUrl": "https://google.serper.dev/search",
+      "query": {
+        "country": "id",
+        "language": "auto",
+        "dateRange": "past_week",
+        "type": "news",
+      },
       "authentication": {
         "type": "none",
         "apiKey": "{{SERPER_API_KEY}}",
@@ -27,9 +33,9 @@
           "concurrency": 1,
           "timeoutMs": 45000,
           "retry": {
-            "maxAttempts": 4,
-            "baseDelayMs": 2000,
-            "maxDelayMs": 20000,
+            "maxAttempts": 1,
+            "baseDelayMs": 1000,
+            "maxDelayMs": 10000,
           },
         },
         {

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -58,6 +58,12 @@ describe("dataCollectionAgentConfigSchema", () => {
       "{{SERPER_API_KEY}}",
     );
     expect(parsed.providers.search.authentication.type).toBe("none");
+    expect(parsed.providers.search.query).toEqual({
+      country: "id",
+      language: "auto",
+      dateRange: "past_week",
+      type: "news",
+    });
     expect(
       parsed.providers.fetch.providers.map((provider) => provider.type),
     ).toEqual(["diffbot", "firecrawl", "jina"]);

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
+import { serperQueryConfigSchema } from "./serper-query";
+
 const concurrencySchema = z
   .number()
   .int()
@@ -35,11 +37,11 @@ const defaultRetry = {
   maxDelayMs: 10_000,
 } as const;
 
-/** Extended retry policy for Diffbot when many tickers share one rate-limit budget. */
-const diffbotDefaultRetry = {
-  maxAttempts: 4,
-  baseDelayMs: 2000,
-  maxDelayMs: 20_000,
+/** Fetch providers fail fast and rely on the ordered provider chain for fallback. */
+const fetchDefaultRetry = {
+  maxAttempts: 1,
+  baseDelayMs: 1000,
+  maxDelayMs: 10_000,
 } as const;
 
 const authenticationSchema = z.object({
@@ -74,7 +76,14 @@ const searchProviderSchema = z.object({
   baseUrl: z
     .string()
     .default("https://google.serper.dev/search")
-    .describe("Serper search endpoint that accepts POST { q }."),
+    .describe(
+      "Serper API host and path. The search type overrides the path to /search or /news.",
+    ),
+  query: serperQueryConfigSchema
+    .default({})
+    .describe(
+      "Serper query parameters: country (gl), language (hl), date range (tbs), and type.",
+    ),
   authentication: z
     .object({
       type: z.enum(["bearer", "none"]).default("none"),
@@ -124,7 +133,7 @@ export const fetchProviderConfigSchema = z.object({
     .default(30_000)
     .optional()
     .describe("HTTP request timeout in milliseconds."),
-  retry: retrySchema.default(defaultRetry).optional(),
+  retry: retrySchema.default(fetchDefaultRetry).optional(),
 });
 
 /** Recommended Diffbot provider defaults for the fetch chain. */
@@ -138,7 +147,7 @@ export const defaultDiffbotFetchProvider = {
   rateLimit: { requests: 1, perSeconds: 1 },
   concurrency: 1,
   timeoutMs: 45_000,
-  retry: diffbotDefaultRetry,
+  retry: fetchDefaultRetry,
 };
 
 /** Recommended Firecrawl provider defaults for the fetch chain. */
@@ -153,7 +162,7 @@ export const defaultFirecrawlFetchProvider = {
   rateLimit: { requests: 1, perSeconds: 1 },
   concurrency: 1,
   timeoutMs: 45_000,
-  retry: defaultRetry,
+  retry: fetchDefaultRetry,
 };
 
 /** Recommended Jina provider defaults for the fetch chain. */
@@ -168,7 +177,7 @@ export const defaultJinaFetchProvider = {
   rateLimit: { requests: 2, perSeconds: 1 },
   concurrency: 1,
   timeoutMs: 45_000,
-  retry: defaultRetry,
+  retry: fetchDefaultRetry,
 };
 
 /** Default ordered fetch-provider chain: Diffbot, then Firecrawl, then Jina. */

--- a/apps/mediapulse/agents/data-collection/src/utilities/serper-query.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/serper-query.test.ts
@@ -1,0 +1,116 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSerperRequestBody,
+  resolveSerperEndpoint,
+  serperDateRangeToTbs,
+  serperQueryConfigSchema,
+} from "./serper-query";
+
+describe("serperDateRangeToTbs", () => {
+  it("maps past_week to qdr:w", () => {
+    // Act
+    const tbs = serperDateRangeToTbs("past_week");
+
+    // Assert
+    expect(tbs).toBe("qdr:w");
+  });
+
+  it("returns undefined for all", () => {
+    // Act
+    const tbs = serperDateRangeToTbs("all");
+
+    // Assert
+    expect(tbs).toBeUndefined();
+  });
+});
+
+describe("resolveSerperEndpoint", () => {
+  it("uses the news path when type is news", () => {
+    // Act
+    const endpoint = resolveSerperEndpoint(
+      "https://google.serper.dev/search",
+      "news",
+    );
+
+    // Assert
+    expect(endpoint).toBe("https://google.serper.dev/news");
+  });
+
+  it("uses the search path when type is search", () => {
+    // Act
+    const endpoint = resolveSerperEndpoint(
+      "https://google.serper.dev/news",
+      "search",
+    );
+
+    // Assert
+    expect(endpoint).toBe("https://google.serper.dev/search");
+  });
+});
+
+describe("buildSerperRequestBody", () => {
+  it("builds the default Indonesia news payload with past week and auto language", () => {
+    // Setup
+    const queryConfig = serperQueryConfigSchema.parse({});
+
+    // Act
+    const body = buildSerperRequestBody("BBCA stock news", queryConfig);
+
+    // Assert
+    expect(body).toEqual({
+      q: "BBCA stock news",
+      gl: "id",
+      type: "news",
+      tbs: "qdr:w",
+    });
+  });
+
+  it("includes hl when language is not auto", () => {
+    // Setup
+    const queryConfig = serperQueryConfigSchema.parse({
+      language: "en",
+      type: "search",
+      dateRange: "past_day",
+    });
+
+    // Act
+    const body = buildSerperRequestBody("query", queryConfig);
+
+    // Assert
+    expect(body).toEqual({
+      q: "query",
+      gl: "id",
+      hl: "en",
+      tbs: "qdr:d",
+    });
+  });
+
+  it("omits tbs when dateRange is all", () => {
+    // Setup
+    const queryConfig = serperQueryConfigSchema.parse({ dateRange: "all" });
+
+    // Act
+    const body = buildSerperRequestBody("query", queryConfig);
+
+    // Assert
+    expect(body).not.toHaveProperty("tbs");
+  });
+});
+
+describe("serperQueryConfigSchema", () => {
+  it("defaults to Indonesia, auto language, past week, and news", () => {
+    // Act
+    const parsed = serperQueryConfigSchema.parse({});
+
+    // Assert
+    expect(parsed).toEqual({
+      country: "id",
+      language: "auto",
+      dateRange: "past_week",
+      type: "news",
+    });
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/serper-query.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/serper-query.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+
+/** Serper `tbs` presets exposed in Hermes config. */
+export const serperDateRangeSchema = z.enum([
+  "past_hour",
+  "past_day",
+  "past_week",
+  "past_month",
+  "past_year",
+  "all",
+]);
+
+export type SerperDateRange = z.infer<typeof serperDateRangeSchema>;
+
+/** Serper search mode — `news` uses the `/news` endpoint. */
+export const serperSearchTypeSchema = z.enum(["search", "news"]);
+
+export type SerperSearchType = z.infer<typeof serperSearchTypeSchema>;
+
+/** Hermes-configurable Serper query parameters (see https://serper.dev). */
+export const serperQueryConfigSchema = z.object({
+  country: z
+    .string()
+    .default("id")
+    .describe("Serper `gl` country code (default Indonesia)."),
+  language: z
+    .union([z.literal("auto"), z.string().min(2)])
+    .default("auto")
+    .describe('Serper `hl` language code, or "auto" to omit the parameter.'),
+  dateRange: serperDateRangeSchema
+    .default("past_week")
+    .describe("Serper `tbs` time filter (default past week)."),
+  type: serperSearchTypeSchema
+    .default("news")
+    .describe("Serper search type. News uses the /news endpoint."),
+  num: z
+    .number()
+    .int()
+    .positive()
+    .max(100)
+    .optional()
+    .describe("Optional number of Serper results per query."),
+  location: z
+    .string()
+    .optional()
+    .describe("Optional Serper location for localized results."),
+});
+
+export type SerperQueryConfig = z.infer<typeof serperQueryConfigSchema>;
+
+const SERPER_DATE_RANGE_TO_TBS: Record<SerperDateRange, string | undefined> = {
+  past_hour: "qdr:h",
+  past_day: "qdr:d",
+  past_week: "qdr:w",
+  past_month: "qdr:m",
+  past_year: "qdr:y",
+  all: undefined,
+};
+
+/**
+ * Maps a configured date-range preset to Serper's `tbs` query parameter.
+ *
+ * @param dateRange - Hermes date-range preset.
+ * @returns Serper `tbs` value, or `undefined` when no time filter applies.
+ */
+export const serperDateRangeToTbs = (
+  dateRange: SerperDateRange,
+): string | undefined => SERPER_DATE_RANGE_TO_TBS[dateRange];
+
+/**
+ * Resolves the Serper POST URL from the configured base URL and search type.
+ *
+ * @param baseUrl - Provider base URL from Hermes config.
+ * @param type - Serper search type (`search` or `news`).
+ */
+export const resolveSerperEndpoint = (
+  baseUrl: string,
+  type: SerperSearchType,
+): string => {
+  const url = new URL(baseUrl);
+  url.pathname = type === "news" ? "/news" : "/search";
+  return url.href.replace(/\/$/, "");
+};
+
+/**
+ * Builds the JSON body for a Serper search or news request.
+ *
+ * @param queryText - Search query string from the Agent Data API.
+ * @param queryConfig - Serper query settings from Hermes config.
+ */
+export const buildSerperRequestBody = (
+  queryText: string,
+  queryConfig: SerperQueryConfig,
+): Record<string, string | number> => {
+  const body: Record<string, string | number> = {
+    q: queryText,
+    gl: queryConfig.country,
+  };
+
+  if (queryConfig.language !== "auto") {
+    body.hl = queryConfig.language;
+  }
+
+  if (queryConfig.type === "news") {
+    body.type = "news";
+  }
+
+  const tbs = serperDateRangeToTbs(queryConfig.dateRange);
+  if (tbs) {
+    body.tbs = tbs;
+  }
+
+  if (queryConfig.num !== undefined) {
+    body.num = queryConfig.num;
+  }
+
+  if (queryConfig.location) {
+    body.location = queryConfig.location;
+  }
+
+  return body;
+};

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.test.ts
@@ -14,6 +14,12 @@ import { type SearchQuery, performWebSearch } from "./web-search";
 
 const defaultConfig = {
   baseUrl: "https://google.serper.dev/search",
+  query: {
+    country: "id",
+    language: "auto" as const,
+    dateRange: "past_week" as const,
+    type: "news" as const,
+  },
   authentication: {
     type: "none" as const,
     apiKey: "serper-key",
@@ -78,11 +84,11 @@ describe("performWebSearch", () => {
     );
   });
 
-  it("calls Serper and maps the first organic result", async () => {
+  it("calls Serper news with Indonesia defaults and maps the first result", async () => {
     // Setup
     const postMock = vi.fn().mockReturnValue(
       mockGotPostResponse({
-        organic: [
+        news: [
           {
             link: "http://example.com",
             title: "Title",
@@ -105,9 +111,14 @@ describe("performWebSearch", () => {
 
     // Assert
     expect(postMock).toHaveBeenCalledWith(
-      "https://google.serper.dev/search",
+      "https://google.serper.dev/news",
       expect.objectContaining({
-        json: { q: "search" },
+        json: {
+          q: "search",
+          gl: "id",
+          type: "news",
+          tbs: "qdr:w",
+        },
         headers: expect.objectContaining({
           "X-API-KEY": "serper-key",
         }),

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
@@ -4,6 +4,7 @@ import { logger as defaultLogger } from "@workspace/logger";
 import { RateLimiter, type StageThrottleStats, withRetry } from "./resilience";
 import { classifyError, isRetryableError } from "./error-classification";
 import { pMap } from "./p-map";
+import { buildSerperRequestBody, resolveSerperEndpoint } from "./serper-query";
 import type { ConfigSchemaType } from "./config-schema";
 import type { DataCollectionFailure } from "@workspace/agent-data-api-contract";
 
@@ -69,9 +70,19 @@ const serperOrganicItemSchema = z.object({
   snippet: z.string().optional(),
 });
 
+/** Zod schema for Serper.dev API news result item. */
+const serperNewsItemSchema = z.object({
+  link: z.string().url().optional(),
+  title: z.string().optional(),
+  snippet: z.string().optional(),
+  date: z.string().optional(),
+  source: z.string().optional(),
+});
+
 /** Zod schema for Serper.dev API search response. */
 export const serperResponseSchema = z.object({
   organic: z.array(serperOrganicItemSchema).optional(),
+  news: z.array(serperNewsItemSchema).optional(),
 });
 
 export type SerperResponse = z.infer<typeof serperResponseSchema>;
@@ -107,8 +118,10 @@ const searchOneQuery = async (
     await rateLimiter.acquire();
 
     const fetchTask = async () => {
-      const response = await gotClient.post(config.baseUrl, {
-        json: { q: query.text },
+      const endpoint = resolveSerperEndpoint(config.baseUrl, config.query.type);
+      const requestBody = buildSerperRequestBody(query.text, config.query);
+      const response = await gotClient.post(endpoint, {
+        json: requestBody,
         headers: {
           "Content-Type": "application/json",
           ...authHeaders,
@@ -123,19 +136,22 @@ const searchOneQuery = async (
         throw parsed.error;
       }
 
-      const organic = parsed.data.organic ?? [];
-      if (organic.length === 0) {
+      const items =
+        config.query.type === "news"
+          ? (parsed.data.news ?? [])
+          : (parsed.data.organic ?? []);
+      if (items.length === 0) {
         throw new Error("Semantic validation failed");
       }
-      return organic;
+      return items;
     };
 
-    const organic = config.retry
+    const serpItems = config.retry
       ? await withRetry(fetchTask, config.retry, isRetryableError)
       : await fetchTask();
 
     const queryResults: WebSearchAttemptResult[] = [];
-    for (const [serpIndex, item] of organic.entries()) {
+    for (const [serpIndex, item] of serpItems.entries()) {
       if (!item.link) {
         continue;
       }


### PR DESCRIPTION
## Summary

Serper search in data-collection used a bare `{ q }` POST to `/search`, which missed country, date range, and news targeting we want for Indonesian tickers. Fetch providers also retried Diffbot up to four times before trying Firecrawl, which added delay on rate limits. This PR adds Hermes-configurable Serper query settings with sensible defaults and cuts fetch retries to one attempt per provider.

## Related issues

Closes #600

## Important changes

- Add `providers.search.query` with defaults: country `id`, language `auto`, dateRange `past_week`, type `news`
- POST to `/news` with `gl`, `type`, and `tbs: qdr:w`, parsing the `news` array in responses
- New `serper-query.ts` helpers for endpoint resolution and request body building
- Fetch provider default retry policy is now `maxAttempts: 1` (Diffbot, Firecrawl, Jina)

## Other changes

- Update `config.example.jsonc` and tests for the new Serper payload and schema defaults

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/serper-query.ts` - Serper config mapping and request body
- `apps/mediapulse/agents/data-collection/src/utilities/web-search.ts` - uses query config on each search
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` - Hermes schema defaults

## How to test

1. `pnpm --filter @mediapulse/data-collection type:check && pnpm --filter @mediapulse/data-collection test --run`
2. Confirm 146 tests pass, including Serper news payload assertions in `web-search.test.ts`
3. Optional: invoke data-collection with empty Hermes config and confirm Serper requests hit `/news` with `gl: id` and `tbs: qdr:w`
