### PR TITLE
Format Resend from addresses with MediaPulse display name

### DIFF
--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -97,7 +97,7 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(payload).toMatchObject({
       html: "<p>h</p>",
       text: "plain",
-      from: "from@example.com",
+      from: '"CEO (Chief Email Officer) - MediaPulse" <from@example.com>',
       to: "u@example.com",
       subject: newsletter.subject,
       headers: {

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 
 import { renderNewsletterEmail } from "@workspace/email-templates";
 import type { LoggerLike } from "@workspace/agent-runtime";
-import { createUnsubscribeToken } from "@workspace/utils";
+import { createUnsubscribeToken, formatResendSender } from "@workspace/utils";
 import { Resend } from "resend";
 
 import {
@@ -100,7 +100,7 @@ export async function deliverNewsletterToSubscribers(
     });
 
   const deliveredSet = new Set(deliveredUserTickerIds);
-  const from = config.resend.from;
+  const from = formatResendSender(config.resend.from);
 
   const results: RecipientSendResult[] = [];
   const resendMessageIds: string[] = [];

--- a/apps/mediapulse/agents/user-registration/src/index.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.test.ts
@@ -57,6 +57,11 @@ vi.mock("@workspace/utils", () => ({
   withRetry: async <T>(fn: () => Promise<T>): Promise<T> => fn(),
   buildVCard: ({ name, email }: { name: string; email: string }) =>
     `BEGIN:VCARD\r\nFN:${name}\r\nEMAIL:${email}\r\nEND:VCARD`,
+  MEDIAPULSE_SENDER_NAME: "CEO (Chief Email Officer) - MediaPulse",
+  formatResendSender: (address: string) =>
+    address.includes("<")
+      ? address
+      : `"CEO (Chief Email Officer) - MediaPulse" <${address}>`,
 }));
 
 const AUTH_HEADERS = {

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -22,6 +22,11 @@ vi.mock("@workspace/utils", () => ({
   withRetry: async (fn: () => unknown) => fn(),
   buildVCard: ({ name, email }: { name: string; email: string }) =>
     `BEGIN:VCARD\r\nFN:${name}\r\nEMAIL:${email}\r\nEND:VCARD`,
+  MEDIAPULSE_SENDER_NAME: "CEO (Chief Email Officer) - MediaPulse",
+  formatResendSender: (address: string) =>
+    address.includes("<")
+      ? address
+      : `"CEO (Chief Email Officer) - MediaPulse" <${address}>`,
 }));
 
 vi.mock("@workspace/logger", () => ({
@@ -161,6 +166,7 @@ describe("createRunHandler", () => {
     expect(result.details.results[0].status).toBe("confirmed_archived");
     expect(emailSend).toHaveBeenCalledWith(
       expect.objectContaining({
+        from: '"CEO (Chief Email Officer) - MediaPulse" <from@test.example>',
         subject: "Subscription Confirmed - MediaPulse",
       }),
     );
@@ -461,10 +467,56 @@ describe("createRunHandler", () => {
     expect(result.details.results[0].status).toBe("invalid_ticker_archived");
     expect(emailSend).toHaveBeenCalledWith(
       expect.objectContaining({
+        from: '"CEO (Chief Email Officer) - MediaPulse" <from@test.example>',
         subject: "Invalid Ticker Selection - MediaPulse",
       }),
     );
     expect(archiveMessage).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("does not double-wrap the from when resendSender already contains a display name", async () => {
+    const emailSend = vi.fn().mockResolvedValue({ data: { id: "email-id" } });
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => [
+          makeMessage({
+            from: {
+              emailAddress: { address: "nowrap@run-test.example" },
+            },
+          }),
+        ],
+        archiveMessage: vi.fn().mockResolvedValue(undefined),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: emailSend };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: true,
+              userTickerId: "ut-nowrap",
+            }),
+          },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    const alreadyFormatted = '"Acme Newsletter" <already@example.com>';
+    await run(
+      makeCtx({
+        config: { ...makeCtx().config, resendSender: alreadyFormatted },
+      }) as any,
+    );
+
+    expect(emailSend).toHaveBeenCalledWith(
+      expect.objectContaining({ from: alreadyFormatted }),
+    );
   });
 
   it("archives as unparseable when the subject and body contain no ticker", async () => {

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -9,7 +9,13 @@ import {
   type AgentDataApiClient,
 } from "@workspace/agent-data-api-client";
 import { renderNewsletterEmail } from "@workspace/email-templates";
-import { withRetry, type RetryConfig } from "@workspace/utils";
+import {
+  withRetry,
+  type RetryConfig,
+  MEDIAPULSE_SENDER_NAME,
+  formatResendSender,
+  buildVCard,
+} from "@workspace/utils";
 import { Resend } from "resend";
 import { logger } from "@workspace/logger";
 import type { UserRegistrationConfig } from "./config-schema.js";
@@ -19,7 +25,6 @@ import {
   extractTickerSymbol,
   resolveSubscriberDisplayName,
 } from "./lib/parser.js";
-import { buildVCard } from "@workspace/utils";
 
 export type Input = { maxMessagesPerRun: number; watermark?: string };
 export type Config = UserRegistrationConfig;
@@ -127,8 +132,6 @@ function buildNextDeliveryLabel(
 
   return `${day} at ${timeLabel}`;
 }
-
-const MEDIAPULSE_SENDER_NAME = "CEO (Chief Email Officer) - MediaPulse";
 
 type ResendTransactionalPayload = {
   from: string;
@@ -525,7 +528,7 @@ async function processMessage({
           template: "invalid-ticker",
         },
         payload: {
-          from: config.resendSender,
+          from: formatResendSender(config.resendSender),
           to: senderEmail,
           subject: "Invalid Ticker Selection - MediaPulse",
           html,
@@ -583,7 +586,7 @@ async function processMessage({
           template: "registration-confirmation",
         },
         payload: {
-          from: config.resendSender,
+          from: formatResendSender(config.resendSender),
           to: senderEmail,
           subject: "Subscription Confirmed - MediaPulse",
           html,

--- a/packages/shared/utils/src/format-resend-sender.test.ts
+++ b/packages/shared/utils/src/format-resend-sender.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatResendSender,
+  MEDIAPULSE_SENDER_NAME,
+} from "./format-resend-sender.js";
+
+describe("formatResendSender", () => {
+  it("wraps a bare address with the default branded display name (double-quoted)", () => {
+    const result = formatResendSender("hello@example.com");
+
+    expect(result).toBe(`"${MEDIAPULSE_SENDER_NAME}" <hello@example.com>`);
+  });
+
+  it("wraps a bare address with a custom display name", () => {
+    const result = formatResendSender("hello@example.com", "Acme Newsletter");
+
+    expect(result).toBe('"Acme Newsletter" <hello@example.com>');
+  });
+
+  it("returns the address unchanged when it already contains a display name", () => {
+    const already =
+      '"CEO (Chief Email Officer) - MediaPulse" <hello@example.com>';
+    const result = formatResendSender(already);
+
+    expect(result).toBe(already);
+  });
+});

--- a/packages/shared/utils/src/format-resend-sender.ts
+++ b/packages/shared/utils/src/format-resend-sender.ts
@@ -1,0 +1,22 @@
+export const MEDIAPULSE_SENDER_NAME = "CEO (Chief Email Officer) - MediaPulse";
+
+/**
+ * Formats a Resend `from` value with a display name.
+ *
+ * Returns `address` unchanged when it already contains `<…>` (operator-supplied display name).
+ * Otherwise returns `"name" <address>` — the name is double-quoted because it contains
+ * parentheses, which RFC 5322 treats as comment delimiters in an unquoted display-name.
+ *
+ * @param address - The sender email address (bare or already formatted).
+ * @param name - Display name to prepend. Defaults to {@link MEDIAPULSE_SENDER_NAME}.
+ */
+export function formatResendSender(
+  address: string,
+  name: string = MEDIAPULSE_SENDER_NAME,
+): string {
+  if (address.includes("<")) {
+    return address;
+  }
+
+  return `"${name}" <${address}>`;
+}

--- a/packages/shared/utils/src/index.ts
+++ b/packages/shared/utils/src/index.ts
@@ -23,3 +23,7 @@ export type {
   UrlNoiseReason,
 } from "./article-source-url-filter.js";
 export { buildVCard } from "./build-vcard.js";
+export {
+  MEDIAPULSE_SENDER_NAME,
+  formatResendSender,
+} from "./format-resend-sender.js";


### PR DESCRIPTION
## Summary

Delivery and user-registration now send Resend mail with a consistent **CEO (Chief Email Officer) - MediaPulse** display name when config only supplies a bare email. A shared helper quotes the name for RFC 5322 and skips addresses that already include a display name.

## Related issues

Closes #639

## Important changes

- `formatResendSender` and `MEDIAPULSE_SENDER_NAME` exported from `@workspace/utils`.
- Delivery agent formats `config.resend.from` before each newsletter send.
- User-registration agent formats `resendSender` on invalid-ticker and confirmation emails.

## Other changes

- Tests cover double-wrap prevention and updated send payload expectations.

## Key files to review

- `packages/shared/utils/src/format-resend-sender.ts` — quoting rules and passthrough when `<` is present.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` — formatted `from` on send.
- `apps/mediapulse/agents/user-registration/src/run.ts` — formatted `from` on transactional sends.

## How to test

1. `pnpm --filter @workspace/utils build && pnpm --filter @workspace/utils --filter @mediapulse/delivery --filter @mediapulse/user-registration-agent test`
2. In staging, trigger a registration confirmation or newsletter delivery with a bare sender email and confirm the inbox shows the MediaPulse display name.
3. Set `resendSender` to an already formatted `"Custom" <addr>` value and confirm Resend receives it unchanged.
