### PR TITLE
Use short keyword queries in query-analysis agent

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts
+++ b/apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts
@@ -30,17 +30,14 @@ const largeCapConsumerExemplar: QueryExemplar = {
     "- CL (Colgate-Palmolive) relevance=0.9",
   ].join("\n"),
   queries: [
-    { text: "P&G pricing vs Unilever consumer staples", intent: "fundamental" },
-    { text: "Gillette market share erosion latest", intent: "breaking" },
-    { text: "Pampers diaper category volume trends", intent: "fundamental" },
-    { text: "Procter Gamble organic sales guidance", intent: "fundamental" },
-    { text: "PG relation changes brand portfolio", intent: "kg_change" },
-    { text: "why is PG stock moving today", intent: "breaking" },
-    { text: "P&G China demand slowdown impact", intent: "breaking" },
-    {
-      text: "Colgate-Palmolive vs PG margin comparison",
-      intent: "fundamental",
-    },
+    { text: "Procter Gamble", intent: "breaking" },
+    { text: "Gillette market share", intent: "breaking" },
+    { text: "Pampers diaper market", intent: "industry_trend" },
+    { text: "consumer staples pricing", intent: "macro" },
+    { text: "household products China demand", intent: "macro" },
+    { text: "Unilever consumer goods", intent: "competitor" },
+    { text: "personal care regulation", intent: "regulatory" },
+    { text: "consumer staples ESG", intent: "esg" },
   ],
 };
 
@@ -60,16 +57,13 @@ const midCapIndustrialExemplar: QueryExemplar = {
     "- HON (Honeywell) relevance=0.85",
   ].join("\n"),
   queries: [
-    { text: "Rockwell Automation order backlog trend", intent: "fundamental" },
-    { text: "ROK vs Emerson automation revenue mix", intent: "fundamental" },
-    { text: "Allen-Bradley supply chain lead times", intent: "breaking" },
-    {
-      text: "Rockwell FactoryTalk software attach rate",
-      intent: "fundamental",
-    },
-    { text: "ROK entity relation changes acquisitions", intent: "kg_change" },
-    { text: "industrial automation capex cycle 2026", intent: "breaking" },
-    { text: "Honeywell vs Rockwell margin outlook", intent: "fundamental" },
+    { text: "Rockwell Automation", intent: "breaking" },
+    { text: "Allen-Bradley supply chain", intent: "supply_chain" },
+    { text: "industrial automation backlog", intent: "industry_trend" },
+    { text: "factory automation capex", intent: "macro" },
+    { text: "Emerson automation market", intent: "competitor" },
+    { text: "industrial software regulation", intent: "regulatory" },
+    { text: "automation semiconductor supply", intent: "supply_chain" },
   ],
 };
 
@@ -88,20 +82,14 @@ const regulatedFinancialExemplar: QueryExemplar = {
     "- Recent events: stress_test, dividend_increase",
   ].join("\n"),
   queries: [
-    { text: "JPMorgan net interest margin Q2 outlook", intent: "fundamental" },
-    {
-      text: "Basel III endgame impact JPM capital ratios",
-      intent: "fundamental",
-    },
-    { text: "JPM stress test results Fed response", intent: "breaking" },
-    {
-      text: "Chase consumer credit card delinquency trend",
-      intent: "fundamental",
-    },
-    { text: "JPMorgan relation changes subsidiary map", intent: "kg_change" },
-    { text: "why is JPM stock falling today", intent: "breaking" },
-    { text: "JPM dividend increase vs peers yield", intent: "fundamental" },
-    { text: "First Republic integration cost overrun", intent: "breaking" },
+    { text: "JPMorgan Chase", intent: "breaking" },
+    { text: "Basel III bank capital", intent: "regulatory" },
+    { text: "bank stress test Fed", intent: "regulatory" },
+    { text: "credit card delinquency US", intent: "macro" },
+    { text: "bank net interest margin", intent: "industry_trend" },
+    { text: "First Republic acquisition integration", intent: "kg_change" },
+    { text: "banking sector ESG", intent: "esg" },
+    { text: "consumer banking regulation", intent: "regulatory" },
   ],
 };
 
