### PR TITLE
Fix agent activity step status in registry API and dashboard

### DIFF
--- a/apps/hermes/agent-registry-api/src/routes/agent-activity.ts
+++ b/apps/hermes/agent-registry-api/src/routes/agent-activity.ts
@@ -1,7 +1,8 @@
-import { prisma } from "@hermes/orchestration-database";
 import { Context } from "hono";
 import { z } from "zod";
 import { validateBody } from "@workspace/api-utils";
+
+import { postAgentActivity as postAgentActivityService } from "../services/post-agent-activity";
 
 const postAgentActivityBodySchema = z.object({
   jobId: z.string().uuid(),
@@ -13,6 +14,8 @@ const postAgentActivityBodySchema = z.object({
 /**
  * POST /agent-activity — records one activity heartbeat for a Hermes job.
  *
+ * Prior rows still marked `processing` for the same job are completed before insert.
+ *
  * @param context - Hono request context.
  * @returns The server-generated row id.
  */
@@ -21,15 +24,7 @@ export async function postAgentActivity(context: Context): Promise<Response> {
   try {
     const body = await validateBody(context, postAgentActivityBodySchema);
 
-    const row = await prisma.agentActivity.create({
-      data: {
-        jobId: body.jobId,
-        title: body.title,
-        description: body.description ?? null,
-        status: body.status,
-      },
-      select: { id: true },
-    });
+    const row = await postAgentActivityService(body);
 
     return context.json({ id: row.id }, 201);
   } catch (response) {

--- a/apps/hermes/agent-registry-api/src/services/post-agent-activity.test.ts
+++ b/apps/hermes/agent-registry-api/src/services/post-agent-activity.test.ts
@@ -1,0 +1,119 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@hermes/env", () => ({
+  env: {
+    ORCHESTRATION_DATABASE_URL:
+      "postgresql://user:pass@localhost:5432/db?schema=orchestration",
+  },
+}));
+
+vi.mock("@hermes/orchestration-database", () => ({
+  prisma: {
+    $transaction: vi.fn(),
+  },
+}));
+
+import {
+  postAgentActivity,
+  postAgentActivityWithinTransaction,
+  type PostAgentActivityInput,
+} from "./post-agent-activity";
+
+const sampleInput = {
+  jobId: "70829892-e244-4df5-a3bf-f41fae0692fe",
+  title: "Loaded article batch",
+  description: "6 sources",
+  status: "processing",
+} satisfies PostAgentActivityInput;
+
+describe("postAgentActivityWithinTransaction", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("completes open rows for the job before creating the new row", async () => {
+    // Setup
+    const updateMany = vi.fn().mockResolvedValue({ count: 2 });
+    const create = vi.fn().mockResolvedValue({ id: "row-new" });
+
+    // Act
+    const result = await postAgentActivityWithinTransaction(sampleInput, {
+      updateMany,
+      create,
+    });
+
+    // Assert
+    expect(updateMany).toHaveBeenCalledWith({
+      where: { jobId: sampleInput.jobId, status: "processing" },
+      data: { status: "completed" },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        jobId: sampleInput.jobId,
+        title: sampleInput.title,
+        description: sampleInput.description,
+        status: sampleInput.status,
+      },
+      select: { id: true },
+    });
+    expect(result).toEqual({ id: "row-new" });
+  });
+
+  it("stores null description when omitted", async () => {
+    // Setup
+    const updateMany = vi.fn().mockResolvedValue({ count: 0 });
+    const create = vi.fn().mockResolvedValue({ id: "row-final" });
+
+    // Act
+    await postAgentActivityWithinTransaction(
+      {
+        jobId: sampleInput.jobId,
+        title: "Article analysis complete",
+        status: "completed",
+      },
+      { updateMany, create },
+    );
+
+    // Assert
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        jobId: sampleInput.jobId,
+        title: "Article analysis complete",
+        description: null,
+        status: "completed",
+      },
+      select: { id: true },
+    });
+  });
+});
+
+describe("postAgentActivity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("delegates to the transaction-scoped helper", async () => {
+    // Setup
+    const updateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const create = vi.fn().mockResolvedValue({ id: "row-tx" });
+    const $transaction = vi.fn(
+      async (
+        fn: (tx: {
+          agentActivity: {
+            updateMany: typeof updateMany;
+            create: typeof create;
+          };
+        }) => Promise<{ id: string }>,
+      ) => fn({ agentActivity: { updateMany, create } }),
+    );
+
+    // Act
+    const result = await postAgentActivity(sampleInput, { $transaction });
+
+    // Assert
+    expect($transaction).toHaveBeenCalledOnce();
+    expect(result).toEqual({ id: "row-tx" });
+  });
+});

--- a/apps/hermes/agent-registry-api/src/services/post-agent-activity.ts
+++ b/apps/hermes/agent-registry-api/src/services/post-agent-activity.ts
@@ -1,0 +1,60 @@
+import { type Prisma, prisma } from "@hermes/orchestration-database";
+
+/** Body shape accepted by POST /agent-activity. */
+export type PostAgentActivityInput = {
+  jobId: string;
+  title: string;
+  description?: string;
+  status: "processing" | "completed";
+};
+
+type AgentActivityDelegate = Pick<
+  Prisma.TransactionClient["agentActivity"],
+  "updateMany" | "create"
+>;
+
+type PostAgentActivityDb = Pick<typeof prisma, "$transaction">;
+
+/**
+ * Marks prior in-progress rows completed and inserts the new activity row.
+ *
+ * @param input - Validated POST body fields.
+ * @param agentActivity - Prisma delegate (transaction-scoped in production).
+ * @returns The created row id.
+ */
+export const postAgentActivityWithinTransaction = async (
+  input: PostAgentActivityInput,
+  agentActivity: AgentActivityDelegate,
+): Promise<{ id: string }> => {
+  await agentActivity.updateMany({
+    where: { jobId: input.jobId, status: "processing" },
+    data: { status: "completed" },
+  });
+
+  const row = await agentActivity.create({
+    data: {
+      jobId: input.jobId,
+      title: input.title,
+      description: input.description ?? null,
+      status: input.status,
+    },
+    select: { id: true },
+  });
+
+  return { id: row.id };
+};
+
+/**
+ * Records agent activity for a Hermes job inside a single DB transaction.
+ *
+ * @param input - Validated POST body fields.
+ * @param db - Prisma client (injectable for tests).
+ * @returns The created row id.
+ */
+export const postAgentActivity = async (
+  input: PostAgentActivityInput,
+  db: PostAgentActivityDb = prisma,
+): Promise<{ id: string }> =>
+  db.$transaction((tx) =>
+    postAgentActivityWithinTransaction(input, tx.agentActivity),
+  );

