### PR TITLE
Anchor competitive landscape on KG competitors

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -395,6 +395,34 @@ const requireCitationSchema = z
     "Final pruning pass: drops uncited rows, enforces one article per bullet, removes empty sections.",
   );
 
+const competitiveFocusSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, run the competitive-focus gate after polish to drop or flag issuer-only bullets.",
+      ),
+    policy: z
+      .enum(["warn", "flag", "drop"])
+      .default("drop")
+      .describe(
+        "warn = log only; flag = prepend [ISSUER-ONLY] marker; drop = remove the bullet (product intent).",
+      ),
+    maxCompetitorsInPrompt: z
+      .number()
+      .int()
+      .positive()
+      .default(6)
+      .describe(
+        "Maximum named competitors to include in the user prompt directive.",
+      ),
+  })
+  .default({})
+  .describe(
+    "Competitor-anchored Competitive Landscape gate: drops bullets that describe the issuer with no rival in sight.",
+  );
+
 const qualitySchema = z
   .object({
     selfCritique: selfCritiqueSchema,
@@ -402,6 +430,7 @@ const qualitySchema = z
     polish: polishSchema,
     crossRunDedup: crossRunDedupSchema,
     requireCitation: requireCitationSchema,
+    competitiveFocus: competitiveFocusSchema,
   })
   .default({})
   .describe("Post-generation repair, verification, polish, and dedup passes.");