@@ -120,16 +108,13 @@ const techPlatformExemplar: QueryExemplar = {
     '- 2026-05-10 (reuters.com) — "Salesforce unveils Agentforce roadmap"',
   ].join("\n"),
   queries: [
-    {
-      text: "Salesforce Agentforce adoption enterprise pilots",
-      intent: "breaking",
-    },
-    { text: "CRM AI agents monetization model", intent: "fundamental" },
-    { text: "Slack integration Salesforce bundle attach", intent: "kg_change" },
-    { text: "Salesforce seat compression ARR impact", intent: "fundamental" },
-    { text: "CRM vs Microsoft Dynamics AI comparison", intent: "fundamental" },
-    { text: "Salesforce Data Cloud growth rate", intent: "fundamental" },
-    { text: "why is CRM moving after earnings", intent: "breaking" },
+    { text: "Salesforce", intent: "breaking" },
+    { text: "enterprise AI agents", intent: "technology_trend" },
+    { text: "CRM software seat compression", intent: "industry_trend" },
+    { text: "Slack enterprise adoption", intent: "kg_change" },
+    { text: "Microsoft Dynamics AI", intent: "competitor" },
+    { text: "SaaS data cloud market", intent: "industry_trend" },
+    { text: "enterprise software regulation", intent: "regulatory" },
   ],
 };
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -53,7 +53,7 @@ const GOLDEN_PROMPT_FINGERPRINT_FIXTURE = {
     headlineSamples: [] as [],
     kgNeighborhood: [] as [],
   },
