### PR TITLE
Show entity and relation evidence on Hermes detail pages

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts
@@ -2,7 +2,7 @@
  * Hermes `table-v1` manifest for canonical knowledge-graph entities (read-only list + detail).
  */
 
-import type { DashboardPageInput } from "@hermes/domain-contract";
+import type { DashboardPageInput, DetailBlock } from "@hermes/domain-contract";
 import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
 import {
   columnsFor,
@@ -13,6 +13,44 @@ import { entitiesCustomActionsForManifest } from "./custom-actions";
 
 /** URL path segment for this resource under `/v1/hermes-dashboard/`. */
 export const entitiesHermesPathSegment = "entities" as const;
+
+const entitiesMetadataBlock = {
+  type: "keyValue",
+  label: "Metadata",
+  rows: [
+    { field: "id", label: "Entity id", copyAction: true },
+    { field: "canonicalName", label: "Name", copyAction: true },
+    { field: "entityTypeName", label: "Type" },
+    { field: "typeId", label: "Type id", copyAction: true },
+    { field: "createdAt", label: "Created", format: "date-time" },
+    { field: "updatedAt", label: "Updated", format: "date-time" },
+  ],
+} satisfies DetailBlock;
+
+const entitiesDescriptionBlock = {
+  type: "markdown",
+  label: "Description",
+  field: "description",
+} satisfies DetailBlock;
+
+const entitiesEvidenceBlock = {
+  type: "subTable",
+  label: "Evidence",
+  field: "evidence",
+  captionTemplate: "Evidence ({evidence.length} sources)",
+  emptyState: "No provenance evidence recorded for this entity.",
+  columns: [
+    {
+      field: "title",
+      label: "Source",
+      type: "text",
+      truncate: 80,
+      linkTemplate: "/dashboard/{integrationId}/data-sources/{id}",
+    },
+    { field: "confidence", label: "Confidence", type: "number" },
+    { field: "lastSeenAt", label: "Last seen", type: "date-time" },
+  ],
+} satisfies DetailBlock;
 
 /** Hermes `table-v1` manifest page for KG entities. */
 export const entitiesDashboardPage = {
@@ -42,4 +80,9 @@ export const entitiesDashboardPage = {
   ]),
   actions: { create: false, update: false, delete: false, view: true },
   customActions: entitiesCustomActionsForManifest,
+  detailBlocks: [
+    entitiesMetadataBlock,
+    entitiesDescriptionBlock,
+    entitiesEvidenceBlock,
+  ],
 } satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entities/detail-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/detail-mapper.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for entity detail mapping with provenance evidence.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { DetailRow } from "./detail-mapper";
