### PR TITLE
Return KG competitors from content-generation GET

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -189,6 +189,8 @@ describe("agent-data-api", () => {
         ],
         tickerSymbol: "TEST",
         tickerName: "Test Company",
+        competitors: [],
+        issuerAliases: ["TEST", "Test Company"],
       });
 
       const { app } = await import("./index.js");

--- a/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
@@ -8,10 +8,20 @@ vi.mock("@mediapulse/database", () => ({
     },
     ticker: {
       findUniqueOrThrow: vi.fn(),
+      findUnique: vi.fn(),
     },
     newsletter: {
       create: vi.fn(),
       findFirst: vi.fn(),
+      findMany: vi.fn(),
+    },
+    entityType: {
+      findFirst: vi.fn(),
+    },
+    tickerEntity: {
+      findFirst: vi.fn(),
+    },
+    entityRelation: {
       findMany: vi.fn(),
     },
   },
@@ -19,6 +29,7 @@ vi.mock("@mediapulse/database", () => ({
 
 import {
   createNewsletter,
+  getCompetitorsForTicker,
   getDataSourcesForTicker,
   getLatestNewsletter,
   getRecentNewsletterSubjects,
@@ -30,10 +41,20 @@ type MockDb = {
   };
   ticker: {
     findUniqueOrThrow: ReturnType<typeof vi.fn>;
+    findUnique: ReturnType<typeof vi.fn>;
   };
   newsletter: {
     create: ReturnType<typeof vi.fn>;
     findFirst: ReturnType<typeof vi.fn>;
+  };
+  entityType: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+  tickerEntity: {
+    findFirst: ReturnType<typeof vi.fn>;
+  };
+  entityRelation: {
+    findMany: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -43,10 +64,20 @@ const createMockDb = (): MockDb => ({
   },
   ticker: {
     findUniqueOrThrow: vi.fn(),
+    findUnique: vi.fn().mockResolvedValue(null),
   },
   newsletter: {
     create: vi.fn(),
     findFirst: vi.fn(),
+  },
+  entityType: {
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  tickerEntity: {
+    findFirst: vi.fn().mockResolvedValue(null),
+  },
+  entityRelation: {
+    findMany: vi.fn().mockResolvedValue([]),
   },
 });
 
@@ -464,5 +495,396 @@ describe("getRecentNewsletterSubjects", () => {
         orderBy: { createdAt: "desc" },
       }),
     );
+  });
+});
+
+type MockEntityRelationDb = {
+  entityRelation: { findMany: ReturnType<typeof vi.fn> };
+};
+
+const makeCompanyEntity = (
+  id: string,
+  canonicalName: string,
+  aliases: string[] = [],
+) => ({
+  id,
+  canonicalName,
+  type: { name: "COMPANY" },
+  aliases: aliases.map((alias) => ({ alias })),
+});
+
+const makeRelation = (
+  fromEntityId: string,
+  toEntityId: string,
+  fromEntity: ReturnType<typeof makeCompanyEntity>,
+  toEntity: ReturnType<typeof makeCompanyEntity>,
+  relationTypeName: string,
+  weight: number,
+) => ({
+  fromEntityId,
+  toEntityId,
+  weight,
+  relationType: { name: relationTypeName },
+  fromEntity,
+  toEntity,
+});
+
+describe("getCompetitorsForTicker — competitor resolution", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns COMPETITOR before SECTOR_PEER when ordered by weight desc", async () => {
+    // Setup
+    const issuerEntityId = "entity-bbca";
+    const issuerEntity = makeCompanyEntity(
+      issuerEntityId,
+      "Bank Central Asia",
+      ["BBCA"],
+    );
+    const mandiriEntity = makeCompanyEntity("entity-mandiri", "Bank Mandiri", [
+      "Mandiri",
+    ]);
+    const briEntity = makeCompanyEntity("entity-bri", "Bank BRI", ["BRI"]);
+
+    const db: MockEntityRelationDb = {
+      entityRelation: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            makeRelation(
+              issuerEntityId,
+              "entity-mandiri",
+              issuerEntity,
+              mandiriEntity,
+              "COMPETITOR",
+              0.9,
+            ),
+            makeRelation(
+              issuerEntityId,
+              "entity-bri",
+              issuerEntity,
+              briEntity,
+              "SECTOR_PEER",
+              0.6,
+            ),
+          ]),
+      },
+    };
+    const issuerNormalizedAliasSet = new Set(["bank central asia", "bbca"]);
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      issuerEntityId,
+      issuerNormalizedAliasSet,
+      {},
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(2);
+    expect(result[0]?.name).toBe("Bank Mandiri");
+    expect(result[0]?.relation).toBe("COMPETITOR");
+    expect(result[0]?.weight).toBe(0.9);
+    expect(result[1]?.name).toBe("Bank BRI");
+    expect(result[1]?.relation).toBe("SECTOR_PEER");
+    expect(result[1]?.weight).toBe(0.6);
+  });
+
+  it("filters out a self-loop edge pointing back to the issuer entityId", async () => {
+    // Setup
+    const issuerEntityId = "entity-bbca";
+    const issuerEntity = makeCompanyEntity(
+      issuerEntityId,
+      "Bank Central Asia",
+      ["BBCA"],
+    );
+
+    const db: MockEntityRelationDb = {
+      entityRelation: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            makeRelation(
+              issuerEntityId,
+              issuerEntityId,
+              issuerEntity,
+              issuerEntity,
+              "COMPETITOR",
+              1.0,
+            ),
+          ]),
+      },
+    };
+    const issuerNormalizedAliasSet = new Set(["bank central asia", "bbca"]);
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      issuerEntityId,
+      issuerNormalizedAliasSet,
+      {},
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(0);
+  });
+
+  it("filters out a peer whose normalized name matches an issuer alias", async () => {
+    // Setup
+    const issuerEntityId = "entity-bbca";
+    const issuerEntity = makeCompanyEntity(
+      issuerEntityId,
+      "Bank Central Asia",
+      ["BBCA"],
+    );
+    const aliasMatchEntity = makeCompanyEntity(
+      "entity-other",
+      "Bank Central Asia",
+      [],
+    );
+
+    const db: MockEntityRelationDb = {
+      entityRelation: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            makeRelation(
+              issuerEntityId,
+              "entity-other",
+              issuerEntity,
+              aliasMatchEntity,
+              "COMPETITOR",
+              0.8,
+            ),
+          ]),
+      },
+    };
+    const issuerNormalizedAliasSet = new Set(["bank central asia", "bbca"]);
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      issuerEntityId,
+      issuerNormalizedAliasSet,
+      {},
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(0);
+  });
+
+  it("deduplicates by entityId, keeping first occurrence", async () => {
+    // Setup
+    const issuerEntityId = "entity-bbca";
+    const issuerEntity = makeCompanyEntity(
+      issuerEntityId,
+      "Bank Central Asia",
+      ["BBCA"],
+    );
+    const mandiriEntity = makeCompanyEntity(
+      "entity-mandiri",
+      "Bank Mandiri",
+      [],
+    );
+
+    const db: MockEntityRelationDb = {
+      entityRelation: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            makeRelation(
+              issuerEntityId,
+              "entity-mandiri",
+              issuerEntity,
+              mandiriEntity,
+              "COMPETITOR",
+              0.9,
+            ),
+            makeRelation(
+              issuerEntityId,
+              "entity-mandiri",
+              issuerEntity,
+              mandiriEntity,
+              "SECTOR_PEER",
+              0.5,
+            ),
+          ]),
+      },
+    };
+    const issuerNormalizedAliasSet = new Set(["bank central asia", "bbca"]);
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      issuerEntityId,
+      issuerNormalizedAliasSet,
+      {},
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(1);
+    expect(result[0]?.relation).toBe("COMPETITOR");
+  });
+
+  it("respects maxCompetitors cap", async () => {
+    // Setup
+    const issuerEntityId = "entity-issuer";
+    const issuerEntity = makeCompanyEntity(issuerEntityId, "Issuer Corp", []);
+    const peerRelations = Array.from({ length: 10 }, (_, index) => {
+      const peerEntity = makeCompanyEntity(
+        `entity-peer-${index}`,
+        `Peer ${index}`,
+        [],
+      );
+      return makeRelation(
+        issuerEntityId,
+        `entity-peer-${index}`,
+        issuerEntity,
+        peerEntity,
+        "SECTOR_PEER",
+        0.5,
+      );
+    });
+
+    const db: MockEntityRelationDb = {
+      entityRelation: { findMany: vi.fn().mockResolvedValue(peerRelations) },
+    };
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      issuerEntityId,
+      new Set(["issuer corp"]),
+      { maxCompetitors: 3 },
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(3);
+  });
+
+  it("returns empty array when entityRelation.findMany returns no edges", async () => {
+    // Setup
+    const db: MockEntityRelationDb = {
+      entityRelation: { findMany: vi.fn().mockResolvedValue([]) },
+    };
+
+    // Act
+    const result = await getCompetitorsForTicker(
+      "entity-issuer",
+      new Set(["issuer corp"]),
+      {},
+      db as Parameters<typeof getCompetitorsForTicker>[3],
+    );
+
+    // Assert
+    expect(result).toHaveLength(0);
+  });
+});
+
+describe("getDataSourcesForTicker — competitors and issuerAliases in response", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns competitors and issuerAliases when anchor and edges exist", async () => {
+    // Setup
+    const db = createMockDb();
+    db.ticker.findUniqueOrThrow.mockResolvedValue({
+      symbol: "BBCA",
+      name: "Bank Central Asia",
+    });
+    db.ticker.findUnique.mockResolvedValue({
+      symbol: "BBCA",
+      name: "Bank Central Asia",
+    });
+    db.dataSource.findMany.mockResolvedValue([]);
+    db.entityType.findFirst.mockResolvedValue({ id: "type-company" });
+    db.tickerEntity.findFirst.mockResolvedValue({
+      entityId: "entity-bbca",
+      entity: {
+        canonicalName: "Bank Central Asia",
+        aliases: [{ alias: "BBCA" }, { alias: "PT Bank Central Asia Tbk" }],
+      },
+    });
+    db.entityRelation.findMany.mockResolvedValue([
+      makeRelation(
+        "entity-bbca",
+        "entity-mandiri",
+        makeCompanyEntity("entity-bbca", "Bank Central Asia", ["BBCA"]),
+        makeCompanyEntity("entity-mandiri", "Bank Mandiri", ["Mandiri"]),
+        "COMPETITOR",
+        0.9,
+      ),
+    ]);
+
+    // Act
+    const result = await getDataSourcesForTicker("ticker-bbca", {
+      db: db as unknown as NonNullable<GetDataSourcesDeps["db"]>,
+      now: () => new Date("2026-05-01T10:00:00.000Z"),
+    });
+
+    // Assert
+    expect(result.competitors).toHaveLength(1);
+    expect(result.competitors[0]?.name).toBe("Bank Mandiri");
+    expect(result.competitors[0]?.relation).toBe("COMPETITOR");
+    expect(result.issuerAliases).toContain("BBCA");
+    expect(result.issuerAliases).toContain("Bank Central Asia");
+    expect(result.issuerAliases).toContain("PT Bank Central Asia Tbk");
+  });
+
+  it("returns empty competitors and fallback issuerAliases when no KG anchor exists", async () => {
+    // Setup
+    const db = createMockDb();
+    db.ticker.findUniqueOrThrow.mockResolvedValue({
+      symbol: "NEW",
+      name: "New Company",
+    });
+    // ticker.findUnique returns null by default in createMockDb — anchor lookup short-circuits
+    db.dataSource.findMany.mockResolvedValue([]);
+
+    // Act
+    const result = await getDataSourcesForTicker("ticker-new", {
+      db: db as unknown as NonNullable<GetDataSourcesDeps["db"]>,
+      now: () => new Date("2026-05-01T10:00:00.000Z"),
+    });
+
+    // Assert
+    expect(result.competitors).toEqual([]);
+    expect(result.issuerAliases).toEqual(["NEW", "New Company"]);
+    expect(result.dataSources).toEqual([]);
+    expect(result.tickerSymbol).toBe("NEW");
+    expect(result.tickerName).toBe("New Company");
+  });
+
+  it("returns empty competitors when anchor exists but no peer edges", async () => {
+    // Setup
+    const db = createMockDb();
+    db.ticker.findUniqueOrThrow.mockResolvedValue({
+      symbol: "SOLO",
+      name: "Solo Corp",
+    });
+    db.ticker.findUnique.mockResolvedValue({
+      symbol: "SOLO",
+      name: "Solo Corp",
+    });
+    db.dataSource.findMany.mockResolvedValue([]);
+    db.entityType.findFirst.mockResolvedValue({ id: "type-company" });
+    db.tickerEntity.findFirst.mockResolvedValue({
+      entityId: "entity-solo",
+      entity: { canonicalName: "Solo Corp", aliases: [] },
+    });
+    // entityRelation.findMany returns [] by default in createMockDb
+
+    // Act
+    const result = await getDataSourcesForTicker("ticker-solo", {
+      db: db as unknown as NonNullable<GetDataSourcesDeps["db"]>,
+      now: () => new Date("2026-05-01T10:00:00.000Z"),
+    });
+
+    // Assert
+    expect(result.competitors).toEqual([]);
+    expect(result.issuerAliases).toContain("SOLO");
+    expect(result.issuerAliases).toContain("Solo Corp");
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/content-generation.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.ts
@@ -7,6 +7,8 @@ import type { Prisma } from "@mediapulse/database";
 import { flattenBulletsFromNewsletterWire } from "../lib/flatten-newsletter-wire-bullets.js";
 
 const MAX_RECENT_BULLETS = 200;
+const MAX_COMPETITOR_EDGE_FETCH = 50;
+const MAX_COMPETITORS_DEFAULT = 8;
 
 type DataSourceWithScore = Prisma.DataSourceGetPayload<{
   include: {
@@ -20,12 +22,172 @@ type DataSourceWithScore = Prisma.DataSourceGetPayload<{
 
 type ContentGenerationDb = {
   dataSource: Pick<typeof prisma.dataSource, "findMany">;
-  ticker: Pick<typeof prisma.ticker, "findUniqueOrThrow">;
+  ticker: Pick<typeof prisma.ticker, "findUniqueOrThrow" | "findUnique">;
   newsletter: Pick<
     typeof prisma.newsletter,
     "create" | "findFirst" | "findMany"
   >;
+  entity: Pick<typeof prisma.entity, "findFirst" | "findMany">;
+  entityAlias: Pick<typeof prisma.entityAlias, "findMany">;
+  tickerEntity: Pick<typeof prisma.tickerEntity, "findFirst" | "findMany">;
+  entityRelation: Pick<typeof prisma.entityRelation, "findMany">;
+  relationType: Pick<typeof prisma.relationType, "findMany">;
+  entityType: Pick<typeof prisma.entityType, "findFirst">;
 };
+
+type IssuerAnchor = {
+  entityId: string;
+  canonicalName: string;
+  aliases: string[];
+};
+
+export type CompetitorEntry = {
+  name: string;
+  aliases: string[];
+  relation: string;
+  weight: number;
+};
+
+const normalizeName = (value: string): string => value.trim().toLowerCase();
+
+async function findIssuerAnchorForTicker(
+  tickerId: string,
+  db: Pick<ContentGenerationDb, "ticker" | "entityType" | "tickerEntity">,
+): Promise<IssuerAnchor | null> {
+  const ticker = await db.ticker.findUnique({
+    where: { id: tickerId },
+    select: { symbol: true, name: true },
+  } satisfies Prisma.TickerFindUniqueArgs);
+  if (!ticker) return null;
+
+  const companyType = await db.entityType.findFirst({
+    where: { name: "COMPANY" },
+    select: { id: true },
+  } satisfies Prisma.EntityTypeFindFirstArgs);
+  if (!companyType) return null;
+
+  const tickerEntityRow = await db.tickerEntity.findFirst({
+    where: {
+      tickerId,
+      source: "SEED",
+      entity: { typeId: companyType.id },
+    },
+    select: {
+      entityId: true,
+      entity: {
+        select: {
+          canonicalName: true,
+          aliases: { select: { alias: true } },
+        },
+      },
+    },
+  } satisfies Prisma.TickerEntityFindFirstArgs);
+  if (!tickerEntityRow) return null;
+
+  const storedAliases = tickerEntityRow.entity.aliases.map((row) => row.alias);
+  const aliases = [
+    ...new Set(
+      [ticker.symbol, ticker.name, ...storedAliases].filter(
+        (value) => value.length > 0,
+      ),
+    ),
+  ];
+
+  return {
+    entityId: tickerEntityRow.entityId,
+    canonicalName: tickerEntityRow.entity.canonicalName,
+    aliases,
+  };
+}
+
+/**
+ * Reads COMPETITOR and SECTOR_PEER edges from the issuer entity, returning a
+ * ranked, capped, self-excluded list of peer COMPANY entities.
+ *
+ * @param issuerEntityId - KG entity id for the ticker's issuer anchor.
+ * @param issuerNormalizedAliasSet - Normalized alias strings for the issuer (self-exclusion guard).
+ * @param opts - Optional cap override.
+ * @param db - Database delegates.
+ * @returns Competitor entries ordered by weight desc, then lastSeenAt desc.
+ */
+export async function getCompetitorsForTicker(
+  issuerEntityId: string,
+  issuerNormalizedAliasSet: ReadonlySet<string>,
+  opts: { maxCompetitors?: number },
+  db: Pick<ContentGenerationDb, "entityRelation">,
+): Promise<CompetitorEntry[]> {
+  const maxCompetitors = opts.maxCompetitors ?? MAX_COMPETITORS_DEFAULT;
+
+  const relations = await db.entityRelation.findMany({
+    where: {
+      OR: [{ fromEntityId: issuerEntityId }, { toEntityId: issuerEntityId }],
+      relationType: {
+        name: { in: ["COMPETITOR", "SECTOR_PEER"] },
+      },
+    },
+    select: {
+      fromEntityId: true,
+      toEntityId: true,
+      weight: true,
+      relationType: { select: { name: true } },
+      fromEntity: {
+        select: {
+          id: true,
+          canonicalName: true,
+          type: { select: { name: true } },
+          aliases: { select: { alias: true } },
+        },
+      },
+      toEntity: {
+        select: {
+          id: true,
+          canonicalName: true,
+          type: { select: { name: true } },
+          aliases: { select: { alias: true } },
+        },
+      },
+    },
+    orderBy: [{ weight: "desc" }, { lastSeenAt: "desc" }],
+    take: MAX_COMPETITOR_EDGE_FETCH,
+  } satisfies Prisma.EntityRelationFindManyArgs);
+
+  const seenEntityIds = new Set<string>();
+  const competitors: CompetitorEntry[] = [];
+
+  for (const relation of relations) {
+    if (competitors.length >= maxCompetitors) break;
+
+    const peerEntity =
+      relation.fromEntityId === issuerEntityId
+        ? relation.toEntity
+        : relation.fromEntity;
+
+    if (peerEntity.type.name !== "COMPANY") continue;
+    if (peerEntity.id === issuerEntityId) continue;
+
+    const peerNormalizedName = normalizeName(peerEntity.canonicalName);
+    if (issuerNormalizedAliasSet.has(peerNormalizedName)) continue;
+    const peerNormalizedAliases = peerEntity.aliases.map((aliasRow) =>
+      normalizeName(aliasRow.alias),
+    );
+    if (
+      peerNormalizedAliases.some((alias) => issuerNormalizedAliasSet.has(alias))
+    )
+      continue;
+
+    if (seenEntityIds.has(peerEntity.id)) continue;
+    seenEntityIds.add(peerEntity.id);
+
+    competitors.push({
+      name: peerEntity.canonicalName,
+      aliases: peerEntity.aliases.map((aliasRow) => aliasRow.alias),
+      relation: relation.relationType.name,
+      weight: relation.weight,
+    });
+  }
+
+  return competitors;
+}
 
 /**
  * Returns today's selected data sources for a ticker, plus the ticker's
@@ -38,7 +200,10 @@ type ContentGenerationDb = {
 export const getDataSourcesForTicker = async (
   tickerId: string,
   deps: {
-    db?: Pick<ContentGenerationDb, "dataSource" | "ticker">;
+    db?: Pick<
+      ContentGenerationDb,
+      "dataSource" | "ticker" | "entityType" | "tickerEntity" | "entityRelation"
+    >;
     now?: () => Date;
   } = {},
 ) => {
@@ -93,10 +258,29 @@ export const getDataSourcesForTicker = async (
       }: DataSourceWithScore) => dataSource,
     );
 
+  const anchor = await findIssuerAnchorForTicker(tickerId, db);
+  const issuerAliases: string[] =
+    anchor?.aliases ??
+    [ticker.symbol, ticker.name].filter((value) => value.length > 0);
+  const competitorEntries = anchor
+    ? await getCompetitorsForTicker(
+        anchor.entityId,
+        new Set(issuerAliases.map(normalizeName)),
+        {},
+        db,
+      )
+    : [];
+  const competitors = competitorEntries.map((entry) => ({
+    name: entry.name,
+    relation: entry.relation,
+  }));
+
   return {
     dataSources,
     tickerSymbol: ticker.symbol,
     tickerName: ticker.name,
+    competitors,
+    issuerAliases,
   };
 };
 

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -53,7 +53,7 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 
 Implemented in `apps/mediapulse/agent-data-api/src/routes/content-generation.ts`. Schemas live in `@workspace/agent-data-api-contract` (`content-generation.ts`).
 
-- **GET** — Query: `tickerId` (required). Returns today's selected data sources for the ticker ordered by relevance score.
+- **GET** — Query: `tickerId` (required). Returns today's selected data sources for the ticker ordered by relevance score, plus `competitors` (ranked peer COMPANY names from `COMPETITOR` / `SECTOR_PEER` KG edges) and `issuerAliases` (ticker symbol, legal name, and KG aliases). Both list fields default to `[]` when the issuer anchor or peer graph is missing.
 - **POST** — Body validated by `postContentGenerationBodySchema`. Required fields: `subject`, `content`, `tickerId`. Optional field: `description`. The following optional provenance and token-usage fields are also accepted; all are stored as `null` when omitted (backward-compatible — existing callers that omit these fields continue to work):
 
 | Field              | Type               | Description                                |

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -11,7 +11,7 @@ The content-generation agent takes **selected data sources** (scored by the anal
 ## Features
 
 - **Input:** `tickerId` as a non-empty string (UUID or opaque Hermes ticker id). Receives bearer token from Hermes.
-- **Fetches** selected high-relevance sources for the ticker from `GET /api/v1/content-generation` (rows where `article_relevance.selected = true` and scored today).
+- **Fetches** selected high-relevance sources, resolved competitor names, and issuer aliases for the ticker from `GET /api/v1/content-generation` (rows where `article_relevance.selected = true` and scored today; competitors come from `COMPETITOR`/`SECTOR_PEER` edges off the ticker's KG anchor, see [KG competitor resolution](#kg-competitor-resolution)).
 - **Calls OpenAI** via the Vercel AI SDK (`generateObject` from `ai` with `@ai-sdk/openai` provider) to generate structured **industry intelligence** newsletter JSON (subject, multi-section briefing, quick hits with `articleIndex` grounding). The API key, optional API base URL, and model id are **not** read from environment variables; they come from the **agent config** selected for the pipeline step in Hermes (Dashboard → Agent configs), so admins can manage credentials centrally (optionally using [variable expansion](/hermes/agent-hermes-contract#variables-in-config-and-params) for secrets).
 - **Serializes** the validated object to plain text with the first-line marker `MP_NEWSLETTER` and deterministic `BEGIN … END` blocks. URLs are **never** taken from model text; they are injected from Hermes-selected sources using each `articleIndex`. Inline `(Article N)` markers that the model sometimes writes into bullet, quick-hit, or prose text are **stripped deterministically** at wire serialization — subscribers see citations only via the rendered `Read the full article: <url>` line. Prompt-side blocks (the brainstorm memo and numeric-anchor sidecar) intentionally keep `(Article N)` tags as LLM input and are not part of the email body. Legacy bodies without the marker (`EXECUTIVE SUMMARY` / `TOP N NEWS`) are unchanged for historical rows. The shared email package parses both shapes (see `@workspace/email-templates` `parseNewsletterBody`).
 - **Retries** transient LLM failures (rate limits, 5xx errors, timeouts) using exponential backoff with optional jitter, up to `reliability.llmRetry.maxAttempts` (default 3). Non-retryable errors (auth, bad request, schema validation) short-circuit immediately.
@@ -605,3 +605,32 @@ One info log per run: `{ sectionsRemoved, bulletsRemovedUncited, bulletsRemovedD
 ### Rollout
 
 The pass is **on by default**. To opt out a ticker while assessing output quality, set `requireCitation.enabled: false` in its Hermes config. The `dedupeScope: 'newsletter'` option is available but not the shipped default — use it when per-section dedup still allows duplicate articles across the briefing.
+
+## KG competitor resolution
+
+`GET /api/v1/content-generation` resolves the ticker's KG issuer anchor and returns two additional fields alongside `dataSources`:
+
+| Field           | Type                                    | Description                                                                                           |
+| --------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `competitors`   | `{ name: string; relation: string }[]`  | Peer COMPANY entities off the issuer's `COMPETITOR` / `SECTOR_PEER` edges, ranked by weight.         |
+| `issuerAliases` | `string[]`                              | All known names for the issuer (ticker symbol, legal name, KG aliases). Always at least symbol + name. |
+
+### How competitors are resolved
+
+1. The service looks up the ticker's KG anchor: the COMPANY entity linked to the ticker via `ticker_entity` with `source = SEED` (written by `ensureTickerIssuerCompanyAnchor` in the analysis agent).
+2. From the anchor, it reads `entity_relation` rows where the issuer is either endpoint and the relation type is `COMPETITOR` or `SECTOR_PEER`.
+3. The other endpoint entity is kept only if its type is COMPANY and its entity id or normalized names do not match any issuer alias (self-loop guard).
+4. Duplicate peer entities (same entity id appearing in multiple edges) are deduped; the first occurrence wins.
+5. Results are ordered by `weight` desc then `lastSeenAt` desc, capped at 8.
+
+### Ranking and relation tags
+
+`COMPETITOR` edges are the strong signal (explicit competitor data). `SECTOR_PEER` edges are the fallback when explicit edges are sparse. The `relation` field is passed through so consuming code (see [[72-competitor-anchored-competitive-landscape]]) can weight direct competitors differently from sector peers.
+
+### Graceful degradation
+
+A ticker with no KG anchor (not yet analyzed, or analysis found no issuer entity) returns `competitors: []` and `issuerAliases: [symbol, name]` without error. A ticker with an anchor but no peer edges returns `competitors: []`. Both cases are safe for consumers that have not yet been updated to use these fields, since both default to `[]` in the contract schema.
+
+### Observability
+
+No extra log line for the empty-graph path; the resolution is a few indexed reads well within the existing request latency budget. If you see unexpectedly empty `competitors` arrays for tickers that should have peer data, confirm the analysis agent has run `ensureTickerIssuerCompanyAnchor` for the ticker and seeded `COMPETITOR`/`SECTOR_PEER` relation types via `seed-kg-vocabulary`.

--- a/packages/shared/agent-data-api-contract/src/content-generation.ts
+++ b/packages/shared/agent-data-api-contract/src/content-generation.ts
@@ -30,10 +30,17 @@ export const contentGenerationDataSourceSchema = z
   })
   .passthrough();
 
+export const contentGenerationCompetitorSchema = z.object({
+  name: z.string(),
+  relation: z.string(),
+});
+
 export const getContentGenerationResponseSchema = z.object({
   dataSources: z.array(contentGenerationDataSourceSchema),
   tickerSymbol: z.string(),
   tickerName: z.string(),
+  competitors: z.array(contentGenerationCompetitorSchema).default([]),
+  issuerAliases: z.array(z.string()).default([]),
 });
 
 export const postContentGenerationResponseSchema = z.object({
@@ -91,6 +98,9 @@ export type PostContentGenerationBody = z.infer<
 >;
 export type GetContentGenerationResponse = z.infer<
   typeof getContentGenerationResponseSchema
+>;
+export type ContentGenerationCompetitor = z.infer<
+  typeof contentGenerationCompetitorSchema
 >;
 export type PostContentGenerationResponse = z.infer<
   typeof postContentGenerationResponseSchema

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -33,6 +33,7 @@ export {
   type PostAnalysisDataSourceDeleteResponse,
 } from "./analysis-data-source-delete.js";
 export {
+  contentGenerationCompetitorSchema,
   contentGenerationDataSourceSchema,
   getContentGenerationQuerySchema,
   getContentGenerationResponseSchema,
@@ -44,6 +45,7 @@ export {
   getContentGenerationBulletsRecentResponseSchema,
   postContentGenerationBodySchema,
   postContentGenerationResponseSchema,
+  type ContentGenerationCompetitor,
   type GetContentGenerationQuery,
   type GetContentGenerationResponse,
   type GetContentGenerationNewslettersLatestQuery,


### PR DESCRIPTION
## Summary

This PR extends `GET /api/v1/content-generation` so the content-generation agent receives ranked competitor names and issuer aliases with its daily sources. Peers come from the ticker's KG issuer anchor and `COMPETITOR` / `SECTOR_PEER` edges.

## Related issues

Closes #629

## Important changes

- `getContentGenerationResponseSchema` adds `competitors` and `issuerAliases` (both default to `[]`).
- `getDataSourcesForTicker` resolves the SEED `ticker_entity` anchor, reads peer edges, filters self-loops and issuer-alias matches, dedupes, and caps at eight peers.
- `getCompetitorsForTicker` is exported for focused unit tests on ranking and exclusion rules.

## Other changes

- Route integration test mock updated for the new response fields.
- Dev docs in agent-data-api and content-generation describe resolution and graceful degradation.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/content-generation.ts` - anchor lookup, peer ranking, and GET response assembly.
- `apps/mediapulse/agent-data-api/src/services/content-generation.test.ts` - competitor resolution and response integration tests.
- `packages/shared/agent-data-api-contract/src/content-generation.ts` - response schema extension.

## How to test

1. `corepack pnpm format:check`
2. `corepack pnpm --filter @workspace/agent-data-api-contract type:check`
3. `corepack pnpm --filter @mediapulse/agent-data-api type:check && corepack pnpm --filter @mediapulse/agent-data-api test:coverage`
4. Call `GET /api/v1/content-generation?tickerId=<id>` for a ticker with KG peer edges and confirm `competitors` and `issuerAliases` populate.