--- a/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "vitest";
+
+import type { IndustryNewsletterStructure } from "../industry-newsletter-schema.js";
+
+import {
+  enforceCompetitiveFocus,
+  mentionsAny,
+} from "./competitive-landscape-focus.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeStructure = (
+  bullets: IndustryNewsletterStructure["competitiveLandscape"]["bullets"],
+): IndustryNewsletterStructure => ({
+  subject: "Test Subject",
+  industryPulse: {
+    displayHeading: "Industry Pulse",
+    prose: "Sector overview.",
+  },
+  competitiveLandscape: {
+    displayHeading: "Competitive Landscape",
+    bullets,
+  },
+  dealsAndMovements: {
+    displayHeading: "Deals",
+    bullets: [{ text: "Deal A", articleIndex: 1 }],
+  },
+  regulatoryPolicyWatch: {
+    displayHeading: "Regulatory",
+    bullets: [{ text: "Rule B" }],
+  },
+  disruptorsOrTech: {
+    format: "prose",
+    displayHeading: "Disruptors",
+    prose: "Tech moving fast.",
+  },
+  quickHits: {
+    displayHeading: "Quick Hits",
+    items: [
+      { text: "h1", articleIndex: 1 },
+      { text: "h2", articleIndex: 2 },
+      { text: "h3", articleIndex: 3 },
+      { text: "h4", articleIndex: 4 },
+      { text: "h5", articleIndex: 5 },
+    ],
+  },
+});
+
+const ISSUER_ALIASES = ["Bank Central Asia", "BCA", "BBCA"];
+const COMPETITORS = [
+  { name: "Bank Mandiri", aliases: ["Mandiri"] },
+  { name: "Bank BRI", aliases: ["BRI"] },
+];
+
+// ---------------------------------------------------------------------------
+// mentionsAny
+// ---------------------------------------------------------------------------
+
+describe("mentionsAny — mention detection", () => {
+  it("matches a full name case-insensitively", () => {
+    expect(mentionsAny("BBCA expanded its digital channels", ["BBCA"])).toBe(
+      true,
+    );
+  });
+
+  it("does not match a substring inside a longer word", () => {
+    expect(mentionsAny("BCAse study released today", ["BCA"])).toBe(false);
+  });
+
+  it("matches a multi-word name as a phrase", () => {
+    expect(
+      mentionsAny("Bank Mandiri undercut rivals on SME rates", [
+        "Bank Mandiri",
+      ]),
+    ).toBe(true);
+  });
+
+  it("returns false when none of the names appear", () => {
+    expect(
+      mentionsAny("Sector-wide credit tightening continues", ["BBCA", "BCA"]),
+    ).toBe(false);
+  });
+
+  it("matches at the start and end of the string (no adjacent chars)", () => {
+    expect(mentionsAny("BBCA", ["BBCA"])).toBe(true);
+    expect(mentionsAny("news about BBCA", ["BBCA"])).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceCompetitiveFocus — issuer-only drop
+// ---------------------------------------------------------------------------
+
+describe("enforceCompetitiveFocus — issuer-only drop", () => {
+  it("drops an issuer-only bullet under drop policy", () => {
+    const structure = makeStructure([
+      { text: "BBCA expanded its digital channels", articleIndex: 1 },
+      {
+        text: "Bank Mandiri cut SME lending rates, pressuring BBCA",
+        articleIndex: 2,
+      },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: true,
+    });
+
+    expect(result.summary.evaluated).toBe(1);
+    expect(result.summary.dropped).toBe(1);
+    expect(result.summary.flagged).toBe(0);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(1);
+    expect(result.structure.competitiveLandscape.bullets[0]!.text).toContain(
+      "Bank Mandiri",
+    );
+  });
+
+  it("keeps a bullet that mentions both issuer and competitor", () => {
+    const structure = makeStructure([
+      {
+        text: "Bank Mandiri undercut BBCA on SME rates",
+        articleIndex: 1,
+      },
+      {
+        text: "BRI gained digital market share at BCA's expense",
+        articleIndex: 2,
+      },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: true,
+    });
+
+    expect(result.summary.evaluated).toBe(0);
+    expect(result.summary.dropped).toBe(0);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(2);
+  });
+
+  it("keeps a generic bullet that mentions neither issuer nor competitor", () => {
+    const structure = makeStructure([
+      { text: "Sector-wide credit tightening continues", articleIndex: 1 },
+      { text: "Regulatory reform may reshape lending", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: true,
+    });
+
+    expect(result.summary.evaluated).toBe(0);
+    expect(result.summary.dropped).toBe(0);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(2);
+  });
+
+  it("flags an issuer-only bullet under flag policy (prepends marker)", () => {
+    const structure = makeStructure([
+      { text: "BBCA expanded its digital channels", articleIndex: 1 },
+      { text: "Bank Mandiri launched a new SME product", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "flag",
+    });
+
+    expect(result.summary.flagged).toBe(1);
+    expect(result.summary.dropped).toBe(0);
+    const flaggedBullet = result.structure.competitiveLandscape.bullets.find(
+      (bullet) => bullet.text.startsWith("[ISSUER-ONLY]"),
+    );
+    expect(flaggedBullet).toBeDefined();
+  });
+
+  it("does not drop bullets under warn policy", () => {
+    const structure = makeStructure([
+      { text: "BBCA expanded its digital channels", articleIndex: 1 },
+      { text: "BCA internal strategy unchanged", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "warn",
+    });
+
+    expect(result.summary.dropped).toBe(0);
+    expect(result.summary.flagged).toBe(0);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceCompetitiveFocus — empty competitors no-op
+// ---------------------------------------------------------------------------
+
+describe("enforceCompetitiveFocus — empty competitors is a no-op", () => {
+  it("returns unchanged structure with evaluated=0 when competitors is empty", () => {
+    const structure = makeStructure([
+      { text: "BBCA expanded its digital channels", articleIndex: 1 },
+      { text: "BCA raised its dividend yield", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: [],
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+    });
+
+    expect(result.summary.evaluated).toBe(0);
+    expect(result.summary.dropped).toBe(0);
+    expect(result.summary.flagged).toBe(0);
+    expect(result.summary.competitorCount).toBe(0);
+    expect(result.structure).toBe(structure);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// enforceCompetitiveFocus — floor vs prune handoff
+// ---------------------------------------------------------------------------
+
+describe("enforceCompetitiveFocus — floor vs prune handoff", () => {
+  it("downgrades drops to flags when require-citation is OFF and all bullets are issuer-only", () => {
+    const structure = makeStructure([
+      { text: "BBCA launched a new savings product", articleIndex: 1 },
+      { text: "Bank Central Asia expanded branch network", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: false,
+    });
+
+    expect(result.summary.dropped).toBe(0);
+    expect(result.summary.flagged).toBe(2);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(2);
+    expect(
+      result.structure.competitiveLandscape.bullets.every((bullet) =>
+        bullet.text.startsWith("[ISSUER-ONLY]"),
+      ),
+    ).toBe(true);
+  });
+
+  it("drops one bullet and flags the rest when require-citation is OFF and 3 of 3 are issuer-only", () => {
+    const structure = makeStructure([
+      { text: "BBCA opened new branches", articleIndex: 1 },
+      { text: "BCA upgraded its mobile app", articleIndex: 2 },
+      { text: "Bank Central Asia raised its dividend", articleIndex: 3 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: false,
+    });
+
+    // 3 bullets, floor is 2 → can drop at most 1, flag the remaining 2 issuer-only
+    expect(result.summary.dropped).toBe(1);
+    expect(result.summary.flagged).toBe(2);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(2);
+  });
+
+  it("drops all issuer-only bullets when require-citation is ON, allowing the section to empty", () => {
+    const structure = makeStructure([
+      { text: "BBCA launched a new savings product", articleIndex: 1 },
+      { text: "Bank Central Asia expanded branch network", articleIndex: 2 },
+    ]);
+
+    const result = enforceCompetitiveFocus(structure, {
+      competitors: COMPETITORS,
+      issuerAliases: ISSUER_ALIASES,
+      policy: "drop",
+      requireCitationEnabled: true,
+    });
+
+    expect(result.summary.dropped).toBe(2);
+    expect(result.summary.flagged).toBe(0);
+    expect(result.structure.competitiveLandscape.bullets).toHaveLength(0);
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.ts
@@ -1,0 +1,216 @@
+import type { IndustryNewsletterStructure } from "../industry-newsletter-schema.js";
+
+export type FocusDecision =
+  | { kind: "keep" }
+  | { kind: "flag"; reason: "issuer_only" }
+  | { kind: "drop"; reason: "issuer_only" };
+
+export type FocusReport = {
+  bulletIndex: number;
+  mentionsIssuer: boolean;
+  mentionsCompetitor: boolean;
+  decision: FocusDecision;
+};
+
+export type FocusSummary = {
+  evaluated: number;
+  dropped: number;
+  flagged: number;
+  competitorCount: number;
+};
+
+export type FocusPolicy = "warn" | "flag" | "drop";
+
+export type CompetitorRef = { name: string; aliases?: string[] };
+
+export type EnforceCompetitiveFocusOptions = {
+  competitors: ReadonlyArray<CompetitorRef>;
+  issuerAliases: ReadonlyArray<string>;
+  policy: FocusPolicy;
+  /**
+   * When true, the gate may drop all bullets and let require-citation pruning
+   * remove the empty section. When false, the gate preserves at least
+   * SECTION_MIN_COMPETITIVE_LANDSCAPE bullets by downgrading drops to flags.
+   */
+  requireCitationEnabled?: boolean;
+};
+
+export type EnforceCompetitiveFocusResult = {
+  structure: IndustryNewsletterStructure;
+  reports: FocusReport[];
+  summary: FocusSummary;
+};
+
+const SECTION_MIN_COMPETITIVE_LANDSCAPE = 2;
+
+const FLAG_MARKER = "[ISSUER-ONLY] ";
+
+/**
+ * Case-insensitive, word-boundary substring check.
+ *
+ * Returns true when `text` contains any entry from `names` as a whole
+ * word or phrase (not embedded inside a longer word).
+ *
+ * @param text - Bullet text to scan.
+ * @param names - Candidate names/aliases to look for.
+ */
+export const mentionsAny = (
+  text: string,
+  names: ReadonlyArray<string>,
+): boolean => {
+  const lowerText = text.toLowerCase();
+  return names.some((name) => {
+    const lowerName = name.trim().toLowerCase();
+    if (lowerName.length === 0) return false;
+    let searchStart = 0;
+    while (searchStart < lowerText.length) {
+      const index = lowerText.indexOf(lowerName, searchStart);
+      if (index === -1) return false;
+      const charBefore = index > 0 ? lowerText[index - 1] : null;
+      const charAfter =
+        index + lowerName.length < lowerText.length
+          ? lowerText[index + lowerName.length]
+          : null;
+      const beforeOk = charBefore == null || /\W/.test(charBefore);
+      const afterOk = charAfter == null || /\W/.test(charAfter);
+      if (beforeOk && afterOk) return true;
+      searchStart = index + 1;
+    }
+    return false;
+  });
+};
+
+/**
+ * Walks `competitiveLandscape.bullets`, classifying each bullet as issuer-only,
+ * competitor-grounded, or generic, then applies `policy` to issuer-only bullets.
+ *
+ * A bullet is issuer-only when it mentions the issuer (by any alias) but mentions
+ * no competitor name or alias. Competitor-grounded bullets that mention both the
+ * issuer and a rival (e.g. "Bank Mandiri undercut BBCA on rates") are kept.
+ *
+ * No-op when `competitors` is empty — never strips the section when the KG is sparse.
+ *
+ * Floor/prune handoff: when `requireCitationEnabled` is false the gate keeps at
+ * least `SECTION_MIN_COMPETITIVE_LANDSCAPE` bullets by downgrading excess drops to
+ * flags. When `requireCitationEnabled` is true, drops may reduce the section to zero
+ * and require-citation pruning removes it cleanly.
+ *
+ * @param structure - Post-polish structured newsletter (before URL attach and grounding).
+ * @param opts - Competitors, issuer aliases, policy, and require-citation flag.
+ */
+export function enforceCompetitiveFocus(
+  structure: IndustryNewsletterStructure,
+  opts: EnforceCompetitiveFocusOptions,
+): EnforceCompetitiveFocusResult {
+  const {
+    competitors,
+    issuerAliases,
+    policy,
+    requireCitationEnabled = true,
+  } = opts;
+
+  if (competitors.length === 0) {
+    return {
+      structure,
+      reports: [],
+      summary: { evaluated: 0, dropped: 0, flagged: 0, competitorCount: 0 },
+    };
+  }
+
+  const competitorNames: string[] = competitors.flatMap((competitor) => [
+    competitor.name,
+    ...(competitor.aliases ?? []),
+  ]);
+
+  const bullets = structure.competitiveLandscape.bullets;
+  const reports: FocusReport[] = [];
+  const issuerOnlyIndices: number[] = [];
+
+  for (let bulletIndex = 0; bulletIndex < bullets.length; bulletIndex++) {
+    const bullet = bullets[bulletIndex]!;
+    const mentionsIssuer = mentionsAny(bullet.text, issuerAliases as string[]);
+    const mentionsCompetitor = mentionsAny(bullet.text, competitorNames);
+    const isIssuerOnly = mentionsIssuer && !mentionsCompetitor;
+
+    if (isIssuerOnly) {
+      issuerOnlyIndices.push(bulletIndex);
+    }
+
+    reports.push({
+      bulletIndex,
+      mentionsIssuer,
+      mentionsCompetitor,
+      decision: { kind: "keep" },
+    });
+  }
+
+  if (issuerOnlyIndices.length === 0 || policy === "warn") {
+    return {
+      structure,
+      reports,
+      summary: {
+        evaluated: issuerOnlyIndices.length,
+        dropped: 0,
+        flagged: 0,
+        competitorCount: competitors.length,
+      },
+    };
+  }
+
+  let dropSet = new Set<number>();
+  let flagSet = new Set<number>();
+
+  if (policy === "flag") {
+    flagSet = new Set(issuerOnlyIndices);
+  } else {
+    // policy === "drop"
+    const maxDropCount = requireCitationEnabled
+      ? issuerOnlyIndices.length
+      : Math.max(0, bullets.length - SECTION_MIN_COMPETITIVE_LANDSCAPE);
+    const actualDropCount = Math.min(issuerOnlyIndices.length, maxDropCount);
+    dropSet = new Set(issuerOnlyIndices.slice(0, actualDropCount));
+    flagSet = new Set(issuerOnlyIndices.slice(actualDropCount));
+  }
+
+  for (const bulletIndex of dropSet) {
+    reports[bulletIndex]!.decision = { kind: "drop", reason: "issuer_only" };
+  }
+  for (const bulletIndex of flagSet) {
+    reports[bulletIndex]!.decision = { kind: "flag", reason: "issuer_only" };
+  }
+
+  const newBullets = bullets
+    .map((bullet, bulletIndex) => {
+      if (dropSet.has(bulletIndex)) return null;
+      if (flagSet.has(bulletIndex)) {
+        return { ...bullet, text: `${FLAG_MARKER}${bullet.text}` };
+      }
+      return bullet;
+    })
+    .filter(
+      (bullet): bullet is NonNullable<(typeof bullets)[number]> =>
+        bullet !== null,
+    );
+
+  const newStructure: IndustryNewsletterStructure = {
+    ...structure,
+    competitiveLandscape: {
+      ...structure.competitiveLandscape,
+      bullets: newBullets,
+    },
+  };
+
+  const dropped = dropSet.size;
+  const flagged = flagSet.size;
+
+  return {
+    structure: newStructure,
+    reports,
+    summary: {
+      evaluated: issuerOnlyIndices.length,
+      dropped,
+      flagged,
+      competitorCount: competitors.length,
+    },
+  };
+}

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -10,6 +10,7 @@ import {
   resolveContentGenerationConfig,
 } from "./config-schema.js";
 import {
+  buildCompetitorPromptBlock,
   generateNewsletterWithLlm,
   type GenerateNewsletterObjectArgs,
   type GenerateNewsletterObjectFn,
@@ -2070,5 +2071,99 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
     expect(keys).toContain("competitive-landscape");
     expect(keys).toContain("deals-and-movements");
     expect(keys).toContain("regulatory-policy-watch");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Competitor-anchored prompt injection
+// ---------------------------------------------------------------------------
+
+describe("buildCompetitorPromptBlock", () => {
+  it("returns empty string when competitors list is empty", () => {
+    expect(buildCompetitorPromptBlock([], "Bank Central Asia")).toBe("");
+  });
+
+  it("names competitors and issuer in the directive text", () => {
+    const block = buildCompetitorPromptBlock(
+      [
+        { name: "Bank Mandiri", relation: "COMPETITOR" },
+        { name: "Bank BRI", relation: "SECTOR_PEER" },
+      ],
+      "Bank Central Asia",
+    );
+    expect(block).toContain("Bank Mandiri");
+    expect(block).toContain("Bank BRI");
+    expect(block).toContain("Bank Central Asia");
+    expect(block).toContain(
+      "Do NOT make these bullets about Bank Central Asia",
+    );
+  });
+});
+
+describe("generateNewsletterWithLlm — competitor prompt injection", () => {
+  it("injects competitor directive into the resolved user prompt when competitors are provided", async () => {
+    let capturedPrompt = "";
+    const generateObjectFn: GenerateNewsletterObjectFn = vi
+      .fn()
+      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
+        capturedPrompt = args.prompt;
+        return { object: minimalIndustryBrief() };
+      });
+
+    const competitorConfig = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        quality: {
+          ...conservativeTestConfigInput.quality,
+          competitiveFocus: { enabled: true, policy: "drop" },
+        },
+      }),
+    );
+
+    await generateNewsletterWithLlm(
+      testSources,
+      competitorConfig,
+      {
+        ...testContext,
+        tickerName: "Bank Central Asia",
+        competitors: [
+          { name: "Bank Mandiri", relation: "COMPETITOR" },
+          { name: "Bank BRI", relation: "SECTOR_PEER" },
+        ],
+        issuerAliases: ["Bank Central Asia", "BCA", "BBCA"],
+      },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    expect(capturedPrompt).toContain("Bank Mandiri");
+    expect(capturedPrompt).toContain("Bank BRI");
+    expect(capturedPrompt).toContain(
+      "Do NOT make these bullets about Bank Central Asia",
+    );
+  });
+
+  it("does not inject any directive or broken placeholder when no competitors are provided", async () => {
+    let capturedPrompt = "";
+    const generateObjectFn: GenerateNewsletterObjectFn = vi
+      .fn()
+      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
+        capturedPrompt = args.prompt;
+        return { object: minimalIndustryBrief() };
+      });
+
+    await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      {
+        ...testContext,
+        tickerName: "Bank Central Asia",
+        competitors: [],
+        issuerAliases: ["Bank Central Asia", "BCA"],
+      },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    expect(capturedPrompt).not.toContain("Do NOT make these bullets about");
+    expect(capturedPrompt).not.toContain("{{");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -70,6 +70,10 @@ import {
 } from "./lib/source-ranking.js";
 import { retryWithBackoff } from "./lib/retry.js";
 import { truncateSources } from "./lib/truncate-sources.js";
+import {
+  enforceCompetitiveFocus,
+  type FocusSummary,
+} from "./lib/competitive-landscape-focus.js";
 import type { SourceForGeneration } from "./types.js";
 
 export type { SourceForGeneration };
@@ -147,6 +151,8 @@ export interface GeneratedContentWithProvenance extends GeneratedContent {
   >;
   /** Require-citation pruning counters when the pass is enabled. */
   requireCitationSummary?: PruneSummary;
+  /** Competitive-focus gate counters when the pass ran and had competitors. */
+  competitiveFocusSummary?: FocusSummary;
 }
 
 /**
@@ -484,7 +490,7 @@ You receive exactly {{topNewsCount}} numbered articles (Article 1 … Article {{
 Return JSON matching this shape (camelCase keys):
 - "subject": short email subject (under ~60 chars), sector-relevant, may mention {{tickerName}} or {{tickerSymbol}} once if natural.
 - "industryPulse": { "displayHeading", "prose" } — short lead framing the industry story (no bullet characters in prose).
-- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets; each bullet { "text", "articleIndex" } where articleIndex is a 1-based article number or null when uncited.
+- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets about {{tickerName}}'s COMPETITORS, not {{tickerName}} itself — peer positioning, rival launches, share shifts, competitive threats. Each bullet should name a competitor. Each bullet { "text", "articleIndex" } where articleIndex is a 1-based article number or null when uncited.
 - "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
 - "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
 - "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
@@ -507,6 +513,29 @@ Rules reminder:
 - Quick hits must all include articleIndex.
 
 {{sourceSummaries}}`;
+
+/**
+ * Builds the competitor directive block injected into the user prompt when
+ * the KG has resolved named competitors for the issuer.
+ *
+ * Returns an empty string when `competitors` is empty, so the caller can
+ * safely include it without an extra length guard.
+ *
+ * @param competitors - Named competitors from the KG resolution pass.
+ * @param issuerName - Human-readable issuer name for the directive text.
+ */
+export const buildCompetitorPromptBlock = (
+  competitors: ReadonlyArray<{ name: string; relation: string }>,
+  issuerName: string,
+): string => {
+  if (competitors.length === 0) return "";
+  const nameList = competitors.map((competitor) => competitor.name).join(", ");
+  return [
+    `Competitive Landscape must focus on these competitors of ${issuerName}: ${nameList}.`,
+    `Frame each bullet around a competitor's move, market share shift, product launch, or competitive threat.`,
+    `Do NOT make these bullets about ${issuerName} itself.`,
+  ].join(" ");
+};
 
 /**
  * Builds the LLM user prompt from the list of data sources, substituting
@@ -543,6 +572,8 @@ export function buildUserPrompt(
     exemplarSection?: string;
     /** Editor's memo from the brainstorm pass, injected before article summaries. */
     brainstormText?: string;
+    /** Competitor directive injected above article summaries when the KG has named peers. */
+    competitorSection?: string;
     /** Verbatim figures sidecar injected immediately above article summaries. */
     numericAnchorSection?: string;
     /** Recent bullets to avoid repeating (cross-run dedup preventive arm). */
@@ -574,10 +605,16 @@ export function buildUserPrompt(
       ? `${options.crossRunDedupAvoidanceSection}\n\n`
       : "";
 
+  const competitorPrefix =
+    options.competitorSection !== undefined &&
+    options.competitorSection.length > 0
+      ? `${options.competitorSection}\n\n`
+      : "";
+
   return template
     .replaceAll(
       "{{sourceSummaries}}",
-      `${exemplarPrefix}${brainstormPrefix}${crossRunDedupPrefix}${numericAnchorPrefix}${sourceSummaries}`,
+      `${exemplarPrefix}${brainstormPrefix}${crossRunDedupPrefix}${competitorPrefix}${numericAnchorPrefix}${sourceSummaries}`,
     )
     .replaceAll("{{tickerId}}", context.tickerId)
     .replaceAll("{{tickerName}}", context.tickerName ?? context.tickerId)
@@ -624,6 +661,10 @@ export async function generateNewsletterWithLlm(
     recentSubjects?: string[];
     /** Recent flattened bullets for cross-run dedup. */
     recentBullets?: RecentBullet[];
+    /** KG-resolved competitor list from the content-generation API (plan 71). */
+    competitors?: Array<{ name: string; relation: string }>;
+    /** Issuer aliases from the content-generation API (plan 71). */
+    issuerAliases?: string[];
   },
   deps: {
     generateObjectFn?: GenerateNewsletterObjectFn;
@@ -839,6 +880,16 @@ export async function generateNewsletterWithLlm(
     ? formatRecentBulletsAvoidanceBlock(recentBullets, crossRunDedup.windowDays)
     : "";
 
+  const competitiveFocusConfig = config.quality.competitiveFocus;
+  const promptCompetitors = (context.competitors ?? []).slice(
+    0,
+    competitiveFocusConfig.maxCompetitorsInPrompt,
+  );
+  const competitorSection = buildCompetitorPromptBlock(
+    promptCompetitors,
+    context.tickerName ?? context.tickerId,
+  );
+
   const userTemplate =
     config.prompts?.userPromptTemplate || DEFAULT_USER_PROMPT_TEMPLATE;
   const prompt = buildUserPrompt(
@@ -855,6 +906,7 @@ export async function generateNewsletterWithLlm(
       exemplarSection,
       brainstormText,
       crossRunDedupAvoidanceSection,
+      competitorSection,
       numericAnchorSection,
     },
   );
@@ -1109,7 +1161,38 @@ export async function generateNewsletterWithLlm(
     );
   }
 
-  let groundedStructure = polishedStructure;
+  let focusGateStructure = polishedStructure;
+  let competitiveFocusSummary: FocusSummary | undefined;
+
+  if (
+    competitiveFocusConfig.enabled &&
+    (context.competitors?.length ?? 0) > 0
+  ) {
+    const focusResult = enforceCompetitiveFocus(polishedStructure, {
+      competitors: context.competitors!.map((competitor) => ({
+        name: competitor.name,
+      })),
+      issuerAliases: context.issuerAliases ?? [],
+      policy: competitiveFocusConfig.policy,
+      requireCitationEnabled: config.quality.requireCitation.enabled,
+    });
+    focusGateStructure = focusResult.structure;
+    competitiveFocusSummary = focusResult.summary;
+
+    logger.info(
+      {
+        tickerId: context.tickerId,
+        competitorCount: focusResult.summary.competitorCount,
+        evaluated: focusResult.summary.evaluated,
+        dropped: focusResult.summary.dropped,
+        flagged: focusResult.summary.flagged,
+        policy: competitiveFocusConfig.policy,
+      },
+      "Competitive-focus gate summary",
+    );
+  }
+
+  let groundedStructure = focusGateStructure;
   const citationGrounding = config.quality.citationGrounding;
   if (citationGrounding.enabled) {
     const grounded = groundNewsletterCitations(
@@ -1376,5 +1459,8 @@ export async function generateNewsletterWithLlm(
     ...(critiqueFailed ? { critiqueFailed: true } : {}),
     ...(polishSummary !== undefined ? { polishSummary } : {}),
     ...(requireCitationSummary !== undefined ? { requireCitationSummary } : {}),
+    ...(competitiveFocusSummary !== undefined
+      ? { competitiveFocusSummary }
+      : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -270,6 +270,8 @@ export async function run({
     dataSources: sources,
     tickerName,
     tickerSymbol,
+    competitors,
+    issuerAliases,
   } = await dataApiClient.contentGeneration.get({
     tickerId: input.tickerId,
   });
@@ -396,6 +398,8 @@ export async function run({
       runStartedAt: runStart,
       recentSubjects,
       recentBullets,
+      competitors,
+      issuerAliases,
     });
   } catch (err) {
     const code = classifyLlmError(err);
@@ -440,6 +444,20 @@ export async function run({
         brainstormCompletionTokens: generated.brainstormCompletionTokens,
       },
       "Newsletter two-pass generation: brainstorm leg complete",
+    );
+  }
+
+  if (generated.competitiveFocusSummary !== undefined) {
+    logger.info(
+      {
+        tickerId: input.tickerId,
+        competitorCount: generated.competitiveFocusSummary.competitorCount,
+        evaluated: generated.competitiveFocusSummary.evaluated,
+        dropped: generated.competitiveFocusSummary.dropped,
+        flagged: generated.competitiveFocusSummary.flagged,
+        policy: resolvedConfig.quality.competitiveFocus.policy,
+      },
+      "Competitive-focus gate run summary",
     );
   }
 
@@ -647,6 +665,16 @@ export async function run({
               bulletsRemovedDuplicate:
                 generated.requireCitationSummary.bulletsRemovedDuplicate,
               sectionsKept: generated.requireCitationSummary.sectionsKept,
+            },
+          }
+        : {}),
+      ...(generated.competitiveFocusSummary !== undefined
+        ? {
+            competitiveFocus: {
+              dropped: generated.competitiveFocusSummary.dropped,
+              flagged: generated.competitiveFocusSummary.flagged,
+              competitorCount:
+                generated.competitiveFocusSummary.competitorCount,
             },
           }
         : {}),

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -610,10 +610,10 @@ The pass is **on by default**. To opt out a ticker while assessing output qualit
 
 `GET /api/v1/content-generation` resolves the ticker's KG issuer anchor and returns two additional fields alongside `dataSources`:
 
-| Field           | Type                                    | Description                                                                                           |
-| --------------- | --------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `competitors`   | `{ name: string; relation: string }[]`  | Peer COMPANY entities off the issuer's `COMPETITOR` / `SECTOR_PEER` edges, ranked by weight.         |
-| `issuerAliases` | `string[]`                              | All known names for the issuer (ticker symbol, legal name, KG aliases). Always at least symbol + name. |
+| Field           | Type                                   | Description                                                                                            |
+| --------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `competitors`   | `{ name: string; relation: string }[]` | Peer COMPANY entities off the issuer's `COMPETITOR` / `SECTOR_PEER` edges, ranked by weight.           |
+| `issuerAliases` | `string[]`                             | All known names for the issuer (ticker symbol, legal name, KG aliases). Always at least symbol + name. |
 
 ### How competitors are resolved
 
@@ -634,3 +634,70 @@ A ticker with no KG anchor (not yet analyzed, or analysis found no issuer entity
 ### Observability
 
 No extra log line for the empty-graph path; the resolution is a few indexed reads well within the existing request latency budget. If you see unexpectedly empty `competitors` arrays for tickers that should have peer data, confirm the analysis agent has run `ensureTickerIssuerCompanyAnchor` for the ticker and seeded `COMPETITOR`/`SECTOR_PEER` relation types via `seed-kg-vocabulary`.
+
+## Competitor-anchored Competitive Landscape
+
+Builds on KG competitor resolution (above) to make the Competitive Landscape section actually competitive: bullets about the chosen company's rivals rather than the company itself.
+
+### Where competitors come from
+
+The `competitors` and `issuerAliases` fields returned by `GET /api/v1/content-generation` (see KG competitor resolution above) are threaded through `run.ts` into `generateNewsletterWithLlm`. No extra API call or database read is made at generation time.
+
+### Prompt reframing
+
+When the competitor list is non-empty, a directive block is injected into the user prompt directly above the article summaries:
+
+```
+Competitive Landscape must focus on these competitors of {issuer}: {Name1}, {Name2}, ....
+Frame each bullet around a competitor's move, market share shift, product launch, or competitive threat.
+Do NOT make these bullets about {issuer} itself.
+```
+
+Up to `quality.competitiveFocus.maxCompetitorsInPrompt` (default 6) named competitors are included. The system prompt's `competitiveLandscape` line is also updated to reinforce the competitor-centric framing.
+
+When no competitors are available the prompt uses generic wording ("about {ticker}'s COMPETITORS") and no broken placeholder appears.
+
+### Self-exclusion gate (`enforceCompetitiveFocus`)
+
+After the polish pass, a deterministic gate walks each `competitiveLandscape` bullet and classifies it:
+
+| Classification          | Condition                                        | Action under `drop` policy          |
+| ----------------------- | ------------------------------------------------ | ----------------------------------- |
+| **Competitor-grounded** | mentions a competitor (or both issuer and rival) | kept                                |
+| **Generic**             | mentions neither issuer nor competitor           | kept                                |
+| **Issuer-only**         | mentions issuer and no competitor                | dropped / flagged / logged (policy) |
+
+`mentionsAny` does case-insensitive, word-boundary substring matching across all competitor names and aliases, and all issuer aliases.
+
+**Policy options** (`quality.competitiveFocus.policy`):
+
+- `drop` — remove the issuer-only bullet (product default)
+- `flag` — prepend `[ISSUER-ONLY]` for operator review; bullet is kept
+- `warn` — log only, structure unchanged
+
+### Empty-KG fallback
+
+When `competitors` is empty the gate is a complete no-op: all bullets are kept, `summary.evaluated === 0`. The section is never stripped just because a ticker's graph is sparse. As the analysis agent enriches the graph over time, the named-competitor path activates automatically.
+
+### Floor and prune handoff
+
+The gate defers empty-section cleanup to the require-citation pruning pass (plan 70):
+
+- `requireCitation.enabled: true` — the gate may drop all bullets, leaving the section empty. The prune pass removes the now-empty section.
+- `requireCitation.enabled: false` — the gate preserves at least the schema minimum (2 bullets) by downgrading the last excess drops to `flag`. This prevents the Competitive Landscape from silently disappearing when pruning is off.
+
+### Observability
+
+The gate emits one `info` log line per run when it fires, with `{ competitorCount, evaluated, dropped, flagged, policy }`. The `details` block on the success path includes:
+
+```json
+{
+  "competitiveFocus": {
+    "dropped": 1,
+    "flagged": 0,
+    "competitorCount": 5
+  }
+}
+```
+
+To soft-launch, ship with `policy: 'flag'` and monitor the `flagged` rate in run-details for a week before switching to `drop`.


### PR DESCRIPTION
## Summary

This PR makes the Competitive Landscape section about rivals, not the issuer. It uses KG competitors from the content-generation API to steer the prompt and runs a post-polish gate that drops, flags, or logs issuer-only bullets.

## Related issues

Closes #631

## Important changes

- `run.ts` passes `competitors` and `issuerAliases` from the API into `generateNewsletterWithLlm`.
- `buildCompetitorPromptBlock` injects a named-peer directive above article summaries when the list is non-empty.
- `enforceCompetitiveFocus` classifies landscape bullets and applies `quality.competitiveFocus.policy` (default `drop`).
- Run details include `competitiveFocus` counters when the gate runs.

## Other changes

- System prompt copy for `competitiveLandscape` now asks for competitor-centric bullets.
- Config schema adds `quality.competitiveFocus` with `enabled`, `policy`, and `maxCompetitorsInPrompt`.
- Dev docs describe classification rules, empty-KG fallback, and handoff to require-citation pruning.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.ts` - mention matching and policy application.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` - prompt injection and gate placement in the pipeline.
- `apps/mediapulse/agents/content-generation/src/run.ts` - API threading and run-details exposure.

## How to test

1. `corepack pnpm format:check`
2. `corepack pnpm --filter @mediapulse/content-generation type:check`
3. `corepack pnpm --filter @mediapulse/content-generation test:coverage`
4. Run generation for a ticker with KG competitors and confirm issuer-only landscape bullets are dropped under default config.

