### PR TITLE
Attach vCard to registration confirmation and add contacts CTA

### DIFF
--- a/apps/mediapulse/agents/user-registration/src/index.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.test.ts
@@ -55,6 +55,8 @@ vi.mock("@workspace/email-templates", () => ({
 
 vi.mock("@workspace/utils", () => ({
   withRetry: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
+  buildVCard: ({ name, email }: { name: string; email: string }) =>
+    `BEGIN:VCARD\r\nFN:${name}\r\nEMAIL:${email}\r\nEND:VCARD`,
 }));
 
 const AUTH_HEADERS = {

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -20,6 +20,8 @@ vi.mock("@workspace/email-templates", () => ({
 // Simplify withRetry to call through immediately – no delays, no retries.
 vi.mock("@workspace/utils", () => ({
   withRetry: async (fn: () => unknown) => fn(),
+  buildVCard: ({ name, email }: { name: string; email: string }) =>
+    `BEGIN:VCARD\r\nFN:${name}\r\nEMAIL:${email}\r\nEND:VCARD`,
 }));
 
 vi.mock("@workspace/logger", () => ({
@@ -166,6 +168,51 @@ describe("createRunHandler", () => {
       expect.objectContaining({ userTickerId: "ut-1" }),
     );
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("attaches a MediaPulse.vcf to the confirmation email for a new subscription", async () => {
+    const emailSend = vi.fn().mockResolvedValue({ data: { id: "email-id" } });
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            from: { emailAddress: { address: "vcf@run-test.example" } },
+          }),
+        ],
+        archiveMessage: vi.fn().mockResolvedValue(undefined),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: emailSend };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: true,
+              userTickerId: "ut-vcf",
+            }),
+          },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    await run(makeCtx() as any);
+
+    const payload = emailSend.mock.calls[0]![0] as any;
+    expect(payload.attachments).toHaveLength(1);
+    expect(payload.attachments[0].filename).toBe("MediaPulse.vcf");
+
+    const decoded = Buffer.from(
+      payload.attachments[0].content,
+      "base64",
+    ).toString("utf-8");
+    expect(decoded).toContain("from@test.example");
+    expect(decoded).toContain("CEO (Chief Email Officer) - MediaPulse");
   });
 
   it("does not confirm or archive when Resend returns an error envelope for a new subscription", async () => {

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -19,6 +19,7 @@ import {
   extractTickerSymbol,
   resolveSubscriberDisplayName,
 } from "./lib/parser.js";
+import { buildVCard } from "@workspace/utils";
 
 export type Input = { maxMessagesPerRun: number; watermark?: string };
 export type Config = UserRegistrationConfig;
@@ -127,12 +128,15 @@ function buildNextDeliveryLabel(
   return `${day} at ${timeLabel}`;
 }
 
+const MEDIAPULSE_SENDER_NAME = "CEO (Chief Email Officer) - MediaPulse";
+
 type ResendTransactionalPayload = {
   from: string;
   to: string;
   subject: string;
   html: string;
   text: string;
+  attachments?: { filename: string; content: string }[];
 };
 
 /**
@@ -562,6 +566,12 @@ async function processMessage({
         nextDeliveryLabel,
       });
 
+      const vcf = buildVCard({
+        name: MEDIAPULSE_SENDER_NAME,
+        email: config.resendSender,
+      });
+      const vcfBase64 = Buffer.from(vcf).toString("base64");
+
       await sendResendTransactionalEmail({
         resend,
         retryConfig,
@@ -578,6 +588,7 @@ async function processMessage({
           subject: "Subscription Confirmed - MediaPulse",
           html,
           text,
+          attachments: [{ filename: "MediaPulse.vcf", content: vcfBase64 }],
         },
       });
 

--- a/apps/mediapulse/user-registration/app/layout.test.tsx
+++ b/apps/mediapulse/user-registration/app/layout.test.tsx
@@ -25,7 +25,36 @@ vi.mock("@workspace/ui/lib/utils", () => ({
   cn: (...classes: (string | undefined)[]) => classes.filter(Boolean).join(" "),
 }));
 
-import RootLayout from "./layout";
+import RootLayout, { metadata } from "./layout";
+
+describe("metadata", () => {
+  const expectedTitle = "MediaPulse - Business newsletter";
+  const expectedDescription =
+    "Subscribe to MediaPulse and get the latest business and industry news for your chosen ticker delivered straight to your inbox.";
+
+  it("has the business-framed title", () => {
+    expect(metadata.title).toBe(expectedTitle);
+  });
+
+  it("has the business-framed description", () => {
+    expect(metadata.description).toBe(expectedDescription);
+  });
+
+  it("has matching openGraph title and description", () => {
+    expect(metadata.openGraph?.title).toBe(expectedTitle);
+    expect(metadata.openGraph?.description).toBe(expectedDescription);
+  });
+
+  it("has matching twitter title and description", () => {
+    expect(
+      (metadata.twitter as { title?: string; description?: string })?.title,
+    ).toBe(expectedTitle);
+    expect(
+      (metadata.twitter as { title?: string; description?: string })
+        ?.description,
+    ).toBe(expectedDescription);
+  });
+});
 
 describe("RootLayout", () => {
   it("renders children content", () => {

--- a/apps/mediapulse/user-registration/app/layout.tsx
+++ b/apps/mediapulse/user-registration/app/layout.tsx
@@ -4,10 +4,24 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "sonner";
 
+const PAGE_TITLE = "MediaPulse - Business newsletter";
+const PAGE_DESCRIPTION =
+  "Subscribe to MediaPulse and get the latest business and industry news for your chosen ticker delivered straight to your inbox.";
+
 export const metadata: Metadata = {
-  title: "MediaPulse — Stock Newsletter",
-  description:
-    "Subscribe to MediaPulse and get the latest stock news for your chosen ticker delivered straight to your inbox.",
+  title: PAGE_TITLE,
+  description: PAGE_DESCRIPTION,
+  openGraph: {
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+    type: "website",
+    siteName: "MediaPulse",
+  },
+  twitter: {
+    card: "summary",
+    title: PAGE_TITLE,
+    description: PAGE_DESCRIPTION,
+  },
 };
 
 import { Providers } from "@/components/providers";

--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -1,12 +1,19 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RegistrationForm } from "./registration-form";
 import type { Ticker } from "@/lib/tickers";
 
 vi.mock("@mediapulse/env/app-user-registration", () => ({
   env: { NEXT_PUBLIC_REGISTRATION_EMAIL: "registration@test.example" },
+}));
+
+vi.mock("@workspace/utils", () => ({
+  buildVCard: vi.fn(
+    ({ name, email }: { name: string; email: string }) =>
+      `BEGIN:VCARD\r\nFN:${name}\r\nEMAIL:${email}\r\nEND:VCARD`,
+  ),
 }));
 
 const sampleTickers: Ticker[] = [
@@ -16,8 +23,16 @@ const sampleTickers: Ticker[] = [
 ];
 
 describe("RegistrationForm", () => {
+  beforeEach(() => {
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:mock-url"),
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("renders the name and ticker search inputs", () => {
@@ -87,5 +102,55 @@ describe("RegistrationForm", () => {
     expect(screen.getByText(/Almost done/i)).toBeInTheDocument();
     expect(screen.getByText(/tap/i)).toBeInTheDocument();
     expect(screen.getByText(/Send/i)).toBeInTheDocument();
+  });
+
+  it("shows spam/junk reassurance text and 'Add to contacts' button after submit", async () => {
+    // Setup
+    const user = userEvent.setup();
+    render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.click(screen.getByLabelText(/Stock ticker/i));
+    await user.click(screen.getByText(/Bank Central Asia Tbk/i));
+    await user.click(
+      screen.getByRole("button", { name: /Open email app to subscribe/i }),
+    );
+
+    // Assert
+    expect(screen.getByText(/spam|junk/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("triggers a vCard download when 'Add to contacts' is clicked", async () => {
+    // Setup
+    const user = userEvent.setup();
+    render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
+
+    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.click(screen.getByLabelText(/Stock ticker/i));
+    await user.click(screen.getByText(/Bank Central Asia Tbk/i));
+    await user.click(
+      screen.getByRole("button", { name: /Open email app to subscribe/i }),
+    );
+
+    // Spy on createElement after render so the mock only captures the anchor
+    // created by downloadVCard, not elements created by React during rendering.
+    const anchorClickSpy = vi.fn();
+    const mockAnchor = { href: "", download: "", click: anchorClickSpy };
+    vi.spyOn(document, "createElement").mockReturnValueOnce(
+      mockAnchor as unknown as HTMLElement,
+    );
+
+    // Act
+    await user.click(
+      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+    );
+
+    // Assert
+    expect(URL.createObjectURL).toHaveBeenCalledTimes(1);
+    expect(mockAnchor.download).toBe("MediaPulse.vcf");
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -8,6 +8,24 @@ import { Label } from "@workspace/ui/components/label";
 import { cn } from "@workspace/ui/lib/utils";
 import { type Ticker } from "@/lib/tickers";
 import { useRegistrationForm } from "@/hooks/use-registration-form";
+import { env } from "@mediapulse/env/app-user-registration";
+import { buildVCard } from "@workspace/utils";
+
+const MEDIAPULSE_SENDER_NAME = "CEO (Chief Email Officer) - MediaPulse";
+
+function downloadVCard(): void {
+  const vcf = buildVCard({
+    name: MEDIAPULSE_SENDER_NAME,
+    email: env.NEXT_PUBLIC_REGISTRATION_EMAIL,
+  });
+  const blob = new Blob([vcf], { type: "text/vcard;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "MediaPulse.vcf";
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
 
 type Props = {
   tickers: Ticker[];
@@ -58,10 +76,19 @@ const RegistrationForm = ({
             own mailbox so we can register you for{" "}
             <strong>{selectedTicker?.KodeEmiten}</strong>.
           </p>
+          <p className="text-xs text-muted-foreground">
+            A confirmation email is on the way. If it does not appear, check
+            your spam or junk folder.
+          </p>
         </div>
-        <Button variant="outline" onClick={resetForm}>
-          Subscribe to another ticker
-        </Button>
+        <div className="flex flex-col items-center gap-3">
+          <Button variant="outline" onClick={downloadVCard}>
+            Add MediaPulse to your contacts
+          </Button>
+          <Button variant="ghost" onClick={resetForm}>
+            Subscribe to another ticker
+          </Button>
+        </div>
       </div>
     );
   }

--- a/apps/mediapulse/user-registration/package.json
+++ b/apps/mediapulse/user-registration/package.json
@@ -29,7 +29,8 @@
     "react-dom": "catalog:",
     "sonner": "catalog:",
     "zod": "catalog:",
-    "@workspace/agent-data-api-client": "workspace:*"
+    "@workspace/agent-data-api-client": "workspace:*",
+    "@workspace/utils": "workspace:*"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "catalog:",

--- a/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
@@ -12,4 +12,13 @@ describe("RegistrationConfirmationEmail", () => {
     expect(text).toContain("AAPL");
     expect(text).toMatch(/Subscription Confirmed/i);
   });
+
+  it("contains the add-to-contacts tip in HTML and text", async () => {
+    const { html, text } = await renderNewsletterEmail({
+      variant: "registration-confirmation",
+      tickerSymbol: "AAPL",
+    });
+    expect(html).toMatch(/contacts/i);
+    expect(text).toMatch(/contacts/i);
+  });
 });

--- a/packages/shared/email-templates/src/registration/registration-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.tsx
@@ -53,6 +53,10 @@ export const RegistrationConfirmationEmail = ({
           </Text>
           <Hr style={hr} />
           <Text style={footer}>
+            Add MediaPulse to your contacts so future newsletters land in your
+            inbox, not spam or junk.
+          </Text>
+          <Text style={footer}>
             You are receiving this because you subscribed to updates on
             MediaPulse.
           </Text>

--- a/packages/shared/utils/src/build-vcard.test.ts
+++ b/packages/shared/utils/src/build-vcard.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { buildVCard } from "./build-vcard.js";
+
+describe("buildVCard", () => {
+  it("emits a valid vCard 3.0 with the given name and email", () => {
+    const card = buildVCard({
+      name: "CEO (Chief Email Officer) - MediaPulse",
+      email: "mediapulse@example.com",
+    });
+
+    expect(card).toContain("BEGIN:VCARD");
+    expect(card).toContain("VERSION:3.0");
+    expect(card).toContain("FN:CEO (Chief Email Officer) - MediaPulse");
+    expect(card).toContain("ORG:MediaPulse");
+    expect(card).toContain("EMAIL;TYPE=INTERNET:mediapulse@example.com");
+    expect(card).toContain("END:VCARD");
+  });
+
+  it("uses CRLF line endings", () => {
+    const card = buildVCard({ name: "Test", email: "test@example.com" });
+
+    expect(card).toContain("\r\n");
+    expect(card.split("\r\n").length).toBeGreaterThan(1);
+  });
+});

--- a/packages/shared/utils/src/build-vcard.ts
+++ b/packages/shared/utils/src/build-vcard.ts
@@ -1,0 +1,19 @@
+/**
+ * Builds a minimal vCard 3.0 string for the given contact.
+ *
+ * @param params.name - The full name (FN) to embed in the card.
+ * @param params.email - The email address to embed in the card.
+ * @returns A valid vCard 3.0 string with CRLF line endings.
+ */
+export function buildVCard(params: { name: string; email: string }): string {
+  const { name, email } = params;
+
+  return [
+    "BEGIN:VCARD",
+    "VERSION:3.0",
+    `FN:${name}`,
+    "ORG:MediaPulse",
+    `EMAIL;TYPE=INTERNET:${email}`,
+    "END:VCARD",
+  ].join("\r\n");
+}

--- a/packages/shared/utils/src/index.ts
+++ b/packages/shared/utils/src/index.ts
@@ -22,3 +22,4 @@ export type {
   UrlNoiseDecision,
   UrlNoiseReason,
 } from "./article-source-url-filter.js";
+export { buildVCard } from "./build-vcard.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,7 +309,7 @@ importers:
         version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
-        version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -999,6 +999,9 @@ importers:
       '@workspace/ui':
         specifier: workspace:*
         version: link:../../../packages/shared/ui
+      '@workspace/utils':
+        specifier: workspace:*
+        version: link:../../../packages/shared/utils
       dotenv:
         specifier: 'catalog:'
         version: 17.2.3
@@ -18332,7 +18335,7 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76


### PR DESCRIPTION
## Summary

Subscribers can add MediaPulse to their address book so confirmation and future newsletters are less likely to hit spam. The agent attaches a vCard to the confirmation email; the registration success page offers the same download, with short guidance in the email and UI.

## Related issues

Closes #637

## Important changes

- New `buildVCard` helper in `@workspace/utils` (vCard 3.0, CRLF line endings).
- User-registration agent sends `MediaPulse.vcf` as a base64 Resend attachment on confirmation.
- Success screen adds "Add MediaPulse to your contacts" plus a spam/junk folder note.

## Other changes

- Registration confirmation email footer nudges users to save the contact.
- Registration app layout metadata and Open Graph / Twitter tags updated for sharing.

## Key files to review

- `packages/shared/utils/src/build-vcard.ts` — vCard format and fields.
- `apps/mediapulse/agents/user-registration/src/run.ts` — attachment on confirmation send.
- `apps/mediapulse/user-registration/components/registration-form.tsx` — client-side vCard download.
- `packages/shared/email-templates/src/registration/registration-confirmation.tsx` — contacts copy in email.

## How to test

1. `pnpm --filter @workspace/utils build && pnpm --filter @workspace/utils --filter @mediapulse/user-registration-agent --filter @mediapulse/user-registration --filter @workspace/email-templates test`
2. Trigger a registration confirmation in dev/staging and confirm the email includes `MediaPulse.vcf`.
3. Complete the web form and use "Add MediaPulse to your contacts"; open the downloaded `.vcf` and verify name/email match config.
