### PR TITLE
Add first newsletter delivery time to registration confirmation email

### DIFF
--- a/apps/mediapulse/agents/user-registration/src/config-schema.ts
+++ b/apps/mediapulse/agents/user-registration/src/config-schema.ts
@@ -27,6 +27,9 @@ export const ConfigSchema = z.object({
     })
     .optional()
     .default({}),
+  newsletterDeliveryHour: z.number().int().min(0).max(23).optional(),
+  newsletterDeliveryTimezone: z.string().optional(),
+  newsletterDeliveryTimeLabel: z.string().optional(),
 });
 
 export type UserRegistrationConfig = z.input<typeof ConfigSchema>;

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -109,6 +109,24 @@ function assertResendSendSucceeded(result: ResendEmailsSendResult): void {
   }
 }
 
+function buildNextDeliveryLabel(
+  hour: number,
+  timezone: string,
+  timeLabel: string,
+): string {
+  const currentHour = parseInt(
+    new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      hour12: false,
+      timeZone: timezone,
+    }).format(new Date()),
+    10,
+  );
+  const day = currentHour < hour ? "today" : "tomorrow";
+
+  return `${day} at ${timeLabel}`;
+}
+
 type ResendTransactionalPayload = {
   from: string;
   to: string;
@@ -527,9 +545,21 @@ async function processMessage({
         "Sending confirmation email for new or unconfirmed subscription.",
       );
 
+      const nextDeliveryLabel =
+        config.newsletterDeliveryHour !== undefined &&
+        config.newsletterDeliveryTimezone !== undefined &&
+        config.newsletterDeliveryTimeLabel !== undefined
+          ? buildNextDeliveryLabel(
+              config.newsletterDeliveryHour,
+              config.newsletterDeliveryTimezone,
+              config.newsletterDeliveryTimeLabel,
+            )
+          : undefined;
+
       const { html, text } = await renderNewsletterEmail({
         variant: "registration-confirmation",
         tickerSymbol,
+        nextDeliveryLabel,
       });
 
       await sendResendTransactionalEmail({

--- a/packages/shared/email-templates/src/registration/registration-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.tsx
@@ -14,6 +14,8 @@ import type { CSSProperties, ReactElement } from "react";
 export interface RegistrationConfirmationEmailProps {
   /** The ticker symbol the user subscribed to. */
   tickerSymbol: string;
+  /** Human-readable label for when the first newsletter will arrive, e.g. "today at 9:00 AM WIB". */
+  nextDeliveryLabel?: string;
 }
 
 /**
@@ -24,6 +26,7 @@ export interface RegistrationConfirmationEmailProps {
  */
 export const RegistrationConfirmationEmail = ({
   tickerSymbol,
+  nextDeliveryLabel,
 }: RegistrationConfirmationEmailProps): ReactElement => {
   return (
     <Html>
@@ -40,6 +43,9 @@ export const RegistrationConfirmationEmail = ({
             {"\n\n"}
             Your subscription to the '{tickerSymbol}' newsletter has been
             confirmed.
+            {nextDeliveryLabel !== undefined
+              ? `\n\nYou will receive your first ${tickerSymbol} newsletter ${nextDeliveryLabel}.`
+              : ""}
             {"\n\n"}
             Thank you,
             {"\n"}
@@ -58,6 +64,7 @@ export const RegistrationConfirmationEmail = ({
 
 RegistrationConfirmationEmail.PreviewProps = {
   tickerSymbol: "AAPL",
+  nextDeliveryLabel: "today at 9:00 AM WIB",
 } satisfies RegistrationConfirmationEmailProps;
 
 export default RegistrationConfirmationEmail;

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -24,6 +24,7 @@ export type RenderNewsletterEmailInput =
       })
   | ({
       variant: "registration-confirmation";
+      nextDeliveryLabel?: string;
     } & RegistrationConfirmationEmailProps)
   | ({ variant: "invalid-ticker" } & InvalidTickerEmailProps);
 
@@ -91,7 +92,10 @@ function newsletterElementForVariant(
       );
     case "registration-confirmation":
       return (
-        <RegistrationConfirmationEmail tickerSymbol={input.tickerSymbol} />
+        <RegistrationConfirmationEmail
+          tickerSymbol={input.tickerSymbol}
+          nextDeliveryLabel={input.nextDeliveryLabel}
+        />
       );
     case "invalid-ticker":
       return <InvalidTickerEmail tickerSymbol={input.tickerSymbol} />;


### PR DESCRIPTION
## Summary

New subscribers get a registration confirmation email but no hint about when the first newsletter lands. This PR adds optional Hermes config on the user-registration agent (hour, timezone, display label) and prints a short “first newsletter today/tomorrow at …” line when all three are set.

## Related issues

Closes #612

## Important changes

- Config schema: `newsletterDeliveryHour`, `newsletterDeliveryTimezone`, `newsletterDeliveryTimeLabel` (all optional).
- `buildNextDeliveryLabel` picks “today” vs “tomorrow” from the current hour in the configured timezone.
- Registration confirmation template and `renderNewsletterEmail` accept `nextDeliveryLabel`.

## Other changes

- None.

## Key files to review

- `apps/mediapulse/agents/user-registration/src/run.ts` - label builder and Resend render call.
- `apps/mediapulse/agents/user-registration/src/config-schema.ts` - new optional fields.
- `packages/shared/email-templates/src/registration/registration-confirmation.tsx` - email copy.

## How to test

1. `cd apps/mediapulse/agents/user-registration && npx vitest run`
2. `cd packages/shared/email-templates && npx vitest run`
3. Set the three config fields on a user-registration agent config in Hermes, trigger a confirmation send, and confirm the email mentions first newsletter timing.
4. Omit the config fields and confirm the email matches the previous copy.
