### PR TITLE
Prune uncited industry pulse and add lead citation link

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -355,6 +355,7 @@ const crossRunDedupSchema = z
   .describe("Cross-run semantic dedup against recent newsletter bullets.");
 
 const requireCitationSectionEnum = z.enum([
+  "industryPulse",
   "competitiveLandscape",
   "dealsAndMovements",
   "regulatoryPolicyWatch",
@@ -373,6 +374,7 @@ const requireCitationSchema = z
     sections: z
       .array(requireCitationSectionEnum)
       .default([
+        "industryPulse",
         "competitiveLandscape",
         "dealsAndMovements",
         "regulatoryPolicyWatch",
@@ -380,7 +382,7 @@ const requireCitationSchema = z
         "quickHits",
       ])
       .describe(
-        "Which body sections to apply pruning to. industry-pulse is always exempt.",
+        "Which sections to apply pruning to. industry-pulse is kept only when it resolves a citation.",
       ),
     dedupeArticlesWithinSection: z
       .boolean()
@@ -393,12 +395,6 @@ const requireCitationSchema = z
       .default("section")
       .describe(
         "section = dedup URLs per section only; newsletter = dedup URLs across all sections.",
-      ),
-    keepIndustryPulse: z
-      .literal(true)
-      .default(true)
-      .describe(
-        "industry-pulse is always kept; this field exists to document that invariant.",
       ),
   })
   .default({})

--- a/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
@@ -75,16 +75,21 @@ export const formatIndustryNewsletterWire = (
     parts.push(block.trimEnd(), "");
   };
 
