### PR TITLE
Enforce competitor-anchored competitive landscape in industry newsletters

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -2,6 +2,7 @@
 
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
 import { describe, expect, it } from "vitest";
+import { zodToJsonSchema } from "zod-to-json-schema";
 
 import {
   buildDraftRelevanceRow,
@@ -172,5 +173,59 @@ describe("resolveArticleAnalysisConfig", () => {
     expect(resolved.scoreBreakdownVersion).toBe(
       articleAnalysisConfigDefaults.scoreBreakdownVersion,
     );
+  });
+
+  it("resolves all per-pass reasoningEffort to undefined when unset", () => {
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse(minimalConfig),
+    );
+
+    expect(resolved.extractionReasoningEffort).toBeUndefined();
+    expect(resolved.brainstormReasoningEffort).toBeUndefined();
+    expect(resolved.relationCritiqueReasoningEffort).toBeUndefined();
+    expect(resolved.vocabularyRepairReasoningEffort).toBeUndefined();
+  });
+
+  it("resolves all per-pass reasoningEffort to agent-wide default when set", () => {
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse({
+        ...minimalConfig,
+        reasoningEffort: "medium",
+      }),
+    );
+
+    expect(resolved.extractionReasoningEffort).toBe("medium");
+    expect(resolved.brainstormReasoningEffort).toBe("medium");
+    expect(resolved.relationCritiqueReasoningEffort).toBe("medium");
+    expect(resolved.vocabularyRepairReasoningEffort).toBe("medium");
+  });
+
+  it("per-pass override wins over agent-wide reasoningEffort", () => {
+    const resolved = resolveArticleAnalysisConfig(
+      articleAnalysisConfigSchema.parse({
+        ...minimalConfig,
+        reasoningEffort: "high",
+        brainstormReasoningEffort: "low",
+        vocabularyRepairReasoningEffort: "minimal",
+      }),
+    );
+
+    expect(resolved.extractionReasoningEffort).toBe("high");
+    expect(resolved.brainstormReasoningEffort).toBe("low");
+    expect(resolved.relationCritiqueReasoningEffort).toBe("high");
+    expect(resolved.vocabularyRepairReasoningEffort).toBe("minimal");
+  });
+
+  it("JSON schema exposes reasoningEffort as a four-value enum", () => {
+    const jsonSchema = zodToJsonSchema(articleAnalysisConfigSchema, {
+      $refStrategy: "none",
+    });
+    const schemaStr = JSON.stringify(jsonSchema);
+
+    expect(schemaStr).toContain("reasoningEffort");
+    expect(schemaStr).toContain('"minimal"');
+    expect(schemaStr).toContain('"low"');
+    expect(schemaStr).toContain('"medium"');
+    expect(schemaStr).toContain('"high"');
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,4 +1,5 @@
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
+import { reasoningEffortSchema } from "@workspace/agent-runtime";
 import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
 import type { ArticleAnalysisRunPolicy } from "./article-analysis-run-policy.js";
 import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
@@ -27,6 +28,11 @@ export const articleAnalysisConfigSchema = z
     openaiApiKey: z.string().min(1),
     /** Chat model id (e.g. `gpt-4o-mini`). */
     openaiModel: z.string().min(1).optional(),
+    /**
+     * Reasoning effort applied to all LLM passes when the model supports it (gpt-5/o-series).
+     * Leave unset for non-reasoning models like gpt-4o-mini.
+     */
+    reasoningEffort: reasoningEffortSchema.optional(),
     /** Max output tokens for `generateObject`. */
     maxOutputTokens: z.number().int().positive().optional(),
     /** Truncate article text in the LLM user message (full text remains in DB). */
@@ -52,6 +58,8 @@ export const articleAnalysisConfigSchema = z
     useBrainstormPass: z.boolean().optional(),
     /** Chat model for the brainstorm pass (defaults to `openaiModel`). */
     brainstormModel: z.string().min(1).optional(),
+    /** Overrides `reasoningEffort` for the brainstorm pass. */
+    brainstormReasoningEffort: reasoningEffortSchema.optional(),
     /** Max output tokens for the brainstorm `generateText` call. */
     brainstormMaxOutputTokens: z.number().int().positive().optional(),
     /** Max concurrent per-source extractions (1 = sequential; opt-in parallelism). */
@@ -66,6 +74,8 @@ export const articleAnalysisConfigSchema = z
     relationCritiqueMinRelationCount: z.number().int().nonnegative().optional(),
     /** Chat model for relation critique (defaults to `openaiModel`). */
     relationCritiqueModel: z.string().min(1).optional(),
+    /** Overrides `reasoningEffort` for the relation-critique pass. */
+    relationCritiqueReasoningEffort: reasoningEffortSchema.optional(),
     /**
      * How to handle vocabulary-invalid extraction rows.
      * `strict` skips the whole source (legacy). `partition` drops bad rows. `repair` partitions then re-labels bad rows once.
@@ -73,6 +83,8 @@ export const articleAnalysisConfigSchema = z
     vocabularyPolicy: z.enum(["strict", "partition", "repair"]).optional(),
     /** Chat model for vocabulary repair (defaults to `openaiModel`). */
     vocabularyRepairModel: z.string().min(1).optional(),
+    /** Overrides `reasoningEffort` for the vocabulary-repair pass. */
+    vocabularyRepairReasoningEffort: reasoningEffortSchema.optional(),
     /** Skip repair when rejected row count exceeds this cap (likely systemic vocabulary drift). */
     vocabularyRepairMaxItems: z.number().int().positive().optional(),
     /** Post-extraction grounding policy for hallucinated entities. */
@@ -187,6 +199,14 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   useBrainstormPass: boolean;
   brainstormModel: string;
   brainstormMaxOutputTokens: number;
+  /** Resolved reasoning effort for the extraction pass (falls back to `reasoningEffort`). */
+  extractionReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  /** Resolved reasoning effort for the brainstorm pass. */
+  brainstormReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  /** Resolved reasoning effort for the relation-critique pass. */
+  relationCritiqueReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  /** Resolved reasoning effort for the vocabulary-repair pass. */
+  vocabularyRepairReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
   extractionConcurrency: number;
   runDeadlineMs?: number;
   useRelationSelfCritique: boolean;
@@ -300,6 +320,7 @@ export const resolveArticleAnalysisConfig = (
 ): ResolvedArticleAnalysisConfig => {
   const openaiModel =
     config.openaiModel ?? articleAnalysisConfigDefaults.openaiModel;
+  const defaultEffort = config.reasoningEffort;
 
   return {
     ...config,
@@ -459,6 +480,33 @@ export const resolveArticleAnalysisConfig = (
     analysisGetDataSourceLimitMax:
       config.analysisGetDataSourceLimitMax ??
       articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,
+    // Reasoning effort: per-pass overrides fall back to the agent-wide default.
+    // All values remain undefined when the operator has not set reasoning effort
+    // (safe for non-reasoning models such as gpt-4o-mini).
+    ...(defaultEffort !== undefined
+      ? { extractionReasoningEffort: defaultEffort }
+      : {}),
+    ...(config.brainstormReasoningEffort !== undefined
+      ? { brainstormReasoningEffort: config.brainstormReasoningEffort }
+      : defaultEffort !== undefined
+        ? { brainstormReasoningEffort: defaultEffort }
+        : {}),
+    ...(config.relationCritiqueReasoningEffort !== undefined
+      ? {
+          relationCritiqueReasoningEffort:
+            config.relationCritiqueReasoningEffort,
+        }
+      : defaultEffort !== undefined
+        ? { relationCritiqueReasoningEffort: defaultEffort }
+        : {}),
+    ...(config.vocabularyRepairReasoningEffort !== undefined
+      ? {
+          vocabularyRepairReasoningEffort:
+            config.vocabularyRepairReasoningEffort,
+        }
+      : defaultEffort !== undefined
+        ? { vocabularyRepairReasoningEffort: defaultEffort }
+        : {}),
   };
 };
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -1,5 +1,9 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject, generateText, type ModelMessage } from "ai";
+import {
+  buildOpenAiReasoningProviderOptions,
+  type OpenAiReasoningProviderOptions,
+} from "@workspace/agent-runtime";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
@@ -97,6 +101,7 @@ export type GenerateTextForBrainstorm = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   maxOutputTokens: number;
   messages: ModelMessage[];
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<ArticleBrainstormCallResult>;
 
 /**
@@ -168,6 +173,7 @@ export type GenerateObjectForRelationCritique = (args: {
   schema: typeof llmRelationCritiqueSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{
   object: LlmRelationCritiqueWireOutput;
   usage: LlmExtractionUsage | null;
@@ -178,6 +184,7 @@ export type GenerateObjectForExtraction = (args: {
   schema: typeof llmExtractionOpenAiWireSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{
   object: LlmExtractionWireOutput;
   usage: LlmExtractionUsage | null;
@@ -217,6 +224,7 @@ export type GenerateObjectForVocabularyRepair = (args: {
   schema: typeof llmVocabularyRepairWireSchema;
   maxOutputTokens: number;
   messages: ModelMessage[];
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{
   object: LlmVocabularyRepairWireOutput;
   usage: LlmExtractionUsage | null;
@@ -251,7 +259,11 @@ export const normalizeLlmUsageFromSdk = (usage: {
 const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
   args,
 ) => {
-  const result = await generateObject(args);
+  const { providerOptions, ...rest } = args;
+  const result = await generateObject({
+    ...rest,
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
+  });
   return {
     object: result.object,
     usage: normalizeLlmUsageFromSdk(result.usage),
@@ -261,7 +273,11 @@ const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
 const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
   args,
 ) => {
-  const result = await generateText(args);
+  const { providerOptions, ...rest } = args;
+  const result = await generateText({
+    ...rest,
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
+  });
   return {
     text: result.text,
     usage: normalizeLlmUsageFromSdk(result.usage),
@@ -270,7 +286,11 @@ const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
 
 const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritique =
   async (args) => {
-    const result = await generateObject(args);
+    const { providerOptions, ...rest } = args;
+    const result = await generateObject({
+      ...rest,
+      ...(providerOptions !== undefined ? { providerOptions } : {}),
+    });
     return {
       object: result.object,
       usage: normalizeLlmUsageFromSdk(result.usage),
@@ -279,7 +299,11 @@ const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritiqu
 
 const defaultGenerateObjectForVocabularyRepair: GenerateObjectForVocabularyRepair =
   async (args) => {
-    const result = await generateObject(args);
+    const { providerOptions, ...rest } = args;
+    const result = await generateObject({
+      ...rest,
+      ...(providerOptions !== undefined ? { providerOptions } : {}),
+    });
     return {
       object: result.object,
       usage: normalizeLlmUsageFromSdk(result.usage),
@@ -452,6 +476,7 @@ export const fetchArticleBrainstorm = async (
     model: string;
     maxOutputTokens: number;
     messages: ModelMessage[];
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
     generateTextForBrainstorm: defaultGenerateTextForBrainstorm,
@@ -462,6 +487,9 @@ export const fetchArticleBrainstorm = async (
     model: openai(params.model),
     maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
 };
 
@@ -527,6 +555,7 @@ export const extractEntitiesAndRelationsForSource = async (
     messages: ModelMessage[];
     exemplars?: readonly ResolvedExemplar[];
     brainstormText?: string;
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
     generateObjectForExtraction: defaultGenerateObjectForExtraction,
@@ -554,6 +583,9 @@ export const extractEntitiesAndRelationsForSource = async (
     schema: llmExtractionOpenAiWireSchema,
     maxOutputTokens: params.maxOutputTokens,
     messages,
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
   return {
     object: normalizeLlmExtractionWire(raw.object),
@@ -723,6 +755,7 @@ export const critiqueExtractedRelations = async (
     model: string;
     maxOutputTokens: number;
     messages: ModelMessage[];
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateObjectForRelationCritique: GenerateObjectForRelationCritique;
@@ -736,6 +769,9 @@ export const critiqueExtractedRelations = async (
     schema: llmRelationCritiqueSchema,
     maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
   return {
     ratings: raw.object.ratings,
@@ -884,6 +920,7 @@ export const repairExtractionVocabulary = async (
     ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">;
     badEntities: readonly BadEntityRecord[];
     badRelations: readonly BadRelationRecord[];
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateObjectForVocabularyRepair: GenerateObjectForVocabularyRepair;
@@ -901,6 +938,9 @@ export const repairExtractionVocabulary = async (
       params.badEntities,
       params.badRelations,
     ),
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
 
   if (

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -1,6 +1,7 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
+import { buildOpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 
 import { applyPerArticleExtractionCaps } from "./analysis-caps-dedupe.js";
 import {
@@ -294,6 +295,9 @@ export const createProcessOneSource =
       if (shouldRunBrainstorm) {
         try {
           const brainstormStartedAt = Date.now();
+          const brainstormProviderOptions = buildOpenAiReasoningProviderOptions(
+            cfg.brainstormReasoningEffort,
+          );
           const brainstormResult = await fetchArticleBrainstorm({
             apiKey: cfg.openaiApiKey,
             model: cfg.brainstormModel,
@@ -314,6 +318,9 @@ export const createProcessOneSource =
                 }),
               },
             ],
+            ...(brainstormProviderOptions !== undefined
+              ? { providerOptions: brainstormProviderOptions }
+              : {}),
           });
           outcome.brainstormCalls = 1;
           outcome.brainstormLatencyMs = Date.now() - brainstormStartedAt;
@@ -342,6 +349,9 @@ export const createProcessOneSource =
         );
       }
 
+      const extractionProviderOptions = buildOpenAiReasoningProviderOptions(
+        cfg.extractionReasoningEffort,
+      );
       const extractedResult = await extractEntitiesAndRelationsForSource({
         apiKey: cfg.openaiApiKey,
         model: cfg.openaiModel,
@@ -357,6 +367,9 @@ export const createProcessOneSource =
           ? { exemplars: resolvedExemplars }
           : {}),
         ...(brainstormText !== undefined ? { brainstormText } : {}),
+        ...(extractionProviderOptions !== undefined
+          ? { providerOptions: extractionProviderOptions }
+          : {}),
       });
       outcome.extractionLatencyMs = Date.now() - t0;
       outcome.extractionCalls = 1;
@@ -409,6 +422,9 @@ export const createProcessOneSource =
         ) {
           outcome.vocabularyRepairCallsAttempted = 1;
           try {
+            const repairProviderOptions = buildOpenAiReasoningProviderOptions(
+              cfg.vocabularyRepairReasoningEffort,
+            );
             const repairResult = await repairExtractionVocabulary({
               apiKey: cfg.openaiApiKey,
               model: cfg.vocabularyRepairModel,
@@ -416,6 +432,9 @@ export const createProcessOneSource =
               ctx,
               badEntities: partitioned.badEntities,
               badRelations: partitioned.badRelations,
+              ...(repairProviderOptions !== undefined
+                ? { providerOptions: repairProviderOptions }
+                : {}),
             });
             outcome.repairUsage = repairResult.usage;
 
@@ -533,6 +552,9 @@ export const createProcessOneSource =
       } else if (critiqueEligible) {
         try {
           const critiqueStartedAt = Date.now();
+          const critiqueProviderOptions = buildOpenAiReasoningProviderOptions(
+            cfg.relationCritiqueReasoningEffort,
+          );
           const critiqueResult = await critiqueExtractedRelations({
             apiKey: cfg.openaiApiKey,
             model: cfg.relationCritiqueModel,
@@ -542,6 +564,9 @@ export const createProcessOneSource =
               articleBody: source.content,
               candidates: resolved.relations,
             }),
+            ...(critiqueProviderOptions !== undefined
+              ? { providerOptions: critiqueProviderOptions }
+              : {}),
           });
           outcome.relationCritiqueCalls = 1;
           outcome.critiqueLatencyMs = Date.now() - critiqueStartedAt;

--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -300,6 +300,18 @@ describe("ContentGenerationConfigSchema", () => {
     expect(schemaStr).not.toContain('"openai"');
   });
 
+  it("JSON schema exposes credentials.reasoningEffort as a four-value enum for Hermes dropdown", () => {
+    const jsonSchema = zodToJsonSchema(ContentGenerationConfigSchema, {
+      $refStrategy: "none",
+    });
+    const schemaStr = JSON.stringify(jsonSchema);
+    expect(schemaStr).toContain("reasoningEffort");
+    expect(schemaStr).toContain('"minimal"');
+    expect(schemaStr).toContain('"low"');
+    expect(schemaStr).toContain('"medium"');
+    expect(schemaStr).toContain('"high"');
+  });
+
   it("parses reliability.llmRetry with all fields provided", () => {
     const parsed = ContentGenerationConfigSchema.parse({
       ...testCredentials,
@@ -508,5 +520,45 @@ describe("resolveContentGenerationConfig", () => {
 
     expect(resolved.critiqueModel).toBe("gpt-4o");
     expect(resolved.subjectLineModel).toBe("gpt-4o");
+  });
+
+  it("resolves all per-pass reasoningEffort to undefined when unset", () => {
+    const resolved = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({ ...testCredentials }),
+    );
+
+    expect(resolved.structuredReasoningEffort).toBeUndefined();
+    expect(resolved.brainstormReasoningEffort).toBeUndefined();
+    expect(resolved.critiqueReasoningEffort).toBeUndefined();
+    expect(resolved.subjectLineReasoningEffort).toBeUndefined();
+  });
+
+  it("resolves per-pass reasoningEffort to credentials default when no overrides", () => {
+    const resolved = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
+      }),
+    );
+
+    expect(resolved.structuredReasoningEffort).toBe("high");
+    expect(resolved.brainstormReasoningEffort).toBe("high");
+    expect(resolved.critiqueReasoningEffort).toBe("high");
+    expect(resolved.subjectLineReasoningEffort).toBe("high");
+  });
+
+  it("per-pass override wins over credentials default", () => {
+    const resolved = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
+        creativity: { brainstorm: { reasoningEffort: "low" } },
+        quality: { selfCritique: { reasoningEffort: "medium" } },
+        delivery: { subjectLine: { reasoningEffort: "low" } },
+      }),
+    );
+
+    expect(resolved.structuredReasoningEffort).toBe("high");
+    expect(resolved.brainstormReasoningEffort).toBe("low");
+    expect(resolved.critiqueReasoningEffort).toBe("medium");
+    expect(resolved.subjectLineReasoningEffort).toBe("low");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
+import { reasoningEffortSchema } from "@workspace/agent-runtime";
 
 /** Maximum length for each optional `prompts.*` string (Hermes JSON config). */
 export const CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
@@ -187,6 +188,11 @@ const brainstormSchema = z
       .describe(
         "Chat model for the brainstorm pass. If omitted, uses credentials.chatModel.",
       ),
+    reasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Overrides credentials.reasoningEffort for the brainstorm pass.",
+      ),
     maxOutputTokens: z
       .number()
       .int()
@@ -234,6 +240,11 @@ const selfCritiqueSchema = z
       .optional()
       .describe(
         "Chat model for the critique pass. If omitted, uses credentials.chatModel.",
+      ),
+    reasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Overrides credentials.reasoningEffort for the self-critique pass.",
       ),
     critiqueMaxOutputTokens: z
       .number()
