### PR TITLE
Add entity and relation provenance via evidence join tables

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -573,6 +573,8 @@ describe("agent-data-api", () => {
         relationsCreated: 0,
         articlesScored: 1,
         articlesSelected: 0,
+        entityEvidenceUpserted: 0,
+        relationEvidenceUpserted: 0,
       });
 
       const { app } = await import("./index.js");

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -107,6 +107,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -157,6 +159,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -199,6 +203,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -239,6 +245,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -282,6 +290,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -323,6 +333,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -364,6 +376,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -419,6 +433,8 @@ describe("loadAnalysisContext", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: {
         upsert: vi.fn(),
@@ -465,6 +481,8 @@ describe("applyAnalysisPost", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn() },
     };
@@ -484,6 +502,8 @@ describe("applyAnalysisPost", () => {
             },
           ],
           articleRelevances: [],
+          entityEvidence: [],
+          relationEvidence: [],
         },
         { db: db as never },
       ),
@@ -504,6 +524,8 @@ describe("applyAnalysisPost", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn(), count: vi.fn() },
     };
@@ -528,6 +550,8 @@ describe("applyAnalysisPost", () => {
           selected: false,
         },
       ],
+      entityEvidence: [],
+      relationEvidence: [],
     };
 
     await applyAnalysisPost(body, { db: db as never });
@@ -585,6 +609,8 @@ describe("applyAnalysisPost", () => {
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
       articleEntity: { upsert: vi.fn() },
       articleRelevance: { upsert: vi.fn(), count: vi.fn() },
     };
@@ -604,6 +630,8 @@ describe("applyAnalysisPost", () => {
           },
         ],
         articleRelevances: [],
+        entityEvidence: [],
+        relationEvidence: [],
       },
       { db: db as never },
     );
@@ -618,6 +646,110 @@ describe("applyAnalysisPost", () => {
         dataSourceId: DS,
       }),
       expect.stringContaining("entityName not in ticker vocabulary"),
+    );
+  });
+
+  it("upserts entity and relation evidence for known vocabulary", async () => {
+    // Setup
+    const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+    const ENT_ID = "11111111-1111-4111-a111-111111111111";
+    const REL_ID = "33333333-3333-4333-a333-333333333333";
+    const TYPE_ID = "44444444-4444-4444-a444-444444444444";
+    const db = {
+      dataSource: {
+        findMany: vi.fn(),
+        findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
+        findFirst: vi.fn(),
+      },
+      entityType: { findMany: vi.fn() },
+      relationType: { findMany: vi.fn() },
+      entity: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(null),
+        create: vi.fn().mockResolvedValue({ id: ENT_ID }),
+      },
+      entityAlias: { createMany: vi.fn() },
+      tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
+      entityRelation: {
+        create: vi.fn().mockResolvedValue({ id: REL_ID }),
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+      entityEvidence: { upsert: vi.fn() },
+      entityRelationEvidence: { upsert: vi.fn() },
+      articleEntity: { upsert: vi.fn() },
+      articleRelevance: { upsert: vi.fn(), count: vi.fn() },
+    };
+
+    // Act
+    const result = await applyAnalysisPost(
+      {
+        tickerId: "ticker-1",
+        entities: [
+          {
+            canonicalName: "Acme Corp",
+            typeId: TYPE_ID,
+            aliases: [],
+          },
+        ],
+        relations: [
+          {
+            fromEntityName: "Acme Corp",
+            toEntityName: "Acme Corp",
+            relationTypeId: "22222222-2222-4222-a222-222222222222",
+          },
+        ],
+        articleEntities: [],
+        articleRelevances: [],
+        entityEvidence: [
+          {
+            dataSourceId: DS,
+            entityName: "Acme Corp",
+            confidence: 0.85,
+          },
+        ],
+        relationEvidence: [
+          {
+            dataSourceId: DS,
+            fromEntityName: "Acme Corp",
+            toEntityName: "Acme Corp",
+            relationTypeId: "22222222-2222-4222-a222-222222222222",
+            evidenceSpan: "Acme announced",
+          },
+        ],
+      },
+      { db: db as never },
+    );
+
+    // Assert
+    expect(result.entityEvidenceUpserted).toBe(1);
+    expect(result.relationEvidenceUpserted).toBe(1);
+    expect(db.entityEvidence.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          entityId_dataSourceId_tickerId: {
+            entityId: ENT_ID,
+            dataSourceId: DS,
+            tickerId: "ticker-1",
+          },
+        },
+        create: expect.objectContaining({
+          confidence: 0.85,
+        }),
+      }),
+    );
+    expect(db.entityRelationEvidence.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          entityRelationId_dataSourceId_tickerId: {
+            entityRelationId: REL_ID,
+            dataSourceId: DS,
+            tickerId: "ticker-1",
+          },
+        },
+        create: expect.objectContaining({
+          evidenceSpan: "Acme announced",
+        }),
+      }),
     );
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -33,6 +33,8 @@ type AnalysisDb = {
   entityAlias: Pick<typeof prisma.entityAlias, "createMany">;
   tickerEntity: Pick<typeof prisma.tickerEntity, "create" | "findFirst">;
   entityRelation: Pick<typeof prisma.entityRelation, "create" | "findUnique">;
+  entityEvidence: Pick<typeof prisma.entityEvidence, "upsert">;
+  entityRelationEvidence: Pick<typeof prisma.entityRelationEvidence, "upsert">;
   articleEntity: Pick<typeof prisma.articleEntity, "upsert">;
   articleRelevance: Pick<
     typeof prisma.articleRelevance,
@@ -223,12 +225,20 @@ export const applyAnalysisPost = async (
   deps: { db?: AnalysisWriteDb } = {},
 ): Promise<PostAnalysisResponse> => {
   const db = deps.db ?? defaultDb;
+  const entityEvidence = body.entityEvidence ?? [];
+  const relationEvidence = body.relationEvidence ?? [];
 
   const dataSourceIds = new Set<string>();
   for (const row of body.articleEntities) {
     dataSourceIds.add(row.dataSourceId);
   }
   for (const row of body.articleRelevances) {
+    dataSourceIds.add(row.dataSourceId);
+  }
+  for (const row of entityEvidence) {
+    dataSourceIds.add(row.dataSourceId);
+  }
+  for (const row of relationEvidence) {
     dataSourceIds.add(row.dataSourceId);
   }
 
@@ -327,6 +337,7 @@ export const applyAnalysisPost = async (
   }
 
   let relationsCreated = 0;
+  const relationNameKeyToId = new Map<string, string>();
   for (const rel of body.relations) {
     const fromId = nameToEntityId.get(
       normalizeAnalysisName(rel.fromEntityName),
@@ -348,16 +359,125 @@ export const applyAnalysisPost = async (
       },
       select: { id: true },
     });
+    const relationId =
+      existingRel?.id ??
+      (
+        await db.entityRelation.create({
+          data: {
+            fromEntityId: fromId,
+            toEntityId: toId,
+            relationTypeId: rel.relationTypeId,
+          },
+          select: { id: true },
+        })
+      ).id;
     if (!existingRel) {
-      await db.entityRelation.create({
-        data: {
-          fromEntityId: fromId,
-          toEntityId: toId,
-          relationTypeId: rel.relationTypeId,
-        },
-      });
       relationsCreated += 1;
     }
+    relationNameKeyToId.set(buildRelationNameKey(rel), relationId);
+  }
+
+  let entityEvidenceUpserted = 0;
+  for (const evidence of entityEvidence) {
+    let entityId: string | undefined = nameToEntityId.get(
+      normalizeAnalysisName(evidence.entityName),
+    );
+    if (entityId === undefined) {
+      entityId =
+        (await resolveEntityIdByNameForTicker(
+          db,
+          body.tickerId,
+          evidence.entityName,
+        )) ?? undefined;
+    }
+    if (entityId === undefined) {
+      logger.warn(
+        {
+          tickerId: body.tickerId,
+          entityName: evidence.entityName,
+          dataSourceId: evidence.dataSourceId,
+        },
+        "entity evidence skipped: entityName not in ticker vocabulary",
+      );
+      continue;
+    }
+
+    await db.entityEvidence.upsert({
+      where: {
+        entityId_dataSourceId_tickerId: {
+          entityId,
+          dataSourceId: evidence.dataSourceId,
+          tickerId: body.tickerId,
+        },
+      },
+      create: {
+        entityId,
+        dataSourceId: evidence.dataSourceId,
+        tickerId: body.tickerId,
+        confidence: evidence.confidence ?? null,
+        lastSeenAt: new Date(),
+      },
+      update: {
+        ...(evidence.confidence !== undefined && evidence.confidence !== null
+          ? { confidence: evidence.confidence }
+          : {}),
+        lastSeenAt: new Date(),
+      },
+    });
+    entityEvidenceUpserted += 1;
+  }
+
+  let relationEvidenceUpserted = 0;
+  for (const evidence of relationEvidence) {
+    let entityRelationId = relationNameKeyToId.get(
+      buildRelationNameKey(evidence),
+    );
+    if (entityRelationId === undefined) {
+      entityRelationId =
+        (await resolveEntityRelationIdByNames(db, body.tickerId, evidence)) ??
+        undefined;
+    }
+    if (entityRelationId === undefined) {
+      logger.warn(
+        {
+          tickerId: body.tickerId,
+          fromEntityName: evidence.fromEntityName,
+          toEntityName: evidence.toEntityName,
+          relationTypeId: evidence.relationTypeId,
+          dataSourceId: evidence.dataSourceId,
+        },
+        "relation evidence skipped: relation not found for ticker vocabulary",
+      );
+      continue;
+    }
+
+    await db.entityRelationEvidence.upsert({
+      where: {
+        entityRelationId_dataSourceId_tickerId: {
+          entityRelationId,
+          dataSourceId: evidence.dataSourceId,
+          tickerId: body.tickerId,
+        },
+      },
+      create: {
+        entityRelationId,
+        dataSourceId: evidence.dataSourceId,
+        tickerId: body.tickerId,
+        confidence: evidence.confidence ?? null,
+        evidenceSpan: evidence.evidenceSpan?.trim() ?? null,
+        lastSeenAt: new Date(),
+      },
+      update: {
+        ...(evidence.confidence !== undefined && evidence.confidence !== null
+          ? { confidence: evidence.confidence }
+          : {}),
+        ...(evidence.evidenceSpan !== undefined
+          ? { evidenceSpan: evidence.evidenceSpan?.trim() ?? null }
+          : {}),
+        lastSeenAt: new Date(),
+      },
+    });
+    relationEvidenceUpserted += 1;
   }
 
   for (const mention of body.articleEntities) {
@@ -444,6 +564,8 @@ export const applyAnalysisPost = async (
     relationsCreated,
     articlesScored,
     articlesSelected,
+    entityEvidenceUpserted,
+    relationEvidenceUpserted,
   };
 };
 
@@ -547,4 +669,90 @@ async function resolveEntityIdByNameForTicker(
     select: { id: true },
   });
   return entity?.id ?? null;
