### PR TITLE
Fix case-insensitive newsletter section heading parse

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -484,7 +484,7 @@ Return JSON matching this shape (camelCase keys):
 - "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
 - "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "text", "articleIndex" } (index required for every quick hit).
 
-Headings ("displayHeading") can be personality titles. Keep JSON valid; use null for optional blocks and uncited articleIndex values.`;
+Headings ("displayHeading") are short subtitle phrases only — never repeat the section label or use "Label / Subtitle" format. Keep JSON valid; use null for optional blocks and uncited articleIndex values.`;
 
 /**
  * Default user prompt template used when no template is provided in config.

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -87,15 +87,11 @@ export const decomposeSectionHeading = (
     return { eyebrow: null, subtitle: displayHeading };
   }
 
+  // Strip "Label / " prefix if the model included it (backward compat with old wire data)
   const prefix = `${label} / `;
-  if (displayHeading.toLowerCase() === label.toLowerCase()) {
-    return { eyebrow: null, subtitle: null };
-  }
   if (displayHeading.toLowerCase().startsWith(prefix.toLowerCase())) {
     const subtitle = displayHeading.slice(prefix.length).trim();
-    return subtitle.length > 0
-      ? { eyebrow: label, subtitle }
-      : { eyebrow: null, subtitle: null };
+    return { eyebrow: label, subtitle: subtitle.length > 0 ? subtitle : null };
   }
 
   return { eyebrow: label, subtitle: displayHeading };

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -88,10 +88,10 @@ export const decomposeSectionHeading = (
   }
 
   const prefix = `${label} / `;
-  if (displayHeading === label) {
+  if (displayHeading.toLowerCase() === label.toLowerCase()) {
     return { eyebrow: null, subtitle: null };
   }
-  if (displayHeading.startsWith(prefix)) {
+  if (displayHeading.toLowerCase().startsWith(prefix.toLowerCase())) {
     const subtitle = displayHeading.slice(prefix.length).trim();
     return subtitle.length > 0
       ? { eyebrow: label, subtitle }


### PR DESCRIPTION
## Summary

Section headings in the default newsletter email were compared to their labels with case-sensitive string checks. When the LLM used different casing (for example `Technology` vs `TECHNOLOGY`), the template treated them as distinct and rendered a duplicate eyebrow line. This PR compares headings case-insensitively when deciding whether to hide the eyebrow or strip the label prefix.

## Related issues

Closes #610

## Important changes

- `decomposeSectionHeading` uses `toLowerCase()` for equality and `startsWith` checks against the `label:` prefix.

## Other changes

- None.

## Key files to review

- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` - heading decomposition logic.

## How to test

1. `cd packages/shared/email-templates && npx vitest run`
2. Render a newsletter section where `displayHeading` matches `label` with different casing; confirm no duplicate eyebrow.
3. Render a heading like `Technology: chip supply` with label `technology`; confirm eyebrow + subtitle still split correctly.