@@ -459,6 +470,11 @@ const subjectLineSchema = z
       .describe(
         "Chat model for subject candidates. If omitted, uses credentials.chatModel.",
       ),
+    reasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Overrides credentials.reasoningEffort for the subject-line pass.",
+      ),
     weights: z
       .object({
         lengthFit: z
@@ -537,6 +553,11 @@ const credentialsSchema = z
       .positive()
       .optional()
       .describe("Maximum tokens to generate per LLM call."),
+    reasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Reasoning effort for LLM passes when the model supports it (gpt-5/o-series). Leave unset for non-reasoning models like gpt-4o-mini.",
+      ),
     timeoutMs: z
       .number()
       .int()
@@ -744,13 +765,21 @@ export type ResolvedPersistRetryConfig =
   ContentGenerationConfig["reliability"]["persistRetry"];
 
 /**
- * Content-generation config with per-pass model ids resolved to credentials.chatModel
- * when omitted. Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
+ * Content-generation config with per-pass model ids and reasoning effort levels
+ * resolved. Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
+ *
+ * Per-pass reasoning effort falls back to `credentials.reasoningEffort` when the
+ * pass-level override is unset. All values may be `undefined` when the operator has
+ * not set reasoning effort — this is safe for non-reasoning models.
  */
 export type ResolvedContentGenerationConfig = ContentGenerationConfig & {
   brainstormModel: string;
   critiqueModel: string;
   subjectLineModel: string;
+  structuredReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  brainstormReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  critiqueReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
+  subjectLineReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
 };
 
 type RetryFields = {
@@ -800,11 +829,36 @@ export function resolveContentGenerationConfig(
 ): ResolvedContentGenerationConfig {
   const parsed = ContentGenerationConfigSchema.parse(config);
   const chatModel = parsed.credentials.chatModel;
+  const defaultEffort = parsed.credentials.reasoningEffort;
 
   return {
     ...parsed,
     brainstormModel: parsed.creativity.brainstorm.model ?? chatModel,
     critiqueModel: parsed.quality.selfCritique.critiqueModel ?? chatModel,
     subjectLineModel: parsed.delivery.subjectLine.model ?? chatModel,
+    ...(defaultEffort !== undefined
+      ? { structuredReasoningEffort: defaultEffort }
+      : {}),
+    ...(parsed.creativity.brainstorm.reasoningEffort !== undefined
+      ? {
+          brainstormReasoningEffort:
+            parsed.creativity.brainstorm.reasoningEffort,
+        }
+      : defaultEffort !== undefined
+        ? { brainstormReasoningEffort: defaultEffort }
+        : {}),
+    ...(parsed.quality.selfCritique.reasoningEffort !== undefined
+      ? { critiqueReasoningEffort: parsed.quality.selfCritique.reasoningEffort }
+      : defaultEffort !== undefined
+        ? { critiqueReasoningEffort: defaultEffort }
+        : {}),
+    ...(parsed.delivery.subjectLine.reasoningEffort !== undefined
+      ? {
+          subjectLineReasoningEffort:
+            parsed.delivery.subjectLine.reasoningEffort,
+        }
+      : defaultEffort !== undefined
+        ? { subjectLineReasoningEffort: defaultEffort }
+        : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject } from "ai";
+import type { OpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 import { z } from "zod";
 
 import type { IndustryNewsletterStructure } from "../industry-newsletter-schema.js";
@@ -243,6 +244,8 @@ export type GenerateObjectForNewsletterCritiqueArgs = {
   maxOutputTokens: number;
   maxRetries: number;
   timeout?: number;
+  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
+  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Injectable wrapper around critique `generateObject` for tests. */
@@ -263,6 +266,9 @@ const defaultGenerateObjectForNewsletterCritique: GenerateObjectForNewsletterCri
       maxRetries: args.maxRetries,
       maxOutputTokens: args.maxOutputTokens,
       ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+      ...(args.providerOptions !== undefined
+        ? { providerOptions: args.providerOptions }
+        : {}),
     });
     const usage = result.usage
       ? {
@@ -288,6 +294,7 @@ export const critiqueNewsletter = async (
     system: string;
     prompt: string;
     timeout?: number;
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateObjectFn?: GenerateObjectForNewsletterCritique;
@@ -311,6 +318,9 @@ export const critiqueNewsletter = async (
     maxOutputTokens: params.maxOutputTokens,
     maxRetries: 0,
     ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
 
   return {

--- a/apps/mediapulse/agents/content-generation/src/lib/subject-line.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/subject-line.ts
@@ -1,5 +1,6 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject } from "ai";
+import type { OpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 import { z } from "zod";
 
 import {
@@ -409,6 +410,8 @@ export type GenerateObjectForSubjectCandidatesArgs = {
   prompt: string;
   maxRetries: number;
   timeout?: number;
+  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
+  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Injectable wrapper around subject-candidate `generateObject` for tests. */
@@ -428,6 +431,9 @@ const defaultGenerateObjectForSubjectCandidates: GenerateObjectForSubjectCandida
       prompt: args.prompt,
       maxRetries: args.maxRetries,
       ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
+      ...(args.providerOptions !== undefined
+        ? { providerOptions: args.providerOptions }
+        : {}),
     });
     const usage = result.usage
       ? {
@@ -453,6 +459,7 @@ export const fetchSubjectCandidates = async (
     system: string;
     prompt: string;
     timeout?: number;
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateObjectFn?: GenerateObjectForSubjectCandidates;
@@ -475,6 +482,9 @@ export const fetchSubjectCandidates = async (
     prompt: params.prompt,
     maxRetries: 0,
     ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
 
   return {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -1,6 +1,7 @@
 import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import type { OpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 
 import { parseIndustryNewsletterWire } from "@workspace/email-templates/parse-industry-newsletter-wire";
@@ -2165,5 +2166,109 @@ describe("generateNewsletterWithLlm — competitor prompt injection", () => {
 
     expect(capturedPrompt).not.toContain("Do NOT make these bullets about");
     expect(capturedPrompt).not.toContain("{{");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reasoning effort wiring
+// ---------------------------------------------------------------------------
+
+describe("generateNewsletterWithLlm — reasoning effort", () => {
+  it("does not pass providerOptions to the structured generateFn when reasoningEffort is unset", async () => {
+    let capturedArgs: GenerateNewsletterObjectArgs | undefined;
+    const generateObjectFn: GenerateNewsletterObjectFn = vi
+      .fn()
+      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
+        capturedArgs = args;
+        return { object: minimalIndustryBrief() };
+      });
+
+    await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+    });
+
+    expect(capturedArgs?.providerOptions).toBeUndefined();
+  });
+
+  it("passes providerOptions with reasoningEffort to the structured generateFn when set", async () => {
+    let capturedArgs: GenerateNewsletterObjectArgs | undefined;
+    const generateObjectFn: GenerateNewsletterObjectFn = vi
+      .fn()
+      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
+        capturedArgs = args;
+        return { object: minimalIndustryBrief() };
+      });
+
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
+      }),
+    );
+
+    await generateNewsletterWithLlm(testSources, config, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+    });
+
+    expect(capturedArgs?.providerOptions).toEqual({
+      openai: { reasoningEffort: "high" },
+    });
+  });
+
+  it("per-pass subject-line override is independent of structured-pass effort", async () => {
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    let capturedSubjectArgs:
+      | { providerOptions?: OpenAiReasoningProviderOptions }
+      | undefined;
+    const subjectGenerateObjectFn = vi
+      .fn()
+      .mockImplementation(
+        async (args: { providerOptions?: OpenAiReasoningProviderOptions }) => {
+          capturedSubjectArgs = args;
+          return {
+            object: {
+              candidates: [
+                {
+                  subject: "Top Story Today",
+                  style: "declarative",
+                  preheader: "Industry news",
+                },
+                {
+                  subject: "Markets Move Fast",
+                  style: "numeric",
+                  preheader: "Key figures",
+                },
+                {
+                  subject: "What Changed?",
+                  style: "question",
+                  preheader: "Sector update",
+                },
+              ],
+            },
+            usage: { promptTokens: 10, completionTokens: 5 },
+          };
+        },
+      );
+
+    const config = resolveContentGenerationConfig(
+      ContentGenerationConfigSchema.parse({
+        ...conservativeTestConfigInput,
+        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
+        delivery: { subjectLine: { enabled: true, reasoningEffort: "low" } },
+      }),
+    );
+
+    await generateNewsletterWithLlm(testSources, config, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+      subjectGenerateObjectFn,
+    });
+
+    expect(capturedSubjectArgs?.providerOptions).toEqual({
+      openai: { reasoningEffort: "low" },
+    });
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -2,6 +2,10 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject, generateText } from "ai";
 import type { z } from "zod";
 
+import {
+  buildOpenAiReasoningProviderOptions,
+  type OpenAiReasoningProviderOptions,
+} from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
@@ -124,6 +128,13 @@ export interface GeneratedContentWithProvenance extends GeneratedContent {
   brainstormPromptTokens: number | null;
   /** Brainstorm-pass completion tokens. */
   brainstormCompletionTokens: number | null;
+  /**
+   * Reasoning tokens consumed by the structured pass.
+   * Present only when the model reports them (gpt-5/o-series with reasoning effort set).
+   * Reasoning tokens come out of the output budget, so a tight `credentials.maxTokens`
+   * can truncate the structured JSON when reasoning effort is enabled.
+   */
+  structuredReasoningTokens?: number;
   /** Per-bullet grounding reports (present when citation grounding is enabled). */
   citationGroundingReports?: BulletGroundingReport[];
   /** Rolled-up citation grounding counters for run details. */
@@ -180,6 +191,8 @@ export type GenerateNewsletterObjectArgs = {
   timeout?: number;
   /** Maximum tokens to generate (passed to `generateObject`). */
   maxTokens?: number;
+  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
+  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Token usage extracted from a single `generateObject` response. */
@@ -187,6 +200,7 @@ export type GenerateNewsletterObjectUsage = {
   promptTokens?: number;
   completionTokens?: number;
   totalTokens?: number;
+  reasoningTokens?: number;
 };
 
 /** Result of a single `generateObject` call for newsletter generation. */
@@ -207,7 +221,11 @@ export type GenerateNewsletterObjectFn = (
 const defaultGenerateNewsletterObject: GenerateNewsletterObjectFn = async (
   args,
 ) => {
-  const result = await generateObject(args);
+  const { providerOptions, ...rest } = args;
+  const result = await generateObject({
+    ...rest,
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
+  });
   // AI SDK v6 uses inputTokens/outputTokens (not promptTokens/completionTokens).
   // We map to the contract names (promptTokens/completionTokens/totalTokens) here
   // so the rest of the codebase speaks the contract vocabulary.
@@ -220,6 +238,10 @@ const defaultGenerateNewsletterObject: GenerateNewsletterObjectFn = async (
           result.usage.outputTokens !== undefined
             ? result.usage.inputTokens + result.usage.outputTokens
             : undefined,
+        // reasoningTokens is present on reasoning models (gpt-5/o-series).
+        ...(result.usage.reasoningTokens !== undefined
+          ? { reasoningTokens: result.usage.reasoningTokens }
+          : {}),
       }
     : undefined;
   return { object: result.object, usage };
@@ -235,6 +257,8 @@ export type GenerateTextForNewsletterBrainstormArgs = {
   maxRetries: number;
   /** Per-request timeout in milliseconds (passed to the AI SDK). */
   timeout?: number;
+  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
+  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Token usage from a brainstorm `generateText` response. */
@@ -256,7 +280,11 @@ export type GenerateTextForNewsletterBrainstorm = (
 
 const defaultGenerateTextForNewsletterBrainstorm: GenerateTextForNewsletterBrainstorm =
   async (args) => {
-    const result = await generateText(args);
+    const { providerOptions, ...rest } = args;
+    const result = await generateText({
+      ...rest,
+      ...(providerOptions !== undefined ? { providerOptions } : {}),
+    });
     const usage =
       result.usage !== undefined
         ? {
@@ -447,6 +475,7 @@ export const fetchNewsletterBrainstorm = async (
     system: string;
     prompt: string;
     timeout?: number;
+    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateTextFn?: GenerateTextForNewsletterBrainstorm;
@@ -466,6 +495,9 @@ export const fetchNewsletterBrainstorm = async (
     maxOutputTokens: params.maxOutputTokens,
     maxRetries: 0,
     ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
+    ...(params.providerOptions !== undefined
+      ? { providerOptions: params.providerOptions }
+      : {}),
   });
 };
 
@@ -793,6 +825,9 @@ export async function generateNewsletterWithLlm(
 
     try {
       const brainstormStartedAt = nowFn();
+      const brainstormProviderOptions = buildOpenAiReasoningProviderOptions(
+        config.brainstormReasoningEffort,
+      );
       const brainstormResult = await fetchNewsletterBrainstorm(
         {
           apiKey: config.credentials.openaiApiKey,
@@ -804,6 +839,9 @@ export async function generateNewsletterWithLlm(
           system: brainstormSystemPrompt,
           prompt: brainstormUserPrompt,
           ...(timeout !== undefined ? { timeout } : {}),
+          ...(brainstormProviderOptions !== undefined
+            ? { providerOptions: brainstormProviderOptions }
+            : {}),
         },
         { generateTextFn: deps.generateTextFn },
       );
@@ -916,6 +954,25 @@ export async function generateNewsletterWithLlm(
       ? Math.max(1, timeout - (nowFn() - generationStartedAt))
       : timeout;
 
+  // Reasoning tokens are consumed from the output budget. When using a
+  // reasoning model, ensure credentials.maxTokens is large enough to
+  // accommodate both reasoning tokens and the structured JSON output.
+  // See the config reference for recommended pairings.
+  const structuredProviderOptions = buildOpenAiReasoningProviderOptions(
+    config.structuredReasoningEffort,
+  );
+
+  logger.info(
+    {
+      tickerId: context.tickerId,
+      structuredReasoningEffort: config.structuredReasoningEffort,
+      brainstormReasoningEffort: config.brainstormReasoningEffort,
+      critiqueReasoningEffort: config.critiqueReasoningEffort,
+      subjectLineReasoningEffort: config.subjectLineReasoningEffort,
+    },
+    "LLM passes: effective reasoning effort per pass",
+  );
+
   const result = await retryWithBackoff(
     async () => {
       return generateFn({
@@ -928,6 +985,9 @@ export async function generateNewsletterWithLlm(
           ? { timeout: structuredTimeout }
           : {}),
         ...(maxTokens !== undefined ? { maxTokens } : {}),
+        ...(structuredProviderOptions !== undefined
+          ? { providerOptions: structuredProviderOptions }
+          : {}),
       });
     },
     config.reliability.llmRetry,
@@ -1054,6 +1114,10 @@ export async function generateNewsletterWithLlm(
             candidates.length * CRITIQUE_TOKENS_PER_CANDIDATE,
         );
 
+        const critiqueProviderOptions = buildOpenAiReasoningProviderOptions(
+          config.critiqueReasoningEffort,
+        );
+
         try {
           const critiqueResult = await critiqueNewsletter(
             {
@@ -1067,6 +1131,9 @@ export async function generateNewsletterWithLlm(
               prompt: critiquePrompt,
               ...(critiqueTimeout !== undefined
                 ? { timeout: critiqueTimeout }
+                : {}),
+              ...(critiqueProviderOptions !== undefined
+                ? { providerOptions: critiqueProviderOptions }
                 : {}),
             },
             { generateObjectFn: deps.critiqueGenerateObjectFn },
@@ -1275,6 +1342,10 @@ export async function generateNewsletterWithLlm(
           ? Math.max(1, timeout - (nowFn() - generationStartedAt))
           : undefined;
 
+      const subjectProviderOptions = buildOpenAiReasoningProviderOptions(
+        config.subjectLineReasoningEffort,
+      );
+
       const subjectResult = await fetchSubjectCandidates(
         {
           apiKey: config.credentials.openaiApiKey,
@@ -1286,6 +1357,9 @@ export async function generateNewsletterWithLlm(
           system: subjectSystem,
           prompt: subjectPrompt,
           ...(subjectTimeout !== undefined ? { timeout: subjectTimeout } : {}),
+          ...(subjectProviderOptions !== undefined
+            ? { providerOptions: subjectProviderOptions }
+            : {}),
         },
         { generateObjectFn: deps.subjectGenerateObjectFn },
       );
@@ -1443,6 +1517,9 @@ export async function generateNewsletterWithLlm(
     brainstormUsed,
     brainstormPromptTokens,
     brainstormCompletionTokens,
+    ...(usage?.reasoningTokens !== undefined
+      ? { structuredReasoningTokens: usage.reasoningTokens }
+      : {}),
     ...(citationGroundingReports !== undefined
       ? { citationGroundingReports }
       : {}),

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -574,6 +574,30 @@ export async function run({
     success: true,
     details: {
       promptHash,
+      ...(resolvedConfig.structuredReasoningEffort !== undefined ||
+      resolvedConfig.brainstormReasoningEffort !== undefined ||
+      resolvedConfig.critiqueReasoningEffort !== undefined ||
+      resolvedConfig.subjectLineReasoningEffort !== undefined
+        ? {
+            reasoningEffort: {
+              ...(resolvedConfig.structuredReasoningEffort !== undefined
+                ? { structured: resolvedConfig.structuredReasoningEffort }
+                : {}),
+              ...(resolvedConfig.brainstormReasoningEffort !== undefined
+                ? { brainstorm: resolvedConfig.brainstormReasoningEffort }
+                : {}),
+              ...(resolvedConfig.critiqueReasoningEffort !== undefined
+                ? { critique: resolvedConfig.critiqueReasoningEffort }
+                : {}),
+              ...(resolvedConfig.subjectLineReasoningEffort !== undefined
+                ? { subjectLine: resolvedConfig.subjectLineReasoningEffort }
+                : {}),
+            },
+          }
+        : {}),
+      ...(generated.structuredReasoningTokens !== undefined
+        ? { reasoningTokens: generated.structuredReasoningTokens }
+        : {}),
       brainstormUsed: generated.brainstormUsed,
       ...(generated.brainstormPromptTokens !== null
         ? { brainstormPromptTokens: generated.brainstormPromptTokens }

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -5,6 +5,7 @@ import {
   queryAnalysisIntentSchema,
   type QueryAnalysisIntentWeights,
 } from "@workspace/agent-data-api-contract";
+import { reasoningEffortSchema } from "@workspace/agent-runtime";
 import {
   DEFAULT_DETERMINISTIC_PACK,
   DETERMINISTIC_PACK_NAMES,
@@ -99,9 +100,14 @@ const samplingSchema = z
       .describe(
         "Optional fixed seed for reproducible LLM output when the model supports it.",
       ),
+    reasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Reasoning effort for query-generation LLM calls when the model supports it (gpt-5/o-series). Leave unset for non-reasoning models like gpt-4o-mini.",
+      ),
   })
   .default({})
-  .describe("Optional LLM reproducibility settings.");
+  .describe("Optional LLM reproducibility and reasoning settings.");
 
 const templatesSchema = z
   .object({
@@ -174,6 +180,11 @@ const creativitySchema = z
       .optional()
       .describe(
         "Model id for the brainstorm pass. If omitted, uses credentials.chatModel (default {{OPENAI_MODEL}}).",
+      ),
+    brainstormReasoningEffort: reasoningEffortSchema
+      .optional()
+      .describe(
+        "Overrides sampling.reasoningEffort for the brainstorm pass only.",
       ),
   })
   .default({})

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -28,6 +28,7 @@ import {
   resolveWildcardSystemContent,
   resolveWildcardUserContent,
   selectCandidatesToDropFromCritique,
+  type LlmQuerySampling,
 } from "./llm-queries";
 import { DEFAULT_QUERY_PERSONAS } from "./personas/default-personas";
 
@@ -957,5 +958,111 @@ describe("fetchWildcardCandidates", () => {
       { text: "First odd angle", intent: "wildcard" },
       { text: "Second odd angle", intent: "wildcard" },
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// llmSamplingOptions + reasoning effort
+// ---------------------------------------------------------------------------
+
+describe("llmSamplingOptions — reasoning effort", () => {
+  const reasoningEffortContext = {
+    ticker: {
+      id: "11111111-1111-4111-a111-111111111111",
+      symbol: "ACME",
+      name: "Acme Co",
+      metadata: null,
+    },
+    topEntities: [] as [],
+    recentThemes: [] as [],
+    recentRelationDeltas: [] as [],
+    peers: [] as [],
+    calendar: { recentEventTypes: [] as string[] },
+    headlineSamples: [] as [],
+    kgNeighborhood: [] as [],
+  };
+
+  const reasoningEffortStrategy = {
+    queryCount: 5,
+    language: "en",
+    minDeterministicCount: 2,
+    intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+  };
+
+  it("does not include providerOptions when sampling.reasoningEffort is unset", async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const generateTextForBrainstorm = vi
+      .fn()
+      .mockImplementation(async (args: Record<string, unknown>) => {
+        capturedArgs = args;
+        return { text: "" };
+      });
+
+    const sampling: LlmQuerySampling = {};
+    await fetchBrainstormBullets(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        strategy: reasoningEffortStrategy,
+        context: reasoningEffortContext,
+        sampling,
+      },
+      { generateTextForBrainstorm },
+    );
+
+    expect(capturedArgs?.providerOptions).toBeUndefined();
+  });
+
+  it("includes providerOptions when sampling.reasoningEffort is set", async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const generateTextForBrainstorm = vi
+      .fn()
+      .mockImplementation(async (args: Record<string, unknown>) => {
+        capturedArgs = args;
+        return { text: "" };
+      });
+
+    const sampling: LlmQuerySampling = { reasoningEffort: "high" };
+    await fetchBrainstormBullets(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        strategy: reasoningEffortStrategy,
+        context: reasoningEffortContext,
+        sampling,
+      },
+      { generateTextForBrainstorm },
+    );
+
+    expect(capturedArgs?.providerOptions).toEqual({
+      openai: { reasoningEffort: "high" },
+    });
+  });
+
+  it("brainstormReasoningEffort override takes precedence over sampling.reasoningEffort", async () => {
+    let capturedArgs: Record<string, unknown> | undefined;
+    const generateTextForBrainstorm = vi
+      .fn()
+      .mockImplementation(async (args: Record<string, unknown>) => {
+        capturedArgs = args;
+        return { text: "" };
+      });
+
+    const sampling: LlmQuerySampling = { reasoningEffort: "high" };
+    await fetchBrainstormBullets(
+      {
+        apiKey: "sk-test",
+        model: "gpt-4o-mini",
+        strategy: reasoningEffortStrategy,
+        context: reasoningEffortContext,
+        sampling,
+        brainstormReasoningEffort: "low",
+      },
+      { generateTextForBrainstorm },
+    );
+
+    expect(capturedArgs?.providerOptions).toEqual({
+      openai: { reasoningEffort: "low" },
+    });
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -1,6 +1,11 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { generateObject, generateText } from "ai";
 import type { ModelMessage } from "ai";
+import { buildOpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
+import type {
+  OpenAiReasoningEffort,
+  OpenAiReasoningProviderOptions,
+} from "@workspace/agent-runtime";
 import {
   QUERY_ANALYSIS_STANDARD_INTENTS,
   queryAnalysisIntentSchema,
@@ -381,12 +386,21 @@ export const buildStructuredQueryMessages = (options: {
 
 export type LlmQuerySampling = {
   seed?: number;
+  reasoningEffort?: OpenAiReasoningEffort;
 };
 
-/** Returns optional seed fields for AI SDK calls when configured. */
-const llmSamplingOptions = (sampling: LlmQuerySampling): { seed?: number } => ({
-  ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
-});
+/** Returns seed and providerOptions fields for AI SDK calls when configured. */
+const llmSamplingOptions = (
+  sampling: LlmQuerySampling,
+): { seed?: number; providerOptions?: OpenAiReasoningProviderOptions } => {
+  const providerOptions = buildOpenAiReasoningProviderOptions(
+    sampling.reasoningEffort,
+  );
+  return {
+    ...(sampling.seed !== undefined ? { seed: sampling.seed } : {}),
+    ...(providerOptions !== undefined ? { providerOptions } : {}),
+  };
+};
 
 export type GenerateObjectForWildcards = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
@@ -394,6 +408,7 @@ export type GenerateObjectForWildcards = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   seed?: number;
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{ object: z.infer<typeof llmWildcardOutputSchema> }>;
 
 export type GenerateObjectForQueries = (args: {
@@ -402,6 +417,7 @@ export type GenerateObjectForQueries = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   seed?: number;
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{ object: z.infer<typeof llmQueriesOutputSchema> }>;
 
 export type GenerateObjectForCritique = (args: {
@@ -410,6 +426,7 @@ export type GenerateObjectForCritique = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   seed?: number;
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{ object: z.infer<typeof llmCritiqueOutputSchema> }>;
 
 export type GenerateTextForBrainstorm = (args: {
@@ -417,6 +434,7 @@ export type GenerateTextForBrainstorm = (args: {
   messages: ModelMessage[];
   maxOutputTokens: number;
   seed?: number;
+  providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<{ text: string }>;
 
 /**
@@ -433,6 +451,8 @@ export const fetchBrainstormBullets = async (
     strategy: LlmQueryStrategyPrompt;
     context: GetQueryAnalysisResponse;
     sampling: LlmQuerySampling;
+    /** Overrides `sampling.reasoningEffort` for the brainstorm pass only. */
+    brainstormReasoningEffort?: OpenAiReasoningEffort;
   },
   deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
     generateTextForBrainstorm: generateText,
@@ -443,6 +463,13 @@ export const fetchBrainstormBullets = async (
     params.strategy,
     params.context,
   );
+  const effectiveBrainstormSampling: LlmQuerySampling =
+    params.brainstormReasoningEffort !== undefined
+      ? {
+          ...params.sampling,
+          reasoningEffort: params.brainstormReasoningEffort,
+        }
+      : params.sampling;
   const { text } = await deps.generateTextForBrainstorm({
     model: openai(params.model),
     messages: [
@@ -450,7 +477,7 @@ export const fetchBrainstormBullets = async (
       { role: "user", content: user },
     ],
     maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
-    ...llmSamplingOptions(params.sampling),
+    ...llmSamplingOptions(effectiveBrainstormSampling),
   });
   return parseBrainstormBullets(text);
 };
@@ -600,6 +627,8 @@ export type FetchQueryAnalysisLlmCandidatesParams = {
   sampling: LlmQuerySampling;
   useBrainstormPass: boolean;
   fewShotExemplarCount: number;
+  /** Overrides `sampling.reasoningEffort` for the brainstorm pass only. */
+  brainstormReasoningEffort?: OpenAiReasoningEffort;
 };
 
 /**
@@ -627,6 +656,9 @@ export const fetchQueryAnalysisLlmCandidates = async (
       strategy: params.strategy,
       context: params.context,
       sampling: params.sampling,
+      ...(params.brainstormReasoningEffort !== undefined
+        ? { brainstormReasoningEffort: params.brainstormReasoningEffort }
+        : {}),
     });
   }
 

--- a/packages/shared/agent-runtime/src/index.ts
+++ b/packages/shared/agent-runtime/src/index.ts
@@ -9,6 +9,12 @@ export {
   type HermesTickerId,
 } from "./schemas/hermes-ticker-id.js";
 export {
+  reasoningEffortSchema,
+  type OpenAiReasoningEffort,
+  type OpenAiReasoningProviderOptions,
+  buildOpenAiReasoningProviderOptions,
+} from "./schemas/reasoning-effort.js";
+export {
   hermesInvokeCorrelationFromGetHeader,
   HERMES_HEADER_EXECUTION_ID,
   HERMES_HEADER_JOB_ID,

--- a/packages/shared/agent-runtime/src/schemas/reasoning-effort.test.ts
+++ b/packages/shared/agent-runtime/src/schemas/reasoning-effort.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOpenAiReasoningProviderOptions,
+  reasoningEffortSchema,
+} from "./reasoning-effort.js";
+
+describe("reasoningEffortSchema", () => {
+  it("accepts all four valid values", () => {
+    for (const value of ["minimal", "low", "medium", "high"] as const) {
+      expect(reasoningEffortSchema.parse(value)).toBe(value);
+    }
+  });
+
+  it("rejects an unknown value", () => {
+    expect(() => reasoningEffortSchema.parse("extreme")).toThrow();
+  });
+});
+
+describe("buildOpenAiReasoningProviderOptions", () => {
+  it("returns undefined when effort is undefined", () => {
+    expect(buildOpenAiReasoningProviderOptions(undefined)).toBeUndefined();
+  });
+
+  it("returns the correct provider option shape for each effort value", () => {
+    for (const effort of ["minimal", "low", "medium", "high"] as const) {
+      expect(buildOpenAiReasoningProviderOptions(effort)).toEqual({
+        openai: { reasoningEffort: effort },
+      });
+    }
+  });
+});

--- a/packages/shared/agent-runtime/src/schemas/reasoning-effort.ts
+++ b/packages/shared/agent-runtime/src/schemas/reasoning-effort.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+
+/**
+ * Reasoning effort level for OpenAI reasoning models.
+ *
+ * `minimal` is gpt-5-only; `low`, `medium`, and `high` cover o-series models.
+ * Validity is model-dependent. Unset means "do not send the parameter" — safe for
+ * non-reasoning models such as gpt-4o-mini.
+ */
+export const reasoningEffortSchema = z.enum([
+  "minimal",
+  "low",
+  "medium",
+  "high",
+]);
+
+/** TypeScript type for {@link reasoningEffortSchema}. */
+export type OpenAiReasoningEffort = z.infer<typeof reasoningEffortSchema>;
+
+/**
+ * Builds the `providerOptions` object required by the AI SDK when reasoning
+ * effort should be sent, or returns `undefined` to omit the parameter entirely.
+ *
+ * @param effort - Resolved reasoning effort level, or `undefined` to omit.
+ * @returns Provider options to spread into `generateObject`/`generateText`, or `undefined`.
+ */
+export const buildOpenAiReasoningProviderOptions = (
+  effort: OpenAiReasoningEffort | undefined,
+): { openai: { reasoningEffort: OpenAiReasoningEffort } } | undefined =>
+  effort === undefined ? undefined : { openai: { reasoningEffort: effort } };
+
+/** AI SDK `providerOptions` shape for OpenAI reasoning effort. */
+export type OpenAiReasoningProviderOptions = NonNullable<
+  ReturnType<typeof buildOpenAiReasoningProviderOptions>
+>;


### PR DESCRIPTION
## Summary

Industry newsletters now pull **KG competitor names** into the landscape prompt, then enforce bullets that actually mention a competitor instead of only the issuer. Uncited rows can be pruned when require-citation is on, and runs record competitive-focus counts in details. Agents also accept optional **OpenAI reasoning effort** on credentials and individual LLM passes.

Closes #633

## Related issues

Closes #633

## Important changes

- Agent-data-api content-generation `GET` returns competitors for prompt injection.
- Post-LLM competitive landscape gate (`warn` / `flag` / `drop`) with issuer-only detection and run-detail summary.
- Require-citation pruning removes uncited bullets/rows while respecting section minimums.
- Shared `reasoningEffort` in `@workspace/agent-runtime` with per-pass overrides in query-analysis, article-analysis, and content-generation.

## Other changes

- Dev-docs updates for content-generation and agent-data-api.
- Config schema tests for new quality and credentials fields.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.ts` — issuer vs competitor matching and policy enforcement.
- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts` — require-citation pruning rules.
- `apps/mediapulse/agent-data-api/src/services/content-generation.ts` — competitor payload on GET.
- `packages/shared/agent-runtime/src/schemas/reasoning-effort.ts` — shared effort schema and providerOptions builder.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — wires focus gate, pruning, and reasoning effort into the pipeline.

## How to test

1. From repo root: `pnpm --filter @mediapulse/content-generation test` and `pnpm --filter @workspace/agent-runtime test`.
2. Run content-generation against a ticker with KG competitors; confirm run details include `competitiveLandscapeFocus` counts when policy is not `warn`.
3. Set `quality.requireCitation.enabled` and verify uncited landscape/quick-hit rows are pruned without breaking schema minimums.
4. Set `credentials.reasoningEffort` (e.g. `low`) on a reasoning model and confirm the agent sends `providerOptions.openai.reasoningEffort`; leave unset on gpt-4o-mini and confirm no providerOptions are passed.