-  pushBlock(
-    [
-      `${BEGIN} industry-pulse`,
-      DISPLAY_HEADING,
-      collapseHeadingLine(briefing.industryPulse.displayHeading),
-      PROSE,
-      stripArticleMarkers(briefing.industryPulse.prose.trim()),
-      END,
-    ].join("\n"),
-  );
+  if (briefing.industryPulse !== undefined) {
+    pushBlock(
+      [
+        `${BEGIN} industry-pulse`,
+        DISPLAY_HEADING,
+        collapseHeadingLine(briefing.industryPulse.displayHeading),
+        PROSE,
+        withOptionalReadLine(
+          stripArticleMarkers(briefing.industryPulse.prose.trim()),
+          briefing.industryPulse.url,
+        ),
+        END,
+      ].join("\n"),
+    );
+  }
 
   const pushBulletSection = (
     machineKey: string,

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
@@ -129,7 +129,7 @@ describe("industryNewsletterStructureLlmSchema", () => {
   it("normalizes nullable articleIndex and optional blocks to the parsed shape", () => {
     const parsed = industryNewsletterStructureLlmSchema.parse({
       subject: "S",
-      industryPulse: { displayHeading: "L", prose: "p" },
+      industryPulse: { displayHeading: "L", prose: "p", articleIndex: null },
       competitiveLandscape: {
         displayHeading: "C",
         bullets: [
@@ -164,5 +164,6 @@ describe("industryNewsletterStructureLlmSchema", () => {
 
     expect(industryNewsletterStructureSchema.parse(parsed)).toEqual(parsed);
     expect(parsed.competitiveLandscape.bullets[1]).toEqual({ text: "b2" });
+    expect(parsed.industryPulse.articleIndex).toBeUndefined();
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
@@ -43,6 +43,7 @@ export const industryNewsletterStructureSchema = z.object({
   industryPulse: z.object({
     displayHeading: z.string().min(1),
     prose: z.string().min(1),
+    articleIndex: articleIndexSchema.optional(),
   }),
   competitiveLandscape: z.object({
     displayHeading: z.string().min(1),
@@ -87,6 +88,25 @@ const industryBriefBulletLlmSchema = z
     },
   );
 
+const industryPulseLlmSchema = z
+  .object({
+    displayHeading: z.string().min(1),
+    prose: z.string().min(1),
+    articleIndex: z.union([articleIndexSchema, z.null()]),
+  })
+  .transform(
+    ({
+      displayHeading,
+      prose,
+      articleIndex,
+    }): z.infer<typeof industryNewsletterStructureSchema>["industryPulse"] => {
+      const normalizedIndex = normalizeOptionalArticleIndex(articleIndex);
+      return normalizedIndex === undefined
+        ? { displayHeading, prose }
+        : { displayHeading, prose, articleIndex: normalizedIndex };
+    },
+  );
+
 const disruptorsOrTechBulletsLlmSchema = z.object({
   format: z.literal("bullets"),
   displayHeading: z.string().min(1),
@@ -107,10 +127,7 @@ const disruptorsOrTechLlmSchema = z.discriminatedUnion("format", [
 export const industryNewsletterStructureLlmSchema = z
   .object({
     subject: z.string().min(1),
-    industryPulse: z.object({
-      displayHeading: z.string().min(1),
-      prose: z.string().min(1),
-    }),
+    industryPulse: industryPulseLlmSchema,
     competitiveLandscape: z.object({
       displayHeading: z.string().min(1),
       bullets: z.array(industryBriefBulletLlmSchema).min(2).max(3),

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
@@ -32,14 +32,15 @@ export type IndustryDisruptorsOrTechResolved =
 /**
  * Industry briefing ready for wire formatting (all URLs from config, not the LLM).
  *
- * `subject` and `industryPulse` are required. The five body sections are optional:
- * absence is represented by the field being `undefined`, never by an empty bullets/items array.
- * A zero-row section is a contradiction the serializer refuses to emit.
+ * `subject` is required. `industryPulse` is optional — it is omitted when the prune
+ * pass removes the lead for lacking a resolvable citation. All five body sections are
+ * optional: absence is represented by the field being `undefined`, never by an empty
+ * bullets/items array. A zero-row section is a contradiction the serializer refuses to emit.
  * See `formatIndustryNewsletterWire` for the wire contract.
  */
 export type IndustryNewsletterResolved = {
   subject: string;
-  industryPulse: { displayHeading: string; prose: string };
+  industryPulse?: { displayHeading: string; prose: string; url?: string };
   competitiveLandscape?: {
     displayHeading: string;
     bullets: IndustryBulletResolved[];
@@ -116,9 +117,18 @@ export const attachIndustryNewsletterSourceUrls = (
           bullets: briefing.disruptorsOrTech.bullets.map(mapBullet),
         };
 
+  const leadUrl = resolveArticleUrlForIndustryNewsletter(
+    briefing.industryPulse.articleIndex,
+    sources,
+  );
+
   return {
     subject: briefing.subject,
-    industryPulse: briefing.industryPulse,
+    industryPulse: {
+      displayHeading: briefing.industryPulse.displayHeading,
+      prose: briefing.industryPulse.prose,
+      ...(leadUrl !== undefined ? { url: leadUrl } : {}),
+    },
     competitiveLandscape: {
       displayHeading: briefing.competitiveLandscape.displayHeading,
       bullets: briefing.competitiveLandscape.bullets.map(mapBullet),

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
@@ -31,6 +31,64 @@ describe("resolveArticleUrlForIndustryNewsletter", () => {
   });
 });
 
+describe("industryNewsletterStructureSchema — industryPulse articleIndex", () => {
+  it("accepts industryPulse without articleIndex", () => {
+    const parsed = industryNewsletterStructureSchema.safeParse({
+      subject: "S",
+      industryPulse: { displayHeading: "L", prose: "p" },
+      competitiveLandscape: {
+        displayHeading: "C",
+        bullets: [{ text: "b1" }, { text: "b2" }],
+      },
+      dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
+      regulatoryPolicyWatch: { displayHeading: "R", bullets: [{ text: "r1" }] },
+      disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
+      quickHits: {
+        displayHeading: "Q",
+        items: [
+          { text: "h1", articleIndex: 1 },
+          { text: "h2", articleIndex: 1 },
+          { text: "h3", articleIndex: 1 },
+          { text: "h4", articleIndex: 1 },
+          { text: "h5", articleIndex: 1 },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.industryPulse.articleIndex).toBeUndefined();
+    }
+  });
+
+  it("accepts industryPulse with a valid articleIndex", () => {
+    const parsed = industryNewsletterStructureSchema.safeParse({
+      subject: "S",
+      industryPulse: { displayHeading: "L", prose: "p", articleIndex: 2 },
+      competitiveLandscape: {
+        displayHeading: "C",
+        bullets: [{ text: "b1" }, { text: "b2" }],
+      },
+      dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
+      regulatoryPolicyWatch: { displayHeading: "R", bullets: [{ text: "r1" }] },
+      disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
+      quickHits: {
+        displayHeading: "Q",
+        items: [
+          { text: "h1", articleIndex: 1 },
+          { text: "h2", articleIndex: 1 },
+          { text: "h3", articleIndex: 1 },
+          { text: "h4", articleIndex: 1 },
+          { text: "h5", articleIndex: 1 },
+        ],
+      },
+    });
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.industryPulse.articleIndex).toBe(2);
+    }
+  });
+});
+
 describe("attachIndustryNewsletterSourceUrls", () => {
   const briefing = industryNewsletterStructureSchema.parse({
     subject: "S",
@@ -345,6 +403,77 @@ describe("formatIndustryNewsletterWire", () => {
       "deals-and-movements",
       "quick-hits",
     ]);
+  });
+
+  it("emits a Read the full article line for a grounded lead and the parser peels it into url", () => {
+    const resolved = attachIndustryNewsletterSourceUrls(
+      industryNewsletterStructureSchema.parse({
+        subject: "S",
+        industryPulse: {
+          displayHeading: "Lead",
+          prose: "Grounded prose.",
+          articleIndex: 1,
+        },
+        competitiveLandscape: {
+          displayHeading: "C",
+          bullets: [
+            { text: "c1", articleIndex: 1 },
+            { text: "c2", articleIndex: 1 },
+          ],
+        },
+        dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
+        regulatoryPolicyWatch: {
+          displayHeading: "R",
+          bullets: [{ text: "r1" }],
+        },
+        disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
+        quickHits: {
+          displayHeading: "Q",
+          items: [
+            { text: "h1", articleIndex: 1 },
+            { text: "h2", articleIndex: 1 },
+            { text: "h3", articleIndex: 1 },
+            { text: "h4", articleIndex: 1 },
+            { text: "h5", articleIndex: 1 },
+          ],
+        },
+      }),
+      [{ url: "https://lead.example" }],
+    );
+
+    expect(resolved.industryPulse?.url).toBe("https://lead.example");
+
+    const wire = formatIndustryNewsletterWire(resolved);
+    expect(wire).toContain("Grounded prose.");
+    expect(wire).toContain("Read the full article: https://lead.example");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+    const pulseSection = parsed?.sections.find(
+      (s) => s.machineKey === "industry-pulse",
+    );
+    expect(pulseSection).toBeDefined();
+    if (pulseSection?.machineKey === "industry-pulse") {
+      expect(pulseSection.prose).toBe("Grounded prose.");
+      expect(pulseSection.url).toBe("https://lead.example");
+    }
+  });
+
+  it("omits industry-pulse when the resolved lead is undefined", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      quickHits: {
+        displayHeading: "Q",
+        items: [{ text: "Hit one", url: "https://a.example" }],
+      },
+    };
+
+    const wire = formatIndustryNewsletterWire(resolved);
+    expect(wire).not.toContain("BEGIN industry-pulse");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+    expect(
+      parsed?.sections.every((s) => s.machineKey !== "industry-pulse"),
+    ).toBe(true);
   });
 
   it("handles the degenerate case of industry-pulse plus a single quick-hit", () => {

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
@@ -7,10 +7,7 @@ const CITED_URL_A = "https://source.example/a";
 const CITED_URL_B = "https://source.example/b";
 const CITED_URL_C = "https://source.example/c";
 
-const basePulse: IndustryNewsletterResolved["industryPulse"] = {
-  displayHeading: "Pulse",
-  prose: "Lead prose.",
-};
+const basePulse = { displayHeading: "Pulse", prose: "Lead prose." };
 
 describe("pruneNewsletterToCitedRows — uncited rows dropped", () => {
   it("keeps cited bullets and drops uncited ones; counts removedBullets correctly", () => {
@@ -255,7 +252,7 @@ describe("pruneNewsletterToCitedRows — section removal", () => {
     expect(summary.sectionsRemoved).toBe(1);
   });
 
-  it("never prunes disruptorsOrTech prose variant", () => {
+  it("removes disruptorsOrTech prose variant as uncited", () => {
     const resolved: IndustryNewsletterResolved = {
       subject: "S",
       industryPulse: basePulse,
@@ -266,25 +263,57 @@ describe("pruneNewsletterToCitedRows — section removal", () => {
       },
     };
 
-    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+    const {
+      resolved: pruned,
+      reports,
+      summary,
+    } = pruneNewsletterToCitedRows(resolved);
 
-    expect(pruned.disruptorsOrTech).toBeDefined();
-    expect((pruned.disruptorsOrTech as { format: string }).format).toBe(
-      "prose",
-    );
-    expect(summary.sectionsKept).toBe(1);
-    expect(summary.sectionsRemoved).toBe(0);
+    expect(pruned.disruptorsOrTech).toBeUndefined();
+    const report = reports.find((r) => r.sectionKey === "disruptorsOrTech");
+    expect(report?.sectionRemoved).toBe(true);
+    expect(report?.removedBullets).toBe(0);
+    expect(summary.sectionsRemoved).toBe(1);
+    expect(summary.sectionsKept).toBe(0);
   });
 
-  it("never prunes industry-pulse regardless of configuration", () => {
+  it("removes industryPulse when uncited and industryPulse is in sections", () => {
     const resolved: IndustryNewsletterResolved = {
       subject: "S",
       industryPulse: { displayHeading: "Lead", prose: "Sector summary." },
     };
 
-    const { resolved: pruned } = pruneNewsletterToCitedRows(resolved);
+    const {
+      resolved: pruned,
+      reports,
+      summary,
+    } = pruneNewsletterToCitedRows(resolved, { sections: ["industryPulse"] });
 
-    expect(pruned.industryPulse.prose).toBe("Sector summary.");
+    expect(pruned.industryPulse).toBeUndefined();
+    const report = reports.find((r) => r.sectionKey === "industryPulse");
+    expect(report?.sectionRemoved).toBe(true);
+    expect(summary.sectionsRemoved).toBe(1);
+    expect(summary.sectionsKept).toBe(0);
+  });
+
+  it("keeps industryPulse when cited and industryPulse is in sections", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: {
+        displayHeading: "Lead",
+        prose: "Sector summary.",
+        url: CITED_URL_A,
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      sections: ["industryPulse"],
+    });
+
+    expect(pruned.industryPulse).toBeDefined();
+    expect(pruned.industryPulse?.url).toBe(CITED_URL_A);
+    expect(summary.sectionsKept).toBe(1);
+    expect(summary.sectionsRemoved).toBe(0);
   });
 
   it("skips sections not in the configured sections list", () => {

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
@@ -25,6 +25,7 @@ export type PruneSummary = {
 };
 
 export type PruneSectionKey =
+  | "industryPulse"
   | "competitiveLandscape"
   | "dealsAndMovements"
   | "regulatoryPolicyWatch"
@@ -92,8 +93,8 @@ function pruneRows<T extends { url?: string }>(
  * Removes uncited and duplicate-article rows from a resolved newsletter.
  *
  * Operates on the resolved structure (URLs already attached) so "cited" is
- * a direct `url !== undefined` check. `industry-pulse` is never touched.
- * A section that drops to zero cited rows is set to `undefined`.
+ * a direct `url !== undefined` check. A section that drops to zero cited rows
+ * is set to `undefined`.
  *
  * @param resolved - Resolved newsletter (post URL attachment).
  * @param opts - Which sections to prune and dedup settings.
@@ -121,6 +122,23 @@ export function pruneNewsletterToCitedRows(
 
   const shouldPrune = (key: PruneSectionKey): boolean =>
     (configuredSections as ReadonlyArray<string>).includes(key);
+
+  // --- industryPulse ---
+  let industryPulse = resolved.industryPulse;
+  if (shouldPrune("industryPulse") && industryPulse !== undefined) {
+    if (industryPulse.url === undefined) {
+      industryPulse = undefined;
+      sectionsRemoved++;
+      reports.push({
+        sectionKey: "industryPulse",
+        removedBullets: 0,
+        removedForDuplicate: 0,
+        sectionRemoved: true,
+      });
+    } else {
+      sectionsKept++;
+    }
+  }
 
   // --- competitiveLandscape ---
   let competitiveLandscape = resolved.competitiveLandscape;
@@ -211,8 +229,15 @@ export function pruneNewsletterToCitedRows(
     resolved.disruptorsOrTech;
   if (shouldPrune("disruptorsOrTech") && disruptorsOrTech !== undefined) {
     if (disruptorsOrTech.format === "prose") {
-      // Prose variant has no individually-sourced rows; exempt from pruning.
-      sectionsKept++;
+      // Prose variant has no citation mechanism — always removed as uncited.
+      disruptorsOrTech = undefined;
+      sectionsRemoved++;
+      reports.push({
+        sectionKey: "disruptorsOrTech",
+        removedBullets: 0,
+        removedForDuplicate: 0,
+        sectionRemoved: true,
+      });
     } else {
       const { kept, removedUncited, removedDuplicate } = pruneRows(
         disruptorsOrTech.bullets,
@@ -267,7 +292,7 @@ export function pruneNewsletterToCitedRows(
   return {
     resolved: {
       subject: resolved.subject,
-      industryPulse: resolved.industryPulse,
+      ...(industryPulse !== undefined ? { industryPulse } : {}),
       ...(competitiveLandscape !== undefined ? { competitiveLandscape } : {}),
       ...(dealsAndMovements !== undefined ? { dealsAndMovements } : {}),
       ...(regulatoryPolicyWatch !== undefined ? { regulatoryPolicyWatch } : {}),

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -1985,9 +1985,18 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
   );
 
   it("removes a section whose bullets are all uncited and keeps cited sections", async () => {
-    // competitive-landscape has only uncited bullets (no articleIndex),
-    // deals has one bullet with articleIndex 1 which resolves to testSources[0].url.
+    // industry-pulse cites article 1 (resolves URL) — survives.
+    // competitive-landscape has only uncited bullets (no articleIndex) — removed.
+    // deals has one bullet with articleIndex 1 — survives.
+    // regulatory-policy-watch has no citations — removed.
+    // disruptors-or-tech uses bullets format with articleIndex 2 — survives.
+    // quick-hits: one uncited (articleIndex 99), one duplicate (articleIndex 1 repeated).
     const generateObjectFn = makeSuccessfulGenerateFn({
+      industryPulse: {
+        displayHeading: "Pulse",
+        prose: "Stocks rose for the third day.",
+        articleIndex: 1,
+      },
       competitiveLandscape: {
         displayHeading: "Competition",
         bullets: [{ text: "Uncited A" }, { text: "Uncited B" }],
@@ -2001,9 +2010,9 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
         bullets: [{ text: "Uncited regulatory" }],
       },
       disruptorsOrTech: {
-        format: "prose",
+        format: "bullets",
         displayHeading: "Disruptors",
-        prose: "Innovation forward.",
+        bullets: [{ text: "Innovation forward.", articleIndex: 2 }],
       },
       quickHits: {
         displayHeading: "Quick Hits",

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -521,7 +521,7 @@ You receive exactly {{topNewsCount}} numbered articles (Article 1 … Article {{
 
 Return JSON matching this shape (camelCase keys):
 - "subject": short email subject (under ~60 chars), sector-relevant, may mention {{tickerName}} or {{tickerSymbol}} once if natural.
-- "industryPulse": { "displayHeading", "prose" } — short lead framing the industry story (no bullet characters in prose).
+- "industryPulse": { "displayHeading", "prose", "articleIndex" } — short lead framing the industry story (no bullet characters in prose). Set "articleIndex" to the single most representative article the lead summarizes; use null when the lead does not lean on a specific article.
 - "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets about {{tickerName}}'s COMPETITORS, not {{tickerName}} itself — peer positioning, rival launches, share shifts, competitive threats. Each bullet should name a competitor. Each bullet { "text", "articleIndex" } where articleIndex is a 1-based article number or null when uncited.
 - "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
 - "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
@@ -1508,6 +1508,8 @@ export async function generateNewsletterWithLlm(
         ? finalStructure.subject.trim()
         : "Your daily briefing",
     content,
+    // Reads the pre-prune finalStructure, so this is safe even when the resolved
+    // lead was later removed by the require-citation pass.
     description: finalStructure.industryPulse.prose.trim() || undefined,
     promptTokens: usage?.promptTokens ?? null,
     completionTokens: usage?.completionTokens ?? null,

--- a/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/content-generation.mdx
@@ -392,7 +392,7 @@ The `MP_NEWSLETTER` wire format supports a variable set of body sections. Only s
 
 | Section                   | Status                                                                    |
 | ------------------------- | ------------------------------------------------------------------------- |
-| `industry-pulse`          | Always emitted. It is the newsletter spine and carries no citation.       |
+| `industry-pulse`          | Omittable when require-citation removes an uncited lead. Optional `articleIndex` adds a Read link when cited. |
 | `competitive-landscape`   | Omittable. Absent when the field is `undefined` on the resolved briefing. |
 | `deals-and-movements`     | Omittable.                                                                |
 | `regulatory-policy-watch` | Omittable.                                                                |
@@ -551,7 +551,7 @@ The pass runs **last**, after URL attachment, so `url !== undefined` is the only
 
 | Section                        | Prunable? | Notes                                        |
 | ------------------------------ | --------- | -------------------------------------------- |
-| `industry-pulse`               | Never     | Framing prose with no single source.         |
+| `industry-pulse`               | Yes       | Removed when no resolved URL; kept when cited via `articleIndex`. |
 | `competitive-landscape`        | Yes       | Bullets variant.                             |
 | `deals-and-movements`          | Yes       | Bullets variant.                             |
 | `regulatory-policy-watch`      | Yes       | Bullets variant.                             |
@@ -594,7 +594,7 @@ Note: with `dedupeScope: 'newsletter'`, `Hit 2` would also be dropped because `h
 | Field                                         | Default   | Description                                                                |
 | --------------------------------------------- | --------- | -------------------------------------------------------------------------- |
 | `requireCitation.enabled`                     | `true`    | Enable the pruning pass. Set to `false` for byte-for-byte current output.  |
-| `requireCitation.sections`                    | all five  | Which body sections to prune. `industry-pulse` is always exempt.           |
+| `requireCitation.sections`                    | all six   | Which sections to prune, including `industryPulse` when listed.            |
 | `requireCitation.dedupeArticlesWithinSection` | `true`    | When false, dedup is skipped (uncited rows are still removed).             |
 | `requireCitation.dedupeScope`                 | `section` | `section` = per-section dedup; `newsletter` = one URL across all sections. |
 

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -278,9 +278,18 @@ export const DefaultNewsletterEmail = ({
           <Section style={header}>
             <Heading style={heading}>{title}</Heading>
             {industryPulseSection !== undefined ? (
-              <Text style={standfirst}>
-                {renderInlineMarkdownLinks(industryPulseSection.prose, link)}
-              </Text>
+              <>
+                <Text style={standfirst}>
+                  {renderInlineMarkdownLinks(industryPulseSection.prose, link)}
+                </Text>
+                {industryPulseSection.url !== undefined ? (
+                  <Text style={newsItemSourceLink}>
+                    <Link href={industryPulseSection.url} style={link}>
+                      Read the full article
+                    </Link>
+                  </Text>
+                ) : null}
+              </>
             ) : null}
           </Section>
           <Hr style={hr} />

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
@@ -72,6 +72,56 @@ describe("parseIndustryNewsletterWire", () => {
     ]);
   });
 
+  it("peels a trailing Read the full article line from the industry-pulse prose into url", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "The Pulse",
+      "PROSE",
+      "Grounded summary of the week.",
+      "Read the full article: https://grounded.example/article",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(parsed).not.toBeUndefined();
+    const pulseSection = parsed?.sections.find(
+      (s) => s.machineKey === "industry-pulse",
+    );
+    expect(pulseSection).toBeDefined();
+    if (pulseSection?.machineKey === "industry-pulse") {
+      expect(pulseSection.prose).toBe("Grounded summary of the week.");
+      expect(pulseSection.url).toBe("https://grounded.example/article");
+    }
+  });
+
+  it("leaves url undefined when industry-pulse prose has no trailing source line", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "The Pulse",
+      "PROSE",
+      "Sector tone stayed stable this week.",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    const pulseSection = parsed?.sections.find(
+      (s) => s.machineKey === "industry-pulse",
+    );
+    if (pulseSection?.machineKey === "industry-pulse") {
+      expect(pulseSection.url).toBeUndefined();
+    }
+  });
+
   it("skipped middle section does not shift the survivors out of order", () => {
     const wire = [
       INDUSTRY_NEWSLETTER_WIRE_MARKER,

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
@@ -17,6 +17,7 @@ export type ParsedIndustryPulseSection = {
   machineKey: "industry-pulse";
   displayHeading: string;
   prose: string;
+  url?: string;
 };
 
 /** Parsed bullet list section (competitive, deals, regulatory, disruptors bullets). */
@@ -148,15 +149,17 @@ export const parseIndustryNewsletterWire = (
         return undefined;
       }
       i += 1;
-      const prose = readUntilToken(new Set(["END"]));
+      const rawProse = readUntilToken(new Set(["END"]));
       if ((lines[i] ?? "").trim() !== "END") {
         return undefined;
       }
       i += 1;
+      const { text: prose, url } = splitTrailingReadLine(rawProse);
       sections.push({
         machineKey: "industry-pulse",
         displayHeading,
         prose,
+        ...(url !== undefined ? { url } : {}),
       });
       continue;
     }

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -453,6 +453,109 @@ describe("renderNewsletterEmail", () => {
     expect(text).toContain(articleUrl);
   });
 
+  it("renders a 'Read the full article' link below the industry-pulse standfirst when the lead has a url", async () => {
+    const industryBody = [
+      "MP_NEWSLETTER",
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "The Pulse",
+      "PROSE",
+      "The sector is shifting rapidly.",
+      "Read the full article: https://lead.example/article",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "Hit one",
+      "ITEM",
+      "Hit two",
+      "ITEM",
+      "Hit three",
+      "ITEM",
+      "Hit four",
+      "ITEM",
+      "Hit five",
+      "END",
+    ].join("\n");
+
+    const { html, text } = await renderNewsletterEmail({
+      title: "Industry Briefing",
+      bodyText: industryBody,
+    });
+
+    expect(html).toContain("The sector is shifting rapidly.");
+    expect(html).toContain('href="https://lead.example/article"');
+    expect(text).toContain("https://lead.example/article");
+  });
+
+  it("renders the industry-pulse standfirst with no source link when the lead has no url", async () => {
+    const industryBody = [
+      "MP_NEWSLETTER",
+      "",
+      "BEGIN industry-pulse",
+      "DISPLAY_HEADING",
+      "The Pulse",
+      "PROSE",
+      "The sector is quiet this week.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "Hit one",
+      "ITEM",
+      "Hit two",
+      "ITEM",
+      "Hit three",
+      "ITEM",
+      "Hit four",
+      "ITEM",
+      "Hit five",
+      "END",
+    ].join("\n");
+
+    const { html } = await renderNewsletterEmail({
+      title: "Industry Briefing",
+      bodyText: industryBody,
+    });
+
+    expect(html).toContain("The sector is quiet this week.");
+    expect(html).not.toContain("Read the full article");
+  });
+
+  it("renders a body starting at the first body section when industry-pulse is absent from the wire", async () => {
+    const industryBody = [
+      "MP_NEWSLETTER",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "Hit one",
+      "ITEM",
+      "Hit two",
+      "ITEM",
+      "Hit three",
+      "ITEM",
+      "Hit four",
+      "ITEM",
+      "Hit five",
+      "END",
+    ].join("\n");
+
+    const { html } = await renderNewsletterEmail({
+      title: "Industry Briefing",
+      bodyText: industryBody,
+    });
+
+    expect(html).not.toContain("BEGIN industry-pulse");
+    expect(html).toContain("Hit one");
+  });
+
   it("renders industry wire bodies with a lead standfirst and eyebrow section headers", async () => {
     const industryBody = [
       "MP_NEWSLETTER",


### PR DESCRIPTION
## Summary

Industry pulse now behaves like the other body sections under require-citation: the lead stays only when `articleIndex` resolves to a source URL, drops from the wire when it does not, and shows a Read link in email when cited.

## Related issues

Closes #635

## Important changes

- LLM schema accepts optional `industryPulse.articleIndex`; URL attachment adds `url` on the resolved lead.
- Prune pass can remove uncited industry pulse when `industryPulse` is listed in `requireCitation.sections` (included in defaults).
- Wire serializer and React email template treat industry-pulse as optional and render the Read line when a URL exists.

## Other changes

- Removed the unused `keepIndustryPulse` config field.
- Updated content-generation dev-docs for prunable industry-pulse.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts` — industry pulse prune branch.
- `apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts` — lead URL resolution.
- `apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts` — optional wire block and Read line.
- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` — optional lead section in email HTML.

## How to test

1. `pnpm --filter @mediapulse/content-generation test`
2. `pnpm --filter @workspace/email-templates test`
3. Run content-generation with `requireCitation.sections` including `industryPulse`; confirm uncited lead is omitted from wire output and cited lead includes a Read link in rendered email.
