### PR TITLE
Improve per-ticker KG anchoring and prompt context

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -464,6 +464,7 @@ describe("agent-data-api", () => {
     it("returns 200 with analysis context when service returns data", async () => {
       const mod = await getAnalysisService();
       vi.mocked(mod.loadAnalysisContext).mockResolvedValue({
+        ticker: { id: TICKER_ID, symbol: "T1", name: "Ticker One" },
         dataSources: [
           {
             id: "33333333-3333-4333-a333-333333333333",
@@ -503,6 +504,7 @@ describe("agent-data-api", () => {
     it("forwards start and end query params to loadAnalysisContext", async () => {
       const mod = await getAnalysisService();
       vi.mocked(mod.loadAnalysisContext).mockResolvedValue({
+        ticker: { id: TICKER_ID, symbol: "T1", name: "Ticker One" },
         dataSources: [],
         dataSourceTotalCount: 0,
         entityTypes: [],

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -97,6 +97,13 @@ describe("loadAnalysisContext", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = {
       dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-1",
+          symbol: "T1",
+          name: "Ticker One",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -149,6 +156,13 @@ describe("loadAnalysisContext", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = {
       dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-2",
+          symbol: "T2",
+          name: "Ticker Two",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -193,6 +207,13 @@ describe("loadAnalysisContext", () => {
         findUnique: vi.fn(),
         findFirst: vi.fn(),
       },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-debounce",
+          symbol: "TD",
+          name: "Ticker Debounce",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -235,6 +256,13 @@ describe("loadAnalysisContext", () => {
     const count = vi.fn().mockResolvedValue(42);
     const db = {
       dataSource: { findMany, count, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-limit",
+          symbol: "TL",
+          name: "Ticker Limit",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -280,6 +308,13 @@ describe("loadAnalysisContext", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = {
       dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-w",
+          symbol: "TW",
+          name: "Ticker Window",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -323,6 +358,13 @@ describe("loadAnalysisContext", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = {
       dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-w",
+          symbol: "TW",
+          name: "Ticker Window",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -366,6 +408,13 @@ describe("loadAnalysisContext", () => {
     const findMany = vi.fn().mockResolvedValue([]);
     const db = {
       dataSource: { findMany, findUnique: vi.fn(), findFirst: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-w",
+          symbol: "TW",
+          name: "Ticker Window",
+        }),
+      },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
       entity: {
@@ -415,6 +464,13 @@ describe("loadAnalysisContext", () => {
         findMany: vi.fn().mockResolvedValue([]),
         findUnique: vi.fn(),
         findFirst: vi.fn(),
+      },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "ticker-3",
+          symbol: "T3",
+          name: "Ticker Three",
+        }),
       },
       entityType: { findMany: vi.fn().mockResolvedValue([]) },
       relationType: { findMany: vi.fn().mockResolvedValue([]) },
@@ -475,6 +531,7 @@ describe("applyAnalysisPost", () => {
           ),
         findFirst: vi.fn(),
       },
+      ticker: { findUnique: vi.fn() },
       entityType: { findMany: vi.fn() },
       relationType: { findMany: vi.fn() },
       entity: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
@@ -518,9 +575,23 @@ describe("applyAnalysisPost", () => {
         findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
         findFirst: vi.fn(),
       },
-      entityType: { findMany: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          symbol: "T1",
+          name: "Ticker One",
+          metadata: null,
+        }),
+      },
+      entityType: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: "company-type" }),
+      },
       relationType: { findMany: vi.fn() },
-      entity: { findMany: vi.fn(), findFirst: vi.fn(), create: vi.fn() },
+      entity: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: "issuer-entity" }),
+        create: vi.fn(),
+      },
       entityAlias: { createMany: vi.fn() },
       tickerEntity: { create: vi.fn(), findFirst: vi.fn() },
       entityRelation: { create: vi.fn(), findUnique: vi.fn() },
@@ -599,11 +670,26 @@ describe("applyAnalysisPost", () => {
         findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
         findFirst: vi.fn(),
       },
-      entityType: { findMany: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          symbol: "T1",
+          name: "Ticker One",
+          metadata: null,
+        }),
+      },
+      entityType: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: "company-type" }),
+      },
       relationType: { findMany: vi.fn() },
       entity: {
         findMany: vi.fn(),
-        findFirst: vi.fn().mockResolvedValue(null),
+        findFirst: vi
+          .fn()
+          // First call is for issuer anchor reuse.
+          .mockResolvedValueOnce({ id: "issuer-entity" })
+          // Subsequent lookups (e.g. Unknown Corp) should not match.
+          .mockResolvedValue(null),
         create: vi.fn(),
       },
       entityAlias: { createMany: vi.fn() },
@@ -661,11 +747,34 @@ describe("applyAnalysisPost", () => {
         findUnique: vi.fn().mockResolvedValue({ tickerId: "ticker-1" }),
         findFirst: vi.fn(),
       },
-      entityType: { findMany: vi.fn() },
+      ticker: {
+        findUnique: vi.fn().mockResolvedValue({
+          symbol: "T1",
+          name: "Ticker One",
+          metadata: null,
+        }),
+      },
+      entityType: {
+        findMany: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue({ id: "company-type" }),
+      },
       relationType: { findMany: vi.fn() },
       entity: {
         findMany: vi.fn(),
-        findFirst: vi.fn().mockResolvedValue(null),
+        findFirst: vi
+          .fn()
+          .mockImplementation(
+            ({
+              where,
+            }: {
+              where: { typeId: string; OR: Array<Record<string, unknown>> };
+            }) =>
+              Promise.resolve(
+                where.typeId === "company-type"
+                  ? { id: "issuer-entity" }
+                  : null,
+              ),
+          ),
         create: vi.fn().mockResolvedValue({ id: ENT_ID }),
       },
       entityAlias: { createMany: vi.fn() },

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -27,7 +27,8 @@ type AnalysisDb = {
     typeof prisma.dataSource,
     "findMany" | "findUnique" | "findFirst" | "count" | "deleteMany"
   >;
-  entityType: Pick<typeof prisma.entityType, "findMany">;
+  ticker: Pick<typeof prisma.ticker, "findUnique">;
+  entityType: Pick<typeof prisma.entityType, "findMany" | "findFirst">;
   relationType: Pick<typeof prisma.relationType, "findMany">;
   entity: Pick<typeof prisma.entity, "findFirst" | "findMany" | "create">;
   entityAlias: Pick<typeof prisma.entityAlias, "createMany">;
@@ -44,12 +45,111 @@ type AnalysisDb = {
 };
 
 /** Database delegates used by analysis POST persistence (no interactive transaction). */
-type AnalysisWriteDb = Omit<
-  AnalysisDb,
-  "$transaction" | "entityType" | "relationType"
->;
+type AnalysisWriteDb = Omit<AnalysisDb, "$transaction" | "relationType">;
 
 const defaultDb: AnalysisDb = prisma;
+
+type TickerIssuerAnchor = {
+  entityId: string;
+  canonicalName: string;
+  aliases: string[];
+};
+
+/**
+ * Ensures the issuer/company node exists for a ticker's KG and is linked via `ticker_entity`.
+ *
+ * This is an anchor node used to make ticker graphs interpretable (issuer-centric edges).
+ * It is created or reused based on alias matching rules and is linked with `source: SEED`.
+ *
+ * @param db - Injectable database delegates for write path.
+ * @param tickerId - Ticker scope.
+ * @returns Anchor metadata (id + names) or null when the ticker/type cannot be resolved.
+ */
+async function ensureTickerIssuerCompanyAnchor(
+  db: Pick<
+    AnalysisDb,
+    "ticker" | "entityType" | "entity" | "entityAlias" | "tickerEntity"
+  >,
+  tickerId: string,
+): Promise<TickerIssuerAnchor | null> {
+  const ticker = await db.ticker.findUnique({
+    where: { id: tickerId },
+    select: { symbol: true, name: true, metadata: true },
+  } satisfies Prisma.TickerFindUniqueArgs);
+  if (!ticker) return null;
+
+  const companyType = await db.entityType.findFirst({
+    where: { name: "COMPANY" },
+    select: { id: true },
+  } satisfies Prisma.EntityTypeFindFirstArgs);
+  if (!companyType) return null;
+
+  const aliases = [ticker.symbol, ticker.name]
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+
+  const canonicalName = ticker.name.trim();
+  const existing = await findReusableEntity(
+    { entity: db.entity },
+    companyType.id,
+    canonicalName,
+    aliases,
+  );
+
+  const entityId =
+    existing?.id ??
+    (
+      await db.entity.create({
+        data: {
+          typeId: companyType.id,
+          canonicalName,
+          description: null,
+          ...(ticker.metadata !== undefined && ticker.metadata !== null
+            ? { metadata: ticker.metadata as Prisma.InputJsonValue }
+            : {}),
+        },
+        select: { id: true },
+      } satisfies Prisma.EntityCreateArgs)
+    ).id;
+
+  if (!existing) {
+    const aliasRows: Prisma.EntityAliasCreateManyInput[] = [];
+    const seenNorm = new Set<string>();
+    for (const raw of aliases) {
+      const n = normalizeAnalysisName(raw);
+      if (seenNorm.has(n)) continue;
+      seenNorm.add(n);
+      aliasRows.push({
+        entityId,
+        alias: raw.trim(),
+        normalizedAlias: n,
+      });
+    }
+    if (aliasRows.length > 0) {
+      await db.entityAlias.createMany({
+        data: aliasRows,
+        skipDuplicates: true,
+      } satisfies Prisma.EntityAliasCreateManyArgs);
+    }
+  }
+
+  const linked = await db.tickerEntity.findFirst({
+    where: { tickerId, entityId },
+    select: { id: true },
+  } satisfies Prisma.TickerEntityFindFirstArgs);
+  if (!linked) {
+    await db.tickerEntity.create({
+      data: { tickerId, entityId, source: "SEED" },
+      select: { id: true },
+    } satisfies Prisma.TickerEntityCreateArgs);
+  }
+
+  return {
+    entityId,
+    canonicalName,
+    aliases: [...new Set(aliases)],
+  };
+}
 
 /**
  * Loads data sources for analysis GET: optional `limit` page plus total row count for the same filters.
@@ -96,6 +196,14 @@ export const loadAnalysisContext = async (
   deps: { db?: AnalysisDb } = {},
 ): Promise<GetAnalysisResponse> => {
   const db = deps.db ?? defaultDb;
+
+  const ticker = await db.ticker.findUnique({
+    where: { id: query.tickerId },
+    select: { id: true, symbol: true, name: true },
+  } satisfies Prisma.TickerFindUniqueArgs);
+  if (!ticker) {
+    throw new Error(`Unknown tickerId ${query.tickerId}`);
+  }
 
   const createdAtWhere =
     query.start !== undefined || query.end !== undefined
@@ -192,6 +300,7 @@ export const loadAnalysisContext = async (
   ]);
 
   return {
+    ticker,
     dataSources,
     dataSourceTotalCount,
     entityTypes,
@@ -332,6 +441,20 @@ export const applyAnalysisPost = async (
     };
     registerName(ent.canonicalName);
     for (const a of ent.aliases) {
+      registerName(a);
+    }
+  }
+
+  const issuerAnchor = await ensureTickerIssuerCompanyAnchor(db, body.tickerId);
+  if (issuerAnchor) {
+    const registerName = (raw: string) => {
+      const k = normalizeAnalysisName(raw);
+      if (!nameToEntityId.has(k)) {
+        nameToEntityId.set(k, issuerAnchor.entityId);
+      }
+    };
+    registerName(issuerAnchor.canonicalName);
+    for (const a of issuerAnchor.aliases) {
       registerName(a);
     }
   }

--- a/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/agent-prompt-fingerprinting.test.ts
@@ -19,6 +19,8 @@ describe("agent prompt fingerprinting (REQ-011)", () => {
     };
     const userArgs = {
       tickerId: "t-1",
+      tickerSymbol: "T1",
+      tickerName: "Ticker One",
       title: "Title",
       contentTruncated: "Body",
     };
@@ -37,6 +39,8 @@ describe("agent prompt fingerprinting (REQ-011)", () => {
   it("differs when analysis GET vocabulary differs but user args match", () => {
     const userArgs = {
       tickerId: "t-1",
+      tickerSymbol: "T1",
+      tickerName: "Ticker One",
       title: "Title",
       contentTruncated: "Body",
     };

--- a/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
@@ -18,7 +18,7 @@ export const ARTICLE_ANALYSIS_REPAIR_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
  * Must include `{{entityTypesBlock}}` and `{{relationTypesBlock}}`.
  */
 export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
-  "You extract knowledge-graph entities and relations from ONE article for equity research tooling.",
+  "You extract knowledge-graph entities and relations from ONE article for industry analysis.",
   "Always include one COMPANY entity representing the issuer (the ticker company). Use tickerSymbol and tickerName from the user message; include tickerSymbol as an alias on that entity.",
   "Use ONLY entity typeId values listed under ENTITY TYPES and ONLY relationTypeId values under RELATION TYPES.",
   "Relation fromEntityName and toEntityName must match canonicalName strings of entities you output (not aliases).",

--- a/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-extraction-prompt-defaults.ts
@@ -19,6 +19,7 @@ export const ARTICLE_ANALYSIS_REPAIR_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
  */
 export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
   "You extract knowledge-graph entities and relations from ONE article for equity research tooling.",
+  "Always include one COMPANY entity representing the issuer (the ticker company). Use tickerSymbol and tickerName from the user message; include tickerSymbol as an alias on that entity.",
   "Use ONLY entity typeId values listed under ENTITY TYPES and ONLY relationTypeId values under RELATION TYPES.",
   "Relation fromEntityName and toEntityName must match canonicalName strings of entities you output (not aliases).",
   "Prefer high-precision entities; omit uncertain extractions.",
@@ -36,6 +37,8 @@ export const ARTICLE_ANALYSIS_EXTRACTION_SYSTEM_PROMPT_TEMPLATE_DEFAULT = [
  */
 export const ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_TEMPLATE_DEFAULT = [
   "tickerId: {{tickerId}}",
+  "tickerSymbol: {{tickerSymbol}}",
+  "tickerName: {{tickerName}}",
   "title: {{title}}",
   "article:",
   "{{articleContent}}",

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -51,10 +51,14 @@ describe("buildExtractionUserContent", () => {
   it("includes ticker title and body", () => {
     const u = buildExtractionUserContent({
       tickerId: "T",
+      tickerSymbol: "TSYM",
+      tickerName: "Ticker Name",
       title: "Hello",
       contentTruncated: "Body text",
     });
     expect(u).toContain("T");
+    expect(u).toContain("TSYM");
+    expect(u).toContain("Ticker Name");
     expect(u).toContain("Hello");
     expect(u).toContain("Body text");
   });
@@ -277,10 +281,13 @@ describe("extractEntitiesAndRelationsForSource", () => {
     // Assert
     const capturedMessages =
       generateObjectForExtraction.mock.calls[0]?.[0]?.messages;
-    expect(capturedMessages?.at(-1)?.content).toBe(
+    const lastCaptured = capturedMessages
+      ? capturedMessages[capturedMessages.length - 1]
+      : undefined;
+    expect(lastCaptured?.content).toBe(
       buildBrainstormFollowUpUserContent(brainstormText),
     );
-    expect(String(capturedMessages?.at(-1)?.content)).toContain("Apple");
+    expect(String(lastCaptured?.content)).toContain("Apple");
   });
 });
 
@@ -301,6 +308,8 @@ describe("buildBrainstormUserContent", () => {
   it("matches extraction user content for the same article fields", () => {
     const args = {
       tickerId: "T",
+      tickerSymbol: "TSYM",
+      tickerName: "Ticker Name",
       title: "Hello",
       contentTruncated: "Body text",
     };

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -328,6 +328,8 @@ export const buildArticleAnalysisExtractionSystemContent = (
  */
 export const buildArticleAnalysisExtractionUserContent = (args: {
   tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
   title: string;
   contentTruncated: string;
 }): string =>
@@ -335,6 +337,8 @@ export const buildArticleAnalysisExtractionUserContent = (args: {
     ARTICLE_ANALYSIS_EXTRACTION_USER_PROMPT_TEMPLATE_DEFAULT,
     {
       tickerId: args.tickerId,
+      tickerSymbol: args.tickerSymbol,
+      tickerName: args.tickerName,
       title: args.title,
       articleContent: args.contentTruncated,
     },
@@ -364,6 +368,8 @@ export const buildBrainstormSystemContent = (
  */
 export const buildBrainstormUserContent = (args: {
   tickerId: string;
+  tickerSymbol: string;
+  tickerName: string;
   title: string;
   contentTruncated: string;
 }): string => buildExtractionUserContent(args);
@@ -528,7 +534,9 @@ export const extractEntitiesAndRelationsForSource = async (
 ): Promise<LlmExtractionCallResult> => {
   const openai = createOpenAI({ apiKey: params.apiKey });
   const systemContent = String(params.messages[0]?.content ?? "");
-  const userContent = String(params.messages.at(-1)?.content ?? "");
+  const userContent = String(
+    params.messages[params.messages.length - 1]?.content ?? "",
+  );
   const shouldBuildMessages =
     (params.exemplars !== undefined && params.exemplars.length > 0) ||
     (params.brainstormText !== undefined &&

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -73,7 +73,7 @@ type ExistingEntity = {
 
 type AnalysisContext = Pick<
   GetAnalysisResponse,
-  "entityTypes" | "relationTypes"
+  "ticker" | "entityTypes" | "relationTypes"
 >;
 
 type BatchSource = {
@@ -277,6 +277,8 @@ export const createProcessOneSource =
       const t0 = Date.now();
       const extractionUserContent = buildArticleAnalysisExtractionUserContent({
         tickerId,
+        tickerSymbol: ctx.ticker.symbol,
+        tickerName: ctx.ticker.name,
         title: source.title,
         contentTruncated: truncated,
       });
@@ -305,6 +307,8 @@ export const createProcessOneSource =
                 role: "user",
                 content: buildBrainstormUserContent({
                   tickerId,
+                  tickerSymbol: ctx.ticker.symbol,
+                  tickerName: ctx.ticker.name,
                   title: source.title,
                   contentTruncated: truncated,
                 }),

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -154,6 +154,7 @@ const relevanceSelectionState = {
 /** Fills `dataSourceTotalCount` when omitted (matches agent-data-api without `limit`). */
 const analysisGetOk = <
   T extends {
+    ticker?: { id: string; symbol: string; name: string };
     dataSources: readonly unknown[];
     entityTypes: unknown[];
     relationTypes: unknown[];
@@ -166,10 +167,18 @@ const analysisGetOk = <
     lastRelevanceScoredAtIso?: string | null;
   },
 ): T & {
+  ticker: { id: string; symbol: string; name: string };
   dataSourceTotalCount: number;
   lastRelevanceScoredAtIso: string | null;
 } => ({
   ...partial,
+  ticker:
+    partial.ticker ??
+    ({
+      id: "ticker-1",
+      symbol: "T1",
+      name: "Ticker One",
+    } as const),
   dataSourceTotalCount:
     partial.dataSourceTotalCount ?? partial.dataSources.length,
   lastRelevanceScoredAtIso:

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -367,7 +367,10 @@ describe("buildStructuredQueryMessages", () => {
     });
     expect(messages[0]?.role).toBe("system");
     expect(messages.filter((m) => m.role === "user")).toHaveLength(3);
-    expect(messages.at(-1)).toEqual({ role: "user", content: "live context" });
+    expect(messages[messages.length - 1]).toEqual({
+      role: "user",
+      content: "live context",
+    });
   });
 
   it("appends brainstorm bullets to the final user message", () => {
@@ -377,7 +380,7 @@ describe("buildStructuredQueryMessages", () => {
       fewShotExemplarCount: 0,
       brainstormBullets: ["angle one", "angle two"],
     });
-    const finalUser = messages.at(-1);
+    const finalUser = messages[messages.length - 1];
     expect(finalUser?.content).toContain("previously brainstormed");
     expect(finalUser?.content).toContain("angle one");
   });
@@ -478,7 +481,8 @@ describe("fetchQueryAnalysisLlmCandidates", () => {
     const messages = fetchLlmQueryCandidatesSpy.mock.calls[0]?.[0]?.messages as
       | { role: string; content: string }[]
       | undefined;
-    expect(messages?.at(-1)?.content).toContain("angle a");
+    const lastMessage = messages ? messages[messages.length - 1] : undefined;
+    expect(lastMessage?.content).toContain("angle a");
   });
 
   it("skips brainstorm when useBrainstormPass is false", async () => {

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -332,7 +332,9 @@ describe("query-analysis run", () => {
     expect(secondCall.broadenSystemNudge).toContain("diversity");
     expect(secondCall.broadenSystemNudge).toContain("Vary phrasing");
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       strategySnapshot: {
         diversityScore?: { composite: number };
         diversityGate?: { diversityRegenerateFired: boolean };
@@ -386,7 +388,9 @@ describe("query-analysis run", () => {
     expect(applySelfCritiquePassMock).toHaveBeenCalledTimes(1);
     expect(mockFetchQueryLlm).toHaveBeenCalledTimes(2);
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       strategySnapshot: {
         useBrainstormPass?: boolean;
         useSelfCritique?: boolean;
@@ -426,7 +430,9 @@ describe("query-analysis run", () => {
     });
 
     expect(mockFetchWildcard).toHaveBeenCalledTimes(1);
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       queries: Array<{ intent: string }>;
     };
     const wildcardRows = createPayload.queries.filter(
@@ -456,7 +462,9 @@ describe("query-analysis run", () => {
       token: "Bearer t",
     });
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       queries: Array<{ text: string }>;
       strategySnapshot: {
         languageQuotas: Array<{ language: string; share: number }>;
@@ -501,7 +509,9 @@ describe("query-analysis run", () => {
       token: "Bearer t",
     });
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       strategySnapshot: {
         intentWeights: { regulatory: number };
         appliedEventBias?: {
@@ -562,7 +572,9 @@ describe("runQueryAnalysis derived minDeterministicCount", () => {
       token: "Bearer t",
     });
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       strategySnapshot: { minDeterministicCount: number; maxTokens?: number };
     };
     expect(createPayload.strategySnapshot.minDeterministicCount).toBe(4);
@@ -584,7 +596,9 @@ describe("runQueryAnalysis derived minDeterministicCount", () => {
       token: "Bearer t",
     });
 
-    const createPayload = mockCreate.mock.calls.at(-1)?.[0] as {
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
       strategySnapshot: { minDeterministicCount: number };
     };
     expect(createPayload.strategySnapshot.minDeterministicCount).toBe(2);

--- a/dev-docs/docs/mediapulse/knowledge-graph/relation-types.mdx
+++ b/dev-docs/docs/mediapulse/knowledge-graph/relation-types.mdx
@@ -8,7 +8,7 @@ icon: Link
 
 `/dashboard/relation-types` defines the allowed relationship labels used when analysis extracts edges between entities.
 
-Typical labels: `CEO_OF`, `SUBSIDIARY_OF`, `PARENT_OF`, `COMPETITOR_OF`, `INVESTOR_IN`, `PARTNER_OF`, `SUPPLIES_TO`.
+Typical labels: `CEO_OF`, `EMPLOYEE_OF`, `SUBSIDIARY_OF`, `PARENT_OF`, `COMPETITOR`, `INVESTOR_IN`, `PARTNER_OF`, `SUPPLIES_TO`.
 
 These rows directly control relation extraction behavior in `entity_relation`.
 

--- a/packages/mediapulse/database/scripts/seed-kg-vocabulary.test.ts
+++ b/packages/mediapulse/database/scripts/seed-kg-vocabulary.test.ts
@@ -36,10 +36,10 @@ describe("seedKgVocabulary", () => {
 
     expect(result).toEqual({
       entityTypesSeeded: 6,
-      relationTypesSeeded: 7,
+      relationTypesSeeded: 8,
     });
     expect(db.entityType.upsert).toHaveBeenCalledTimes(6);
-    expect(db.relationType.upsert).toHaveBeenCalledTimes(7);
+    expect(db.relationType.upsert).toHaveBeenCalledTimes(8);
   });
 
   it("upserts by unique name with description updates", async () => {

--- a/packages/mediapulse/database/scripts/seed-kg-vocabulary.ts
+++ b/packages/mediapulse/database/scripts/seed-kg-vocabulary.ts
@@ -46,6 +46,11 @@ const DEFAULT_RELATION_TYPES = [
     description: "Person is the CEO or top executive of a company",
   },
   {
+    name: "EMPLOYEE_OF",
+    description:
+      "Person is employed by a company (any role). Direction: PERSON -> COMPANY.",
+  },
+  {
     name: "SUBSIDIARY_OF",
     description: "Company is a subsidiary or child entity of another company",
   },

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -237,6 +237,11 @@ describe("createAgentDataApiClient", () => {
   it("builds analysis GET with typed query and auth header", async () => {
     const getFn = vi.fn().mockResolvedValue({
       body: JSON.stringify({
+        ticker: {
+          id: "11111111-1111-4111-a111-111111111111",
+          symbol: "T1",
+          name: "Ticker One",
+        },
         dataSources: [],
         dataSourceTotalCount: 0,
         entityTypes: [],
@@ -272,6 +277,11 @@ describe("createAgentDataApiClient", () => {
   it("serializes optional start and end on analysis GET", async () => {
     const getFn = vi.fn().mockResolvedValue({
       body: JSON.stringify({
+        ticker: {
+          id: "11111111-1111-4111-a111-111111111111",
+          symbol: "T1",
+          name: "Ticker One",
+        },
         dataSources: [],
         dataSourceTotalCount: 0,
         entityTypes: [],

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -160,6 +160,12 @@ export const analysisExistingEntitySchema = z.object({
   aliases: z.array(z.string()),
 });
 
+export const analysisTickerSchema = z.object({
+  id: z.string().uuid(),
+  symbol: z.string(),
+  name: z.string(),
+});
+
 /** UTC-day selection budget for article relevance (see article-analysis agent). */
 export const analysisRelevanceSelectionStateSchema = z.object({
   /** ISO 8601 instant for UTC midnight at the start of the scoring "today". */
@@ -169,6 +175,7 @@ export const analysisRelevanceSelectionStateSchema = z.object({
 });
 
 export const getAnalysisResponseSchema = z.object({
+  ticker: analysisTickerSchema,
   dataSources: z.array(analysisDataSourceSchema),
   /** Count of data sources matching the GET filters (ignores `limit` on the request). */
   dataSourceTotalCount: z.number().int().nonnegative(),


### PR DESCRIPTION
## Summary

Make the per-ticker KG more consistent by ensuring every ticker has a seeded issuer COMPANY anchor, adding `EMPLOYEE_OF` to the relation vocabulary, and passing ticker symbol/name into the article-analysis extraction prompt.

## Important changes

- Ensure analysis GET returns `ticker` `{ id, symbol, name }` so agents can build issuer-anchored prompts.
- Ensure analysis POST creates/reuses a COMPANY issuer anchor and links it to the ticker via `ticker_entity` (`source: SEED`).
- Add `EMPLOYEE_OF` to the seeded `relation_type` vocabulary.
- Extend article-analysis prompt inputs to include `tickerSymbol` and `tickerName`.

## How to test

- `pnpm code-quality`

## Related issues

- Closes #623
