### PR TITLE
Polish registration success UI and confirmation contact card copy

### DIFF
--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -104,7 +104,7 @@ describe("RegistrationForm", () => {
     expect(screen.getByText(/Send/i)).toBeInTheDocument();
   });
 
-  it("shows spam/junk reassurance text and 'Add to contacts' button after submit", async () => {
+  it("shows spam/junk reassurance text and download contact card button after submit", async () => {
     // Setup
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
@@ -119,11 +119,11 @@ describe("RegistrationForm", () => {
     // Assert
     expect(screen.getByText(/spam|junk/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+      screen.getByRole("button", { name: /Download contact card/i }),
     ).toBeInTheDocument();
   });
 
-  it("triggers a vCard download when 'Add to contacts' is clicked", async () => {
+  it("triggers a vCard download when download contact card is clicked", async () => {
     // Setup
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
@@ -145,7 +145,7 @@ describe("RegistrationForm", () => {
 
     // Act
     await user.click(
-      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+      screen.getByRole("button", { name: /Download contact card/i }),
     );
 
     // Assert

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -68,27 +68,25 @@ const RegistrationForm = ({
         <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Mail className="size-8" aria-hidden />
         </div>
-        <div className="space-y-2">
+        <div className="space-y-1">
           <h1 className="text-xl font-bold">Almost done</h1>
           <p className="text-sm text-muted-foreground">
-            Open your email app if it did not open automatically. You should see
-            a draft addressed to MediaPulse. Tap <strong>Send</strong> from your
-            own mailbox so we can register you for{" "}
-            <strong>{selectedTicker?.KodeEmiten}</strong>.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            A confirmation email is on the way. If it does not appear, check
-            your spam or junk folder.
+            Tap <strong>Send</strong> on the draft in your email app to
+            subscribe for <strong>{selectedTicker?.KodeEmiten}</strong>.
           </p>
         </div>
-        <div className="flex flex-col items-center gap-3">
-          <Button variant="outline" onClick={downloadVCard}>
-            Add MediaPulse to your contacts
-          </Button>
-          <Button variant="ghost" onClick={resetForm}>
-            Subscribe to another ticker
+        <div className="w-full rounded-lg border bg-muted/30 px-4 py-3 space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Save MediaPulse to your contacts so newsletters land in your inbox,
+            not spam or junk.
+          </p>
+          <Button variant="outline" className="w-full" onClick={downloadVCard}>
+            Download contact card
           </Button>
         </div>
+        <Button variant="ghost" size="sm" onClick={resetForm}>
+          Subscribe to another ticker
+        </Button>
       </div>
     );
   }

--- a/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
@@ -13,12 +13,12 @@ describe("RegistrationConfirmationEmail", () => {
     expect(text).toMatch(/Subscription Confirmed/i);
   });
 
-  it("contains the add-to-contacts tip in HTML and text", async () => {
+  it("mentions the attached contact card in HTML and text", async () => {
     const { html, text } = await renderNewsletterEmail({
       variant: "registration-confirmation",
       tickerSymbol: "AAPL",
     });
-    expect(html).toMatch(/contacts/i);
-    expect(text).toMatch(/contacts/i);
+    expect(html).toMatch(/contact card/i);
+    expect(text).toMatch(/contact card/i);
   });
 });

--- a/packages/shared/email-templates/src/registration/registration-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.tsx
@@ -47,15 +47,15 @@ export const RegistrationConfirmationEmail = ({
               ? `\n\nYou will receive your first ${tickerSymbol} newsletter ${nextDeliveryLabel}.`
               : ""}
             {"\n\n"}
+            We've attached a contact card to this email. Open it to add
+            MediaPulse to your contacts and ensure future newsletters land in
+            your inbox, not spam or junk.
+            {"\n\n"}
             Thank you,
             {"\n"}
             MediaPulse Team
           </Text>
           <Hr style={hr} />
-          <Text style={footer}>
-            Add MediaPulse to your contacts so future newsletters land in your
-            inbox, not spam or junk.
-          </Text>
           <Text style={footer}>
             You are receiving this because you subscribed to updates on
             MediaPulse.


### PR DESCRIPTION
## Summary

The registration success screen now focuses on tapping Send in the mail draft, with contact-card guidance in a bordered panel and a full-width download button. The confirmation email explains the attached vCard in the thank-you paragraph instead of repeating it in the footer.

## Related issues

Closes #641

## Important changes

- Shorter post-submit copy on the success screen; spam/inbox guidance lives next to the download action.
- "Download contact card" replaces the previous add-to-contacts label; layout uses a muted panel plus ghost action for another ticker.
- Confirmation email body mentions opening the attached contact card.

## Other changes

- Tests updated for new button label and email copy assertions.

## Key files to review

- `apps/mediapulse/user-registration/components/registration-form.tsx` — success state layout and copy.
- `packages/shared/email-templates/src/registration/registration-confirmation.tsx` — vCard instructions in the main text block.

## How to test

1. `pnpm --filter @mediapulse/user-registration --filter @workspace/email-templates test`
2. Complete a registration in the app (or dev fixture) and confirm the success panel shows Send instructions plus "Download contact card".
3. Render or send a confirmation email and confirm the body references the attached contact card without a duplicate footer tip.