--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
@@ -44,6 +44,8 @@ import {
   useScheduleExecutionInvocationsModal,
   type ScheduleExecutionInvocationRow,
 } from "./use-schedule-execution-invocations-modal";
+import { isActivityRowInProgress } from "@/lib/derive-activity-row-durations";
+
 import { useAgentActivityModal } from "./use-agent-activity-modal";
 import { LiveElapsed } from "./live-elapsed";
 
@@ -326,9 +328,12 @@ export const ScheduleExecutionInvocationsTable = ({
           ) : (
             <div className="flex flex-col">
               {activityRows.map((row, index) => {
-                const isLastRow = index === activityRows.length - 1;
-                const showLiveElapsed =
-                  isLastRow && row.status === "processing";
+                const inProgress = isActivityRowInProgress(
+                  row,
+                  index,
+                  activityRows.length,
+                );
+                const showLiveElapsed = inProgress;
                 const durationLabel =
                   !showLiveElapsed && row.durationMs != null
                     ? formatActivityDuration(row.durationMs)
@@ -348,7 +353,7 @@ export const ScheduleExecutionInvocationsTable = ({
                             {durationLabel}
                           </span>
                         ) : null}
-                        {row.status === "processing" ? (
+                        {inProgress ? (
                           <Loader2 className="size-4 animate-spin text-muted-foreground" />
                         ) : (
                           <CheckCircle2 className="size-4 text-green-500" />

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
@@ -1,6 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { attachActivityRowDurations } from "./derive-activity-row-durations";
+import {
+  attachActivityRowDurations,
+  isActivityRowInProgress,
+} from "./derive-activity-row-durations";
+
+describe("isActivityRowInProgress", () => {
+  it("treats superseded processing rows as completed in the UI", () => {
+    const row = {
+      status: "processing" as const,
+    };
+
+    expect(isActivityRowInProgress(row, 0, 3)).toBe(false);
+    expect(isActivityRowInProgress(row, 1, 3)).toBe(false);
+    expect(isActivityRowInProgress(row, 2, 3)).toBe(true);
+  });
+
+  it("returns false for the last row when the run is completed", () => {
+    expect(isActivityRowInProgress({ status: "completed" }, 2, 3)).toBe(false);
+  });
+});
 
 describe("attachActivityRowDurations", () => {
   it("diffs consecutive rows and uses total fallback for last completed row", () => {

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
@@ -11,6 +11,23 @@ export type ActivityRow = {
 type ActivityRowFromServer = Omit<ActivityRow, "durationMs">;
 
 /**
+ * Whether the row should show an in-progress spinner in the activity dialog.
+ *
+ * New checkpoints complete prior `processing` rows on the server; older runs may
+ * still have stale status until the UI infers completion from row order.
+ *
+ * @param row - Activity row from the server.
+ * @param index - Zero-based index in the ordered list.
+ * @param rowCount - Total rows for the job.
+ * @returns True only for the last row while the run is still open.
+ */
+export const isActivityRowInProgress = (
+  row: Pick<ActivityRow, "status">,
+  index: number,
+  rowCount: number,
+): boolean => index === rowCount - 1 && row.status === "processing";
+
+/**
  * Derives per-step durations from consecutive `createdAt` timestamps.
  *
  * @param rows - Activity rows ordered oldest first from the data-api.


### PR DESCRIPTION
## Summary

The activity modal showed a spinner on every step except the last, even when the job had finished. Agents only append rows with `processing` and never update older ones. This change marks prior in-progress rows as `completed` when a new checkpoint is posted, and treats superseded rows as done in the UI so older runs still look right.

## Related issues

Closes #606

## Important changes

- `POST /api/agent-activity` runs a transaction: complete open `processing` rows for the job, then insert the new row.
- Activity dialog uses `isActivityRowInProgress` so only the last row can spin while a run is open.

## Other changes

- Service layer and unit tests in agent-registry-api for the transaction helper.

## Key files to review

- `apps/hermes/agent-registry-api/src/services/post-agent-activity.ts` - completes prior steps before insert.
- `apps/hermes/agent-registry-api/src/routes/agent-activity.ts` - delegates to the service.
- `apps/hermes/dashboard/lib/derive-activity-row-durations.ts` - `isActivityRowInProgress` for stale historical rows.
- `apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx` - icon and live elapsed wiring.

## How to test

1. Run `cd apps/hermes/agent-registry-api && npx vitest run` and `cd apps/hermes/dashboard && npx vitest run lib/derive-activity-row-durations.test.ts`.
2. Deploy or run agent-registry-api locally, trigger an agent run with activity reporting, open **Show activity** on the invocation.
3. Confirm finished steps show a green check; only the current step spins while the job is running.
