### PR TITLE
Support optional sections in industry newsletter wire

### DIFF
--- a/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.test.ts
+++ b/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+
+import { flattenBulletsFromNewsletterWire } from "./flatten-newsletter-wire-bullets.js";
+
+const MARKER = "MP_NEWSLETTER";
+
+const buildWire = (sections: string[]): string =>
+  [MARKER, "", ...sections].join("\n").trimEnd() + "\n";
+
+describe("flattenBulletsFromNewsletterWire", () => {
+  it("returns empty array for non-wire content", () => {
+    const result = flattenBulletsFromNewsletterWire("id1", "not a wire", "2024-01-01T00:00:00Z");
+    expect(result).toEqual([]);
+  });
+
+  it("flattens all sections from a full wire", () => {
+    const wire = buildWire([
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "Pulse",
+      "PROSE",
+      "Lead.",
+      "END",
+      "",
+      "BEGIN competitive-landscape",
+      "DISPLAY_HEADING",
+      "Competition",
+      "BULLET",
+      "Rival A underbid.",
+      "BULLET",
+      "Fleet oversupply.",
+      "END",
+      "",
+      "BEGIN deals-and-movements",
+      "DISPLAY_HEADING",
+      "Deals",
+      "BULLET",
+      "A deal closed.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "One.",
+      "ITEM",
+      "Two.",
+      "END",
+      "",
+    ]);
+
+    const result = flattenBulletsFromNewsletterWire("id1", wire, "2024-01-01T00:00:00Z");
+
+    const sectionKeys = result.map((r) => r.sectionKey);
+    expect(sectionKeys).toContain("competitiveLandscape");
+    expect(sectionKeys).toContain("dealsAndMovements");
+    expect(sectionKeys).toContain("quickHits");
+    expect(result.filter((r) => r.sectionKey === "competitiveLandscape")).toHaveLength(2);
+  });
+
+  it("flattens without throwing when competitive-landscape is absent", () => {
+    const wire = buildWire([
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "Pulse",
+      "PROSE",
+      "Lead.",
+      "END",
+      "",
+      "BEGIN deals-and-movements",
+      "DISPLAY_HEADING",
+      "Deals",
+      "BULLET",
+      "A deal closed.",
+      "BULLET",
+      "Another deal.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "Hit one.",
+      "ITEM",
+      "Hit two.",
+      "END",
+      "",
+    ]);
+
+    const result = flattenBulletsFromNewsletterWire("id2", wire, "2024-01-01T00:00:00Z");
+
+    expect(result.some((r) => r.sectionKey === "competitiveLandscape")).toBe(false);
+    expect(result.filter((r) => r.sectionKey === "dealsAndMovements")).toHaveLength(2);
+    expect(result.filter((r) => r.sectionKey === "quickHits")).toHaveLength(2);
+    expect(result.every((r) => r.newsletterId === "id2")).toBe(true);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.test.ts
+++ b/apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.test.ts
@@ -9,7 +9,11 @@ const buildWire = (sections: string[]): string =>
 
 describe("flattenBulletsFromNewsletterWire", () => {
   it("returns empty array for non-wire content", () => {
-    const result = flattenBulletsFromNewsletterWire("id1", "not a wire", "2024-01-01T00:00:00Z");
+    const result = flattenBulletsFromNewsletterWire(
+      "id1",
+      "not a wire",
+      "2024-01-01T00:00:00Z",
+    );
     expect(result).toEqual([]);
   });
 
@@ -49,13 +53,19 @@ describe("flattenBulletsFromNewsletterWire", () => {
       "",
     ]);
 
-    const result = flattenBulletsFromNewsletterWire("id1", wire, "2024-01-01T00:00:00Z");
+    const result = flattenBulletsFromNewsletterWire(
+      "id1",
+      wire,
+      "2024-01-01T00:00:00Z",
+    );
 
     const sectionKeys = result.map((r) => r.sectionKey);
     expect(sectionKeys).toContain("competitiveLandscape");
     expect(sectionKeys).toContain("dealsAndMovements");
     expect(sectionKeys).toContain("quickHits");
-    expect(result.filter((r) => r.sectionKey === "competitiveLandscape")).toHaveLength(2);
+    expect(
+      result.filter((r) => r.sectionKey === "competitiveLandscape"),
+    ).toHaveLength(2);
   });
 
   it("flattens without throwing when competitive-landscape is absent", () => {
@@ -87,10 +97,18 @@ describe("flattenBulletsFromNewsletterWire", () => {
       "",
     ]);
 
-    const result = flattenBulletsFromNewsletterWire("id2", wire, "2024-01-01T00:00:00Z");
+    const result = flattenBulletsFromNewsletterWire(
+      "id2",
+      wire,
+      "2024-01-01T00:00:00Z",
+    );
 
-    expect(result.some((r) => r.sectionKey === "competitiveLandscape")).toBe(false);
-    expect(result.filter((r) => r.sectionKey === "dealsAndMovements")).toHaveLength(2);
+    expect(result.some((r) => r.sectionKey === "competitiveLandscape")).toBe(
+      false,
+    );
+    expect(
+      result.filter((r) => r.sectionKey === "dealsAndMovements"),
+    ).toHaveLength(2);
     expect(result.filter((r) => r.sectionKey === "quickHits")).toHaveLength(2);
     expect(result.every((r) => r.newsletterId === "id2")).toBe(true);
   });

--- a/apps/mediapulse/agents/content-generation/package.json
+++ b/apps/mediapulse/agents/content-generation/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
+    "@workspace/email-templates": "workspace:*",
     "@workspace/typescript-config": "workspace:*",
     "dotenv-cli": "catalog:",
     "typescript": "catalog:",

--- a/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
@@ -6,6 +6,8 @@ import type { IndustryNewsletterResolved } from "./industry-newsletter-urls.js";
  *
  * Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_MARKER` in
  * `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts`.
+ * Section presence in the wire is variable — only sections present on the resolved briefing
+ * with at least one row are emitted. Do not assume all six sections always appear.
  */
 export const INDUSTRY_NEWSLETTER_WIRE_MARKER = "MP_NEWSLETTER";
 
@@ -50,8 +52,16 @@ const withOptionalReadLine = (text: string, url?: string): string => {
   return `${text.trimEnd()}\n${READ_FULL_ARTICLE_LABEL}: ${trimmedUrl}`;
 };
 
+const hasRows = (section: { bullets: ReadonlyArray<unknown> }): boolean =>
+  section.bullets.length > 0;
+
 /**
  * Serializes a resolved industry briefing into the plain-text wire format.
+ *
+ * Only sections that are present on the briefing AND have at least one row are emitted.
+ * Section order is always: competitive-landscape → deals-and-movements →
+ * regulatory-policy-watch → disruptors-or-tech → quick-hits. Omitting a middle section
+ * never reorders the survivors.
  *
  * @param briefing - Ground-truth briefing with URLs attached from sources.
  * @returns Wire body whose first line is {@link INDUSTRY_NEWSLETTER_WIRE_MARKER}.
@@ -96,67 +106,104 @@ export const formatIndustryNewsletterWire = (
     pushBlock(lines.join("\n"));
   };
 
-  pushBulletSection(
-    "competitive-landscape",
-    briefing.competitiveLandscape.displayHeading,
-    briefing.competitiveLandscape.bullets,
-  );
-  pushBulletSection(
-    "deals-and-movements",
-    briefing.dealsAndMovements.displayHeading,
-    briefing.dealsAndMovements.bullets,
-  );
-  pushBulletSection(
-    "regulatory-policy-watch",
-    briefing.regulatoryPolicyWatch.displayHeading,
-    briefing.regulatoryPolicyWatch.bullets,
-  );
-
-  const d = briefing.disruptorsOrTech;
-  if (d.format === "prose") {
-    pushBlock(
-      [
-        `${BEGIN} disruptors-or-tech`,
+  // Body sections are emitted in a fixed order so omitting a middle section never
+  // reorders the survivors. Each emitter is a no-op when the section is absent or
+  // has no rows.
+  const bodyEmitters: Array<() => void> = [
+    () => {
+      if (
+        briefing.competitiveLandscape !== undefined &&
+        hasRows(briefing.competitiveLandscape)
+      ) {
+        pushBulletSection(
+          "competitive-landscape",
+          briefing.competitiveLandscape.displayHeading,
+          briefing.competitiveLandscape.bullets,
+        );
+      }
+    },
+    () => {
+      if (
+        briefing.dealsAndMovements !== undefined &&
+        hasRows(briefing.dealsAndMovements)
+      ) {
+        pushBulletSection(
+          "deals-and-movements",
+          briefing.dealsAndMovements.displayHeading,
+          briefing.dealsAndMovements.bullets,
+        );
+      }
+    },
+    () => {
+      if (
+        briefing.regulatoryPolicyWatch !== undefined &&
+        hasRows(briefing.regulatoryPolicyWatch)
+      ) {
+        pushBulletSection(
+          "regulatory-policy-watch",
+          briefing.regulatoryPolicyWatch.displayHeading,
+          briefing.regulatoryPolicyWatch.bullets,
+        );
+      }
+    },
+    () => {
+      const d = briefing.disruptorsOrTech;
+      if (d === undefined) return;
+      if (d.format === "prose") {
+        pushBlock(
+          [
+            `${BEGIN} disruptors-or-tech`,
+            DISPLAY_HEADING,
+            collapseHeadingLine(d.displayHeading),
+            FORMAT,
+            "prose",
+            PROSE,
+            stripArticleMarkers(d.prose.trim()),
+            END,
+          ].join("\n"),
+        );
+      } else {
+        if (!hasRows(d)) return;
+        const lines: string[] = [
+          `${BEGIN} disruptors-or-tech`,
+          DISPLAY_HEADING,
+          collapseHeadingLine(d.displayHeading),
+          FORMAT,
+          "bullets",
+        ];
+        for (const b of d.bullets) {
+          lines.push(
+            BULLET,
+            withOptionalReadLine(stripArticleMarkers(b.text), b.url),
+          );
+        }
+        lines.push(END);
+        pushBlock(lines.join("\n"));
+      }
+    },
+    () => {
+      if (briefing.quickHits === undefined || briefing.quickHits.items.length === 0) {
+        return;
+      }
+      const qhLines: string[] = [
+        `${BEGIN} quick-hits`,
         DISPLAY_HEADING,
-        collapseHeadingLine(d.displayHeading),
-        FORMAT,
-        "prose",
-        PROSE,
-        stripArticleMarkers(d.prose.trim()),
-        END,
-      ].join("\n"),
-    );
-  } else {
-    const lines: string[] = [
-      `${BEGIN} disruptors-or-tech`,
-      DISPLAY_HEADING,
-      collapseHeadingLine(d.displayHeading),
-      FORMAT,
-      "bullets",
-    ];
-    for (const b of d.bullets) {
-      lines.push(
-        BULLET,
-        withOptionalReadLine(stripArticleMarkers(b.text), b.url),
-      );
-    }
-    lines.push(END);
-    pushBlock(lines.join("\n"));
-  }
-
-  const qhLines: string[] = [
-    `${BEGIN} quick-hits`,
-    DISPLAY_HEADING,
-    collapseHeadingLine(briefing.quickHits.displayHeading),
+        collapseHeadingLine(briefing.quickHits.displayHeading),
+      ];
+      for (const item of briefing.quickHits.items) {
+        qhLines.push(
+          ITEM,
+          withOptionalReadLine(stripArticleMarkers(item.text), item.url),
+        );
+      }
+      qhLines.push(END);
+      pushBlock(qhLines.join("\n"));
+    },
   ];
-  for (const item of briefing.quickHits.items) {
-    qhLines.push(
-      ITEM,
-      withOptionalReadLine(stripArticleMarkers(item.text), item.url),
-    );
+
+  for (const emit of bodyEmitters) {
+    emit();
   }
-  qhLines.push(END);
-  pushBlock(qhLines.join("\n"));
 
   return parts.join("\n").trimEnd() + "\n";
 };

--- a/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
@@ -182,7 +182,10 @@ export const formatIndustryNewsletterWire = (
       }
     },
     () => {
-      if (briefing.quickHits === undefined || briefing.quickHits.items.length === 0) {
+      if (
+        briefing.quickHits === undefined ||
+        briefing.quickHits.items.length === 0
+      ) {
         return;
       }
       const qhLines: string[] = [

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
@@ -29,24 +29,31 @@ export type IndustryDisruptorsOrTechResolved =
       bullets: IndustryBulletResolved[];
     };
 
-/** Industry briefing ready for wire formatting (all URLs from config, not the LLM). */
+/**
+ * Industry briefing ready for wire formatting (all URLs from config, not the LLM).
+ *
+ * `subject` and `industryPulse` are required. The five body sections are optional:
+ * absence is represented by the field being `undefined`, never by an empty bullets/items array.
+ * A zero-row section is a contradiction the serializer refuses to emit.
+ * See `formatIndustryNewsletterWire` for the wire contract.
+ */
 export type IndustryNewsletterResolved = {
   subject: string;
   industryPulse: { displayHeading: string; prose: string };
-  competitiveLandscape: {
+  competitiveLandscape?: {
     displayHeading: string;
     bullets: IndustryBulletResolved[];
   };
-  dealsAndMovements: {
+  dealsAndMovements?: {
     displayHeading: string;
     bullets: IndustryBulletResolved[];
   };
-  regulatoryPolicyWatch: {
+  regulatoryPolicyWatch?: {
     displayHeading: string;
     bullets: IndustryBulletResolved[];
   };
-  disruptorsOrTech: IndustryDisruptorsOrTechResolved;
-  quickHits: {
+  disruptorsOrTech?: IndustryDisruptorsOrTechResolved;
+  quickHits?: {
     displayHeading: string;
     items: IndustryQuickHitResolved[];
   };

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
@@ -73,16 +73,16 @@ describe("attachIndustryNewsletterSourceUrls", () => {
       { url: "  https://two.example  " },
     ];
     const resolved = attachIndustryNewsletterSourceUrls(briefing, sources);
+    expect(resolved.competitiveLandscape).toBeDefined();
+    expect(resolved.disruptorsOrTech).toBeDefined();
+    const competitiveLandscape = resolved.competitiveLandscape!;
+    const disruptorsOrTech = resolved.disruptorsOrTech!;
 
-    expect(resolved.competitiveLandscape.bullets[0]?.url).toBe(
-      "https://one.example",
-    );
-    expect(resolved.competitiveLandscape.bullets[1]?.url).toBeUndefined();
-    expect(resolved.disruptorsOrTech.format).toBe("bullets");
-    if (resolved.disruptorsOrTech.format === "bullets") {
-      expect(resolved.disruptorsOrTech.bullets[0]?.url).toBe(
-        "https://two.example",
-      );
+    expect(competitiveLandscape.bullets[0]?.url).toBe("https://one.example");
+    expect(competitiveLandscape.bullets[1]?.url).toBeUndefined();
+    expect(disruptorsOrTech.format).toBe("bullets");
+    if (disruptorsOrTech.format === "bullets") {
+      expect(disruptorsOrTech.bullets[0]?.url).toBe("https://two.example");
     }
   });
 });
@@ -298,10 +298,7 @@ describe("formatIndustryNewsletterWire", () => {
         industryPulse: { displayHeading: "Lead", prose: "Pulse prose." },
         competitiveLandscape: {
           displayHeading: "C",
-          bullets: [
-            { text: "c1", articleIndex: 1 },
-            { text: "c2" },
-          ],
+          bullets: [{ text: "c1", articleIndex: 1 }, { text: "c2" }],
         },
         dealsAndMovements: {
           displayHeading: "Deals",
@@ -343,7 +340,11 @@ describe("formatIndustryNewsletterWire", () => {
     expect(parsed).not.toBeUndefined();
     expect(parsed?.format).toBe("industry");
     const keys = parsed?.sections.map((s) => s.machineKey);
-    expect(keys).toEqual(["industry-pulse", "deals-and-movements", "quick-hits"]);
+    expect(keys).toEqual([
+      "industry-pulse",
+      "deals-and-movements",
+      "quick-hits",
+    ]);
   });
 
   it("handles the degenerate case of industry-pulse plus a single quick-hit", () => {

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
@@ -9,7 +9,9 @@ import { industryNewsletterStructureSchema } from "./industry-newsletter-schema.
 import {
   attachIndustryNewsletterSourceUrls,
   resolveArticleUrlForIndustryNewsletter,
+  type IndustryNewsletterResolved,
 } from "./industry-newsletter-urls.js";
+import { parseIndustryNewsletterWire } from "@workspace/email-templates/parse-industry-newsletter-wire";
 
 describe("resolveArticleUrlForIndustryNewsletter", () => {
   const sources = [{ url: "https://a.example" }, { url: "https://b.example" }];
@@ -246,6 +248,121 @@ describe("formatIndustryNewsletterWire", () => {
     expect(wire).toContain("The award locks in multi-year revenue.");
     expect(wire).toContain("Read the full article: https://one.example");
     expect(wire).toContain("Read the full article: https://two.example");
+  });
+
+  it("omits absent sections and preserves order of survivors", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: { displayHeading: "L", prose: "p" },
+      competitiveLandscape: undefined,
+      dealsAndMovements: {
+        displayHeading: "D",
+        bullets: [{ text: "d1" }],
+      },
+      regulatoryPolicyWatch: undefined,
+      disruptorsOrTech: {
+        format: "bullets",
+        displayHeading: "X",
+        bullets: [{ text: "x1" }],
+      },
+      quickHits: {
+        displayHeading: "Q",
+        items: [
+          { text: "h1" },
+          { text: "h2" },
+          { text: "h3" },
+          { text: "h4" },
+          { text: "h5" },
+        ],
+      },
+    };
+
+    const wire = formatIndustryNewsletterWire(resolved);
+
+    expect(wire).not.toContain("BEGIN competitive-landscape");
+    expect(wire).not.toContain("BEGIN regulatory-policy-watch");
+    expect(wire).toContain("BEGIN deals-and-movements");
+    expect(wire).toContain("BEGIN disruptors-or-tech");
+    expect(wire).toContain("BEGIN quick-hits");
+    const dealsIndex = wire.indexOf("BEGIN deals-and-movements");
+    const disruptorsIndex = wire.indexOf("BEGIN disruptors-or-tech");
+    const quickHitsIndex = wire.indexOf("BEGIN quick-hits");
+    expect(dealsIndex).toBeLessThan(disruptorsIndex);
+    expect(disruptorsIndex).toBeLessThan(quickHitsIndex);
+  });
+
+  it("round-trips a partial briefing through the parser with sections in order", () => {
+    const resolved = attachIndustryNewsletterSourceUrls(
+      industryNewsletterStructureSchema.parse({
+        subject: "S",
+        industryPulse: { displayHeading: "Lead", prose: "Pulse prose." },
+        competitiveLandscape: {
+          displayHeading: "C",
+          bullets: [
+            { text: "c1", articleIndex: 1 },
+            { text: "c2" },
+          ],
+        },
+        dealsAndMovements: {
+          displayHeading: "Deals",
+          bullets: [{ text: "d1" }],
+        },
+        regulatoryPolicyWatch: {
+          displayHeading: "R",
+          bullets: [{ text: "r1" }],
+        },
+        disruptorsOrTech: {
+          format: "prose",
+          displayHeading: "X",
+          prose: "disruptor prose",
+        },
+        quickHits: {
+          displayHeading: "Q",
+          items: [
+            { text: "h1", articleIndex: 1 },
+            { text: "h2", articleIndex: 1 },
+            { text: "h3", articleIndex: 1 },
+            { text: "h4", articleIndex: 1 },
+            { text: "h5", articleIndex: 1 },
+          ],
+        },
+      }),
+      [{ url: "https://src.example" }],
+    );
+
+    const partial: IndustryNewsletterResolved = {
+      subject: resolved.subject,
+      industryPulse: resolved.industryPulse,
+      dealsAndMovements: resolved.dealsAndMovements,
+      quickHits: resolved.quickHits,
+    };
+
+    const wire = formatIndustryNewsletterWire(partial);
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(parsed).not.toBeUndefined();
+    expect(parsed?.format).toBe("industry");
+    const keys = parsed?.sections.map((s) => s.machineKey);
+    expect(keys).toEqual(["industry-pulse", "deals-and-movements", "quick-hits"]);
+  });
+
+  it("handles the degenerate case of industry-pulse plus a single quick-hit", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: { displayHeading: "L", prose: "Pulse prose." },
+      quickHits: {
+        displayHeading: "Q",
+        items: [{ text: "Only hit" }],
+      },
+    };
+
+    const wire = formatIndustryNewsletterWire(resolved);
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(wire.startsWith(`${INDUSTRY_NEWSLETTER_WIRE_MARKER}\n`)).toBe(true);
+    expect(parsed).not.toBeUndefined();
+    const keys = parsed?.sections.map((s) => s.machineKey);
+    expect(keys).toEqual(["industry-pulse", "quick-hits"]);
   });
 
   it("is idempotent and leaves marker-free input unchanged on re-format", () => {

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -383,6 +383,33 @@ This is **not** per-recipient A/B testing. The agent picks one winner per newsle
 
 Enable on one pilot ticker, aggregate a week of ranked logs into a “subject style winners by ticker” view, then tune `subjectLine.weights` for tickers where declarative lines underperform.
 
+## Wire format: optional sections
+
+The `MP_NEWSLETTER` wire format supports a variable set of body sections. Only sections present on the resolved briefing with at least one row are emitted by the serializer.
+
+### Mandatory vs omittable
+
+| Section | Status |
+|---|---|
+| `industry-pulse` | Always emitted. It is the newsletter spine and carries no citation. |
+| `competitive-landscape` | Omittable. Absent when the field is `undefined` on the resolved briefing. |
+| `deals-and-movements` | Omittable. |
+| `regulatory-policy-watch` | Omittable. |
+| `disruptors-or-tech` | Omittable. The bullets variant is also suppressed when it has zero rows. |
+| `quick-hits` | Omittable. |
+
+### Representation of absence
+
+Absence is always represented by the section field being `undefined` on `IndustryNewsletterResolved`, never by an empty `bullets` or `items` array. A zero-row section is a contradiction the serializer refuses to emit.
+
+### Parser and renderer behavior
+
+The wire parser (`parseIndustryNewsletterWire`) accepts any in-order subset of sections. Omitting a middle section never shifts the survivors. A wire containing only `industry-pulse` parses to `{ format: 'industry', sections: [industry-pulse] }`. The renderer maps over whatever sections the parser returns and has a defensive guard that renders nothing for any zero-bullet section that arrives.
+
+### LLM schema is unchanged
+
+The LLM output schema (`industryNewsletterStructureSchema`) is not relaxed. The model is still asked to produce all sections with their current minimums. Optionality lives only in the post-LLM resolved and wire layers. The pruning pass in plan 70 (`require-citation-and-prune-sections`) is what will produce partial newsletters in practice by dropping sections that have no grounded content.
+
 ## Cross-run dedup
 
 Subscribers should not see the same bullet on Monday, Wednesday, and Friday when nothing new happened. Cross-run dedup adds **longitudinal memory** across the last N days of persisted newsletters.

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -199,6 +199,9 @@ export const DefaultNewsletterEmail = ({
     }
 
     if ("bullets" in section) {
+      if (section.bullets.length === 0) {
+        return <Fragment key={`${section.machineKey}-${String(index)}`} />;
+      }
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
           {renderSectionHeader(section.machineKey, section.displayHeading)}

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
@@ -65,7 +65,11 @@ describe("parseIndustryNewsletterWire", () => {
 
     expect(parsed?.format).toBe("industry");
     const keys = parsed?.sections.map((s) => s.machineKey);
-    expect(keys).toEqual(["industry-pulse", "deals-and-movements", "quick-hits"]);
+    expect(keys).toEqual([
+      "industry-pulse",
+      "deals-and-movements",
+      "quick-hits",
+    ]);
   });
 
   it("skipped middle section does not shift the survivors out of order", () => {

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  parseIndustryNewsletterWire,
+  INDUSTRY_NEWSLETTER_WIRE_MARKER,
+} from "./parse-industry-newsletter-wire.js";
+
+describe("parseIndustryNewsletterWire", () => {
+  it("returns undefined when the marker is missing", () => {
+    expect(parseIndustryNewsletterWire("not a newsletter")).toBeUndefined();
+    expect(parseIndustryNewsletterWire("")).toBeUndefined();
+  });
+
+  it("parses a wire containing only industry-pulse", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "The Pulse",
+      "PROSE",
+      "Sector tone stayed stable this week.",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(parsed).not.toBeUndefined();
+    expect(parsed?.format).toBe("industry");
+    expect(parsed?.sections).toHaveLength(1);
+    expect(parsed?.sections[0]?.machineKey).toBe("industry-pulse");
+  });
+
+  it("accepts any in-order subset of body sections", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "Pulse",
+      "PROSE",
+      "Pulse prose.",
+      "END",
+      "",
+      "BEGIN deals-and-movements",
+      "DISPLAY_HEADING",
+      "Deals",
+      "BULLET",
+      "A deal closed.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "Hit one.",
+      "ITEM",
+      "Hit two.",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(parsed?.format).toBe("industry");
+    const keys = parsed?.sections.map((s) => s.machineKey);
+    expect(keys).toEqual(["industry-pulse", "deals-and-movements", "quick-hits"]);
+  });
+
+  it("skipped middle section does not shift the survivors out of order", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "Pulse",
+      "PROSE",
+      "Lead.",
+      "END",
+      "",
+      "BEGIN regulatory-policy-watch",
+      "DISPLAY_HEADING",
+      "Policy",
+      "BULLET",
+      "A regulation passed.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "One.",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    const keys = parsed?.sections.map((s) => s.machineKey);
+    expect(keys).toEqual([
+      "industry-pulse",
+      "regulatory-policy-watch",
+      "quick-hits",
+    ]);
+  });
+});

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
@@ -1,4 +1,8 @@
-/** Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_MARKER` in content-generation `format-industry-newsletter.ts`. */
+/**
+ * Keep in sync with `INDUSTRY_NEWSLETTER_WIRE_MARKER` in content-generation `format-industry-newsletter.ts`.
+ * Section presence is variable — only sections with at least one row are emitted by the serializer.
+ * Do not assume all six sections always appear; the parser accepts any in-order subset.
+ */
 export const INDUSTRY_NEWSLETTER_WIRE_MARKER = "MP_NEWSLETTER";
 
 const READ_FULL_ARTICLE_LABEL = "Read the full article";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -606,6 +606,9 @@ importers:
       '@types/bun':
         specifier: latest
         version: 1.3.11
+      '@workspace/email-templates':
+        specifier: workspace:*
+        version: link:../../../../packages/shared/email-templates
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../../../../packages/shared/typescript-config


### PR DESCRIPTION
## Summary

This change lets the industry newsletter wire carry partial briefings safely. Optional sections are now represented explicitly in the resolved model, and the formatter/parser path keeps section ordering stable when middle sections are missing.

## Related issues

Closes #625

## Important changes

- `IndustryNewsletterResolved` now marks body sections as optional so absence is modeled as `undefined` instead of empty arrays.
- `formatIndustryNewsletterWire` emits only present sections with rows, while preserving the canonical section order.
- `parseIndustryNewsletterWire` and downstream rendering/flattening paths now handle partial wires without shifting surviving sections.

## Other changes

- Added new tests for parser-only subsets, formatter round-trips, and flattening behavior when sections are absent.
- Added a defensive zero-bullet section guard in the default newsletter renderer.
- Documented optional section wire behavior in the content-generation docs.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts` - optional section emission and fixed-order serializer logic.
- `apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts` - resolved type contract changed to optional body sections.
- `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts` - parser expectations updated for in-order subsets.
- `apps/mediapulse/agent-data-api/src/lib/flatten-newsletter-wire-bullets.test.ts` - coverage for flattening partial wires.

## How to test

1. `corepack pnpm format:check`
2. `corepack pnpm --filter @mediapulse/content-generation type:check && corepack pnpm --filter @mediapulse/content-generation test:coverage`
3. `corepack pnpm --filter @workspace/email-templates type:check && corepack pnpm --filter @workspace/email-templates test:coverage`
4. Note: `corepack pnpm code-quality` currently fails in unrelated package code at `packages/mediapulse/database/scripts/seed-data-collection-local.ts` due to missing Prisma types (`TickerUpsertArgs`, `SearchQueryUpsertArgs`).

