### PR TITLE
Add require-citation pruning for industry newsletters

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -343,12 +343,65 @@ const crossRunDedupSchema = z
   .default({})
   .describe("Cross-run semantic dedup against recent newsletter bullets.");
 
+const requireCitationSectionEnum = z.enum([
+  "competitiveLandscape",
+  "dealsAndMovements",
+  "regulatoryPolicyWatch",
+  "disruptorsOrTech",
+  "quickHits",
+]);
+
+const requireCitationSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, run the require-citation pruning pass as the final transform.",
+      ),
+    sections: z
+      .array(requireCitationSectionEnum)
+      .default([
+        "competitiveLandscape",
+        "dealsAndMovements",
+        "regulatoryPolicyWatch",
+        "disruptorsOrTech",
+        "quickHits",
+      ])
+      .describe(
+        "Which body sections to apply pruning to. industry-pulse is always exempt.",
+      ),
+    dedupeArticlesWithinSection: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, keep only the first row for a given article URL within the dedup scope.",
+      ),
+    dedupeScope: z
+      .enum(["section", "newsletter"])
+      .default("section")
+      .describe(
+        "section = dedup URLs per section only; newsletter = dedup URLs across all sections.",
+      ),
+    keepIndustryPulse: z
+      .literal(true)
+      .default(true)
+      .describe(
+        "industry-pulse is always kept; this field exists to document that invariant.",
+      ),
+  })
+  .default({})
+  .describe(
+    "Final pruning pass: drops uncited rows, enforces one article per bullet, removes empty sections.",
+  );
+
 const qualitySchema = z
   .object({
     selfCritique: selfCritiqueSchema,
     citationGrounding: citationGroundingSchema,
     polish: polishSchema,
     crossRunDedup: crossRunDedupSchema,
+    requireCitation: requireCitationSchema,
   })
   .default({})
   .describe("Post-generation repair, verification, polish, and dedup passes.");

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
@@ -1,0 +1,360 @@
+import { describe, expect, it } from "vitest";
+
+import type { IndustryNewsletterResolved } from "../industry-newsletter-urls.js";
+import { pruneNewsletterToCitedRows } from "./prune-uncited-rows.js";
+
+const CITED_URL_A = "https://source.example/a";
+const CITED_URL_B = "https://source.example/b";
+const CITED_URL_C = "https://source.example/c";
+
+const basePulse: IndustryNewsletterResolved["industryPulse"] = {
+  displayHeading: "Pulse",
+  prose: "Lead prose.",
+};
+
+describe("pruneNewsletterToCitedRows — uncited rows dropped", () => {
+  it("keeps cited bullets and drops uncited ones; counts removedBullets correctly", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          { text: "Cited A", url: CITED_URL_A },
+          { text: "No citation" },
+          { text: "Cited B", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const {
+      resolved: pruned,
+      reports,
+      summary,
+    } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(2);
+    expect(pruned.competitiveLandscape?.bullets[0]?.text).toBe("Cited A");
+    expect(pruned.competitiveLandscape?.bullets[1]?.text).toBe("Cited B");
+
+    const report = reports.find((r) => r.sectionKey === "competitiveLandscape");
+    expect(report?.removedBullets).toBe(1);
+    expect(report?.sectionRemoved).toBe(false);
+
+    expect(summary.bulletsRemovedUncited).toBe(1);
+    expect(summary.bulletsRemovedDuplicate).toBe(0);
+    expect(summary.sectionsKept).toBe(1);
+    expect(summary.sectionsRemoved).toBe(0);
+  });
+
+  it("treats a bullet with url undefined as uncited (out-of-range articleIndex resolves to undefined)", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [
+          { text: "Good deal", url: CITED_URL_A },
+          { text: "Bad index" },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(summary.bulletsRemovedUncited).toBe(1);
+  });
+
+  it("quick-hits without url are dropped; items with url are kept", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      quickHits: {
+        displayHeading: "Quick Hits",
+        items: [
+          { text: "Cited", url: CITED_URL_A },
+          { text: "Uncited" },
+          { text: "Cited too", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.quickHits?.items).toHaveLength(2);
+    expect(summary.bulletsRemovedUncited).toBe(1);
+  });
+});
+
+describe("pruneNewsletterToCitedRows — duplicate article dedup", () => {
+  it("keeps first bullet per URL within a section, drops later duplicates", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          { text: "First cite A", url: CITED_URL_A },
+          { text: "Second cite A", url: CITED_URL_A },
+          { text: "First cite B", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const {
+      resolved: pruned,
+      reports,
+      summary,
+    } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(2);
+    expect(pruned.competitiveLandscape?.bullets[0]?.text).toBe("First cite A");
+    expect(pruned.competitiveLandscape?.bullets[1]?.text).toBe("First cite B");
+
+    const report = reports.find((r) => r.sectionKey === "competitiveLandscape");
+    expect(report?.removedForDuplicate).toBe(1);
+    expect(summary.bulletsRemovedDuplicate).toBe(1);
+    expect(summary.bulletsRemovedUncited).toBe(0);
+  });
+
+  it("dedupeScope 'section' isolates dedup per section — same URL allowed in different sections", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "CL bullet", url: CITED_URL_A }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "Deals bullet", url: CITED_URL_A }],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      dedupeScope: "section",
+    });
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(1);
+    expect(pruned.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(summary.bulletsRemovedDuplicate).toBe(0);
+  });
+
+  it("dedupeScope 'newsletter' drops second section bullet reusing an article from a prior section", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "CL bullet", url: CITED_URL_A }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [
+          { text: "Deals bullet citing same article", url: CITED_URL_A },
+          { text: "Deals bullet citing new article", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      dedupeScope: "newsletter",
+    });
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(1);
+    expect(pruned.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(pruned.dealsAndMovements?.bullets[0]?.text).toBe(
+      "Deals bullet citing new article",
+    );
+    expect(summary.bulletsRemovedDuplicate).toBe(1);
+  });
+
+  it("dedupeArticlesWithinSection false disables dedup entirely", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          { text: "First", url: CITED_URL_A },
+          { text: "Duplicate", url: CITED_URL_A },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      dedupeArticlesWithinSection: false,
+    });
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(2);
+    expect(summary.bulletsRemovedDuplicate).toBe(0);
+  });
+});
+
+describe("pruneNewsletterToCitedRows — section removal", () => {
+  it("removes a section when all its bullets are uncited", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      regulatoryPolicyWatch: {
+        displayHeading: "Policy",
+        bullets: [{ text: "Uncited bullet" }],
+      },
+    };
+
+    const {
+      resolved: pruned,
+      reports,
+      summary,
+    } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.regulatoryPolicyWatch).toBeUndefined();
+
+    const report = reports.find(
+      (r) => r.sectionKey === "regulatoryPolicyWatch",
+    );
+    expect(report?.sectionRemoved).toBe(true);
+    expect(report?.removedBullets).toBe(1);
+
+    expect(summary.sectionsRemoved).toBe(1);
+    expect(summary.sectionsKept).toBe(0);
+  });
+
+  it("keeps a section with exactly one cited bullet (the min-one floor)", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "One good deal", url: CITED_URL_A }],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(summary.sectionsRemoved).toBe(0);
+    expect(summary.sectionsKept).toBe(1);
+  });
+
+  it("removes disruptorsOrTech bullets variant when all bullets are uncited", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      disruptorsOrTech: {
+        format: "bullets",
+        displayHeading: "Tech",
+        bullets: [{ text: "Uncited tech" }],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.disruptorsOrTech).toBeUndefined();
+    expect(summary.sectionsRemoved).toBe(1);
+  });
+
+  it("never prunes disruptorsOrTech prose variant", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      disruptorsOrTech: {
+        format: "prose",
+        displayHeading: "Tech",
+        prose: "Innovation is happening.",
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.disruptorsOrTech).toBeDefined();
+    expect((pruned.disruptorsOrTech as { format: string }).format).toBe(
+      "prose",
+    );
+    expect(summary.sectionsKept).toBe(1);
+    expect(summary.sectionsRemoved).toBe(0);
+  });
+
+  it("never prunes industry-pulse regardless of configuration", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: { displayHeading: "Lead", prose: "Sector summary." },
+    };
+
+    const { resolved: pruned } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.industryPulse.prose).toBe("Sector summary.");
+  });
+
+  it("skips sections not in the configured sections list", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "Uncited" }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "Uncited" }],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      sections: ["dealsAndMovements"],
+    });
+
+    // competitiveLandscape was not in scope — passes through unchanged
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(1);
+    // dealsAndMovements was in scope and had no cited rows — removed
+    expect(pruned.dealsAndMovements).toBeUndefined();
+    expect(summary.sectionsRemoved).toBe(1);
+  });
+
+  it("removes quickHits section when all items are uncited", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      quickHits: {
+        displayHeading: "Quick Hits",
+        items: [{ text: "No url" }, { text: "Also no url" }],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(pruned.quickHits).toBeUndefined();
+    expect(summary.sectionsRemoved).toBe(1);
+  });
+
+  it("produces correct aggregate summary across multiple sections", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "Cited", url: CITED_URL_A }, { text: "Uncited" }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "Uncited only" }],
+      },
+      quickHits: {
+        displayHeading: "Quick Hits",
+        items: [
+          { text: "Cited A", url: CITED_URL_A },
+          { text: "Cited A dup", url: CITED_URL_A },
+          { text: "Cited B", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const { summary } = pruneNewsletterToCitedRows(resolved);
+
+    expect(summary.bulletsRemovedUncited).toBe(2);
+    expect(summary.bulletsRemovedDuplicate).toBe(1);
+    expect(summary.sectionsRemoved).toBe(1);
+    expect(summary.sectionsKept).toBe(2);
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
@@ -1,0 +1,285 @@
+import type {
+  IndustryBulletResolved,
+  IndustryDisruptorsOrTechResolved,
+  IndustryNewsletterResolved,
+  IndustryQuickHitResolved,
+} from "../industry-newsletter-urls.js";
+
+/** Why a row was removed by the prune pass. */
+export type PrunedRowReason = "uncited" | "duplicate_article";
+
+/** Per-section outcome for a single prune pass. */
+export type PruneReport = {
+  sectionKey: string;
+  removedBullets: number;
+  removedForDuplicate: number;
+  sectionRemoved: boolean;
+};
+
+/** Rolled-up counters for the run-details surface. */
+export type PruneSummary = {
+  sectionsRemoved: number;
+  bulletsRemovedUncited: number;
+  bulletsRemovedDuplicate: number;
+  sectionsKept: number;
+};
+
+export type PruneSectionKey =
+  | "competitiveLandscape"
+  | "dealsAndMovements"
+  | "regulatoryPolicyWatch"
+  | "disruptorsOrTech"
+  | "quickHits";
+
+export type PruneOptions = {
+  /** Which body sections to apply pruning to. Defaults to all five. */
+  sections?: ReadonlyArray<PruneSectionKey>;
+  /** When true, two rows citing the same article URL in the same scope are deduped. */
+  dedupeArticlesWithinSection?: boolean;
+  /**
+   * Controls whether dedup tracks seen URLs per-section ('section') or across
+   * the entire newsletter ('newsletter'). Defaults to 'section'.
+   */
+  dedupeScope?: "section" | "newsletter";
+};
+
+export type PruneNewsletterResult = {
+  resolved: IndustryNewsletterResolved;
+  reports: PruneReport[];
+  summary: PruneSummary;
+};
+
+const ALL_SECTIONS: ReadonlyArray<PruneSectionKey> = [
+  "competitiveLandscape",
+  "dealsAndMovements",
+  "regulatoryPolicyWatch",
+  "disruptorsOrTech",
+  "quickHits",
+];
+
+/** A row is cited iff `url` resolved to a non-empty string during `attachIndustryNewsletterSourceUrls`. */
+const isRowCited = (row: { url?: string }): boolean => row.url !== undefined;
+
+function pruneRows<T extends { url?: string }>(
+  rows: ReadonlyArray<T>,
+  seenUrls: Set<string>,
+  dedupeEnabled: boolean,
+): { kept: T[]; removedUncited: number; removedDuplicate: number } {
+  let removedUncited = 0;
+  let removedDuplicate = 0;
+  const kept: T[] = [];
+
+  for (const row of rows) {
+    if (!isRowCited(row)) {
+      removedUncited++;
+      continue;
+    }
+    if (dedupeEnabled) {
+      const url = row.url!;
+      if (seenUrls.has(url)) {
+        removedDuplicate++;
+        continue;
+      }
+      seenUrls.add(url);
+    }
+    kept.push(row);
+  }
+
+  return { kept, removedUncited, removedDuplicate };
+}
+
+/**
+ * Removes uncited and duplicate-article rows from a resolved newsletter.
+ *
+ * Operates on the resolved structure (URLs already attached) so "cited" is
+ * a direct `url !== undefined` check. `industry-pulse` is never touched.
+ * A section that drops to zero cited rows is set to `undefined`.
+ *
+ * @param resolved - Resolved newsletter (post URL attachment).
+ * @param opts - Which sections to prune and dedup settings.
+ * @returns Pruned resolved structure, per-section reports, and rolled-up summary.
+ */
+export function pruneNewsletterToCitedRows(
+  resolved: IndustryNewsletterResolved,
+  opts: PruneOptions = {},
+): PruneNewsletterResult {
+  const configuredSections = opts.sections ?? ALL_SECTIONS;
+  const dedupeEnabled = opts.dedupeArticlesWithinSection ?? true;
+  const dedupeScope = opts.dedupeScope ?? "section";
+
+  const reports: PruneReport[] = [];
+  let sectionsRemoved = 0;
+  let bulletsRemovedUncited = 0;
+  let bulletsRemovedDuplicate = 0;
+  let sectionsKept = 0;
+
+  // Shared URL set used when dedupeScope === 'newsletter'.
+  const newsletterSeenUrls = new Set<string>();
+
+  const getSeenUrls = (): Set<string> =>
+    dedupeScope === "newsletter" ? newsletterSeenUrls : new Set<string>();
+
+  const shouldPrune = (key: PruneSectionKey): boolean =>
+    (configuredSections as ReadonlyArray<string>).includes(key);
+
+  // --- competitiveLandscape ---
+  let competitiveLandscape = resolved.competitiveLandscape;
+  if (
+    shouldPrune("competitiveLandscape") &&
+    competitiveLandscape !== undefined
+  ) {
+    const { kept, removedUncited, removedDuplicate } = pruneRows(
+      competitiveLandscape.bullets,
+      getSeenUrls(),
+      dedupeEnabled,
+    );
+    bulletsRemovedUncited += removedUncited;
+    bulletsRemovedDuplicate += removedDuplicate;
+    const sectionRemoved = kept.length === 0;
+    reports.push({
+      sectionKey: "competitiveLandscape",
+      removedBullets: removedUncited,
+      removedForDuplicate: removedDuplicate,
+      sectionRemoved,
+    });
+    if (sectionRemoved) {
+      sectionsRemoved++;
+      competitiveLandscape = undefined;
+    } else {
+      sectionsKept++;
+      competitiveLandscape = { ...competitiveLandscape, bullets: kept };
+    }
+  }
+
+  // --- dealsAndMovements ---
+  let dealsAndMovements = resolved.dealsAndMovements;
+  if (shouldPrune("dealsAndMovements") && dealsAndMovements !== undefined) {
+    const { kept, removedUncited, removedDuplicate } = pruneRows(
+      dealsAndMovements.bullets,
+      getSeenUrls(),
+      dedupeEnabled,
+    );
+    bulletsRemovedUncited += removedUncited;
+    bulletsRemovedDuplicate += removedDuplicate;
+    const sectionRemoved = kept.length === 0;
+    reports.push({
+      sectionKey: "dealsAndMovements",
+      removedBullets: removedUncited,
+      removedForDuplicate: removedDuplicate,
+      sectionRemoved,
+    });
+    if (sectionRemoved) {
+      sectionsRemoved++;
+      dealsAndMovements = undefined;
+    } else {
+      sectionsKept++;
+      dealsAndMovements = { ...dealsAndMovements, bullets: kept };
+    }
+  }
+
+  // --- regulatoryPolicyWatch ---
+  let regulatoryPolicyWatch = resolved.regulatoryPolicyWatch;
+  if (
+    shouldPrune("regulatoryPolicyWatch") &&
+    regulatoryPolicyWatch !== undefined
+  ) {
+    const { kept, removedUncited, removedDuplicate } = pruneRows(
+      regulatoryPolicyWatch.bullets,
+      getSeenUrls(),
+      dedupeEnabled,
+    );
+    bulletsRemovedUncited += removedUncited;
+    bulletsRemovedDuplicate += removedDuplicate;
+    const sectionRemoved = kept.length === 0;
+    reports.push({
+      sectionKey: "regulatoryPolicyWatch",
+      removedBullets: removedUncited,
+      removedForDuplicate: removedDuplicate,
+      sectionRemoved,
+    });
+    if (sectionRemoved) {
+      sectionsRemoved++;
+      regulatoryPolicyWatch = undefined;
+    } else {
+      sectionsKept++;
+      regulatoryPolicyWatch = { ...regulatoryPolicyWatch, bullets: kept };
+    }
+  }
+
+  // --- disruptorsOrTech ---
+  let disruptorsOrTech: IndustryDisruptorsOrTechResolved | undefined =
+    resolved.disruptorsOrTech;
+  if (shouldPrune("disruptorsOrTech") && disruptorsOrTech !== undefined) {
+    if (disruptorsOrTech.format === "prose") {
+      // Prose variant has no individually-sourced rows; exempt from pruning.
+      sectionsKept++;
+    } else {
+      const { kept, removedUncited, removedDuplicate } = pruneRows(
+        disruptorsOrTech.bullets,
+        getSeenUrls(),
+        dedupeEnabled,
+      );
+      bulletsRemovedUncited += removedUncited;
+      bulletsRemovedDuplicate += removedDuplicate;
+      const sectionRemoved = kept.length === 0;
+      reports.push({
+        sectionKey: "disruptorsOrTech",
+        removedBullets: removedUncited,
+        removedForDuplicate: removedDuplicate,
+        sectionRemoved,
+      });
+      if (sectionRemoved) {
+        sectionsRemoved++;
+        disruptorsOrTech = undefined;
+      } else {
+        sectionsKept++;
+        disruptorsOrTech = { ...disruptorsOrTech, bullets: kept };
+      }
+    }
+  }
+
+  // --- quickHits ---
+  let quickHits = resolved.quickHits;
+  if (shouldPrune("quickHits") && quickHits !== undefined) {
+    const { kept, removedUncited, removedDuplicate } = pruneRows(
+      quickHits.items,
+      getSeenUrls(),
+      dedupeEnabled,
+    );
+    bulletsRemovedUncited += removedUncited;
+    bulletsRemovedDuplicate += removedDuplicate;
+    const sectionRemoved = kept.length === 0;
+    reports.push({
+      sectionKey: "quickHits",
+      removedBullets: removedUncited,
+      removedForDuplicate: removedDuplicate,
+      sectionRemoved,
+    });
+    if (sectionRemoved) {
+      sectionsRemoved++;
+      quickHits = undefined;
+    } else {
+      sectionsKept++;
+      quickHits = { ...quickHits, items: kept };
+    }
+  }
+
+  return {
+    resolved: {
+      subject: resolved.subject,
+      industryPulse: resolved.industryPulse,
+      ...(competitiveLandscape !== undefined ? { competitiveLandscape } : {}),
+      ...(dealsAndMovements !== undefined ? { dealsAndMovements } : {}),
+      ...(regulatoryPolicyWatch !== undefined ? { regulatoryPolicyWatch } : {}),
+      ...(disruptorsOrTech !== undefined ? { disruptorsOrTech } : {}),
+      ...(quickHits !== undefined ? { quickHits } : {}),
+    },
+    reports,
+    summary: {
+      sectionsRemoved,
+      bulletsRemovedUncited,
+      bulletsRemovedDuplicate,
+      sectionsKept,
+    },
+  };
+}

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { logger } from "@workspace/logger";
 
+import { parseIndustryNewsletterWire } from "@workspace/email-templates/parse-industry-newsletter-wire";
+
 import {
   ContentGenerationConfigSchema,
   resolveContentGenerationConfig,
@@ -46,6 +48,7 @@ const conservativeTestConfigInput = {
     polish: { enabled: false },
     crossRunDedup: { enabled: false },
     selfCritique: { enabled: false },
+    requireCitation: { enabled: false },
   },
   delivery: {
     subjectLine: { enabled: false },
@@ -1961,5 +1964,111 @@ describe("generateNewsletterWithLlm — best-quality default profile", () => {
     expect(result.numericAnchorSummary).toBeDefined();
     expect(result.critiqueSummary).toBeDefined();
     expect(result.subjectLineSummary).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: require-citation pruning pass
+// ---------------------------------------------------------------------------
+
+describe("generateNewsletterWithLlm — require-citation pruning", () => {
+  const requireCitationConfig = resolveContentGenerationConfig(
+    ContentGenerationConfigSchema.parse({
+      ...conservativeTestConfigInput,
+      quality: {
+        ...conservativeTestConfigInput.quality,
+        requireCitation: { enabled: true },
+      },
+    }),
+  );
+
+  it("removes a section whose bullets are all uncited and keeps cited sections", async () => {
+    // competitive-landscape has only uncited bullets (no articleIndex),
+    // deals has one bullet with articleIndex 1 which resolves to testSources[0].url.
+    const generateObjectFn = makeSuccessfulGenerateFn({
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "Uncited A" }, { text: "Uncited B" }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "Cited deal", articleIndex: 1 }],
+      },
+      regulatoryPolicyWatch: {
+        displayHeading: "Regulatory",
+        bullets: [{ text: "Uncited regulatory" }],
+      },
+      disruptorsOrTech: {
+        format: "prose",
+        displayHeading: "Disruptors",
+        prose: "Innovation forward.",
+      },
+      quickHits: {
+        displayHeading: "Quick Hits",
+        items: [
+          { text: "Hit with source", articleIndex: 1 },
+          { text: "Hit with source 2", articleIndex: 2 },
+          { text: "Hit with source 3", articleIndex: 3 },
+          { text: "Hit uncited" },
+          { text: "Hit duplicate", articleIndex: 1 },
+        ],
+      },
+    });
+
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      requireCitationConfig,
+      { tickerId: "TEST", date: "2024-01-01" },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    const parsed = parseIndustryNewsletterWire(result.content);
+
+    const keys = parsed?.sections.map((s) => s.machineKey) ?? [];
+    expect(keys).toContain("industry-pulse");
+    expect(keys).not.toContain("competitive-landscape");
+    expect(keys).toContain("deals-and-movements");
+    expect(keys).not.toContain("regulatory-policy-watch");
+    expect(keys).toContain("disruptors-or-tech");
+    expect(keys).toContain("quick-hits");
+
+    expect(result.requireCitationSummary).toBeDefined();
+    expect(result.requireCitationSummary?.sectionsRemoved).toBe(2);
+    expect(
+      result.requireCitationSummary?.bulletsRemovedUncited,
+    ).toBeGreaterThan(0);
+    expect(result.requireCitationSummary?.bulletsRemovedDuplicate).toBe(1);
+  });
+
+  it("passes content through unchanged when requireCitation is disabled", async () => {
+    const generateObjectFn = makeSuccessfulGenerateFn({
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: "Uncited" }],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: "Uncited" }],
+      },
+      regulatoryPolicyWatch: {
+        displayHeading: "Regulatory",
+        bullets: [{ text: "Uncited" }],
+      },
+    });
+
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      { tickerId: "TEST", date: "2024-01-01" },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    expect(result.requireCitationSummary).toBeUndefined();
+    // All sections remain since pruning is off
+    const parsed = parseIndustryNewsletterWire(result.content);
+    const keys = parsed?.sections.map((s) => s.machineKey) ?? [];
+    expect(keys).toContain("competitive-landscape");
+    expect(keys).toContain("deals-and-movements");
+    expect(keys).toContain("regulatory-policy-watch");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -2009,7 +2009,7 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
           { text: "Hit with source", articleIndex: 1 },
           { text: "Hit with source 2", articleIndex: 2 },
           { text: "Hit with source 3", articleIndex: 3 },
-          { text: "Hit uncited" },
+          { text: "Hit uncited", articleIndex: 99 },
           { text: "Hit duplicate", articleIndex: 1 },
         ],
       },

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -11,6 +11,10 @@ import {
   industryNewsletterStructureSchema,
 } from "./industry-newsletter-schema.js";
 import { attachIndustryNewsletterSourceUrls } from "./industry-newsletter-urls.js";