+import { mapEvidenceRow, mapRowToDetailItem } from "./detail-mapper";
+
+const buildEvidenceRow = (
+  overrides: Partial<DetailRow["entityEvidence"][number]> = {},
+): DetailRow["entityEvidence"][number] => ({
+  id: "evidence-1",
+  entityId: "ent-1",
+  dataSourceId: "ds-1",
+  tickerId: "ticker-1",
+  confidence: 0.82,
+  createdAt: new Date("2024-05-01T00:00:00.000Z"),
+  lastSeenAt: new Date("2024-06-01T00:00:00.000Z"),
+  dataSource: {
+    id: "ds-1",
+    title: "Example article",
+    url: "https://example.com/article",
+  },
+  ...overrides,
+});
+
+const buildDetailRow = (
+  evidence: DetailRow["entityEvidence"] = [],
+): DetailRow =>
+  ({
+    id: "ent-1",
+    typeId: "type-1",
+    canonicalName: "Example Co",
+    description: "A company",
+    metadata: null,
+    createdAt: new Date("2024-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2024-04-02T00:00:00.000Z"),
+    type: { name: "ORG" },
+    entityEvidence: evidence,
+  }) as DetailRow;
+
+describe("mapEvidenceRow", () => {
+  it("maps data source link fields and timestamps", () => {
+    const row = buildEvidenceRow();
+
+    const item = mapEvidenceRow(row);
+
+    expect(item).toEqual({
+      id: "ds-1",
+      title: "Example article",
+      url: "https://example.com/article",
+      confidence: 0.82,
+      lastSeenAt: "2024-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("preserves null confidence", () => {
+    const item = mapEvidenceRow(buildEvidenceRow({ confidence: null }));
+
+    expect(item.confidence).toBeNull();
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("returns empty evidence when none is linked", () => {
+    const detail = mapRowToDetailItem(buildDetailRow());
+
+    expect(detail.evidence).toEqual([]);
+    expect(detail.canonicalName).toBe("Example Co");
+    expect(detail.entityTypeName).toBe("ORG");
+  });
+
+  it("maps multiple evidence rows in query order", () => {
+    const detail = mapRowToDetailItem(
+      buildDetailRow([
+        buildEvidenceRow({
+          id: "evidence-newer",
+          lastSeenAt: new Date("2024-07-01T00:00:00.000Z"),
+          dataSource: {
+            id: "ds-newer",
+            title: "Newer article",
+            url: "https://example.com/newer",
+          },
+        }),
+        buildEvidenceRow({
+          id: "evidence-older",
+          lastSeenAt: new Date("2024-05-01T00:00:00.000Z"),
+          dataSource: {
+            id: "ds-older",
+            title: "Older article",
+            url: "https://example.com/older",
+          },
+        }),
+      ]),
+    );
+
+    expect(detail.evidence).toHaveLength(2);
+    expect(detail.evidence[0]?.id).toBe("ds-newer");
+    expect(detail.evidence[1]?.id).toBe("ds-older");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entities/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/detail-mapper.ts
@@ -1,0 +1,75 @@
+/**
+ * Detail payload mapper for entity read views, including provenance evidence rows.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/**
+ * `include` passed to `entity.findUnique` for Hermes detail pages.
+ */
+export const detailInclude = {
+  type: {
+    select: {
+      name: true,
+    },
+  },
+  entityEvidence: {
+    orderBy: {
+      lastSeenAt: "desc" as const,
+    },
+    include: {
+      dataSource: {
+        select: {
+          id: true,
+          title: true,
+          url: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.EntityInclude;
+
+/**
+ * Prisma row shape for `entity.findUnique` when loading the detail view.
+ */
+export type DetailRow = Prisma.EntityGetPayload<{
+  include: typeof detailInclude;
+}>;
+
+/**
+ * Maps one entity evidence join row to a Hermes `subTable` item.
+ *
+ * @param row - Evidence row with joined data source from {@link detailInclude}.
+ * @returns Serializable evidence row for the detail payload.
+ */
+export const mapEvidenceRow = (row: DetailRow["entityEvidence"][number]) => ({
+  id: row.dataSource.id,
+  title: row.dataSource.title,
+  url: row.dataSource.url,
+  confidence: row.confidence,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+});
+
+/** JSON evidence row type; derived from {@link mapEvidenceRow}. */
+export type EvidenceItem = ReturnType<typeof mapEvidenceRow>;
+
+/**
+ * Maps an entity row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entity.findUnique` using {@link detailInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: DetailRow) => ({
+  id: row.id,
+  typeId: row.typeId,
+  entityTypeName: row.type.name,
+  canonicalName: row.canonicalName,
+  description: row.description,
+  metadata: row.metadata,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+  evidence: row.entityEvidence.map(mapEvidenceRow),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.test.ts
@@ -7,7 +7,6 @@ import { describe, expect, it } from "vitest";
 import type { ListRow } from "./list-mapper";
 import {
   ENTITY_DESCRIPTION_PREVIEW_MAX,
-  mapRowToDetailItem,
   mapRowToListItem,
   truncateDescriptionPreview,
 } from "./list-mapper";
@@ -49,29 +48,5 @@ describe("mapRowToListItem", () => {
     expect(item.entityTypeName).toBe("ORG");
     expect(item.descriptionPreview).toBe("Short");
     expect(item.createdAt).toBe("2024-04-01T12:00:00.000Z");
-  });
-});
-
-describe("mapRowToDetailItem", () => {
-  it("includes metadata and type id", () => {
-    const createdAt = new Date("2024-04-01T00:00:00.000Z");
-    const updatedAt = new Date("2024-04-02T00:00:00.000Z");
-    const row = {
-      id: "ent-2",
-      typeId: "type-9",
-      canonicalName: "Other",
-      description: null,
-      metadata: { tier: 1 },
-      createdAt,
-      updatedAt,
-      type: { name: "PERSON" },
-    } as ListRow;
-
-    const detail = mapRowToDetailItem(row);
-
-    expect(detail.typeId).toBe("type-9");
-    expect(detail.metadata).toEqual({ tier: 1 });
-    expect(detail.entityTypeName).toBe("PERSON");
-    expect(detail.description).toBeNull();
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/list-mapper.ts
@@ -64,23 +64,3 @@ export const mapRowToListItem = (row: ListRow) => ({
 
 /** JSON list item type; derived from {@link mapRowToListItem}. */
 export type ListItem = ReturnType<typeof mapRowToListItem>;
-
-/**
- * Maps an entity row to the JSON detail payload (GET by id).
- *
- * @param row - Row from `prisma.entity.findUnique` using {@link listInclude}.
- * @returns Serializable detail record for the Hermes read-only detail page.
- */
-export const mapRowToDetailItem = (row: ListRow) => ({
-  id: row.id,
-  typeId: row.typeId,
-  entityTypeName: row.type.name,
-  canonicalName: row.canonicalName,
-  description: row.description,
-  metadata: row.metadata,
-  createdAt: row.createdAt.toISOString(),
-  updatedAt: row.updatedAt.toISOString(),
-});
-
-/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
-export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entities/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entities/routes.ts
@@ -9,11 +9,8 @@ import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates
 import { registerTableV1CustomActionRoutes } from "../../hermes-dashboard/templates/table-v1/register-table-v1-custom-actions";
 import { parsePagination } from "../../lib/list-pagination";
 import { entitiesTableV1CustomActionRegistrations } from "./custom-actions";
-import {
-  listInclude,
-  mapRowToDetailItem,
-  mapRowToListItem,
-} from "./list-mapper";
+import { detailInclude, mapRowToDetailItem } from "./detail-mapper";
+import { listInclude, mapRowToListItem } from "./list-mapper";
 import { entitiesHermesPathSegment } from "./dashboard-page";
 
 /**
@@ -110,7 +107,7 @@ entitiesRoutes.get("/meta", (c) => {
 entitiesRoutes.get("/:id", async (c) => {
   const row = await prisma.entity.findUnique({
     where: { id: c.req.param("id") },
-    include: listInclude,
+    include: detailInclude,
   } satisfies Prisma.EntityFindUniqueArgs);
 
   if (!row) {

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts
@@ -2,7 +2,7 @@
  * Hermes `table-v1` manifest for knowledge-graph entity relations (CRUD list + detail).
  */
 
-import type { DashboardPageInput } from "@hermes/domain-contract";
+import type { DashboardPageInput, DetailBlock } from "@hermes/domain-contract";
 import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
 import {
   columnsFor,
@@ -17,6 +17,47 @@ import {
 
 /** URL path segment for this resource under `/v1/hermes-dashboard/`. */
 export const entityRelationsHermesPathSegment = "entity-relations" as const;
+
+const entityRelationsMetadataBlock = {
+  type: "keyValue",
+  label: "Metadata",
+  rows: [
+    { field: "id", label: "Relation id", copyAction: true },
+    {
+      field: "fromEntityName",
+      label: "From",
+      linkTemplate: "/dashboard/{integrationId}/entities/{fromEntityId}",
+    },
+    {
+      field: "toEntityName",
+      label: "To",
+      linkTemplate: "/dashboard/{integrationId}/entities/{toEntityId}",
+    },
+    { field: "relationTypeName", label: "Relation type" },
+    { field: "weight", label: "Weight", format: "text" },
+    { field: "lastSeenAt", label: "Last seen", format: "date-time" },
+    { field: "createdAt", label: "Created", format: "date-time" },
+  ],
+} satisfies DetailBlock;
+
+const entityRelationsEvidenceBlock = {
+  type: "subTable",
+  label: "Evidence",
+  field: "evidence",
+  captionTemplate: "Evidence ({evidence.length} sources)",
+  emptyState: "No provenance evidence recorded for this relation.",
+  columns: [
+    {
+      field: "title",
+      label: "Source",
+      type: "text",
+      truncate: 80,
+      linkTemplate: "/dashboard/{integrationId}/data-sources/{id}",
+    },
+    { field: "confidence", label: "Confidence", type: "number" },
+    { field: "lastSeenAt", label: "Last seen", type: "date-time" },
+  ],
+} satisfies DetailBlock;
 
 /** Hermes `table-v1` manifest page for KG entity relations (edges). */
 export const entityRelationsDashboardPage = {
@@ -53,4 +94,5 @@ export const entityRelationsDashboardPage = {
   createSchema: entityRelationCreateFormJsonSchema,
   updateSchema: entityRelationUpdateFormJsonSchema,
   customActions: entityRelationsCustomActionsForManifest,
+  detailBlocks: [entityRelationsMetadataBlock, entityRelationsEvidenceBlock],
 } satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/detail-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/detail-mapper.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for entity-relation detail mapping with provenance evidence.
+ */
+
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import type { DetailRow } from "./detail-mapper";
+import { mapEvidenceRow, mapRowToDetailItem } from "./detail-mapper";
+
+const buildEvidenceRow = (
+  overrides: Partial<DetailRow["evidence"][number]> = {},
+): DetailRow["evidence"][number] => ({
+  id: "evidence-1",
+  entityRelationId: "rel-1",
+  dataSourceId: "ds-1",
+  tickerId: "ticker-1",
+  confidence: 0.91,
+  evidenceSpan: "Company A acquired Company B",
+  createdAt: new Date("2024-05-01T00:00:00.000Z"),
+  lastSeenAt: new Date("2024-06-01T00:00:00.000Z"),
+  dataSource: {
+    id: "ds-1",
+    title: "Acquisition report",
+    url: "https://example.com/acquisition",
+  },
+  ...overrides,
+});
+
+const buildDetailRow = (evidence: DetailRow["evidence"] = []): DetailRow =>
+  ({
+    id: "rel-1",
+    fromEntityId: "from-1",
+    toEntityId: "to-1",
+    relationTypeId: "type-1",
+    weight: 0.75,
+    lastSeenAt: new Date("2024-08-01T00:00:00.000Z"),
+    createdAt: new Date("2024-07-01T00:00:00.000Z"),
+    fromEntity: { id: "from-1", canonicalName: "Parent Inc" },
+    toEntity: { id: "to-1", canonicalName: "Child LLC" },
+    relationType: { name: "SUBSIDIARY_OF" },
+    evidence,
+  }) as DetailRow;
+
+describe("mapEvidenceRow", () => {
+  it("maps data source link fields and timestamps", () => {
+    const item = mapEvidenceRow(buildEvidenceRow());
+
+    expect(item).toEqual({
+      id: "ds-1",
+      title: "Acquisition report",
+      url: "https://example.com/acquisition",
+      confidence: 0.91,
+      lastSeenAt: "2024-06-01T00:00:00.000Z",
+    });
+  });
+
+  it("preserves null confidence", () => {
+    const item = mapEvidenceRow(buildEvidenceRow({ confidence: null }));
+
+    expect(item.confidence).toBeNull();
+  });
+});
+
+describe("mapRowToDetailItem", () => {
+  it("returns empty evidence when none is linked", () => {
+    const detail = mapRowToDetailItem(buildDetailRow());
+
+    expect(detail.evidence).toEqual([]);
+    expect(detail.fromEntityName).toBe("Parent Inc");
+    expect(detail.relationTypeName).toBe("SUBSIDIARY_OF");
+  });
+
+  it("maps multiple evidence rows in query order", () => {
+    const detail = mapRowToDetailItem(
+      buildDetailRow([
+        buildEvidenceRow({
+          id: "evidence-newer",
+          lastSeenAt: new Date("2024-07-01T00:00:00.000Z"),
+          dataSource: {
+            id: "ds-newer",
+            title: "Newer article",
+            url: "https://example.com/newer",
+          },
+        }),
+        buildEvidenceRow({
+          id: "evidence-older",
+          lastSeenAt: new Date("2024-05-01T00:00:00.000Z"),
+          dataSource: {
+            id: "ds-older",
+            title: "Older article",
+            url: "https://example.com/older",
+          },
+        }),
+      ]),
+    );
+
+    expect(detail.evidence).toHaveLength(2);
+    expect(detail.evidence[0]?.id).toBe("ds-newer");
+    expect(detail.evidence[1]?.id).toBe("ds-older");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/detail-mapper.ts
@@ -1,0 +1,89 @@
+/**
+ * Detail payload mapper for entity-relation read views, including provenance evidence rows.
+ */
+
+import type { Prisma } from "@mediapulse/database";
+
+/**
+ * `include` passed to `entityRelation.findUnique` for Hermes detail pages.
+ */
+export const detailInclude = {
+  fromEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  toEntity: {
+    select: {
+      id: true,
+      canonicalName: true,
+    },
+  },
+  relationType: {
+    select: {
+      name: true,
+    },
+  },
+  evidence: {
+    orderBy: {
+      lastSeenAt: "desc" as const,
+    },
+    include: {
+      dataSource: {
+        select: {
+          id: true,
+          title: true,
+          url: true,
+        },
+      },
+    },
+  },
+} satisfies Prisma.EntityRelationInclude;
+
+/**
+ * Prisma row shape for `entityRelation.findUnique` when loading the detail view.
+ */
+export type DetailRow = Prisma.EntityRelationGetPayload<{
+  include: typeof detailInclude;
+}>;
+
+/**
+ * Maps one relation evidence join row to a Hermes `subTable` item.
+ *
+ * @param row - Evidence row with joined data source from {@link detailInclude}.
+ * @returns Serializable evidence row for the detail payload.
+ */
+export const mapEvidenceRow = (row: DetailRow["evidence"][number]) => ({
+  id: row.dataSource.id,
+  title: row.dataSource.title,
+  url: row.dataSource.url,
+  confidence: row.confidence,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+});
+
+/** JSON evidence row type; derived from {@link mapEvidenceRow}. */
+export type EvidenceItem = ReturnType<typeof mapEvidenceRow>;
+
+/**
+ * Maps an entity-relation row to the JSON detail payload (GET by id).
+ *
+ * @param row - Row from `prisma.entityRelation.findUnique` using {@link detailInclude}.
+ * @returns Serializable detail record for the Hermes read-only detail page.
+ */
+export const mapRowToDetailItem = (row: DetailRow) => ({
+  id: row.id,
+  fromEntityId: row.fromEntityId,
+  toEntityId: row.toEntityId,
+  relationTypeId: row.relationTypeId,
+  fromEntityName: row.fromEntity.canonicalName,
+  toEntityName: row.toEntity.canonicalName,
+  relationTypeName: row.relationType.name,
+  weight: row.weight,
+  lastSeenAt: row.lastSeenAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+  evidence: row.evidence.map(mapEvidenceRow),
+});
+
+/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
+export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.test.ts
@@ -5,7 +5,7 @@
 /** @vitest-environment node */
 import { describe, expect, it } from "vitest";
 import type { ListRow } from "./list-mapper";
-import { mapRowToDetailItem, mapRowToListItem } from "./list-mapper";
+import { mapRowToListItem } from "./list-mapper";
 
 describe("mapRowToListItem", () => {
   it("maps joined names and timestamps", () => {
@@ -32,30 +32,5 @@ describe("mapRowToListItem", () => {
     expect(item.weight).toBe(0.75);
     expect(item.lastSeenAt).toBe("2024-08-01T00:00:00.000Z");
     expect(item.createdAt).toBe("2024-07-01T00:00:00.000Z");
-  });
-});
-
-describe("mapRowToDetailItem", () => {
-  it("includes foreign key ids", () => {
-    const lastSeenAt = new Date("2024-08-01T00:00:00.000Z");
-    const createdAt = new Date("2024-07-01T00:00:00.000Z");
-    const row = {
-      id: "rel-2",
-      fromEntityId: "from",
-      toEntityId: "to",
-      relationTypeId: "rtype",
-      weight: 1,
-      lastSeenAt,
-      createdAt,
-      fromEntity: { id: "from", canonicalName: "A" },
-      toEntity: { id: "to", canonicalName: "B" },
-      relationType: { name: "LINKED" },
-    } as ListRow;
-
-    const detail = mapRowToDetailItem(row);
-
-    expect(detail.fromEntityId).toBe("from");
-    expect(detail.toEntityId).toBe("to");
-    expect(detail.relationTypeId).toBe("rtype");
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/list-mapper.ts
@@ -52,25 +52,3 @@ export const mapRowToListItem = (row: ListRow) => ({
 
 /** JSON list item type; derived from {@link mapRowToListItem}. */
 export type ListItem = ReturnType<typeof mapRowToListItem>;
-
-/**
- * Maps an entity-relation row to the JSON detail payload (GET by id).
- *
- * @param row - Row from `prisma.entityRelation.findUnique` using {@link listInclude}.
- * @returns Serializable detail record for the Hermes read-only detail page.
- */
-export const mapRowToDetailItem = (row: ListRow) => ({
-  id: row.id,
-  fromEntityId: row.fromEntityId,
-  toEntityId: row.toEntityId,
-  relationTypeId: row.relationTypeId,
-  fromEntityName: row.fromEntity.canonicalName,
-  toEntityName: row.toEntity.canonicalName,
-  relationTypeName: row.relationType.name,
-  weight: row.weight,
-  lastSeenAt: row.lastSeenAt.toISOString(),
-  createdAt: row.createdAt.toISOString(),
-});
-
-/** JSON detail item type; derived from {@link mapRowToDetailItem}. */
-export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/entity-relations/routes.ts
@@ -10,11 +10,8 @@ import { registerTableV1CustomActionRoutes } from "../../hermes-dashboard/templa
 import { parsePagination } from "../../lib/list-pagination";
 import { entityRelationsTableV1CustomActionRegistrations } from "./custom-actions";
 import { entityRelationsHermesPathSegment } from "./dashboard-page";
-import {
-  listInclude,
-  mapRowToDetailItem,
-  mapRowToListItem,
-} from "./list-mapper";
+import { detailInclude, mapRowToDetailItem } from "./detail-mapper";
+import { listInclude, mapRowToListItem } from "./list-mapper";
 import { resolveEntityRelationEndpointIds } from "./lib/resolve-entity-relation-endpoints";
 import {
   entityRelationCreateBodySchema,
@@ -234,7 +231,7 @@ entityRelationsRoutes.delete("/:id", async (c) => {
 entityRelationsRoutes.get("/:id", async (c) => {
   const row = await prisma.entityRelation.findUnique({
     where: { id: c.req.param("id") },
-    include: listInclude,
+    include: detailInclude,
   } satisfies Prisma.EntityRelationFindUniqueArgs);
 
   if (!row) {

--- a/dev-docs/docs/hermes/integration/detail-blocks.mdx
+++ b/dev-docs/docs/hermes/integration/detail-blocks.mdx
@@ -168,13 +168,13 @@ Every block accepts an optional `sectionRule` that drives a data-dependent badge
 
 The expression language is intentionally tiny and parsed at render time:
 
-| Form | Example |
-| ---- | ------- |
-| Numeric comparison | `delivered < enabled`, `a >= 5` |
-| Equality | `status == "failed"`, `outcome != "success"` |
-| Length | `selectedSources.length == 0` |
-| Presence | `present(activeQuerySet)`, `absent(newsletter.runId)` |
-| Hours between two ISO-8601 strings | `hoursBetween(a.generatedAt, b.createdAt) > 24` |
+| Form                               | Example                                               |
+| ---------------------------------- | ----------------------------------------------------- |
+| Numeric comparison                 | `delivered < enabled`, `a >= 5`                       |
+| Equality                           | `status == "failed"`, `outcome != "success"`          |
+| Length                             | `selectedSources.length == 0`                         |
+| Presence                           | `present(activeQuerySet)`, `absent(newsletter.runId)` |
+| Hours between two ISO-8601 strings | `hoursBetween(a.generatedAt, b.createdAt) > 24`       |
 
 Anything else (boolean `&&`/`||`, arbitrary function calls, arithmetic, etc.) is rejected so the rules stay declarative metadata. Bad expressions never crash the page — invalid rules silently skip the badge.
 
@@ -189,3 +189,17 @@ Hermes reads `detailBlocks` from the meta response (`tableV1MetaResponseSchema`)
 3. Restart the domain API so the manifest re-registers with Hermes (the manifest is pulled from the orchestration `DomainIntegration` row on dashboard load).
 
 Existing integrations that do not declare `detailBlocks` keep their current behavior — the detail page falls back to the built-in key/value layout.
+
+## Provenance evidence on KG detail pages
+
+Mediapulse entities and entity relations expose provenance rows on their Hermes detail pages. The domain-api detail handlers join `entity_evidence` / `entity_relation_evidence` to data sources and return an `evidence` array on `GET {apiPrefix}/{id}`.
+
+Each evidence row includes:
+
+- `id` — data source id (used by `linkTemplate` to jump to the article detail page)
+- `title` — article title
+- `url` — source URL
+- `confidence` — optional extraction confidence
+- `lastSeenAt` — ISO timestamp refreshed on repeat upserts
+
+The manifest declares a `subTable` block bound to `evidence` with a source link to `/dashboard/{integrationId}/data-sources/{id}`. Hermes renders the table automatically; no per-resource dashboard code is required.


### PR DESCRIPTION
## Summary

Hermes operators can now see provenance evidence on entity and entity-relation detail pages. Domain-api detail handlers join the evidence tables from #614 and return normalized rows; the dashboard manifest declares `subTable` blocks so the generic detail renderer shows source links, confidence, and last seen without new Hermes pages.

## Related issues

Closes #616

Refs #614

## Important changes

- Added `detail-mapper.ts` for entities and entity-relations with typed Prisma includes and evidence row mapping
- Entity and entity-relation GET `/:id` routes use the detail includes instead of list-only shapes
- Dashboard manifests gain metadata blocks plus an Evidence `subTable` linking to data-source detail pages
- Dev docs describe the KG evidence detail-block pattern

## Other changes

- Moved detail mapping out of list mappers into dedicated detail mappers (matches search-query-sets pattern)
- Added co-located unit tests for evidence mapping (empty, multiple rows, null confidence)

## Key files to review

- `apps/mediapulse/domain-api/src/resources/entities/detail-mapper.ts` — entity evidence join and JSON shape
- `apps/mediapulse/domain-api/src/resources/entity-relations/detail-mapper.ts` — relation evidence join (Prisma field `evidence`)
- `apps/mediapulse/domain-api/src/resources/entities/dashboard-page.ts` — Hermes detailBlocks for entity detail
- `apps/mediapulse/domain-api/src/resources/entity-relations/dashboard-page.ts` — Hermes detailBlocks for relation detail
- `dev-docs/docs/hermes/integration/detail-blocks.mdx` — operator-facing pattern notes

## How to test

1. Run `pnpm --filter @mediapulse/domain-api test` — all mapper and route tests should pass
2. Restart domain-api so Hermes reloads the manifest
3. Open `/dashboard/mediapulse/entities/{id}` for an entity with evidence rows — confirm the Evidence subTable lists source titles linked to data sources, with confidence and last seen
4. Repeat on `/dashboard/mediapulse/entity-relations/{id}` for a relation with evidence
5. Confirm entities or relations without evidence show the empty-state message
