### PR TITLE
Add agent activity heartbeat and Hermes dashboard view

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/executions/agent-activity-actions.ts
+++ b/apps/hermes/dashboard/app/dashboard/executions/agent-activity-actions.ts
@@ -1,0 +1,22 @@
+"use server";
+
+import type { ActivityRow } from "@/components/use-agent-activity-modal";
+import { getAgentActivities } from "@/lib/agent-activity";
+import { getDashboardSession } from "@/lib/auth-dashboard";
+
+/**
+ * Loads agent activity rows for a job when the dashboard session is valid.
+ *
+ * @param jobId - Hermes job id for the invocation row.
+ * @returns Activity rows or an empty list when unauthorized.
+ */
+export const fetchAgentActivitiesAction = async (
+  jobId: string,
+): Promise<ActivityRow[]> => {
+  const session = await getDashboardSession();
+  if (!session) {
+    return [];
+  }
+
+  return getAgentActivities(jobId);
+};

--- a/apps/hermes/dashboard/components/live-elapsed.tsx
+++ b/apps/hermes/dashboard/components/live-elapsed.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { formatActivityDuration } from "@/lib/format-activity-duration";
+
+import { useLiveElapsed } from "./use-live-elapsed";
+
+type LiveElapsedProps = {
+  startIso: string;
+};
+
+/**
+ * Displays a live-updating elapsed label for an in-progress activity step.
+ *
+ * @param props - ISO start time for the active step.
+ */
+export const LiveElapsed = ({ startIso }: LiveElapsedProps) => {
+  const elapsedMs = useLiveElapsed(startIso);
+
+  return (
+    <span className="text-xs tabular-nums text-muted-foreground mr-2">
+      {formatActivityDuration(elapsedMs)}…
+    </span>
+  );
+};

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.test.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.test.tsx
@@ -2,6 +2,10 @@ import React from "react";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@/app/dashboard/executions/agent-activity-actions", () => ({
+  fetchAgentActivitiesAction: vi.fn().mockResolvedValue([]),
+}));
+
 import { ScheduleExecutionInvocationsTable } from "./schedule-execution-invocations-table";
 
 vi.mock("@workspace/ui/components/dialog", () => ({
@@ -50,8 +54,11 @@ describe("ScheduleExecutionInvocationsTable", () => {
     render(<ScheduleExecutionInvocationsTable invocations={invocations} />);
     fireEvent.click(screen.getByRole("button", { name: "j1" }));
 
-    // Assert
-    expect(screen.getByTestId("dialog")).toHaveAttribute("data-open", "true");
+    // Assert — invocation details dialog (first of two Dialog instances)
+    const openDialogs = screen
+      .getAllByTestId("dialog")
+      .filter((node) => node.getAttribute("data-open") === "true");
+    expect(openDialogs).toHaveLength(1);
     expect(screen.getByText(/"ticker": "ABC"/)).toBeInTheDocument();
     expect(screen.getByText(/"foo": 1/)).toBeInTheDocument();
     expect(screen.getByText("my-agent")).toBeInTheDocument();

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  CheckCircle2,
+  Loader2,
+} from "lucide-react";
 import { format } from "date-fns";
 
 import {
@@ -9,6 +15,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@workspace/ui/components/dialog";
+import { Separator } from "@workspace/ui/components/separator";
 import {
   Table,
   TableBody,
@@ -26,6 +33,8 @@ import {
 import { formatQueueAttemptsDisplay } from "@/lib/format-queue-attempts-display";
 import { resolveInvocationOutcomeLabel } from "@/lib/invocation-display-status";
 
+import { formatActivityDuration } from "@/lib/format-activity-duration";
+
 import {
   useScheduleExecutionInvocationsSort,
   type ScheduleExecutionInvocationSortField,
@@ -35,6 +44,8 @@ import {
   useScheduleExecutionInvocationsModal,
   type ScheduleExecutionInvocationRow,
 } from "./use-schedule-execution-invocations-modal";
+import { useAgentActivityModal } from "./use-agent-activity-modal";
+import { LiveElapsed } from "./live-elapsed";
 
 /**
  * Pretty-prints JSON for read-only display in the modal.
@@ -120,6 +131,14 @@ export const ScheduleExecutionInvocationsTable = ({
     useScheduleExecutionInvocationsSort(invocations);
   const { open, selected, openModal, onOpenChange } =
     useScheduleExecutionInvocationsModal();
+  const {
+    open: activityOpen,
+    jobId: activityJobId,
+    rows: activityRows,
+    loading: activityLoading,
+    openModal: openActivityModal,
+    onOpenChange: onActivityOpenChange,
+  } = useAgentActivityModal();
 
   return (
     <>
@@ -151,12 +170,13 @@ export const ScheduleExecutionInvocationsTable = ({
               </TableHead>
               <TableHead>Duration</TableHead>
               <TableHead>Reason</TableHead>
+              <TableHead>Activity</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {invocations.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={8} className="text-muted-foreground">
+                <TableCell colSpan={9} className="text-muted-foreground">
                   No invocations.
                 </TableCell>
               </TableRow>
@@ -223,6 +243,18 @@ export const ScheduleExecutionInvocationsTable = ({
                     <TableCell className="max-w-md whitespace-normal wrap-break-word text-sm text-muted-foreground">
                       {j.errorSummary ?? "—"}
                     </TableCell>
+                    <TableCell>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => {
+                          void openActivityModal(j.jobId);
+                        }}
+                      >
+                        Show activity
+                      </Button>
+                    </TableCell>
                   </TableRow>
                 );
               })
@@ -271,6 +303,68 @@ export const ScheduleExecutionInvocationsTable = ({
               </div>
             </div>
           ) : null}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={activityOpen} onOpenChange={onActivityOpenChange}>
+        <DialogContent className="flex max-h-[85vh] max-w-lg flex-col gap-4 overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {activityJobId
+                ? `Activity for ${activityJobId.slice(0, 8)}…`
+                : "Activity"}
+            </DialogTitle>
+          </DialogHeader>
+          {activityLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : activityRows == null || activityRows.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No activity recorded.
+            </p>
+          ) : (
+            <div className="flex flex-col">
+              {activityRows.map((row, index) => {
+                const isLastRow = index === activityRows.length - 1;
+                const showLiveElapsed =
+                  isLastRow && row.status === "processing";
+                const durationLabel =
+                  !showLiveElapsed && row.durationMs != null
+                    ? formatActivityDuration(row.durationMs)
+                    : null;
+
+                return (
+                  <div key={row.id}>
+                    {index > 0 ? <Separator className="my-3" /> : null}
+                    <div className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{row.title}</span>
+                        <span className="flex-1" />
+                        {showLiveElapsed ? (
+                          <LiveElapsed startIso={row.createdAt} />
+                        ) : durationLabel ? (
+                          <span className="text-xs tabular-nums text-muted-foreground mr-2">
+                            {durationLabel}
+                          </span>
+                        ) : null}
+                        {row.status === "processing" ? (
+                          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                        ) : (
+                          <CheckCircle2 className="size-4 text-green-500" />
+                        )}
+                      </div>
+                      {row.description ? (
+                        <p className="text-sm text-muted-foreground">
+                          {row.description}
+                        </p>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </DialogContent>
       </Dialog>
     </>

--- a/apps/hermes/dashboard/components/use-agent-activity-modal.ts
+++ b/apps/hermes/dashboard/components/use-agent-activity-modal.ts
@@ -1,0 +1,48 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { fetchAgentActivitiesAction } from "@/app/dashboard/executions/agent-activity-actions";
+import {
+  attachActivityRowDurations,
+  type ActivityRow,
+} from "@/lib/derive-activity-row-durations";
+
+export type { ActivityRow } from "@/lib/derive-activity-row-durations";
+
+/**
+ * Controls the agent activity dialog: async fetch on open and reset on close.
+ *
+ * @returns Dialog state, fetched rows, loading flag, and open/close handlers.
+ */
+export const useAgentActivityModal = () => {
+  const [open, setOpen] = useState(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [rows, setRows] = useState<ActivityRow[] | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const openModal = useCallback(async (nextJobId: string) => {
+    setJobId(nextJobId);
+    setOpen(true);
+    setLoading(true);
+    setRows(null);
+
+    try {
+      const data = await fetchAgentActivitiesAction(nextJobId);
+      setRows(attachActivityRowDurations(data));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const onOpenChange = useCallback((next: boolean) => {
+    setOpen(next);
+    if (!next) {
+      setJobId(null);
+      setRows(null);
+      setLoading(false);
+    }
+  }, []);
+
+  return { open, jobId, rows, loading, openModal, onOpenChange };
+};

--- a/apps/hermes/dashboard/components/use-live-elapsed.ts
+++ b/apps/hermes/dashboard/components/use-live-elapsed.ts
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Tracks elapsed milliseconds from an ISO start instant, updating every second.
+ *
+ * @param startIso - ISO-8601 timestamp when the step started.
+ * @param nowMs - Injectable clock for tests (defaults to `Date.now()`).
+ * @returns Elapsed milliseconds since `startIso`.
+ */
+export const useLiveElapsed = (
+  startIso: string,
+  nowMs: () => number = Date.now,
+): number => {
+  const [elapsedMs, setElapsedMs] = useState(() =>
+    Math.max(0, nowMs() - Date.parse(startIso)),
+  );
+
+  useEffect(() => {
+    const tick = () => {
+      setElapsedMs(Math.max(0, nowMs() - Date.parse(startIso)));
+    };
+
+    tick();
+    const intervalId = window.setInterval(tick, 1000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [startIso, nowMs]);
+
+  return elapsedMs;
+};

--- a/apps/hermes/dashboard/lib/agent-activity.ts
+++ b/apps/hermes/dashboard/lib/agent-activity.ts
@@ -1,0 +1,63 @@
+/** @vitest-environment node */
+
+import { createAgentTokenClient } from "@workspace/agent-auth-client";
+import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
+import { env } from "@hermes/env";
+
+import type { ActivityRow } from "@/components/use-agent-activity-modal";
+
+type AgentActivityClient = Pick<
+  ReturnType<typeof createAgentDataApiClient>,
+  "agentActivity"
+>;
+
+type GetAgentActivitiesDependencies = {
+  getToken?: () => Promise<string>;
+  createClient?: (token: string) => AgentActivityClient;
+};
+
+/**
+ * Loads agent activity rows for a Hermes job from agent-data-api.
+ * Returns an empty list when `AGENT_DATA_API_URL` is not configured.
+ *
+ * @param jobId - Hermes job id to query.
+ * @param dependencies - Injectable token and client factories for tests.
+ * @returns Activity rows ordered as returned by the data-api.
+ */
+export const getAgentActivities = async (
+  jobId: string,
+  dependencies: GetAgentActivitiesDependencies = {},
+): Promise<ActivityRow[]> => {
+  const baseUrl = env.AGENT_DATA_API_URL?.trim();
+  if (!baseUrl) {
+    return [];
+  }
+
+  const getToken =
+    dependencies.getToken ??
+    (async () =>
+      createAgentTokenClient({
+        authApiUrl: env.AGENT_AUTH_API_URL,
+        credential: env.HERMES_INTERNAL_API_KEY,
+      }).getToken());
+
+  const createClient =
+    dependencies.createClient ??
+    ((token: string) =>
+      createAgentDataApiClient({
+        baseUrl,
+        token,
+      }));
+
+  const token = await getToken();
+  const client = createClient(token);
+  const result = await client.agentActivity.get({ jobId });
+
+  return result.data.map((row) => ({
+    id: row.id,
+    title: row.title,
+    description: row.description,
+    status: row.status,
+    createdAt: row.createdAt,
+  }));
+};

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { attachActivityRowDurations } from "./derive-activity-row-durations";
+
+describe("attachActivityRowDurations", () => {
+  it("diffs consecutive rows and uses total fallback for last completed row", () => {
+    const rows = attachActivityRowDurations([
+      {
+        id: "1",
+        title: "Step one",
+        description: null,
+        status: "processing",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "2",
+        title: "Step two",
+        description: null,
+        status: "processing",
+        createdAt: "2026-01-01T00:01:00.000Z",
+      },
+      {
+        id: "3",
+        title: "Step three",
+        description: null,
+        status: "completed",
+        createdAt: "2026-01-01T00:03:30.000Z",
+      },
+    ]);
+
+    expect(rows[0]?.durationMs).toBe(60_000);
+    expect(rows[1]?.durationMs).toBe(150_000);
+    expect(rows[2]?.durationMs).toBe(210_000);
+  });
+
+  it("sets null duration for the last processing row", () => {
+    const rows = attachActivityRowDurations([
+      {
+        id: "1",
+        title: "Step one",
+        description: null,
+        status: "completed",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "2",
+        title: "Step two",
+        description: null,
+        status: "processing",
+        createdAt: "2026-01-01T00:00:45.000Z",
+      },
+    ]);
+
+    expect(rows[0]?.durationMs).toBe(45_000);
+    expect(rows[1]?.durationMs).toBeNull();
+  });
+});

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
@@ -1,0 +1,45 @@
+/** One agent activity row returned by the data-api for a Hermes job. */
+export type ActivityRow = {
+  id: string;
+  title: string;
+  description: string | null;
+  status: "processing" | "completed";
+  createdAt: string;
+  durationMs?: number | null;
+};
+
+type ActivityRowFromServer = Omit<ActivityRow, "durationMs">;
+
+/**
+ * Derives per-step durations from consecutive `createdAt` timestamps.
+ *
+ * @param rows - Activity rows ordered oldest first from the data-api.
+ * @returns Rows with `durationMs` filled for display.
+ */
+export const attachActivityRowDurations = (
+  rows: ActivityRowFromServer[],
+): ActivityRow[] => {
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const firstCreatedAt = Date.parse(rows[0]!.createdAt);
+  const lastCreatedAt = Date.parse(rows[rows.length - 1]!.createdAt);
+  const totalFallbackMs = lastCreatedAt - firstCreatedAt;
+
+  return rows.map((row, index) => {
+    if (index < rows.length - 1) {
+      return {
+        ...row,
+        durationMs:
+          Date.parse(rows[index + 1]!.createdAt) - Date.parse(row.createdAt),
+      };
+    }
+
+    if (row.status === "processing") {
+      return { ...row, durationMs: null };
+    }
+
+    return { ...row, durationMs: totalFallbackMs };
+  });
+};

--- a/apps/hermes/dashboard/lib/format-activity-duration.test.ts
+++ b/apps/hermes/dashboard/lib/format-activity-duration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { formatActivityDuration } from "./format-activity-duration";
+
+describe("formatActivityDuration", () => {
+  it("returns < 1s for sub-second durations", () => {
+    expect(formatActivityDuration(0)).toBe("< 1s");
+    expect(formatActivityDuration(999)).toBe("< 1s");
+  });
+
+  it("returns seconds under one minute", () => {
+    expect(formatActivityDuration(1000)).toBe("1s");
+    expect(formatActivityDuration(45_000)).toBe("45s");
+    expect(formatActivityDuration(59_999)).toBe("59s");
+  });
+
+  it("returns minutes and seconds under one hour", () => {
+    expect(formatActivityDuration(60_000)).toBe("1m");
+    expect(formatActivityDuration(83_000)).toBe("1m 23s");
+    expect(formatActivityDuration(3_599_999)).toBe("59m 59s");
+  });
+
+  it("returns hours and minutes for one hour or more", () => {
+    expect(formatActivityDuration(3_661_000)).toBe("1h 1m");
+    expect(formatActivityDuration(7_440_000)).toBe("2h 4m");
+    expect(formatActivityDuration(3_600_000)).toBe("1h");
+  });
+});

--- a/apps/hermes/dashboard/lib/format-activity-duration.ts
+++ b/apps/hermes/dashboard/lib/format-activity-duration.ts
@@ -1,0 +1,26 @@
+/**
+ * Formats a millisecond delta as a compact human-readable activity step duration.
+ *
+ * @param ms - Elapsed milliseconds (non-negative).
+ * @returns Compact label such as `< 1s`, `45s`, `1m 23s`, or `2h 4m`.
+ */
+export const formatActivityDuration = (ms: number): string => {
+  if (ms < 1000) {
+    return "< 1s";
+  }
+
+  const secTotal = Math.floor(ms / 1000);
+  if (secTotal < 60) {
+    return `${secTotal}s`;
+  }
+
+  const minTotal = Math.floor(secTotal / 60);
+  const sec = secTotal % 60;
+  if (minTotal < 60) {
+    return sec > 0 ? `${minTotal}m ${sec}s` : `${minTotal}m`;
+  }
+
+  const hours = Math.floor(minTotal / 60);
+  const min = minTotal % 60;
+  return min > 0 ? `${hours}h ${min}m` : `${hours}h`;
+};

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -39,6 +39,10 @@ import {
   postDataCollectionFailure,
 } from "./routes/data-collection-failure.js";
 import { getDeliveryRun, postDeliveryRun } from "./routes/delivery-run.js";
+import {
+  getAgentActivity,
+  postAgentActivity,
+} from "./routes/agent-activity.js";
 import { getDelivery, postDeliveryHandler } from "./routes/delivery.js";
 import {
   postUserRegistrationRegisterHandler,
@@ -158,6 +162,10 @@ const routeHandlers = {
   contentGenerationRuns: {
     get: getContentGenerationRuns,
     post: postContentGenerationRun,
+  },
+  agentActivity: {
+    get: getAgentActivity,
+    post: postAgentActivity,
   },
 } satisfies AgentDataApiHandlers;
 

--- a/apps/mediapulse/agent-data-api/src/routes/agent-activity.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/agent-activity.ts
@@ -1,0 +1,73 @@
+import { Context } from "hono";
+
+import {
+  getAgentActivityQuerySchema,
+  getAgentActivityResponseSchema,
+  postAgentActivityBodySchema,
+  postAgentActivityResponseSchema,
+} from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+
+import {
+  getAgentActivityService,
+  postAgentActivityService,
+} from "../services/agent-activity.js";
+
+/**
+ * GET /agent-activity — lists activity rows for a job, oldest first.
+ *
+ * @param context - Hono request context.
+ * @returns Activity rows for the requested `jobId`.
+ */
+export async function getAgentActivity(context: Context): Promise<Response> {
+  try {
+    const rawQuery = context.req.query();
+    const normalizedQuery = Object.fromEntries(
+      Object.entries(rawQuery).map(([key, value]) => [
+        key,
+        Array.isArray(value) ? value[0] : value,
+      ]),
+    );
+    const query = getAgentActivityQuerySchema.parse(normalizedQuery);
+    const rows = await getAgentActivityService(query.jobId);
+
+    const data = rows.map((row) => ({
+      id: row.id,
+      jobId: row.jobId,
+      title: row.title,
+      description: row.description,
+      status: row.status,
+      createdAt: row.createdAt.toISOString(),
+    }));
+
+    const response = getAgentActivityResponseSchema.parse({ data });
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}
+
+/**
+ * POST /agent-activity — records one activity heartbeat for a job.
+ *
+ * @param context - Hono request context.
+ * @returns The server-generated row id.
+ */
+export async function postAgentActivity(context: Context): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const data = await postAgentActivityBodySchema.parseAsync(body);
+
+    const created = await postAgentActivityService({
+      jobId: data.jobId,
+      title: data.title,
+      description: data.description,
+      status: data.status,
+    });
+
+    const response = postAgentActivityResponseSchema.parse(created);
+    return context.json(response, 201);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/agent-activity.ts
+++ b/apps/mediapulse/agent-data-api/src/services/agent-activity.ts
@@ -1,0 +1,61 @@
+import { prisma as mediapulsePrisma } from "@mediapulse/database";
+import type { Prisma } from "@mediapulse/database";
+
+export type AgentActivityDb = {
+  agentActivity: Pick<
+    typeof mediapulsePrisma.agentActivity,
+    "create" | "findMany"
+  >;
+};
+
+/**
+ * Inserts one agent activity row for a Hermes job.
+ *
+ * @param body - Validated POST body from an agent caller.
+ * @param deps - Injectable database dependency (defaults to production Prisma client).
+ * @returns The server-generated row id.
+ */
+export async function postAgentActivityService(
+  body: {
+    jobId: string;
+    title: string;
+    description?: string;
+    status: string;
+  },
+  deps?: { db?: AgentActivityDb },
+): Promise<{ id: string }> {
+  const db = deps?.db ?? mediapulsePrisma;
+
+  const createArgs = {
+    data: {
+      jobId: body.jobId,
+      title: body.title,
+      description: body.description ?? null,
+      status: body.status,
+    },
+    select: { id: true },
+  } satisfies Prisma.AgentActivityCreateArgs;
+
+  return db.agentActivity.create(createArgs);
+}
+
+/**
+ * Lists agent activity rows for a job, oldest first.
+ *
+ * @param jobId - Hermes job id to filter by.
+ * @param deps - Injectable database dependency (defaults to production Prisma client).
+ * @returns Matching rows ordered by `createdAt` ascending.
+ */
+export async function getAgentActivityService(
+  jobId: string,
+  deps?: { db?: AgentActivityDb },
+) {
+  const db = deps?.db ?? mediapulsePrisma;
+
+  const findManyArgs = {
+    where: { jobId },
+    orderBy: { createdAt: "asc" as const },
+  } satisfies Prisma.AgentActivityFindManyArgs;
+
+  return db.agentActivity.findMany(findManyArgs);
+}

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -452,6 +452,21 @@ export const run = async ({
     token,
   });
 
+  const report = (
+    title: string,
+    description?: string,
+    status: "processing" | "completed" = "processing",
+  ) => {
+    const jobId = hermesCorrelation?.jobId;
+    if (jobId) {
+      void dataApiClient.agentActivity
+        .create({ jobId, title, description, status })
+        .catch(() => {});
+    }
+  };
+
+  report("Fetching articles to analyse", `ticker ${input.tickerId}`);
+
   let articlesProcessedForSummary = 0;
   const chunkParseCounts = emptyChunkParseCounts();
   let relevanceRowValidationFailures = 0;
@@ -584,6 +599,11 @@ export const run = async ({
         runStatusLabel: "success",
         semanticFailureReason: "debounce_min_unanalyzed_count",
       });
+      report(
+        "Run debounced",
+        `${unanalyzedBacklogTotal} articles below min ${cfg.debounceMinUnanalyzedCount}`,
+        "completed",
+      );
       return {
         success: true,
         message: `debounce: ${unanalyzedBacklogTotal} unanalyzed source(s) below min ${cfg.debounceMinUnanalyzedCount}; skipping run`,
@@ -635,6 +655,11 @@ export const run = async ({
         runStatusLabel: "success",
         semanticFailureReason: "debounce_min_minutes_since_last_score",
       });
+      report(
+        "Run debounced",
+        `last scored within ${cfg.debounceMinMinutesSinceLastScore}min`,
+        "completed",
+      );
       return {
         success: true,
         message: `debounce: last relevance scored at ${ctx.lastRelevanceScoredAtIso} is within ${cfg.debounceMinMinutesSinceLastScore} minute(s); skipping run`,
@@ -663,6 +688,8 @@ export const run = async ({
     const batch = applyMaxBatchSizeCap(sorted, effectiveMaxBatchSize);
     articlesProcessedForSummary = batch.length;
 
+    report("Loaded article batch", `${batch.length} sources`);
+
     if (batch.length === 0) {
       const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
@@ -683,6 +710,11 @@ export const run = async ({
         extractionCalls: 0,
         runStatusLabel: "success",
       });
+      report(
+        "No articles to process",
+        "analysis context returned 0 sources",
+        "completed",
+      );
       return {
         success: true,
         message: "analysis context loaded (0 source(s)); nothing to process",
@@ -728,6 +760,11 @@ export const run = async ({
         extractionCalls: 0,
         semanticFailureReason: "empty_kg_vocabulary",
       });
+      report(
+        "KG vocabulary not configured",
+        `${ctx.entityTypes.length} entity types, ${ctx.relationTypes.length} relation types`,
+        "completed",
+      );
       return {
         success: false,
         message:
@@ -871,6 +908,11 @@ export const run = async ({
         ? runStart + cfg.runDeadlineMs
         : undefined;
 
+    report(
+      "Extracting entities and relations",
+      `${batch.length} articles via LLM`,
+    );
+
     const walkResult = await runExtractionsInParallel(batch, processOneSource, {
       concurrency: cfg.extractionConcurrency,
       deadlineAtMs: extractionDeadlineAtMs,
@@ -943,6 +985,14 @@ export const run = async ({
         extractionCalls,
         semanticFailureReason: "extraction_run_policy",
       });
+      report(
+        "Article analysis complete",
+        deriveArticleAnalysisRunStatusLabel(
+          extractionFailures.length,
+          postFailures.length,
+        ),
+        "completed",
+      );
       return {
         success: false,
         message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.runPolicy.minSuccessfulSources}.`,
@@ -1075,6 +1125,11 @@ export const run = async ({
       cfg.maxArticleEntitiesPerRun,
     );
 
+    report(
+      "Persisting knowledge graph",
+      `${entities.length} entities, ${relations.length} relations`,
+    );
+
     const { chunks, parseErrors, droppedRelations } = buildAnalysisPostChunks(
       input.tickerId,
       entities,
@@ -1188,6 +1243,11 @@ export const run = async ({
       }
     }
 
+    report(
+      "Posting article entity mentions",
+      `${articleEntitiesForPost.length} mention rows`,
+    );
+
     let articleEntityRowsPosted = 0;
     let mentionPostChunksCompleted = 0;
     let articleEntityParseErrors: string[] = [];
@@ -1255,6 +1315,10 @@ export const run = async ({
     let relevancePostChunksCompleted = 0;
 
     if (!erPhaseFailed && perSourceSignals.length > 0) {
+      report(
+        "Scoring and posting article relevance",
+        `${perSourceSignals.length} sources`,
+      );
       const weightMap = toRelevanceWeightMapV1(cfg);
       const relevanceDrafts = perSourceSignals.map((sig) =>
         buildDraftRelevanceRow(sig, cfg.scoreBreakdownVersion, weightMap),
@@ -1469,6 +1533,13 @@ export const run = async ({
         ? { llmPromptFingerprint: lastLlmPromptFingerprint }
         : {}),
     });
+
+    const failedCount = extractionFailures.length;
+    report(
+      "Article analysis complete",
+      `${extractionSuccessCount} extracted, ${failedCount} failed`,
+      "completed",
+    );
 
     return {
       success: true,

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -145,6 +145,21 @@ export async function run({
     token,
   });
 
+  const report = (
+    title: string,
+    description?: string,
+    status: "processing" | "completed" = "processing",
+  ) => {
+    const jobId = hermesCorrelation?.jobId;
+    if (jobId) {
+      void dataApiClient.agentActivity
+        .create({ jobId, title, description, status })
+        .catch(() => {});
+    }
+  };
+
+  report("Loading source articles", `ticker ${input.tickerId}`);
+
   const pipelineRunId = hermesCorrelation?.pipelineStepId ?? null;
   const executionId = hermesCorrelation?.executionId ?? null;
 
@@ -180,6 +195,10 @@ export async function run({
   );
 
   const precheckStart = Date.now();
+  report(
+    "Checking freshness",
+    `newsletter window ${windowStart} – ${windowEnd}`,
+  );
   const freshnessResult =
     await dataApiClient.contentGenerationNewslettersLatest.get({
       tickerId: input.tickerId,
@@ -221,6 +240,11 @@ export async function run({
       { tickerId: input.tickerId, outcome },
       "Skipping run: fresh newsletter already exists",
     );
+    report(
+      "Newsletter already generated today",
+      `skipping for ${input.tickerId}`,
+      "completed",
+    );
     await writeDiagnostic({
       dataApiClient,
       tickerId: input.tickerId,
@@ -248,6 +272,11 @@ export async function run({
     tickerId: input.tickerId,
   });
 
+  report(
+    "Fetched source articles",
+    `${sources?.length ?? 0} articles for ${input.tickerId}`,
+  );
+
   const { openaiApiKey: _apiKey, ...safeCredentials } =
     resolvedConfig.credentials;
   const safeConfig = { ...resolvedConfig, credentials: safeCredentials };
@@ -264,6 +293,11 @@ export async function run({
       { tickerId: input.tickerId, outcome },
       "Skipping run: no data sources",
     );
+    report(
+      "No source articles found",
+      `${input.tickerId} has no collected sources yet`,
+      "completed",
+    );
     await writeDiagnostic({
       dataApiClient,
       tickerId: input.tickerId,
@@ -277,6 +311,8 @@ export async function run({
       message: outcome.message ?? "No data sources found for this ticker",
     };
   }
+
+  report("Preparing article context", `${sources.length} articles`);
 
   // Map API sources to the minimal shape needed by the LLM generator.
   const sourcesForLlm: SourceForGeneration[] = sources.map((s) => ({
@@ -295,6 +331,10 @@ export async function run({
     createdAt: string;
   }> = [];
   if (resolvedConfig.quality.crossRunDedup.enabled) {
+    report(
+      "Loading recent newsletter bullets",
+      `last ${resolvedConfig.quality.crossRunDedup.windowDays} days`,
+    );
     try {
       const recent = await dataApiClient.contentGenerationBulletsRecent.get({
         tickerId: input.tickerId,
@@ -316,6 +356,7 @@ export async function run({
 
   let recentSubjects: string[] = [];
   if (resolvedConfig.delivery.subjectLine.enabled) {
+    report("Loading recent subject lines", "last 7 days");
     try {
       const recent = await dataApiClient.contentGenerationNewslettersRecent.get(
         {
@@ -339,6 +380,10 @@ export async function run({
 
   // Generate newsletter with retry-wrapped generateObject.
   let generated: Awaited<ReturnType<typeof generateNewsletterWithLlm>>;
+  report(
+    "Generating newsletter with LLM",
+    `${sourcesForLlm.length} articles · ${resolvedConfig.credentials.chatModel}`,
+  );
   logger.info({ tickerId: input.tickerId }, "LLM generation: start");
   try {
     generated = await generateNewsletterWithLlm(sourcesForLlm, resolvedConfig, {
@@ -371,6 +416,11 @@ export async function run({
       pipelineRunId,
       executionId,
     });
+    report(
+      "Newsletter generation failed",
+      `Newsletter generation failed: ${code}`,
+      "completed",
+    );
     return {
       success: false,
       message: `Newsletter generation failed: ${code}`,
@@ -428,6 +478,10 @@ export async function run({
 
   // Persist generated newsletter via agent-data-api.
   let persistedNewsletterId: string | null = null;
+  report(
+    "Saving newsletter to database",
+    `${resolvedConfig.output.topNewsCount} topics`,
+  );
   logger.info({ tickerId: input.tickerId }, "Persisting newsletter: start");
   try {
     const persistResult = await dataApiClient.contentGeneration.create({
@@ -467,6 +521,11 @@ export async function run({
       pipelineRunId,
       executionId,
     });
+    report(
+      "Newsletter generation failed",
+      `Failed to store generated newsletter: ${code}`,
+      "completed",
+    );
     return {
       success: false,
       message: `Failed to store generated newsletter: ${code}`,
@@ -477,6 +536,11 @@ export async function run({
   // Success path
   // -------------------------------------------------------------------------
   logger.info({ tickerId: input.tickerId }, "Stored newsletter for ticker");
+  report(
+    "Newsletter generated",
+    `${resolvedConfig.output.topNewsCount} topics`,
+    "completed",
+  );
   await writeDiagnostic({
     dataApiClient,
     tickerId: input.tickerId,

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -81,6 +81,21 @@ export async function runDataCollection(
     token,
   });
 
+  const report = (
+    title: string,
+    description?: string,
+    status: "processing" | "completed" = "processing",
+  ) => {
+    const jobId = hermesCorrelation?.jobId;
+    if (jobId) {
+      void dataApiClient.agentActivity
+        .create({ jobId, title, description, status })
+        .catch(() => {});
+    }
+  };
+
+  report("Fetching search queries", `ticker ${input.tickerId}`);
+
   const webSearchConfig = config.providers.search;
   const webFetchConfig = config.providers.fetch;
   const relevanceGateConfig = config.gates.relevance;
@@ -103,6 +118,10 @@ export async function runDataCollection(
     tickerRecord.sector,
     tickerRecord.industry,
   );
+  report(
+    "Loaded ticker context",
+    `${tickerAliases.length} ticker aliases, ${industryAliases.length} industry terms`,
+  );
   if (tickerAliases.length === 0 && industryAliases.length === 0) {
     log.warn(
       { tickerId: input.tickerId },
@@ -121,6 +140,8 @@ export async function runDataCollection(
   const { data: queries = [] } = await dataApiClient.dataCollection.get({
     tickerId: input.tickerId,
   });
+
+  report("Loaded search queries", `${queries.length} queries`);
 
   log.info(
     { queryCount: queries.length },
@@ -146,6 +167,11 @@ export async function runDataCollection(
     limit: 1,
   });
   const existingTodaySourceCount = baselineToday.dataSourceTotalCount;
+
+  report(
+    "Checking daily quota",
+    `${existingTodaySourceCount} sources today, target ${targetDailySuccessfulSources}`,
+  );
 
   let roundsExecuted = 0;
   let refillStopReason:
@@ -187,11 +213,29 @@ export async function runDataCollection(
   let throttleEvents = 0;
 
   if (queries.length === 0) {
+    report(
+      "No search queries available",
+      `ticker ${input.tickerId} has no active queries`,
+      "completed",
+    );
     refillStopReason = "no_queries";
   } else if (existingTodaySourceCount >= targetDailySuccessfulSources) {
+    report(
+      "Daily target already met",
+      `${existingTodaySourceCount} sources already today`,
+      "completed",
+    );
     refillStopReason = "daily_target_met_before_start";
   } else {
+    report(
+      "Running web searches",
+      `${queries.length} queries for ${input.tickerId}`,
+    );
+
     for (let round = 1; round <= maxTotalRounds; round += 1) {
+      if (round > 1) {
+        report("Search refill round", `round ${round} of ${maxTotalRounds}`);
+      }
       roundsExecuted += 1;
       const searchThrottleStats = { throttleEvents: 0 };
       const searchAttemptResults = await performWebSearch(queries, {
@@ -317,6 +361,11 @@ export async function runDataCollection(
         );
       }
 
+      report(
+        "Filtered search results",
+        `${searchSuccessesAfterHostBreaker.length} URLs after dedup, existing-URL and dead-cache checks`,
+      );
+
       const budgetSelection = applyFetchBudget(
         searchSuccessesAfterHostBreaker,
         {
@@ -344,6 +393,11 @@ export async function runDataCollection(
         );
       }
 
+      report(
+        "Fetching article content",
+        `${budgetSelection.hits.length} candidate URLs`,
+      );
+
       const fetchThrottleStats = { throttleEvents: 0 };
       const fetchAttemptResults = await performWebFetch(budgetSelection.hits, {
         config: webFetchConfig,
@@ -366,6 +420,10 @@ export async function runDataCollection(
 
       let persistedThisRoundCount = 0;
       const roundQualityDrops: QualityDropForDeadUrl[] = [];
+      report(
+        "Saving sources to database",
+        `${roundFetchSuccesses.length} deduplicated sources`,
+      );
       for (const page of roundFetchSuccesses) {
         const urlDecision = classifyNoisyUrl(page.url);
         if (urlDecision.blocked) {
@@ -638,6 +696,12 @@ export async function runDataCollection(
       "data collection run completed with policy failure (semantic failure response)",
     );
 
+    report(
+      "Data collection complete",
+      `${totalSources} saved, ${failuresPayload.length} failed`,
+      "completed",
+    );
+
     return {
       success: false,
       message,
@@ -667,6 +731,12 @@ export async function runDataCollection(
       throttleEvents,
     },
     completionMessage,
+  );
+
+  report(
+    "Data collection complete",
+    `${totalSources} saved, ${failuresPayload.length} failed`,
+    "completed",
   );
 
   return {

--- a/apps/mediapulse/agents/delivery/src/index.ts
+++ b/apps/mediapulse/agents/delivery/src/index.ts
@@ -117,6 +117,21 @@ const app = createAgentApp<
         token,
       });
 
+      const report = (
+        title: string,
+        description?: string,
+        status: "processing" | "completed" = "processing",
+      ) => {
+        const jobId = hermesCorrelation?.jobId;
+        if (jobId) {
+          void dataApiClient.agentActivity
+            .create({ jobId, title, description, status })
+            .catch(() => {});
+        }
+      };
+
+      report("Fetching newsletter and subscribers", `ticker ${input.tickerId}`);
+
       let stage: DeliveryRunStage = "fetch";
       let newsletterId: string | null = null;
       let recipientRows: RecipientSendResult[] = [];
@@ -151,6 +166,11 @@ const app = createAgentApp<
           "delivery data-api fetch summary",
         );
 
+        report(
+          "Ready to deliver",
+          `${pendingRecipients} of ${subscriberCount} pending`,
+        );
+
         if (!deliveryData.newsletter) {
           runOutcome = "skipped";
           logger.info(
@@ -179,6 +199,7 @@ const app = createAgentApp<
             runSkipReason: "skipped_no_newsletter",
             recipients: [],
           });
+          report("Delivery skipped", "no newsletter available", "completed");
           return {
             success: true,
             message: "Skipped: no newsletter to deliver",
@@ -217,6 +238,7 @@ const app = createAgentApp<
             runSkipReason: "skipped_no_subscribers",
             recipients: [],
           });
+          report("Delivery skipped", "no subscribers with email", "completed");
           return {
             success: true,
             message: "Skipped: no subscribers with email",
@@ -228,6 +250,7 @@ const app = createAgentApp<
         const resend = new Resend(config.resendApiKey);
 
         stage = "send";
+        report("Sending emails", `${pendingRecipients} recipients via Resend`);
         const sendResult = await deliverNewsletterToSubscribers(
           deliveryData.newsletter,
           deliveryData.subscribers,
@@ -302,6 +325,12 @@ const app = createAgentApp<
             skippedCount,
           },
           "delivery run outcome",
+        );
+
+        report(
+          "Delivery complete",
+          `${successCount} sent, ${failureCount} failed, ${skippedCount} skipped`,
+          "completed",
         );
 
         if (runOutcome === "failed") {

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -4,13 +4,19 @@ import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api
 
 import { queryAnalysisConfigSchema } from "./config-schema";
 
-const { mockGet, mockCreate, mockFetchQueryLlm, mockFetchWildcard } =
-  vi.hoisted(() => ({
-    mockGet: vi.fn(),
-    mockCreate: vi.fn(),
-    mockFetchQueryLlm: vi.fn(),
-    mockFetchWildcard: vi.fn(),
-  }));
+const {
+  mockGet,
+  mockCreate,
+  mockAgentActivityCreate,
+  mockFetchQueryLlm,
+  mockFetchWildcard,
+} = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockCreate: vi.fn(),
+  mockAgentActivityCreate: vi.fn(),
+  mockFetchQueryLlm: vi.fn(),
+  mockFetchWildcard: vi.fn(),
+}));
 
 vi.mock("@mediapulse/env/agents-query-analysis", () => ({
   env: {
@@ -24,6 +30,9 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     queryAnalysis: {
       get: mockGet,
       create: mockCreate,
+    },
+    agentActivity: {
+      create: mockAgentActivityCreate,
     },
   })),
 }));
@@ -90,6 +99,8 @@ describe("query-analysis run", () => {
   beforeEach(async () => {
     mockGet.mockReset();
     mockCreate.mockReset();
+    mockAgentActivityCreate.mockReset();
+    mockAgentActivityCreate.mockResolvedValue(undefined);
     mockFetchQueryLlm.mockReset();
     mockFetchWildcard.mockReset();
 

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -375,6 +375,11 @@ type LanguageSliceSharedConfig = {
   tickerId: string;
   yieldFeedback: QueryAnalysisConfig["dynamics"]["yieldFeedback"];
   priorYield?: GetQueryAnalysisResponse["priorYield"];
+  reportActivity?: (
+    title: string,
+    description?: string,
+    status?: "processing" | "completed",
+  ) => void;
 };
 
 /**
@@ -485,6 +490,10 @@ export const runLanguageQuerySlice = async (params: {
     if (Date.now() - shared.runStartMs > DEFAULT_CRITIC_PASS_DEADLINE_MS) {
       selfCritiqueSkippedDueToDeadline = true;
     } else {
+      shared.reportActivity?.(
+        "Running self-critique pass",
+        `${llmCandidates.length} candidates`,
+      );
       try {
         const critiqueResult = await applySelfCritiquePass({
           apiKey: shared.openaiApiKey,
@@ -639,9 +648,28 @@ export const runQueryAnalysis = async (
     token,
   });
 
+  const report = (
+    title: string,
+    description?: string,
+    status: "processing" | "completed" = "processing",
+  ) => {
+    const jobId = hermesCorrelation?.jobId;
+    if (jobId) {
+      void client.agentActivity
+        .create({ jobId, title, description, status })
+        .catch(() => {});
+    }
+  };
+
+  report("Fetching ticker context", `ticker ${input.tickerId}`);
+
   const queryContext = await client.queryAnalysis.get({
     tickerId: input.tickerId,
   });
+  report(
+    "Loaded ticker context",
+    `${queryContext.topEntities.length} entities, ${queryContext.kgNeighborhood.length} relations`,
+  );
   const {
     credentials,
     output,
@@ -770,7 +798,43 @@ export const runQueryAnalysis = async (
     tickerId: input.tickerId,
     yieldFeedback,
     priorYield: yieldFeedback.enabled ? queryContext.priorYield : undefined,
+    reportActivity: report,
   };
+
+  const deterministicCount = distributedStandard.reduce(
+    (count, languageQuota) => {
+      const sliceTemplatePack = resolveLanguageTemplatePack(
+        languageQuota.language,
+        languageQuota.templatePack,
+        templatePack,
+      );
+      return (
+        count +
+        buildDeterministicQueries(queryContext, {
+          pack: sliceTemplatePack,
+          kgTemplateCap,
+          language: languageQuota.language,
+          ...(yieldFeedback.enabled
+            ? {
+                priorYield: queryContext.priorYield,
+                minTemplateYield: yieldFeedback.minTemplateYield,
+              }
+            : {}),
+        }).length
+      );
+    },
+    0,
+  );
+
+  report(
+    "Building deterministic queries",
+    `${deterministicCount} template queries`,
+  );
+
+  report(
+    "Generating LLM query candidates",
+    `${resolvedPersonas.length} personas`,
+  );
 
   const sliceResults = await Promise.all(
     distributedStandard.map((languageQuota) => {
@@ -820,10 +884,16 @@ export const runQueryAnalysis = async (
     sliceResults.map((slice) => slice.merged),
   );
 
+  report(
+    "Generated LLM query candidates",
+    `${mergedStandard.length} standard queries across ${languageQuotas.length} language(s)`,
+  );
+
   const wildcardLanguages = languageQuotas.map((quota) => quota.language);
 
   let merged = mergedStandard;
   if (wildcardCount > 0) {
+    report("Generating wildcard queries", `${wildcardCount} wildcard slots`);
     const seenKeys = new Set(
       mergedStandard.map((row) => normalizeQueryKey(row.text)),
     );
@@ -877,6 +947,8 @@ export const runQueryAnalysis = async (
       queryCount,
     );
   }
+
+  report("Merged and deduped query set", `${merged.length} total queries`);
 
   const strategySnapshot = {
     queryCount,
@@ -953,6 +1025,8 @@ export const runQueryAnalysis = async (
       }),
     ),
   };
+
+  report("Saving query set", `${merged.length} queries`, "completed");
 
   const response = await client.queryAnalysis.create({
     tickerId: input.tickerId,

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -240,6 +240,7 @@ export const createRunHandler =
     input,
     token,
     config,
+    hermesCorrelation,
   }: AgentRunContext<Input, Config>): Promise<AgentRunResult> => {
     const rateLimitConfig: RateLimitConfig = {
       windowMs:
@@ -278,6 +279,24 @@ export const createRunHandler =
       token,
     });
 
+    const report = (
+      title: string,
+      description?: string,
+      status: "processing" | "completed" = "processing",
+    ) => {
+      const jobId = hermesCorrelation?.jobId;
+      if (jobId) {
+        void dataApiClient.agentActivity
+          .create({ jobId, title, description, status })
+          .catch(() => {});
+      }
+    };
+
+    report(
+      "Reading subscription inbox",
+      `up to ${input.maxMessagesPerRun} messages`,
+    );
+
     // Step 0: List messages
     const messages = await withRetry(
       () =>
@@ -297,9 +316,18 @@ export const createRunHandler =
 
     logger.info(`Found ${messages.length} messages to process.`);
 
+    report("Scanning subscription requests", `${messages.length} emails found`);
+
     if (messages.length === 0) {
+      report(
+        "Registration run complete",
+        "0 registered, 0 skipped",
+        "completed",
+      );
       return { success: true, details: { processed: 0, results: [] } };
     }
+
+    report("Processing registrations", `${messages.length} eligible requests`);
 
     // Process messages in parallel with a concurrency limit of 5.
     const CONCURRENCY = 5;
@@ -347,6 +375,19 @@ export const createRunHandler =
       );
       results.push(...batchResults);
     }
+
+    const registeredCount = results.filter(
+      (result) =>
+        result.status === "confirmed_archived" ||
+        result.status === "acknowledged_archived",
+    ).length;
+    const skippedCount = results.length - registeredCount;
+
+    report(
+      "Registration run complete",
+      `${registeredCount} registered, ${skippedCount} skipped`,
+      "completed",
+    );
 
     return {
       success: true,

--- a/packages/mediapulse/database/prisma/migrations/20260529054513_agent_activity/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260529054513_agent_activity/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "agent_activity" (
+    "id" TEXT NOT NULL,
+    "job_id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "status" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "agent_activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "agent_activity_job_id_idx" ON "agent_activity"("job_id");

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -534,3 +534,16 @@ model ContentGenerationRun {
   @@index([outcome, createdAt])
   @@map("content_generation_run")
 }
+
+/// Agent-reported activity heartbeat for a Hermes job (processing/completed steps).
+model AgentActivity {
+  id          String   @id @default(uuid())
+  jobId       String   @map("job_id")
+  title       String
+  description String?
+  status      String
+  createdAt   DateTime @default(now()) @map("created_at")
+
+  @@index([jobId])
+  @@map("agent_activity")
+}

--- a/packages/shared/agent-data-api-contract/src/agent-activity.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-activity.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+export const agentActivityStatusSchema = z.enum(["processing", "completed"]);
+
+export const postAgentActivityBodySchema = z.object({
+  jobId: z.string().uuid(),
+  title: z.string().min(1).max(200),
+  description: z.string().max(500).optional(),
+  status: agentActivityStatusSchema,
+});
+
+export const postAgentActivityResponseSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const getAgentActivityQuerySchema = z.object({
+  jobId: z.string().uuid(),
+});
+
+export const agentActivityListItemSchema = z.object({
+  id: z.string().uuid(),
+  jobId: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  status: agentActivityStatusSchema,
+  createdAt: z.string().datetime(),
+});
+
+export const getAgentActivityResponseSchema = z.object({
+  data: z.array(agentActivityListItemSchema),
+});
+
+export type AgentActivityStatus = z.infer<typeof agentActivityStatusSchema>;
+export type PostAgentActivityBody = z.infer<typeof postAgentActivityBodySchema>;
+export type PostAgentActivityResponse = z.infer<
+  typeof postAgentActivityResponseSchema
+>;
+export type GetAgentActivityQuery = z.infer<typeof getAgentActivityQuerySchema>;
+export type AgentActivityListItem = z.infer<typeof agentActivityListItemSchema>;
+export type GetAgentActivityResponse = z.infer<
+  typeof getAgentActivityResponseSchema
+>;

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 import {
+  getAgentActivityQuerySchema,
+  getAgentActivityResponseSchema,
+  postAgentActivityBodySchema,
+  postAgentActivityResponseSchema,
+} from "./agent-activity.js";
+import {
   getAnalysisQuerySchema,
   getAnalysisResponseSchema,
   postAnalysisBodySchema,
@@ -461,6 +467,28 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postContentGenerationRunBodySchema,
         response: postContentGenerationRunResponseSchema,
+      },
+    },
+  },
+  agentActivity: {
+    v1: {
+      get: {
+        query: getAgentActivityQuerySchema,
+        response: getAgentActivityResponseSchema,
+      },
+      post: {
+        body: postAgentActivityBodySchema,
+        response: postAgentActivityResponseSchema,
+      },
+    },
+    v2: {
+      get: {
+        query: getAgentActivityQuerySchema,
+        response: getAgentActivityResponseSchema,
+      },
+      post: {
+        body: postAgentActivityBodySchema,
+        response: postAgentActivityResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -1,4 +1,18 @@
 export {
+  agentActivityListItemSchema,
+  agentActivityStatusSchema,
+  getAgentActivityQuerySchema,
+  getAgentActivityResponseSchema,
+  postAgentActivityBodySchema,
+  postAgentActivityResponseSchema,
+  type AgentActivityListItem,
+  type AgentActivityStatus,
+  type GetAgentActivityQuery,
+  type GetAgentActivityResponse,
+  type PostAgentActivityBody,
+  type PostAgentActivityResponse,
+} from "./agent-activity.js";
+export {
   AGENT_DATA_API_DEFAULT_VERSION,
   AGENT_DATA_API_LIVE_VERSIONS,
   AGENT_DATA_API_PREFIX,


### PR DESCRIPTION
## Summary

Agents now emit stage checkpoints to agent-data-api during a run. Hermes reads them back and shows a per-invocation activity timeline with step durations and a live elapsed counter on the row still in progress.

Closes #602

## Related issues

Closes #602

## Important changes

- New `AgentActivity` model, migration, and agent-data-api `agentActivity.create` / `agentActivity.get` endpoints wired through the shared contract.
- Hermes schedule executions table: "Show activity" opens a dialog listing checkpoints in order.
- All six agents report at stage boundaries; data-collection, content-generation, article-analysis, and query-analysis also report dense mid-stage checkpoints (quota skips, refill rounds, LLM steps, etc.).
- Duration labels between rows use `formatActivityDuration`; the open step uses `LiveElapsed` for ticking elapsed time.

## Other changes

- Server action `fetchAgentActivitiesAction` and client hook `useAgentActivityModal` isolate fetch/state from the table component.
- Unit tests for duration formatting and row duration derivation.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` — `AgentActivity` model shape.
- `packages/shared/agent-data-api-contract/src/agent-activity.ts` — request/response schemas.
- `apps/mediapulse/agent-data-api/src/services/agent-activity.ts` — persistence and list query.
- `apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx` — dialog UI and row layout.
- `apps/mediapulse/agents/data-collection/src/run.ts` — example of dense checkpoint reporting.

## How to test

1. Apply migration: `pnpm --filter @mediapulse/database db:migrate:deploy` (or dev migrate locally).
2. Run an agent job (e.g. data-collection) and confirm rows appear in `AgentActivity` for that job id.
3. In Hermes, open Dashboard → schedule executions, pick a run with activity, click **Show activity**.
4. Confirm checkpoints appear in order, completed rows show duration since the prior step, and an in-progress run shows live elapsed on the last row.
5. Run dashboard tests: `pnpm --filter @hermes/dashboard test lib/format-activity-duration.test.ts lib/derive-activity-row-durations.test.ts`.