+}
+
+type RelationNameEvidence = Pick<
+  PostAnalysisBody["relationEvidence"][number],
+  "fromEntityName" | "toEntityName" | "relationTypeId"
+>;
+
+/**
+ * Builds a normalized lookup key for relation endpoints and type id.
+ *
+ * @param relation - Relation or evidence row with endpoint names and type id.
+ * @returns Stable map key for relation id resolution.
+ */
+const buildRelationNameKey = (relation: RelationNameEvidence): string =>
+  `${normalizeAnalysisName(relation.fromEntityName)}\0${normalizeAnalysisName(relation.toEntityName)}\0${relation.relationTypeId}`;
+
+/**
+ * Resolves a canonical relation id by endpoint names for a ticker when not in the run-local map.
+ *
+ * @param db - Injectable database delegates for relation lookup.
+ * @param tickerId - Ticker scope.
+ * @param evidence - Relation evidence row with endpoint names.
+ * @returns Entity relation id or null.
+ */
+async function resolveEntityRelationIdByNames(
+  db: Pick<AnalysisWriteDb, "entity" | "entityRelation">,
+  tickerId: string,
+  evidence: RelationNameEvidence,
+): Promise<string | null> {
+  const fromEntity = await db.entity.findFirst({
+    where: {
+      tickerEntities: { some: { tickerId } },
+      OR: [
+        {
+          canonicalName: {
+            equals: evidence.fromEntityName.trim(),
+            mode: "insensitive",
+          },
+        },
+        {
+          aliases: {
+            some: {
+              normalizedAlias: normalizeAnalysisName(evidence.fromEntityName),
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+  const toEntity = await db.entity.findFirst({
+    where: {
+      tickerEntities: { some: { tickerId } },
+      OR: [
+        {
+          canonicalName: {
+            equals: evidence.toEntityName.trim(),
+            mode: "insensitive",
+          },
+        },
+        {
+          aliases: {
+            some: {
+              normalizedAlias: normalizeAnalysisName(evidence.toEntityName),
+            },
+          },
+        },
+      ],
+    },
+    select: { id: true },
+  });
+  if (!fromEntity || !toEntity) {
+    return null;
+  }
+
+  const relation = await db.entityRelation.findUnique({
+    where: {
+      fromEntityId_toEntityId_relationTypeId: {
+        fromEntityId: fromEntity.id,
+        toEntityId: toEntity.id,
+        relationTypeId: evidence.relationTypeId,
+      },
+    },
+    select: { id: true },
+  });
+  return relation?.id ?? null;
 }

--- a/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-article-mentions.ts
@@ -251,6 +251,8 @@ export const buildArticleEntityPostChunks = (
       relations: [],
       articleEntities: [...window],
       articleRelevances: [],
+      entityEvidence: [],
+      relationEvidence: [],
     };
     const parsed = postAnalysisBodySchema.safeParse(body);
     if (!parsed.success) {

--- a/apps/mediapulse/agents/article-analysis/src/analysis-provenance.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-provenance.test.ts
@@ -48,6 +48,32 @@ describe("toEntityEvidenceRowsForSource", () => {
       },
     ]);
   });
+
+  it("omits out-of-range mention confidence from entity evidence", () => {
+    // Setup
+    const entities = [
+      { canonicalName: "Apple Inc", typeId: "t1", aliases: [] as string[] },
+    ];
+    const mentions = [
+      {
+        entityName: "Apple Inc",
+        mentionCount: 1,
+        confidence: 1.5,
+        sentiment: null,
+      },
+    ];
+
+    // Act
+    const rows = toEntityEvidenceRowsForSource(DS, entities, mentions);
+
+    // Assert
+    expect(rows).toEqual([
+      {
+        dataSourceId: DS,
+        entityName: "Apple Inc",
+      },
+    ]);
+  });
 });
 
 describe("toRelationEvidenceRowsForSource", () => {

--- a/apps/mediapulse/agents/article-analysis/src/analysis-provenance.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-provenance.test.ts
@@ -1,0 +1,156 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import {
+  canonicalizeEntityEvidenceRowsToRunEntities,
+  canonicalizeRelationEvidenceRowsToRunEntities,
+  dedupeEntityEvidence,
+  dedupeRelationEvidence,
+  filterEntityEvidenceRowsToRunCatalog,
+  filterRelationEvidenceRowsToRunCatalog,
+  toEntityEvidenceRowsForSource,
+  toRelationEvidenceRowsForSource,
+} from "./analysis-provenance.js";
+
+const DS = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const RID = "22222222-2222-4222-a222-222222222222";
+
+describe("toEntityEvidenceRowsForSource", () => {
+  it("maps capped entities and uses max mention confidence", () => {
+    // Setup
+    const entities = [
+      { canonicalName: "Apple Inc", typeId: "t1", aliases: ["Apple"] },
+    ];
+    const mentions = [
+      {
+        entityName: "Apple",
+        mentionCount: 2,
+        confidence: 0.7,
+        sentiment: null,
+      },
+      {
+        entityName: "Apple Inc",
+        mentionCount: 1,
+        confidence: 0.9,
+        sentiment: null,
+      },
+    ];
+
+    // Act
+    const rows = toEntityEvidenceRowsForSource(DS, entities, mentions);
+
+    // Assert
+    expect(rows).toEqual([
+      {
+        dataSourceId: DS,
+        entityName: "Apple Inc",
+        confidence: 0.9,
+      },
+    ]);
+  });
+});
+
+describe("toRelationEvidenceRowsForSource", () => {
+  it("includes critique evidenceSpan when provided", () => {
+    // Setup
+    const relations = [
+      {
+        fromEntityName: "A",
+        toEntityName: "B",
+        relationTypeId: RID,
+      },
+    ];
+    const evidenceByKey = new Map([["A\0B\0" + RID, "quoted span"]]);
+
+    // Act
+    const rows = toRelationEvidenceRowsForSource(DS, relations, evidenceByKey);
+
+    // Assert
+    expect(rows[0]?.evidenceSpan).toBe("quoted span");
+  });
+});
+
+describe("dedupeEntityEvidence", () => {
+  it("keeps max confidence for duplicate source and entity", () => {
+    // Act
+    const rows = dedupeEntityEvidence([
+      { dataSourceId: DS, entityName: "Acme", confidence: 0.4 },
+      { dataSourceId: DS, entityName: "acme", confidence: 0.8 },
+    ]);
+
+    // Assert
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.confidence).toBe(0.8);
+  });
+});
+
+describe("filter and canonicalize entity evidence", () => {
+  it("drops rows outside run catalog and canonicalizes names", () => {
+    // Setup
+    const catalog = new Set(["apple inc", "apple"]);
+    const entities = [
+      { canonicalName: "Apple Inc", typeId: "t1", aliases: ["Apple"] },
+    ];
+    const rows = [
+      { dataSourceId: DS, entityName: "Apple", confidence: 0.5 },
+      { dataSourceId: DS, entityName: "Ghost", confidence: 0.5 },
+    ];
+
+    // Act
+    const filtered = filterEntityEvidenceRowsToRunCatalog(rows, catalog);
+    const canonical = canonicalizeEntityEvidenceRowsToRunEntities(
+      filtered.rows,
+      entities,
+    );
+
+    // Assert
+    expect(filtered.droppedCount).toBe(1);
+    expect(canonical.rows).toEqual([
+      { dataSourceId: DS, entityName: "Apple Inc", confidence: 0.5 },
+    ]);
+  });
+});
+
+describe("filter and canonicalize relation evidence", () => {
+  it("drops rows with unknown endpoints and canonicalizes names", () => {
+    // Setup
+    const catalog = new Set(["a", "b"]);
+    const entities = [
+      { canonicalName: "A Corp", typeId: "t1", aliases: ["A"] },
+      { canonicalName: "B Corp", typeId: "t1", aliases: ["B"] },
+    ];
+    const rows = [
+      {
+        dataSourceId: DS,
+        fromEntityName: "A",
+        toEntityName: "B",
+        relationTypeId: RID,
+      },
+      {
+        dataSourceId: DS,
+        fromEntityName: "A",
+        toEntityName: "Missing",
+        relationTypeId: RID,
+      },
+    ];
+
+    // Act
+    const filtered = filterRelationEvidenceRowsToRunCatalog(rows, catalog);
+    const canonical = canonicalizeRelationEvidenceRowsToRunEntities(
+      filtered.rows,
+      entities,
+    );
+    const deduped = dedupeRelationEvidence(canonical.rows);
+
+    // Assert
+    expect(filtered.droppedCount).toBe(1);
+    expect(deduped).toEqual([
+      {
+        dataSourceId: DS,
+        fromEntityName: "A Corp",
+        toEntityName: "B Corp",
+        relationTypeId: RID,
+      },
+    ]);
+  });
+});

--- a/apps/mediapulse/agents/article-analysis/src/analysis-provenance.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-provenance.ts
@@ -43,9 +43,13 @@ export const toEntityEvidenceRowsForSource = (
     const aliasConfidence = entity.aliases
       .map((alias) => mentionConfidenceByName.get(normalizeEntityName(alias)))
       .find((value) => value !== undefined);
-    const confidence =
+    const rawConfidence =
       mentionConfidenceByName.get(normalizeEntityName(entity.canonicalName)) ??
       aliasConfidence;
+    const confidence =
+      rawConfidence !== undefined && rawConfidence >= 0 && rawConfidence <= 1
+        ? rawConfidence
+        : undefined;
     return {
       dataSourceId,
       entityName: entity.canonicalName.trim(),
@@ -99,7 +103,10 @@ export const dedupeEntityEvidence = (
     }
     map.set(key, {
       ...existing,
-      ...(row.confidence !== undefined && row.confidence !== null
+      ...(row.confidence !== undefined &&
+      row.confidence !== null &&
+      row.confidence >= 0 &&
+      row.confidence <= 1
         ? {
             confidence: Math.max(existing.confidence ?? 0, row.confidence),
           }

--- a/apps/mediapulse/agents/article-analysis/src/analysis-provenance.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-provenance.ts
@@ -1,0 +1,266 @@
+import type { PostAnalysisBody } from "@workspace/agent-data-api-contract";
+
+import type { ArticleMentionProposal } from "./analysis-article-mentions.js";
+import type {
+  EntityProposal,
+  RelationProposal,
+} from "./analysis-vocabulary.js";
+import { relationCritiqueRowKey } from "./llm-extract-entities.js";
+import { normalizeEntityName } from "./normalize-entity-name.js";
+
+/** One row for `postAnalysisBodySchema.entityEvidence`. */
+export type EntityEvidenceRow = PostAnalysisBody["entityEvidence"][number];
+
+/** One row for `postAnalysisBodySchema.relationEvidence`. */
+export type RelationEvidenceRow = PostAnalysisBody["relationEvidence"][number];
+
+/**
+ * Maps capped entities for one source to entity provenance rows.
+ *
+ * @param dataSourceId - UUID of the `DataSource` row (never from the LLM).
+ * @param entities - Capped entity proposals for the source.
+ * @param mentions - Capped mention proposals used to infer confidence when present.
+ * @returns `entityEvidence` payload rows.
+ */
+export const toEntityEvidenceRowsForSource = (
+  dataSourceId: string,
+  entities: readonly EntityProposal[],
+  mentions: readonly ArticleMentionProposal[],
+): EntityEvidenceRow[] => {
+  const mentionConfidenceByName = new Map<string, number>();
+  for (const mention of mentions) {
+    const key = normalizeEntityName(mention.entityName);
+    const prev = mentionConfidenceByName.get(key);
+    mentionConfidenceByName.set(
+      key,
+      prev === undefined
+        ? mention.confidence
+        : Math.max(prev, mention.confidence),
+    );
+  }
+
+  return entities.map((entity) => {
+    const aliasConfidence = entity.aliases
+      .map((alias) => mentionConfidenceByName.get(normalizeEntityName(alias)))
+      .find((value) => value !== undefined);
+    const confidence =
+      mentionConfidenceByName.get(normalizeEntityName(entity.canonicalName)) ??
+      aliasConfidence;
+    return {
+      dataSourceId,
+      entityName: entity.canonicalName.trim(),
+      ...(confidence !== undefined ? { confidence } : {}),
+    };
+  });
+};
+
+/**
+ * Maps capped relations for one source to relation provenance rows.
+ *
+ * @param dataSourceId - UUID of the `DataSource` row (never from the LLM).
+ * @param relations - Capped relation proposals for the source.
+ * @param evidenceByKey - Optional critique evidence spans keyed by relation triple.
+ * @returns `relationEvidence` payload rows.
+ */
+export const toRelationEvidenceRowsForSource = (
+  dataSourceId: string,
+  relations: readonly RelationProposal[],
+  evidenceByKey?: ReadonlyMap<string, string>,
+): RelationEvidenceRow[] =>
+  relations.map((relation) => {
+    const evidenceSpan = evidenceByKey?.get(relationCritiqueRowKey(relation));
+    return {
+      dataSourceId,
+      fromEntityName: relation.fromEntityName.trim(),
+      toEntityName: relation.toEntityName.trim(),
+      relationTypeId: relation.relationTypeId,
+      ...(evidenceSpan !== undefined && evidenceSpan.length > 0
+        ? { evidenceSpan }
+        : {}),
+    };
+  });
+
+/**
+ * Dedupes by (`dataSourceId`, normalized `entityName`). Keeps max confidence when duplicated.
+ *
+ * @param rows - Rows possibly containing duplicates for the same source and entity.
+ * @returns Deduplicated rows (Map iteration order).
+ */
+export const dedupeEntityEvidence = (
+  rows: readonly EntityEvidenceRow[],
+): EntityEvidenceRow[] => {
+  const map = new Map<string, EntityEvidenceRow>();
+  for (const row of rows) {
+    const key = `${row.dataSourceId}\0${normalizeEntityName(row.entityName)}`;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, { ...row });
+      continue;
+    }
+    map.set(key, {
+      ...existing,
+      ...(row.confidence !== undefined && row.confidence !== null
+        ? {
+            confidence: Math.max(existing.confidence ?? 0, row.confidence),
+          }
+        : {}),
+    });
+  }
+  return [...map.values()];
+};
+
+/**
+ * Dedupes by source, endpoints, and relation type id.
+ *
+ * @param rows - Rows possibly containing duplicates for the same source and relation triple.
+ * @returns Deduplicated rows (Map iteration order).
+ */
+export const dedupeRelationEvidence = (
+  rows: readonly RelationEvidenceRow[],
+): RelationEvidenceRow[] => {
+  const map = new Map<string, RelationEvidenceRow>();
+  for (const row of rows) {
+    const key = `${row.dataSourceId}\0${normalizeEntityName(row.fromEntityName)}\0${normalizeEntityName(row.toEntityName)}\0${row.relationTypeId}`;
+    if (!map.has(key)) {
+      map.set(key, { ...row });
+    }
+  }
+  return [...map.values()];
+};
+
+/**
+ * Canonicalizes entity evidence names using run-level entity proposals.
+ *
+ * @param rows - Evidence rows after run-level filtering.
+ * @param entities - Final run-level entity proposals.
+ * @returns Canonicalized rows and drop count for unmapped names.
+ */
+export const canonicalizeEntityEvidenceRowsToRunEntities = (
+  rows: readonly EntityEvidenceRow[],
+  entities: readonly EntityProposal[],
+): { rows: EntityEvidenceRow[]; droppedCount: number } => {
+  const aliasToCanonical = new Map<string, string>();
+  for (const entity of entities) {
+    aliasToCanonical.set(
+      normalizeEntityName(entity.canonicalName),
+      entity.canonicalName.trim(),
+    );
+    for (const alias of entity.aliases) {
+      aliasToCanonical.set(
+        normalizeEntityName(alias),
+        entity.canonicalName.trim(),
+      );
+    }
+  }
+
+  const out: EntityEvidenceRow[] = [];
+  let droppedCount = 0;
+  for (const row of rows) {
+    const canonicalName = aliasToCanonical.get(
+      normalizeEntityName(row.entityName),
+    );
+    if (!canonicalName) {
+      droppedCount += 1;
+      continue;
+    }
+    out.push({
+      ...row,
+      entityName: canonicalName,
+    });
+  }
+  return { rows: out, droppedCount };
+};
+
+/**
+ * Canonicalizes relation evidence endpoint names using run-level entity proposals.
+ *
+ * @param rows - Evidence rows after run-level filtering.
+ * @param entities - Final run-level entity proposals.
+ * @returns Canonicalized rows and drop count for unmapped endpoint names.
+ */
+export const canonicalizeRelationEvidenceRowsToRunEntities = (
+  rows: readonly RelationEvidenceRow[],
+  entities: readonly EntityProposal[],
+): { rows: RelationEvidenceRow[]; droppedCount: number } => {
+  const aliasToCanonical = new Map<string, string>();
+  for (const entity of entities) {
+    aliasToCanonical.set(
+      normalizeEntityName(entity.canonicalName),
+      entity.canonicalName.trim(),
+    );
+    for (const alias of entity.aliases) {
+      aliasToCanonical.set(
+        normalizeEntityName(alias),
+        entity.canonicalName.trim(),
+      );
+    }
+  }
+
+  const resolveName = (name: string): string | undefined =>
+    aliasToCanonical.get(normalizeEntityName(name));
+
+  const out: RelationEvidenceRow[] = [];
+  let droppedCount = 0;
+  for (const row of rows) {
+    const fromEntityName = resolveName(row.fromEntityName);
+    const toEntityName = resolveName(row.toEntityName);
+    if (!fromEntityName || !toEntityName) {
+      droppedCount += 1;
+      continue;
+    }
+    out.push({
+      ...row,
+      fromEntityName,
+      toEntityName,
+    });
+  }
+  return { rows: out, droppedCount };
+};
+
+/**
+ * Drops entity evidence rows whose names are not in the run-level entity catalog.
+ *
+ * @param rows - Merged evidence rows for the run.
+ * @param catalog - Normalized keys from run-level entities.
+ * @returns Kept rows and drop count.
+ */
+export const filterEntityEvidenceRowsToRunCatalog = (
+  rows: readonly EntityEvidenceRow[],
+  catalog: ReadonlySet<string>,
+): { rows: EntityEvidenceRow[]; droppedCount: number } => {
+  const out: EntityEvidenceRow[] = [];
+  let droppedCount = 0;
+  for (const row of rows) {
+    if (catalog.has(normalizeEntityName(row.entityName))) {
+      out.push(row);
+    } else {
+      droppedCount += 1;
+    }
+  }
+  return { rows: out, droppedCount };
+};
+
+/**
+ * Drops relation evidence rows when either endpoint is not in the run-level entity catalog.
+ *
+ * @param rows - Merged evidence rows for the run.
+ * @param catalog - Normalized keys from run-level entities.
+ * @returns Kept rows and drop count.
+ */
+export const filterRelationEvidenceRowsToRunCatalog = (
+  rows: readonly RelationEvidenceRow[],
+  catalog: ReadonlySet<string>,
+): { rows: RelationEvidenceRow[]; droppedCount: number } => {
+  const out: RelationEvidenceRow[] = [];
+  let droppedCount = 0;
+  for (const row of rows) {
+    const fromOk = catalog.has(normalizeEntityName(row.fromEntityName));
+    const toOk = catalog.has(normalizeEntityName(row.toEntityName));
+    if (fromOk && toOk) {
+      out.push(row);
+    } else {
+      droppedCount += 1;
+    }
+  }
+  return { rows: out, droppedCount };
+};

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-post-chunks.ts
@@ -41,6 +41,8 @@ export const buildArticleRelevancePostChunks = (
       relations: [],
       articleEntities: [],
       articleRelevances: [...window],
+      entityEvidence: [],
+      relationEvidence: [],
     };
     const parsed = postAnalysisBodySchema.safeParse(body);
     if (!parsed.success) {

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.test.ts
@@ -28,6 +28,50 @@ describe("buildEntityNameLookup", () => {
 });
 
 describe("buildAnalysisPostChunks", () => {
+  it("partitions entity and relation evidence per chunk", () => {
+    // Setup
+    const tickerId = "t1";
+    const entities = [
+      { canonicalName: "A", typeId: TID, aliases: [] as string[] },
+      { canonicalName: "B", typeId: TID, aliases: [] as string[] },
+      { canonicalName: "C", typeId: TID, aliases: [] as string[] },
+    ];
+    const relations = [
+      { fromEntityName: "A", toEntityName: "B", relationTypeId: RID },
+      { fromEntityName: "B", toEntityName: "C", relationTypeId: RID },
+    ];
+    const entityEvidence = [
+      { dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", entityName: "A" },
+      { dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", entityName: "C" },
+    ];
+    const relationEvidence = [
+      {
+        dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        fromEntityName: "A",
+        toEntityName: "B",
+        relationTypeId: RID,
+      },
+    ];
+
+    // Act
+    const { chunks } = buildAnalysisPostChunks(
+      tickerId,
+      entities,
+      relations,
+      1,
+      entityEvidence,
+      relationEvidence,
+    );
+
+    // Assert
+    expect(chunks[0]?.entityEvidence).toHaveLength(1);
+    expect(chunks[0]?.entityEvidence[0]?.entityName).toBe("A");
+    expect(chunks[0]?.relationEvidence).toHaveLength(1);
+    expect(chunks[1]?.entityEvidence).toHaveLength(1);
+    expect(chunks[1]?.entityEvidence[0]?.entityName).toBe("C");
+    expect(chunks[1]?.relationEvidence).toHaveLength(0);
+  });
+
   it("includes entity closure per chunk for cross-chunk endpoint reuse", () => {
     // Setup
     const tickerId = "t1";

--- a/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
+++ b/apps/mediapulse/agents/article-analysis/src/build-analysis-post-chunks.ts
@@ -51,11 +51,47 @@ export const buildAnalysisPostChunks = (
   entities: PostAnalysisBody["entities"],
   relations: PostAnalysisBody["relations"],
   postChunkRelationBatchSize: number,
+  entityEvidence: PostAnalysisBody["entityEvidence"] = [],
+  relationEvidence: PostAnalysisBody["relationEvidence"] = [],
 ): BuildAnalysisPostChunksResult => {
   const chunks: PostAnalysisBody[] = [];
   const parseErrors: string[] = [];
   let droppedRelations = 0;
   const nameLookup = buildEntityNameLookup(entities);
+
+  const relationEvidenceKey = (
+    row: PostAnalysisBody["relationEvidence"][number],
+  ): string =>
+    `${normalizeEntityName(row.fromEntityName)}\0${normalizeEntityName(row.toEntityName)}\0${row.relationTypeId}`;
+
+  const entityEvidenceForChunk = (
+    chunkEntities: PostAnalysisBody["entities"],
+  ): PostAnalysisBody["entityEvidence"] => {
+    const allowedNames = new Set<string>();
+    for (const entity of chunkEntities) {
+      allowedNames.add(normalizeEntityName(entity.canonicalName));
+      for (const alias of entity.aliases) {
+        allowedNames.add(normalizeEntityName(alias));
+      }
+    }
+    return entityEvidence.filter((row) =>
+      allowedNames.has(normalizeEntityName(row.entityName)),
+    );
+  };
+
+  const relationEvidenceForChunk = (
+    chunkRelations: PostAnalysisBody["relations"],
+  ): PostAnalysisBody["relationEvidence"] => {
+    const allowedKeys = new Set(
+      chunkRelations.map(
+        (relation) =>
+          `${normalizeEntityName(relation.fromEntityName)}\0${normalizeEntityName(relation.toEntityName)}\0${relation.relationTypeId}`,
+      ),
+    );
+    return relationEvidence.filter((row) =>
+      allowedKeys.has(relationEvidenceKey(row)),
+    );
+  };
 
   if (relations.length === 0) {
     if (entities.length > 0) {
@@ -65,6 +101,8 @@ export const buildAnalysisPostChunks = (
         relations: [],
         articleEntities: [],
         articleRelevances: [],
+        entityEvidence: entityEvidenceForChunk(entities),
+        relationEvidence: [],
       };
       const parsed = postAnalysisBodySchema.safeParse(body);
       if (!parsed.success) {
@@ -121,6 +159,8 @@ export const buildAnalysisPostChunks = (
       relations: filtered,
       articleEntities: [],
       articleRelevances: [],
+      entityEvidence: entityEvidenceForChunk(chunkEntities),
+      relationEvidence: relationEvidenceForChunk(filtered),
     };
 
     const parsed = postAnalysisBodySchema.safeParse(body);

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -10,6 +10,12 @@ import {
   toArticleEntityRowsForSource,
   type ArticleEntityRow,
 } from "./analysis-article-mentions.js";
+import {
+  toEntityEvidenceRowsForSource,
+  toRelationEvidenceRowsForSource,
+  type EntityEvidenceRow,
+  type RelationEvidenceRow,
+} from "./analysis-provenance.js";
 import type { PerSourceRelevanceSignals } from "./analysis-relevance-scoring.js";
 import {
   partitionExtractionByVocabulary,
@@ -84,6 +90,8 @@ export type SourceProcessingOutcome = {
   mergedEntities: EntityProposal[];
   mergedRelations: RelationProposal[];
   mergedArticleEntityRows: ArticleEntityRow[];
+  mergedEntityEvidence: EntityEvidenceRow[];
+  mergedRelationEvidence: RelationEvidenceRow[];
   perSourceSignal?: PerSourceRelevanceSignals;
   extractionFailures: ArticleAnalysisExtractionFailureRecord[];
   droppedByContentQualityDelta: Partial<Record<QualityDropReason, number>>;
@@ -122,6 +130,8 @@ export const createEmptySourceProcessingOutcome =
     mergedEntities: [],
     mergedRelations: [],
     mergedArticleEntityRows: [],
+    mergedEntityEvidence: [],
+    mergedRelationEvidence: [],
     extractionFailures: [],
     droppedByContentQualityDelta: {},
     extractionLatencyMs: 0,
@@ -500,6 +510,7 @@ export const createProcessOneSource =
       );
 
       let relationsAfterCritique = resolved.relations;
+      let relationEvidenceByKey: ReadonlyMap<string, string> | undefined;
       const critiqueEligible =
         cfg.useRelationSelfCritique &&
         resolved.relations.length >= cfg.relationCritiqueMinRelationCount;
@@ -539,6 +550,7 @@ export const createProcessOneSource =
           );
           outcome.relationsDroppedByCritique = critiqueApplied.droppedCount;
           relationsAfterCritique = critiqueApplied.relations;
+          relationEvidenceByKey = critiqueApplied.evidenceByKey;
           for (const relation of resolved.relations) {
             const evidenceSpan = critiqueApplied.evidenceByKey.get(
               relationCritiqueRowKey(relation),
@@ -591,6 +603,16 @@ export const createProcessOneSource =
       outcome.mergedArticleEntityRows = toArticleEntityRowsForSource(
         source.id,
         mentionCapped,
+      );
+      outcome.mergedEntityEvidence = toEntityEvidenceRowsForSource(
+        source.id,
+        capped.entities,
+        mentionCapped,
+      );
+      outcome.mergedRelationEvidence = toRelationEvidenceRowsForSource(
+        source.id,
+        capped.relations,
+        relationEvidenceByKey,
       );
 
       const avgMentionConfidence =

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -18,6 +18,16 @@ import {
   filterArticleEntityRowsToRunCatalog,
   type ArticleEntityRow,
 } from "./analysis-article-mentions.js";
+import {
+  canonicalizeEntityEvidenceRowsToRunEntities,
+  canonicalizeRelationEvidenceRowsToRunEntities,
+  dedupeEntityEvidence,
+  dedupeRelationEvidence,
+  filterEntityEvidenceRowsToRunCatalog,
+  filterRelationEvidenceRowsToRunCatalog,
+  type EntityEvidenceRow,
+  type RelationEvidenceRow,
+} from "./analysis-provenance.js";
 import { buildArticleRelevancePostChunks } from "./analysis-relevance-post-chunks.js";
 import {
   buildDraftRelevanceRow,
@@ -801,6 +811,8 @@ export const run = async ({
     const mergedEntities: EntityProposal[] = [];
     const mergedRelations: RelationProposal[] = [];
     const mergedArticleEntityRows: ArticleEntityRow[] = [];
+    const mergedEntityEvidence: EntityEvidenceRow[] = [];
+    const mergedRelationEvidence: RelationEvidenceRow[] = [];
     const perSourceSignals: PerSourceRelevanceSignals[] = [];
     let vocabularyFailures = 0;
 
@@ -818,6 +830,8 @@ export const run = async ({
       mergedEntities.push(...outcome.mergedEntities);
       mergedRelations.push(...outcome.mergedRelations);
       mergedArticleEntityRows.push(...outcome.mergedArticleEntityRows);
+      mergedEntityEvidence.push(...outcome.mergedEntityEvidence);
+      mergedRelationEvidence.push(...outcome.mergedRelationEvidence);
       if (outcome.perSourceSignal !== undefined) {
         perSourceSignals.push(outcome.perSourceSignal);
       }
@@ -1127,6 +1141,69 @@ export const run = async ({
       cfg.maxArticleEntitiesPerRun,
     );
 
+    const {
+      rows: entityEvidenceForRun,
+      droppedCount: droppedEntityEvidenceNotInRunCatalog,
+    } = filterEntityEvidenceRowsToRunCatalog(
+      dedupeEntityEvidence(mergedEntityEvidence),
+      entityCatalog,
+    );
+    if (droppedEntityEvidenceNotInRunCatalog > 0) {
+      log.warn(
+        { droppedEntityEvidenceNotInRunCatalog },
+        "article-analysis dropped entity evidence not in run entity catalog",
+      );
+    }
+
+    const {
+      rows: relationEvidenceForRun,
+      droppedCount: droppedRelationEvidenceNotInRunCatalog,
+    } = filterRelationEvidenceRowsToRunCatalog(
+      dedupeRelationEvidence(mergedRelationEvidence),
+      entityCatalog,
+    );
+    if (droppedRelationEvidenceNotInRunCatalog > 0) {
+      log.warn(
+        { droppedRelationEvidenceNotInRunCatalog },
+        "article-analysis dropped relation evidence not in run entity catalog",
+      );
+    }
+
+    const {
+      rows: canonicalEntityEvidenceForRun,
+      droppedCount: droppedEntityEvidenceUnmappable,
+    } = canonicalizeEntityEvidenceRowsToRunEntities(
+      entityEvidenceForRun,
+      entities,
+    );
+    if (droppedEntityEvidenceUnmappable > 0) {
+      log.warn(
+        { droppedEntityEvidenceUnmappable },
+        "article-analysis dropped entity evidence not mappable to run canonical entity names",
+      );
+    }
+
+    const {
+      rows: canonicalRelationEvidenceForRun,
+      droppedCount: droppedRelationEvidenceUnmappable,
+    } = canonicalizeRelationEvidenceRowsToRunEntities(
+      relationEvidenceForRun,
+      entities,
+    );
+    if (droppedRelationEvidenceUnmappable > 0) {
+      log.warn(
+        { droppedRelationEvidenceUnmappable },
+        "article-analysis dropped relation evidence not mappable to run canonical entity names",
+      );
+    }
+
+    const entityEvidenceForPost = dedupeEntityEvidence(
+      canonicalEntityEvidenceForRun,
+    );
+    const relationEvidenceForPost = dedupeRelationEvidence(
+      canonicalRelationEvidenceForRun,
+    );
+
     report(
       "Persisting knowledge graph",
       `${entities.length} entities, ${relations.length} relations`,
@@ -1137,6 +1214,8 @@ export const run = async ({
       entities,
       relations,
       cfg.postChunkRelationBatchSize,
+      entityEvidenceForPost,
+      relationEvidenceForPost,
     );
     chunkParseCounts.entityRelationChunkParseErrors = parseErrors.length;
 

--- a/packages/mediapulse/database/prisma/migrations/20260529180000_add_entity_relation_evidence/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260529180000_add_entity_relation_evidence/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "entity_evidence" (
+    "id" TEXT NOT NULL,
+    "entity_id" TEXT NOT NULL,
+    "data_source_id" TEXT NOT NULL,
+    "ticker_id" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "entity_evidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "entity_relation_evidence" (
+    "id" TEXT NOT NULL,
+    "entity_relation_id" TEXT NOT NULL,
+    "data_source_id" TEXT NOT NULL,
+    "ticker_id" TEXT NOT NULL,
+    "confidence" DOUBLE PRECISION,
+    "evidence_span" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_seen_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "entity_relation_evidence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "entity_evidence_ticker_id_data_source_id_idx" ON "entity_evidence"("ticker_id", "data_source_id");
+
+-- CreateIndex
+CREATE INDEX "entity_evidence_data_source_id_idx" ON "entity_evidence"("data_source_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "entity_evidence_entity_id_data_source_id_ticker_id_key" ON "entity_evidence"("entity_id", "data_source_id", "ticker_id");
+
+-- CreateIndex
+CREATE INDEX "entity_relation_evidence_ticker_id_data_source_id_idx" ON "entity_relation_evidence"("ticker_id", "data_source_id");
+
+-- CreateIndex
+CREATE INDEX "entity_relation_evidence_data_source_id_idx" ON "entity_relation_evidence"("data_source_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "entity_relation_evidence_entity_relation_id_data_source_id__key" ON "entity_relation_evidence"("entity_relation_id", "data_source_id", "ticker_id");
+
+-- AddForeignKey
+ALTER TABLE "entity_evidence" ADD CONSTRAINT "entity_evidence_entity_id_fkey" FOREIGN KEY ("entity_id") REFERENCES "entity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "entity_evidence" ADD CONSTRAINT "entity_evidence_data_source_id_fkey" FOREIGN KEY ("data_source_id") REFERENCES "data_source"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "entity_evidence" ADD CONSTRAINT "entity_evidence_ticker_id_fkey" FOREIGN KEY ("ticker_id") REFERENCES "ticker"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "entity_relation_evidence" ADD CONSTRAINT "entity_relation_evidence_entity_relation_id_fkey" FOREIGN KEY ("entity_relation_id") REFERENCES "entity_relation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "entity_relation_evidence" ADD CONSTRAINT "entity_relation_evidence_data_source_id_fkey" FOREIGN KEY ("data_source_id") REFERENCES "data_source"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "entity_relation_evidence" ADD CONSTRAINT "entity_relation_evidence_ticker_id_fkey" FOREIGN KEY ("ticker_id") REFERENCES "ticker"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -53,10 +53,12 @@ model DataSource {
   createdAt     DateTime  @default(now()) @map("created_at")
   updatedAt     DateTime  @updatedAt @map("updated_at")
 
-  ticker            Ticker             @relation(fields: [tickerId], references: [id])
-  searchQuery       SearchQuery        @relation(fields: [searchQueryId], references: [id])
-  articleEntities   ArticleEntity[]
-  articleRelevances ArticleRelevance[]
+  ticker                 Ticker                   @relation(fields: [tickerId], references: [id])
+  searchQuery            SearchQuery              @relation(fields: [searchQueryId], references: [id])
+  articleEntities        ArticleEntity[]
+  articleRelevances      ArticleRelevance[]
+  entityEvidence         EntityEvidence[]
+  entityRelationEvidence EntityRelationEvidence[]
 
   @@map("data_source")
 }
@@ -75,26 +77,26 @@ model DeadUrl {
 }
 
 model Newsletter {
-  id               String   @id @default(uuid())
-  subject          String
-  description      String?
-  content          String
-  tickerId         String   @map("ticker_id")
-  createdAt        DateTime @default(now()) @map("created_at")
-  updatedAt        DateTime @updatedAt @map("updated_at")
+  id          String   @id @default(uuid())
+  subject     String
+  description String?
+  content     String
+  tickerId    String   @map("ticker_id")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
 
-  model            String?  @map("model")
-  agentVersion     String?  @map("agent_version")
-  configVersion    String?  @map("config_version")
-  promptHash       String?  @map("prompt_hash")
-  configSnapshotId String?  @map("config_snapshot_id")
-  promptTokens     Int?     @map("prompt_tokens")
-  completionTokens Int?     @map("completion_tokens")
-  totalTokens      Int?     @map("total_tokens")
+  model            String? @map("model")
+  agentVersion     String? @map("agent_version")
+  configVersion    String? @map("config_version")
+  promptHash       String? @map("prompt_hash")
+  configSnapshotId String? @map("config_snapshot_id")
+  promptTokens     Int?    @map("prompt_tokens")
+  completionTokens Int?    @map("completion_tokens")
+  totalTokens      Int?    @map("total_tokens")
 
-  ticker               Ticker                         @relation(fields: [tickerId], references: [id])
-  deliveryCheckpoints  NewsletterDeliveryCheckpoint[]
-  deliveryRuns         DeliveryRun[]
+  ticker              Ticker                         @relation(fields: [tickerId], references: [id])
+  deliveryCheckpoints NewsletterDeliveryCheckpoint[]
+  deliveryRuns        DeliveryRun[]
 
   @@map("newsletter")
 }
@@ -139,6 +141,7 @@ model Entity {
   aliases         EntityAlias[]
   tickerEntities  TickerEntity[]
   articleEntities ArticleEntity[]
+  entityEvidence  EntityEvidence[]
   relationsFrom   EntityRelation[] @relation("RelationFrom")
   relationsTo     EntityRelation[] @relation("RelationTo")
 
@@ -187,12 +190,54 @@ model EntityRelation {
   lastSeenAt     DateTime @default(now()) @map("last_seen_at")
   createdAt      DateTime @default(now()) @map("created_at")
 
-  fromEntity   Entity       @relation("RelationFrom", fields: [fromEntityId], references: [id], onDelete: Cascade)
-  toEntity     Entity       @relation("RelationTo", fields: [toEntityId], references: [id], onDelete: Cascade)
-  relationType RelationType @relation(fields: [relationTypeId], references: [id])
+  fromEntity   Entity                   @relation("RelationFrom", fields: [fromEntityId], references: [id], onDelete: Cascade)
+  toEntity     Entity                   @relation("RelationTo", fields: [toEntityId], references: [id], onDelete: Cascade)
+  relationType RelationType             @relation(fields: [relationTypeId], references: [id])
+  evidence     EntityRelationEvidence[]
 
   @@unique([fromEntityId, toEntityId, relationTypeId])
   @@map("entity_relation")
+}
+
+/// Provenance link: a canonical entity was observed in a ticker-scoped data source.
+model EntityEvidence {
+  id           String   @id @default(uuid())
+  entityId     String   @map("entity_id")
+  dataSourceId String   @map("data_source_id")
+  tickerId     String   @map("ticker_id")
+  confidence   Float?
+  createdAt    DateTime @default(now()) @map("created_at")
+  lastSeenAt   DateTime @default(now()) @map("last_seen_at")
+
+  entity     Entity     @relation(fields: [entityId], references: [id], onDelete: Cascade)
+  dataSource DataSource @relation(fields: [dataSourceId], references: [id], onDelete: Cascade)
+  ticker     Ticker     @relation(fields: [tickerId], references: [id], onDelete: Cascade)
+
+  @@unique([entityId, dataSourceId, tickerId])
+  @@index([tickerId, dataSourceId])
+  @@index([dataSourceId])
+  @@map("entity_evidence")
+}
+
+/// Provenance link: a canonical entity relation was observed in a ticker-scoped data source.
+model EntityRelationEvidence {
+  id               String   @id @default(uuid())
+  entityRelationId String   @map("entity_relation_id")
+  dataSourceId     String   @map("data_source_id")
+  tickerId         String   @map("ticker_id")
+  confidence       Float?
+  evidenceSpan     String?  @map("evidence_span")
+  createdAt        DateTime @default(now()) @map("created_at")
+  lastSeenAt       DateTime @default(now()) @map("last_seen_at")
+
+  entityRelation EntityRelation @relation(fields: [entityRelationId], references: [id], onDelete: Cascade)
+  dataSource     DataSource     @relation(fields: [dataSourceId], references: [id], onDelete: Cascade)
+  ticker         Ticker         @relation(fields: [tickerId], references: [id], onDelete: Cascade)
+
+  @@unique([entityRelationId, dataSourceId, tickerId])
+  @@index([tickerId, dataSourceId])
+  @@index([dataSourceId])
+  @@map("entity_relation_evidence")
 }
 
 /// Join table connecting an article to entities it mentions with extraction metadata.
@@ -230,21 +275,21 @@ model ArticleRelevance {
 }
 
 model SearchQuery {
-  id        String   @id @default(uuid())
+  id        String            @id @default(uuid())
   text      String
-  tickerId  String   @map("ticker_id")
-  setId     String?  @map("set_id")
+  tickerId  String            @map("ticker_id")
+  setId     String?           @map("set_id")
   source    SearchQuerySource @default(deterministic)
   intent    SearchQueryIntent @default(breaking)
-  rank      Int      @default(1)
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  rank      Int               @default(1)
+  createdAt DateTime          @default(now()) @map("created_at")
+  updatedAt DateTime          @updatedAt @map("updated_at")
 
-  ticker      Ticker       @relation(fields: [tickerId], references: [id])
-  set         SearchQuerySet? @relation(fields: [setId], references: [id], onDelete: SetNull)
-  dataSources DataSource[]
-  dataCollectionFailures  DataCollectionFailure[]
-  searchQueryYields       SearchQueryYield[]
+  ticker                 Ticker                  @relation(fields: [tickerId], references: [id])
+  set                    SearchQuerySet?         @relation(fields: [setId], references: [id], onDelete: SetNull)
+  dataSources            DataSource[]
+  dataCollectionFailures DataCollectionFailure[]
+  searchQueryYields      SearchQueryYield[]
 
   @@unique([setId, text])
   @@index([tickerId, setId])
@@ -255,7 +300,7 @@ model SearchQuery {
 model SearchQueryYield {
   id                String   @id @default(uuid())
   searchQueryId     String   @map("search_query_id")
-  runDate           DateTime @db.Date @map("run_date")
+  runDate           DateTime @map("run_date") @db.Date
   articleCount      Int      @map("article_count")
   novelArticleCount Int      @map("novel_article_count")
   computedAt        DateTime @default(now()) @map("computed_at")
@@ -278,7 +323,7 @@ model SearchQuerySet {
   createdAt        DateTime @default(now()) @map("created_at")
   updatedAt        DateTime @updatedAt @map("updated_at")
 
-  ticker       Ticker        @relation(fields: [tickerId], references: [id], onDelete: Cascade)
+  ticker        Ticker        @relation(fields: [tickerId], references: [id], onDelete: Cascade)
   searchQueries SearchQuery[]
 
   @@index([tickerId, isActive])
@@ -293,17 +338,19 @@ model Ticker {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
 
-  searchQueries     SearchQuery[]
-  searchQuerySets   SearchQuerySet[]
-  dataSources       DataSource[]
-  newsletters       Newsletter[]
-  userTickers       UserTicker[]
-  tickerEntities    TickerEntity[]
-  articleRelevances ArticleRelevance[]
-  dataCollectionRuns        DataCollectionRun[]
-  dataCollectionFailures    DataCollectionFailure[]
-  deliveryRuns              DeliveryRun[]
-  contentGenerationRuns     ContentGenerationRun[]
+  searchQueries          SearchQuery[]
+  searchQuerySets        SearchQuerySet[]
+  dataSources            DataSource[]
+  newsletters            Newsletter[]
+  userTickers            UserTicker[]
+  tickerEntities         TickerEntity[]
+  articleRelevances      ArticleRelevance[]
+  entityEvidence         EntityEvidence[]
+  entityRelationEvidence EntityRelationEvidence[]
+  dataCollectionRuns     DataCollectionRun[]
+  dataCollectionFailures DataCollectionFailure[]
+  deliveryRuns           DeliveryRun[]
+  contentGenerationRuns  ContentGenerationRun[]
 
   @@map("ticker")
 }
@@ -322,17 +369,17 @@ model MediapulseUser {
 }
 
 model UserTicker {
-  id        String   @id @default(uuid())
-  userId    String   @map("user_id")
-  tickerId  String   @map("ticker_id")
-  enabled   Boolean  @default(true)
+  id                      String    @id @default(uuid())
+  userId                  String    @map("user_id")
+  tickerId                String    @map("ticker_id")
+  enabled                 Boolean   @default(true)
   registrationConfirmedAt DateTime? @map("registration_confirmed_at")
   /// When the user voluntarily unsubscribed (null for admin/manual disables).
-  unsubscribedAt    DateTime? @map("unsubscribed_at")
+  unsubscribedAt          DateTime? @map("unsubscribed_at")
   /// How the user unsubscribed: "link" (GET) or "one_click" (POST). Null for admin/manual.
-  unsubscribeMethod String?   @map("unsubscribe_method")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  unsubscribeMethod       String?   @map("unsubscribe_method")
+  createdAt               DateTime  @default(now()) @map("created_at")
+  updatedAt               DateTime  @updatedAt @map("updated_at")
 
   user                MediapulseUser                 @relation(fields: [userId], references: [id], onDelete: Cascade)
   ticker              Ticker                         @relation(fields: [tickerId], references: [id], onDelete: Cascade)
@@ -379,27 +426,27 @@ enum DeliveryRecipientOutcomeStatus {
 }
 
 model DeliveryRun {
-  id                    String              @id @default(uuid())
-  agentId               String              @map("agent_id")
-  agentVersion          String              @map("agent_version")
-  tickerId              String              @map("ticker_id")
-  newsletterId          String?             @map("newsletter_id")
+  id                    String             @id @default(uuid())
+  agentId               String             @map("agent_id")
+  agentVersion          String             @map("agent_version")
+  tickerId              String             @map("ticker_id")
+  newsletterId          String?            @map("newsletter_id")
   outcome               DeliveryRunOutcome
   stage                 DeliveryRunStage?
-  successCount          Int                 @default(0) @map("success_count")
-  failureCount          Int                 @default(0) @map("failure_count")
-  skippedCount          Int                 @default(0) @map("skipped_count")
-  durationMs            Int                 @map("duration_ms")
-  scheduleExecutionId   String?             @map("schedule_execution_id")
+  successCount          Int                @default(0) @map("success_count")
+  failureCount          Int                @default(0) @map("failure_count")
+  skippedCount          Int                @default(0) @map("skipped_count")
+  durationMs            Int                @map("duration_ms")
+  scheduleExecutionId   String?            @map("schedule_execution_id")
   /// Hermes `Schedule.id` from `X-Schedule-Id` (distinct from schedule execution row).
-  hermesScheduleId      String?             @map("hermes_schedule_id")
-  pipelineStepId        String?             @map("pipeline_step_id")
-  jobId                 String?             @map("job_id")
-  hermesExecutionId     String?             @map("hermes_execution_id")
-  runSkipReason         String?             @map("run_skip_reason")
-  resendMessageIds      Json?               @map("resend_message_ids")
-  recipientErrorSummary String?             @map("recipient_error_summary")
-  createdAt             DateTime            @default(now()) @map("created_at")
+  hermesScheduleId      String?            @map("hermes_schedule_id")
+  pipelineStepId        String?            @map("pipeline_step_id")
+  jobId                 String?            @map("job_id")
+  hermesExecutionId     String?            @map("hermes_execution_id")
+  runSkipReason         String?            @map("run_skip_reason")
+  resendMessageIds      Json?              @map("resend_message_ids")
+  recipientErrorSummary String?            @map("recipient_error_summary")
+  createdAt             DateTime           @default(now()) @map("created_at")
 
   ticker     Ticker                     @relation(fields: [tickerId], references: [id])
   newsletter Newsletter?                @relation(fields: [newsletterId], references: [id], onDelete: SetNull)
@@ -415,11 +462,11 @@ model DeliveryRecipientOutcome {
   runId            String                         @map("run_id")
   userTickerId     String                         @map("user_ticker_id")
   status           DeliveryRecipientOutcomeStatus
-  attempts         Int     @default(0)
-  lastErrorCode    String? @map("last_error_code")
-  lastErrorMessage String? @map("last_error_message")
-  errorCategory    String? @map("error_category")
-  resendEmailId    String? @map("resend_email_id")
+  attempts         Int                            @default(0)
+  lastErrorCode    String?                        @map("last_error_code")
+  lastErrorMessage String?                        @map("last_error_message")
+  errorCategory    String?                        @map("error_category")
+  resendEmailId    String?                        @map("resend_email_id")
 
   run DeliveryRun @relation(fields: [runId], references: [id], onDelete: Cascade)
 
@@ -455,45 +502,45 @@ enum DataCollectionErrorCategory {
 }
 
 model DataCollectionRun {
-  id            String   @id @default(uuid())
-  tickerId      String   @map("ticker_id")
-  startedAt     DateTime @map("started_at")
-  completedAt   DateTime? @map("completed_at")
-  status        DataCollectionRunStatus
-  
-  queriesTotal  Int      @default(0) @map("queries_total")
-  urlsTotal     Int      @default(0) @map("urls_total")
-  searchSuccess Int      @default(0) @map("search_success")
-  searchFailed  Int      @default(0) @map("search_failed")
-  fetchSuccess  Int      @default(0) @map("fetch_success")
-  fetchFailed   Int      @default(0) @map("fetch_failed")
-  retryCount    Int      @default(0) @map("retry_count")
+  id          String                  @id @default(uuid())
+  tickerId    String                  @map("ticker_id")
+  startedAt   DateTime                @map("started_at")
+  completedAt DateTime?               @map("completed_at")
+  status      DataCollectionRunStatus
 
-  ticker        Ticker   @relation(fields: [tickerId], references: [id])
-  failures      DataCollectionFailure[]
+  queriesTotal  Int @default(0) @map("queries_total")
+  urlsTotal     Int @default(0) @map("urls_total")
+  searchSuccess Int @default(0) @map("search_success")
+  searchFailed  Int @default(0) @map("search_failed")
+  fetchSuccess  Int @default(0) @map("fetch_success")
+  fetchFailed   Int @default(0) @map("fetch_failed")
+  retryCount    Int @default(0) @map("retry_count")
+
+  ticker   Ticker                  @relation(fields: [tickerId], references: [id])
+  failures DataCollectionFailure[]
 
   @@map("data_collection_run")
 }
 
 model DataCollectionFailure {
-  id            String   @id @default(uuid())
-  runId         String   @map("run_id")
-  tickerId      String   @map("ticker_id")
-  stage         DataCollectionProviderStage
-  provider      DataCollectionProvider
-  
-  searchQueryId String?  @map("search_query_id")
+  id       String                      @id @default(uuid())
+  runId    String                      @map("run_id")
+  tickerId String                      @map("ticker_id")
+  stage    DataCollectionProviderStage
+  provider DataCollectionProvider
+
+  searchQueryId String? @map("search_query_id")
   url           String?
-  
+
   errorCategory DataCollectionErrorCategory @map("error_category")
   retryable     Boolean
-  httpStatus    Int?     @map("http_status")
+  httpStatus    Int?                        @map("http_status")
   message       String
-  createdAt     DateTime @default(now()) @map("created_at")
+  createdAt     DateTime                    @default(now()) @map("created_at")
 
-  run           DataCollectionRun @relation(fields: [runId], references: [id], onDelete: Cascade)
-  ticker        Ticker            @relation(fields: [tickerId], references: [id])
-  searchQuery   SearchQuery?      @relation(fields: [searchQueryId], references: [id])
+  run         DataCollectionRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  ticker      Ticker            @relation(fields: [tickerId], references: [id])
+  searchQuery SearchQuery?      @relation(fields: [searchQueryId], references: [id])
 
   @@map("data_collection_failure")
 }
@@ -513,20 +560,20 @@ enum ContentGenerationRunStage {
 
 /// Diagnostic record for a single content-generation agent invocation.
 model ContentGenerationRun {
-  id              String                       @id @default(uuid())
-  agentId         String                       @map("agent_id")
-  agentVersion    String                       @map("agent_version")
-  tickerId        String                       @map("ticker_id")
-  outcome         ContentGenerationRunOutcome
-  stage           ContentGenerationRunStage?   @map("stage")
-  errorCode       String?                      @map("error_code")
-  errorCategory   String?                      @map("error_category")
-  message         String?
-  durationMs      Int?                         @map("duration_ms")
-  pipelineRunId   String?                      @map("pipeline_run_id")
-  executionId     String?                      @map("execution_id")
-  newsletterId    String?                      @map("newsletter_id")
-  createdAt       DateTime                     @default(now()) @map("created_at")
+  id            String                      @id @default(uuid())
+  agentId       String                      @map("agent_id")
+  agentVersion  String                      @map("agent_version")
+  tickerId      String                      @map("ticker_id")
+  outcome       ContentGenerationRunOutcome
+  stage         ContentGenerationRunStage?  @map("stage")
+  errorCode     String?                     @map("error_code")
+  errorCategory String?                     @map("error_category")
+  message       String?
+  durationMs    Int?                        @map("duration_ms")
+  pipelineRunId String?                     @map("pipeline_run_id")
+  executionId   String?                     @map("execution_id")
+  newsletterId  String?                     @map("newsletter_id")
+  createdAt     DateTime                    @default(now()) @map("created_at")
 
   ticker Ticker @relation(fields: [tickerId], references: [id])
 

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -331,6 +331,8 @@ describe("createAgentDataApiClient", () => {
       relations: [],
       articleEntities: [],
       articleRelevances: [],
+      entityEvidence: [],
+      relationEvidence: [],
     });
 
     expect(postFn).toHaveBeenCalledWith(
@@ -342,6 +344,8 @@ describe("createAgentDataApiClient", () => {
           relations: [],
           articleEntities: [],
           articleRelevances: [],
+          entityEvidence: [],
+          relationEvidence: [],
         },
       }),
     );

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -314,6 +314,8 @@ describe("createAgentDataApiClient", () => {
         relationsCreated: 0,
         articlesScored: 0,
         articlesSelected: 0,
+        entityEvidenceUpserted: 0,
+        relationEvidenceUpserted: 0,
       }),
       statusCode: 200,
     });

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -107,6 +107,29 @@ export const postAnalysisBodySchema = z.object({
       }),
     )
     .default([]),
+  /** Provenance: entity observed in a data source for this ticker. */
+  entityEvidence: z
+    .array(
+      z.object({
+        dataSourceId: z.string().uuid(),
+        entityName: z.string().trim().min(1),
+        confidence: z.number().min(0).max(1).nullish(),
+      }),
+    )
+    .default([]),
+  /** Provenance: relation observed in a data source for this ticker. */
+  relationEvidence: z
+    .array(
+      z.object({
+        dataSourceId: z.string().uuid(),
+        fromEntityName: z.string().trim().min(1),
+        toEntityName: z.string().trim().min(1),
+        relationTypeId: z.string().uuid(),
+        confidence: z.number().min(0).max(1).nullish(),
+        evidenceSpan: z.string().max(280).nullish(),
+      }),
+    )
+    .default([]),
 });
 
 export const analysisDataSourceSchema = z.object({
@@ -166,6 +189,8 @@ export const postAnalysisResponseSchema = z.object({
   relationsCreated: z.number().int().nonnegative(),
   articlesScored: z.number().int().nonnegative(),
   articlesSelected: z.number().int().nonnegative(),
+  entityEvidenceUpserted: z.number().int().nonnegative(),
+  relationEvidenceUpserted: z.number().int().nonnegative(),
 });
 
 export type GetAnalysisQuery = z.infer<typeof getAnalysisQuerySchema>;


### PR DESCRIPTION
## Summary

Entities and relations in Mediapulse are deduped globally, so we had no durable link back to the article (data source) or ticker that produced them. This PR adds evidence join tables and threads provenance through the article-analysis POST pipeline while leaving the canonical KG tables alone.

## Related issues

Closes #614

## Important changes

- Add `EntityEvidence` and `EntityRelationEvidence` Prisma models plus migration with unique `(entity|relation, dataSource, ticker)` keys
- Extend analysis POST contract with `entityEvidence` / `relationEvidence` arrays and `entityEvidenceUpserted` / `relationEvidenceUpserted` response counts
- `applyAnalysisPost` upserts evidence after relations resolve; validates data source IDs against the ticker
- article-analysis builds per-source provenance from capped extractions, merges at run level, and partitions evidence into entity-relation POST chunks
- Relation critique `evidenceSpan` is stored on relation evidence when the critique pass ran

## Other changes

- Mention and relevance chunk builders send empty evidence arrays for schema compatibility
- Unit tests for provenance helpers, chunk partitioning, and API upsert behavior

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` — new evidence models and relations
- `packages/shared/agent-data-api-contract/src/analysis.ts` — POST body/response contract
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — evidence upsert persistence
- `apps/mediapulse/agents/article-analysis/src/analysis-provenance.ts` — per-source and run-level provenance helpers
- `apps/mediapulse/agents/article-analysis/src/run.ts` — wires evidence into chunk POST flow

## How to test

1. Apply migration: `pnpm --filter @mediapulse/database db:migrate:dev`
2. Run targeted tests:
   - `pnpm --filter @mediapulse/agent-data-api test -- src/services/analysis.test.ts`
   - `pnpm --filter @mediapulse/article-analysis exec vitest run src/analysis-provenance.test.ts src/build-analysis-post-chunks.test.ts`
3. Run an article-analysis extraction against a ticker with known articles and confirm `entity_evidence` / `entity_relation_evidence` rows appear for the expected `data_source_id` and `ticker_id`.