+import {
+  pruneNewsletterToCitedRows,
+  type PruneSummary,
+} from "./lib/prune-uncited-rows.js";
 import { isRetryableLlmError } from "./llm-classify-error.js";
 import {
   buildExemplarPromptSection,
@@ -141,6 +145,8 @@ export interface GeneratedContentWithProvenance extends GeneratedContent {
     PolishNewsletterResult,
     "reports" | "totalReplacements" | "rulesFired"
   >;
+  /** Require-citation pruning counters when the pass is enabled. */
+  requireCitationSummary?: PruneSummary;
 }
 
 /**
@@ -484,7 +490,9 @@ Return JSON matching this shape (camelCase keys):
 - "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
 - "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "text", "articleIndex" } (index required for every quick hit).
 
-Headings ("displayHeading") are short subtitle phrases only — never repeat the section label or use "Label / Subtitle" format. Keep JSON valid; use null for optional blocks and uncited articleIndex values.`;
+Headings ("displayHeading") are short subtitle phrases only — never repeat the section label or use "Label / Subtitle" format. Keep JSON valid; use null for optional blocks and uncited articleIndex values.
+
+Every bullet and quick hit must summarize exactly one article and set articleIndex to that one article. Do not blend multiple articles into one bullet, and do not reuse the same article for two bullets in a section.`;
 
 /**
  * Default user prompt template used when no template is provided in config.
@@ -1296,10 +1304,44 @@ export async function generateNewsletterWithLlm(
     );
   }
 
-  const resolved = attachIndustryNewsletterSourceUrls(
+  let resolved = attachIndustryNewsletterSourceUrls(
     finalStructure,
     promptSources,
   );
+
+  let requireCitationSummary: PruneSummary | undefined;
+  const requireCitation = config.quality.requireCitation;
+  if (requireCitation.enabled) {
+    if (citationGrounding.enabled) {
+      logger.info(
+        {
+          tickerId: context.tickerId,
+          groundingPolicy: citationGrounding.policy,
+        },
+        "Citation grounding and require-citation pruning are both enabled; unlinked bullets will be pruned",
+      );
+    }
+
+    const pruned = pruneNewsletterToCitedRows(resolved, {
+      sections: requireCitation.sections,
+      dedupeArticlesWithinSection: requireCitation.dedupeArticlesWithinSection,
+      dedupeScope: requireCitation.dedupeScope,
+    });
+    resolved = pruned.resolved;
+    requireCitationSummary = pruned.summary;
+
+    logger.info(
+      {
+        tickerId: context.tickerId,
+        sectionsRemoved: pruned.summary.sectionsRemoved,
+        bulletsRemovedUncited: pruned.summary.bulletsRemovedUncited,
+        bulletsRemovedDuplicate: pruned.summary.bulletsRemovedDuplicate,
+        sectionsKept: pruned.summary.sectionsKept,
+      },
+      "Require-citation pruning summary",
+    );
+  }
+
   const content = formatIndustryNewsletterWire(resolved);
 
   return {
@@ -1333,5 +1375,6 @@ export async function generateNewsletterWithLlm(
     ...(critiqueSkippedDueToBudget ? { critiqueSkippedDueToBudget: true } : {}),
     ...(critiqueFailed ? { critiqueFailed: true } : {}),
     ...(polishSummary !== undefined ? { polishSummary } : {}),
+    ...(requireCitationSummary !== undefined ? { requireCitationSummary } : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -638,6 +638,18 @@ export async function run({
             },
           }
         : {}),
+      ...(generated.requireCitationSummary !== undefined
+        ? {
+            requireCitation: {
+              sectionsRemoved: generated.requireCitationSummary.sectionsRemoved,
+              bulletsRemovedUncited:
+                generated.requireCitationSummary.bulletsRemovedUncited,
+              bulletsRemovedDuplicate:
+                generated.requireCitationSummary.bulletsRemovedDuplicate,
+              sectionsKept: generated.requireCitationSummary.sectionsKept,
+            },
+          }
+        : {}),
     },
   };
 }

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -37,23 +37,24 @@ Successful runs include `details.promptHash` (16-character hex, same algorithm a
 
 The Hermes form renders nine top-level sections in this order: **Credentials**, **Output**, **Prompts**, **Inputs**, **Creativity**, **Quality**, **Delivery**, **Freshness**, **Reliability**. An empty `{}` applies the best-quality defaults from plan 62 (all quality passes on). Legacy flat keys are rejected — see [Config Reference](/mediapulse/apps/agents/content-generation-config-reference).
 
-| Field | Type | Default | Description |
-|---|---|---|---|
-| `credentials.openaiApiKey` | `string` | `{{OPENAI_API_KEY}}` | OpenAI API key or Hermes variable placeholder. |
-| `credentials.chatModel` | `string` | `{{OPENAI_MODEL}}` | Chat model id or Hermes variable placeholder. |
-| `credentials.baseUrl` | `string (url)` | official | OpenAI-compatible API base URL. |
-| `credentials.timeoutMs` | `number` | `120000` | Per-request timeout in milliseconds. |
-| `output.topNewsCount` | `number` | `10` | Articles in the LLM prompt. |
-| `creativity.brainstorm.enabled` | `boolean` | `true` | Two-pass editor's memo before structured JSON. |
-| `inputs.fewShot.enabled` | `boolean` | `true` | Few-shot exemplar injection. |
-| `inputs.sourceRanking.enabled` | `boolean` | `true` | Pre-LLM source ranking. |
-| `quality.selfCritique.enabled` | `boolean` | `true` | Self-critique pass. |
-| `quality.citationGrounding.enabled` | `boolean` | `true` | Citation grounding. |
-| `quality.polish.enabled` | `boolean` | `true` | Style polish. |
-| `quality.crossRunDedup.enabled` | `boolean` | `true` | Cross-run dedup. |
-| `delivery.subjectLine.enabled` | `boolean` | `true` | Subject-line scoring. |
-| `reliability.llmRetry.maxAttempts` | `number` | `3` | LLM retry attempts. |
-| `reliability.persistRetry.maxAttempts` | `number` | `2` | Persist retry attempts. |
+| Field                                  | Type           | Default              | Description                                                                                |
+| -------------------------------------- | -------------- | -------------------- | ------------------------------------------------------------------------------------------ |
+| `credentials.openaiApiKey`             | `string`       | `{{OPENAI_API_KEY}}` | OpenAI API key or Hermes variable placeholder.                                             |
+| `credentials.chatModel`                | `string`       | `{{OPENAI_MODEL}}`   | Chat model id or Hermes variable placeholder.                                              |
+| `credentials.baseUrl`                  | `string (url)` | official             | OpenAI-compatible API base URL.                                                            |
+| `credentials.timeoutMs`                | `number`       | `120000`             | Per-request timeout in milliseconds.                                                       |
+| `output.topNewsCount`                  | `number`       | `10`                 | Articles in the LLM prompt.                                                                |
+| `creativity.brainstorm.enabled`        | `boolean`      | `true`               | Two-pass editor's memo before structured JSON.                                             |
+| `inputs.fewShot.enabled`               | `boolean`      | `true`               | Few-shot exemplar injection.                                                               |
+| `inputs.sourceRanking.enabled`         | `boolean`      | `true`               | Pre-LLM source ranking.                                                                    |
+| `quality.selfCritique.enabled`         | `boolean`      | `true`               | Self-critique pass.                                                                        |
+| `quality.citationGrounding.enabled`    | `boolean`      | `true`               | Citation grounding.                                                                        |
+| `quality.polish.enabled`               | `boolean`      | `true`               | Style polish.                                                                              |
+| `quality.crossRunDedup.enabled`        | `boolean`      | `true`               | Cross-run dedup.                                                                           |
+| `quality.requireCitation.enabled`      | `boolean`      | `true`               | Require-citation pruning (drops uncited rows, dedupes by article, removes empty sections). |
+| `delivery.subjectLine.enabled`         | `boolean`      | `true`               | Subject-line scoring.                                                                      |
+| `reliability.llmRetry.maxAttempts`     | `number`       | `3`                  | LLM retry attempts.                                                                        |
+| `reliability.persistRetry.maxAttempts` | `number`       | `2`                  | Persist retry attempts.                                                                    |
 
 Full field list: [Config Reference](/mediapulse/apps/agents/content-generation-config-reference).
 
@@ -157,8 +158,8 @@ Newsletter generation can prepend one or two hand-curated **voice exemplars** be
 
 ### What each exemplar teaches
 
-| Exemplar bank id  | Sector tag   | Teaches                                                                                                     |
-| ----------------- | ------------ | ----------------------------------------------------------------------------------------------------------- |
+| Exemplar bank id  | Sector tag   | Teaches                                                        |
+| ----------------- | ------------ | -------------------------------------------------------------- |
 | `industrial-INDX` | `industrial` | Grounded industrial prose, cited bullets, personality headings |
 | `consumer-CONSM`  | `consumer`   | Consumer/financial voice, quick-hit density                    |
 
@@ -210,11 +211,11 @@ Each label forces a different cognitive mode (synthesis, expansion, concrete fig
 
 ### Config
 
-| Field                       | Default        | Description                            |
-| --------------------------- | -------------- | -------------------------------------- |
-| `creativity.brainstorm.enabled` | `true` | Enable two-pass generation |
-| `creativity.brainstorm.model` | `credentials.chatModel` | Cheaper model for the memo leg is fine |
-| `brainstormMaxOutputTokens` | `700`          | Memos are short by design              |
+| Field                           | Default                 | Description                            |
+| ------------------------------- | ----------------------- | -------------------------------------- |
+| `creativity.brainstorm.enabled` | `true`                  | Enable two-pass generation             |
+| `creativity.brainstorm.model`   | `credentials.chatModel` | Cheaper model for the memo leg is fine |
+| `brainstormMaxOutputTokens`     | `700`                   | Memos are short by design              |
 
 ### Cost and timeout
 
@@ -364,12 +365,12 @@ The subject from the main structured pass competes as **candidate 0** with a pre
 
 ### Config
 
-| Field                        | Default        | Description                              |
-| ---------------------------- | -------------- | ---------------------------------------- |
-| `subjectLine.enabled`        | `false`        | Enable candidate generation and scoring  |
-| `subjectLine.candidateCount` | `5`            | Target number of LLM candidates (3–8)    |
-| `delivery.subjectLine.model` | `credentials.chatModel` | Sidecar model (cheaper tier is fine) |
-| `subjectLine.weights.*`      | see axes above | Per-axis weights for the composite score |
+| Field                        | Default                 | Description                              |
+| ---------------------------- | ----------------------- | ---------------------------------------- |
+| `subjectLine.enabled`        | `false`                 | Enable candidate generation and scoring  |
+| `subjectLine.candidateCount` | `5`                     | Target number of LLM candidates (3–8)    |
+| `delivery.subjectLine.model` | `credentials.chatModel` | Sidecar model (cheaper tier is fine)     |
+| `subjectLine.weights.*`      | see axes above          | Per-axis weights for the composite score |
 
 ### Observability
 
@@ -389,14 +390,14 @@ The `MP_NEWSLETTER` wire format supports a variable set of body sections. Only s
 
 ### Mandatory vs omittable
 
-| Section | Status |
-|---|---|
-| `industry-pulse` | Always emitted. It is the newsletter spine and carries no citation. |
-| `competitive-landscape` | Omittable. Absent when the field is `undefined` on the resolved briefing. |
-| `deals-and-movements` | Omittable. |
-| `regulatory-policy-watch` | Omittable. |
-| `disruptors-or-tech` | Omittable. The bullets variant is also suppressed when it has zero rows. |
-| `quick-hits` | Omittable. |
+| Section                   | Status                                                                    |
+| ------------------------- | ------------------------------------------------------------------------- |
+| `industry-pulse`          | Always emitted. It is the newsletter spine and carries no citation.       |
+| `competitive-landscape`   | Omittable. Absent when the field is `undefined` on the resolved briefing. |
+| `deals-and-movements`     | Omittable.                                                                |
+| `regulatory-policy-watch` | Omittable.                                                                |
+| `disruptors-or-tech`      | Omittable. The bullets variant is also suppressed when it has zero rows.  |
+| `quick-hits`              | Omittable.                                                                |
 
 ### Representation of absence
 
@@ -511,14 +512,14 @@ Critique **never** emits output that fails `industryNewsletterStructureSchema`. 
 
 ### Config
 
-| Field                                  | Default        | Description                                  |
-| -------------------------------------- | -------------- | -------------------------------------------- |
-| `selfCritique.enabled`                 | `false`        | Enable the critic pass                       |
-| `selfCritique.dropFraction`            | `0.2`          | Max fraction of bullets rewritten or dropped |
-| `selfCritique.minBulletCount`          | `8`            | Skip critique below this bullet count        |
-| `quality.selfCritique.critiqueModel` | `credentials.chatModel` | Critic model (cheaper tier is fine) |
-| `selfCritique.critiqueMaxOutputTokens` | `1500`         | Output cap for the critic call               |
-| `selfCritique.preferRewriteOverDrop`   | `true`         | Use `suggestedRewrite` before dropping       |
+| Field                                  | Default                 | Description                                  |
+| -------------------------------------- | ----------------------- | -------------------------------------------- |
+| `selfCritique.enabled`                 | `false`                 | Enable the critic pass                       |
+| `selfCritique.dropFraction`            | `0.2`                   | Max fraction of bullets rewritten or dropped |
+| `selfCritique.minBulletCount`          | `8`                     | Skip critique below this bullet count        |
+| `quality.selfCritique.critiqueModel`   | `credentials.chatModel` | Critic model (cheaper tier is fine)          |
+| `selfCritique.critiqueMaxOutputTokens` | `1500`                  | Output cap for the critic call               |
+| `selfCritique.preferRewriteOverDrop`   | `true`                  | Use `suggestedRewrite` before dropping       |
 
 ### Deadline guard
 
@@ -526,7 +527,7 @@ When wall-clock since run start exceeds **70%** of `credentials.timeoutMs` after
 
 ### Pipeline order
 
-`structured JSON` → numeric anchor audit (optional) → self-critique (optional) → style polish (optional) → citation grounding (optional) → subject line (optional) → cross-run dedup (optional) → wire format.
+`structured JSON` → numeric anchor audit (optional) → self-critique (optional) → style polish (optional) → citation grounding (optional) → subject line (optional) → cross-run dedup (optional) → URL attachment → require-citation pruning (optional) → wire format.
 
 ### Observability
 
@@ -535,3 +536,72 @@ Logs include `critique: { bulletsRated, bulletsRewritten, bulletsDropped, floorP
 ### Rollout
 
 Opt in per ticker with `selfCritique.enabled: true`. A cheaper `critiqueModel` paired with a premium structured pass is a sensible default.
+
+## Require-citation pruning
+
+The final transform in the pipeline guarantees that every bullet and quick hit a subscriber sees is backed by exactly one distinct, linkable article. It enforces three rules:
+
+1. **Drop uncited rows** — a bullet or quick-hit whose `articleIndex` is null, out of range, or resolves to an empty URL is removed.
+2. **One article per row** — within the dedup scope, only the first row for a given resolved article URL is kept; later rows citing the same article are dropped.
+3. **Remove empty sections** — a section that reaches zero cited rows is set to `undefined` and omitted from the wire. A section with at least one cited row survives.
+
+The pass runs **last**, after URL attachment, so `url !== undefined` is the only check needed.
+
+### What is pruned
+
+| Section                        | Prunable? | Notes                                        |
+| ------------------------------ | --------- | -------------------------------------------- |
+| `industry-pulse`               | Never     | Framing prose with no single source.         |
+| `competitive-landscape`        | Yes       | Bullets variant.                             |
+| `deals-and-movements`          | Yes       | Bullets variant.                             |
+| `regulatory-policy-watch`      | Yes       | Bullets variant.                             |
+| `disruptors-or-tech` (bullets) | Yes       | Only the bullets variant.                    |
+| `disruptors-or-tech` (prose)   | Never     | Framing prose; exempt like `industry-pulse`. |
+| `quick-hits`                   | Yes       | Items (same URL check).                      |
+
+### Interaction with citation grounding
+
+Citation grounding (`quality.citationGrounding`) runs earlier and can **unlink** a bullet (strip its article URL but keep the text) or **drop** it (remove the row). When both passes are on:
+
+- `policy: drop` — grounding removes the row; the prune pass does not see it. Same outcome, single step.
+- `policy: unlink` — grounding strips the URL; the prune pass then removes the row (no URL). Two steps, same result.
+- `policy: warn` — grounding logs only; the prune pass performs the actual removal.
+
+Pairing `policy: drop` with `requireCitation.enabled: true` keeps all removal logic in grounding. Pairing `policy: unlink` with pruning enabled gives the same reader-facing output through two passes. When both are enabled a log note is emitted at info level.
+
+### Before / after example
+
+**Before pruning** (resolved structure):
+
+```
+competitive-landscape: [{ text: "Rival bid", url: "https://a.com" }, { text: "No source" }]
+regulatory-policy-watch: [{ text: "Permit delay" }]          ← no url
+quick-hits: [{ text: "Hit 1", url: "https://b.com" }, { text: "Hit 2", url: "https://a.com" }, ...]
+```
+
+**After pruning** (dedupeScope: 'section'):
+
+```
+competitive-landscape: [{ text: "Rival bid", url: "https://a.com" }]   ← "No source" dropped
+regulatory-policy-watch: undefined                                       ← section removed
+quick-hits: [{ text: "Hit 1", url: "https://b.com" }, { text: "Hit 2", url: "https://a.com" }, ...]
+```
+
+Note: with `dedupeScope: 'newsletter'`, `Hit 2` would also be dropped because `https://a.com` was already seen in `competitive-landscape`.
+
+### Config
+
+| Field                                         | Default   | Description                                                                |
+| --------------------------------------------- | --------- | -------------------------------------------------------------------------- |
+| `requireCitation.enabled`                     | `true`    | Enable the pruning pass. Set to `false` for byte-for-byte current output.  |
+| `requireCitation.sections`                    | all five  | Which body sections to prune. `industry-pulse` is always exempt.           |
+| `requireCitation.dedupeArticlesWithinSection` | `true`    | When false, dedup is skipped (uncited rows are still removed).             |
+| `requireCitation.dedupeScope`                 | `section` | `section` = per-section dedup; `newsletter` = one URL across all sections. |
+
+### Observability
+
+One info log per run: `{ sectionsRemoved, bulletsRemovedUncited, bulletsRemovedDuplicate, sectionsKept }`. Run details include a `requireCitation` block with the same four counters. A consistently high `sectionsRemoved` count for a ticker signals thin days — check the `lowInformationDay` signal from cross-run dedup and the yield snapshot for root cause.
+
+### Rollout
+
+The pass is **on by default**. To opt out a ticker while assessing output quality, set `requireCitation.enabled: false` in its Hermes config. The `dedupeScope: 'newsletter'` option is available but not the shipped default — use it when per-section dedup still allows duplicate articles across the briefing.


### PR DESCRIPTION
## Summary

This PR adds a final require-citation pruning pass to the content-generation pipeline. After source URLs are attached, the agent drops uncited rows, dedupes repeated article links, and removes sections that end up empty before the wire is serialized.

## Related issues

Closes #627

## Important changes

- New `quality.requireCitation` config controls enablement, target sections, and dedup scope (`section` vs `newsletter`).
- `pruneNewsletterToCitedRows` runs after URL attachment and before wire formatting.
- Run details and logs now include pruning counters (`sectionsRemoved`, `bulletsRemovedUncited`, `bulletsRemovedDuplicate`, `sectionsKept`).
- The LLM system prompt now asks for one article per bullet and no duplicate article reuse within a section.

## Other changes

- Unit tests for the prune helper and an integration test through `generateNewsletterWithLlm`.
- Dev docs for config, pipeline order, grounding interaction, and rollout notes.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts` - pruning rules and summary counters.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` - pipeline hook and prompt update.
- `apps/mediapulse/agents/content-generation/src/config-schema.ts` - `requireCitation` schema defaults.
- `apps/mediapulse/agents/content-generation/src/run.ts` - run-details exposure.

## How to test

1. `corepack pnpm format:check`
2. `corepack pnpm --filter @mediapulse/content-generation type:check`
3. `corepack pnpm --filter @mediapulse/content-generation test:coverage`
4. Confirm a run with `quality.requireCitation.enabled: true` omits uncited sections from the wire and logs the pruning summary.