-  fingerprint: "4e966f9cc2d595b4",
+  fingerprint: "0e5182b717a66aa9",
 } as const;
 
 const emptyEnrichedContext = {

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -113,12 +113,13 @@ export const buildQueryAnalysisSystemContent = (
   ).join("\n");
 
   return [
-    "You generate finance search queries for news and data retrieval.",
+    "You generate short keyword search queries for news monitoring.",
     `Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": ${QUERY_ANALYSIS_INTENT_JSON_UNION} } ] }.`,
-    "Each query must be concise web-search style text.",
+    "Prefer 2–5 word keyword phrases. Do not write full sentences, questions, or analyst-style commentary.",
     `All queries must be in ${strategy.language} (BCP-47). Do not code-mix or translate ticker symbols and proper nouns.`,
     "Do not translate ticker symbols or proper nouns into other languages.",
-    "Focus on external industry intelligence: competitors, regulation, macro forces, technology disruption, and sector trends. Avoid earnings guidance, internal financial projections, and company-specific forecast queries.",
+    "Include the company name or ticker symbol in at most 2 queries — the rest should be bare topic keywords, industry terms, or regulatory terms that stand alone without the company name.",
+    "Generate topic keywords across sectors, regulation, supply chain, ESG, and macro themes relevant to the company's operating environment.",
     [
       "Target approximate intent counts (total queries should not exceed the remaining budget after the deterministic baseline):",
       intentTargetLines,
@@ -268,8 +269,8 @@ export const buildQueryAnalysisUserContent = (
 
 /** System instruction for the free-form brainstorm pass. */
 const BRAINSTORM_SYSTEM_PROMPT = [
-  "You are a financial research analyst brainstorming search angles.",
-  "List 12–20 distinct angles a savvy analyst would search for about the company below.",
+  "You are a news researcher brainstorming keyword search angles.",
+  "List 12–20 distinct keyword topics a journalist or researcher would search for about the company below.",
   "Write free prose as plain bullet points — one angle per line.",
   "Do not output JSON, intent labels, or numbered schema fields.",
 ].join("\n");
@@ -499,9 +500,9 @@ export const resolveWildcardSystemContent = (
 ): string =>
   [
     `Generate ${String(wildcardCount)} short search queries unlike anything an institutional analyst would typically search for.`,
-    "Lateral, surprising, second-order, contrarian, narrative, or culturally-grounded angles welcome.",
+    "Lateral, surprising, second-order, contrarian, or culturally-grounded angles welcome.",
     "Do not use the standard intent taxonomy — these queries are deliberately unconventional.",
-    "Reward odd framings, long-tail questions, and angles a typical analyst would not search for.",
+    "Keep queries short — 2–5 words. Prefer unusual keyword combinations over full questions or sentences.",
     'Return ONLY a JSON object: { "queries": [ { "text": string } ] }.',
     `Write in these languages when natural (BCP-47 codes): ${allowedLanguages.join(", ")}.`,
   ].join("\n\n");

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -469,8 +469,7 @@ describe("query-analysis run", () => {
       { language: "id", share: 0.4 },
     ]);
 
-    const indonesianPattern =
-      /berita terbaru|perubahan relasi|tren industri|regulasi|kompetitor/i;
+    const indonesianPattern = /Indonesia|regulasi/i;
 
     const englishSlice = createPayload.queries.slice(0, 6);
     const indonesianSlice = createPayload.queries.slice(6);
@@ -481,7 +480,7 @@ describe("query-analysis run", () => {
       true,
     );
     expect(
-      indonesianSlice.every((row) => indonesianPattern.test(row.text)),
+      indonesianSlice.some((row) => indonesianPattern.test(row.text)),
     ).toBe(true);
   });
 

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.test.ts
@@ -49,7 +49,7 @@ describe("getDeterministicPack", () => {
 });
 
 describe("default-v1 pack", () => {
-  it("reproduces the original five baseline queries", () => {
+  it("produces five bare keyword baseline queries", () => {
     // Act
     const queries = buildDeterministicQueries(fullContext, {
       pack: "default-v1",
@@ -59,29 +59,29 @@ describe("default-v1 pack", () => {
     // Assert
     expect(queries).toEqual([
       {
-        text: "ACME latest news",
+        text: "ACME",
         intent: "breaking",
-        templateId: "{symbol} latest news",
+        templateId: "{symbol}",
       },
       {
-        text: "Acme Co breaking news",
+        text: "Acme Co",
         intent: "breaking",
-        templateId: "{name} breaking news",
+        templateId: "{name}",
       },
       {
-        text: "Acme Co relation changes",
-        intent: "kg_change",
-        templateId: "{name} relation changes",
-      },
-      {
-        text: "Technology industry trends",
+        text: "Software",
         intent: "industry_trend",
-        templateId: "{sector} industry trends",
+        templateId: "{industry}",
       },
       {
-        text: "Software regulatory policy",
+        text: "Technology",
+        intent: "industry_trend",
+        templateId: "{sector}",
+      },
+      {
+        text: "Software regulation",
         intent: "regulatory",
-        templateId: "{industry} regulatory policy",
+        templateId: "{industry} regulation",
       },
     ]);
   });
@@ -286,12 +286,12 @@ describe("filterPackTemplatesByYield", () => {
       {
         perTemplate: [
           {
-            templateId: "{symbol} latest news",
+            templateId: "{symbol}",
             avgArticles: 0,
             avgNovel: 0.01,
           },
           {
-            templateId: "{name} breaking news",
+            templateId: "{name}",
             avgArticles: 2,
             avgNovel: 0.2,
           },
@@ -303,10 +303,10 @@ describe("filterPackTemplatesByYield", () => {
     );
 
     expect(filtered.templates.map((row) => row.template)).toEqual([
-      "{name} breaking news",
-      "{name} relation changes",
-      "{sector} industry trends",
-      "{industry} regulatory policy",
+      "{name}",
+      "{industry}",
+      "{sector}",
+      "{industry} regulation",
     ]);
   });
 

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -50,40 +50,37 @@ export const DEFAULT_TEMPLATE_PACK_BY_LANGUAGE: Partial<
 const defaultV1Pack: DeterministicPack = {
   name: "default-v1",
   templates: [
-    { template: "{symbol} latest news", intent: "breaking" },
-    { template: "{name} breaking news", intent: "breaking" },
-    { template: "{name} relation changes", intent: "kg_change" },
-    { template: "{sector} industry trends", intent: "industry_trend" },
-    { template: "{industry} regulatory policy", intent: "regulatory" },
+    { template: "{symbol}", intent: "breaking" },
+    { template: "{name}", intent: "breaking" },
+    { template: "{industry}", intent: "industry_trend" },
+    { template: "{sector}", intent: "industry_trend" },
+    { template: "{industry} regulation", intent: "regulatory" },
   ],
 };
 
-/** English locale pack mirroring `default-v1` with natural search phrasing. */
+/** English locale pack — bare keyword templates to avoid phrase/metadata language mismatch. */
 const defaultEnV1Pack: DeterministicPack = {
   name: "default-en-v1",
   templates: [
-    { template: "{symbol} latest news", intent: "breaking" },
-    { template: "{name} breaking news", intent: "breaking" },
-    { template: "{name} relation changes", intent: "kg_change" },
-    {
-      template: "{sector} industry outlook {currentYear}",
-      intent: "industry_trend",
-    },
-    { template: "{industry} regulatory changes", intent: "regulatory" },
-    { template: "{industry} competitive landscape", intent: "competitor" },
+    { template: "{symbol}", intent: "breaking" },
+    { template: "{name}", intent: "breaking" },
+    { template: "{industry}", intent: "industry_trend" },
+    { template: "{sector}", intent: "industry_trend" },
+    { template: "{industry} regulation", intent: "regulatory" },
+    { template: "{sector} {industry}", intent: "industry_trend" },
   ],
 };
 
-/** Bahasa Indonesia locale pack with natural IDX search phrasing. */
+/** Bahasa Indonesia locale pack — bare keyword templates. */
 const defaultIdV1Pack: DeterministicPack = {
   name: "default-id-v1",
   templates: [
-    { template: "berita terbaru {symbol}", intent: "breaking" },
-    { template: "berita terbaru {name}", intent: "breaking" },
-    { template: "perubahan relasi {name}", intent: "kg_change" },
-    { template: "tren industri {sector}", intent: "industry_trend" },
+    { template: "{symbol}", intent: "breaking" },
+    { template: "{name}", intent: "breaking" },
+    { template: "{industry}", intent: "industry_trend" },
+    { template: "{industry} Indonesia", intent: "industry_trend" },
     { template: "regulasi {industry}", intent: "regulatory" },
-    { template: "kompetitor {industry}", intent: "competitor" },
+    { template: "{sector} Indonesia", intent: "macro" },
   ],
 };
 


### PR DESCRIPTION
## Summary

Query-analysis was generating long analyst-style phrases that did not work well as news search terms. This PR retunes prompts, deterministic templates, and default exemplars so the agent favors **2–5 word keyword queries**, uses the company name in at most two queries, and spreads the rest across sector, regulation, and macro topics.

## Related issues

Closes #608

## Important changes

- LLM system/user and wildcard prompts ask for short keyword phrases instead of sentences or questions.
- `default-v1`, `default-en-v1`, and `default-id-v1` deterministic packs use bare symbol/name/industry templates.
- Default exemplars updated to match the keyword style and intent mix.

## Other changes

- Golden prompt fingerprint and pack tests updated for the new template IDs and copy.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` - prompt wording and company-name cap.
- `apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts` - bare keyword templates per locale.
- `apps/mediapulse/agents/query-analysis/src/exemplars/default-exemplars.ts` - few-shot examples for the LLM.

## How to test

1. `cd apps/mediapulse/agents/query-analysis && npx vitest run` (185 tests).
2. Run query-analysis for a ticker in staging and inspect saved queries: mostly short keywords, company name in at most two rows.
3. Confirm Indonesian locale still produces `regulasi` / Indonesia-themed rows where the id pack applies.
