### PR TITLE
Add optional test emails override to delivery agent

### DIFF
--- a/apps/mediapulse/agents/delivery/src/index.test.ts
+++ b/apps/mediapulse/agents/delivery/src/index.test.ts
@@ -1,6 +1,8 @@
 /** @vitest-environment node */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { syntheticTestRecipientUserTickerId } from "./resolve-delivery-recipients.js";
+
 const {
   hoistedLogger,
   mockDeliverNewsletter,
@@ -44,6 +46,7 @@ const NON_UUID_TICKER_ID = "tid-non-uuid-1";
 const EXPANSION_TICKER_ID = "db:ticker:id?take=100";
 const NL_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const UT_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const UT_ID_B = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 const AUTH_HEADERS = { Authorization: "Bearer test-token" };
 
 /** Minimal valid Hermes step config (Resend is config-only, not env). */
@@ -316,6 +319,144 @@ describe("delivery-agent", () => {
       }),
       "delivery run outcome",
     );
+  });
+
+  it("sends to test emails when override is set and DB has no subscribers", async () => {
+    deliveryGetMock.mockResolvedValue({
+      newsletter: {
+        id: NL_ID,
+        subject: "News",
+        content: "Body",
+        symbol: "AAPL",
+      },
+      subscribers: [],
+      deliveredUserTickerIds: [],
+    });
+    mockDeliverNewsletter.mockResolvedValue({
+      results: [
+        {
+          userTickerId: syntheticTestRecipientUserTickerId("test@example.com"),
+          status: "success",
+          attempts: 1,
+          resendEmailId: "re_test",
+        },
+      ],
+      resendMessageIds: ["re_test"],
+    });
+
+    const res = await fetchAgent({
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { tickerId: TICKER_ID, emails: ["test@example.com"] },
+        config: DELIVERY_CONFIG,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockDeliverNewsletter).toHaveBeenCalledWith(
+      expect.objectContaining({ id: NL_ID }),
+      [
+        {
+          userTickerId: syntheticTestRecipientUserTickerId("test@example.com"),
+          email: "test@example.com",
+        },
+      ],
+      [],
+      expect.anything(),
+      expect.objectContaining({ resend: expect.anything() }),
+    );
+    expect(deliveryCreateMock).not.toHaveBeenCalled();
+    expect(deliveryRunCreateMock).toHaveBeenCalled();
+    expect(hoistedLogger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        testEmailOverride: true,
+        testRecipientCount: 1,
+      }),
+      "delivery data-api fetch summary",
+    );
+  });
+
+  it("sends only to listed emails when override filters DB subscribers", async () => {
+    deliveryGetMock.mockResolvedValue({
+      newsletter: {
+        id: NL_ID,
+        subject: "News",
+        content: "Body",
+        symbol: "AAPL",
+      },
+      subscribers: [
+        { userTickerId: UT_ID, email: "u@example.com" },
+        { userTickerId: UT_ID_B, email: "other@example.com" },
+      ],
+      deliveredUserTickerIds: [],
+    });
+    mockDeliverNewsletter.mockResolvedValue({
+      results: [{ userTickerId: UT_ID, status: "success", attempts: 1 }],
+      resendMessageIds: [],
+    });
+
+    await fetchAgent({
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { tickerId: TICKER_ID, emails: ["u@example.com"] },
+        config: DELIVERY_CONFIG,
+      }),
+    });
+
+    expect(mockDeliverNewsletter).toHaveBeenCalledWith(
+      expect.anything(),
+      [{ userTickerId: UT_ID, email: "u@example.com" }],
+      [],
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(deliveryCreateMock).not.toHaveBeenCalled();
+  });
+
+  it("skips when test email override array is empty", async () => {
+    deliveryGetMock.mockResolvedValue({
+      newsletter: {
+        id: NL_ID,
+        subject: "News",
+        content: "Body",
+        symbol: "AAPL",
+      },
+      subscribers: [{ userTickerId: UT_ID, email: "u@example.com" }],
+      deliveredUserTickerIds: [],
+    });
+
+    const res = await fetchAgent({
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { tickerId: TICKER_ID, emails: [] },
+        config: DELIVERY_CONFIG,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockDeliverNewsletter).not.toHaveBeenCalled();
+    expect(deliveryRunCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        runSkipReason: "skipped_no_test_recipients",
+      }),
+    );
+  });
+
+  it("returns 400 when test emails contain an invalid address", async () => {
+    const res = await fetchAgent({
+      method: "POST",
+      headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        input: { tickerId: TICKER_ID, emails: ["not-an-email"] },
+        config: DELIVERY_CONFIG,
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(deliveryGetMock).not.toHaveBeenCalled();
   });
 
   it("returns 400 when tickerId is only whitespace", async () => {

--- a/apps/mediapulse/agents/delivery/src/index.ts
+++ b/apps/mediapulse/agents/delivery/src/index.ts
@@ -20,9 +20,12 @@ import {
   deliverNewsletterToSubscribers,
   type RecipientSendResult,
 } from "./deliver-newsletter.js";
+import { resolveDeliveryRecipients } from "./resolve-delivery-recipients.js";
 
 const BodySchema = z.object({
   tickerId: hermesTickerIdSchema,
+  /** When set, send only to these addresses (manual/test); skips delivery checkpoints. */
+  emails: z.array(z.string().email()).optional(),
 });
 
 type Input = z.infer<typeof BodySchema>;
@@ -149,12 +152,20 @@ const app = createAgentApp<
         const deliveryData = await dataApiClient.delivery.get({
           tickerId: input.tickerId,
         });
+        const { subscribers, isTestEmailOverride } = resolveDeliveryRecipients(
+          input,
+          deliveryData,
+        );
+        const deliveredUserTickerIds = isTestEmailOverride
+          ? []
+          : deliveryData.deliveredUserTickerIds;
         const fetchMs = Date.now() - fetchStarted;
         const subscriberCount = deliveryData.subscribers.length;
         const checkpointCount = deliveryData.deliveredUserTickerIds.length;
+        const recipientCount = subscribers.length;
         const pendingRecipients = pendingRecipientCount(
-          deliveryData.subscribers,
-          deliveryData.deliveredUserTickerIds,
+          subscribers,
+          deliveredUserTickerIds,
         );
         logger.info(
           {
@@ -167,13 +178,21 @@ const app = createAgentApp<
             subscriberCount,
             checkpointCount,
             pendingRecipientCount: pendingRecipients,
+            ...(isTestEmailOverride
+              ? {
+                  testEmailOverride: true,
+                  testRecipientCount: recipientCount,
+                }
+              : {}),
           },
           "delivery data-api fetch summary",
         );
 
         report(
           "Ready to deliver",
-          `${pendingRecipients} of ${subscriberCount} pending`,
+          isTestEmailOverride
+            ? `${pendingRecipients} test recipient(s)`
+            : `${pendingRecipients} of ${subscriberCount} pending`,
         );
 
         if (!deliveryData.newsletter) {
@@ -214,14 +233,21 @@ const app = createAgentApp<
 
         newsletterId = deliveryData.newsletter.id;
 
-        if (deliveryData.subscribers.length === 0) {
+        if (subscribers.length === 0) {
+          const runSkipReason = isTestEmailOverride
+            ? "skipped_no_test_recipients"
+            : "skipped_no_subscribers";
+          const skipMessage = isTestEmailOverride
+            ? "Skipped: no test recipient emails"
+            : "Skipped: no subscribers with email";
           runOutcome = "skipped";
           logger.info(
             {
               tickerId: input.tickerId,
               runId,
               newsletterId,
-              runSkipReason: "skipped_no_subscribers",
+              runSkipReason,
+              ...(isTestEmailOverride ? { testEmailOverride: true } : {}),
             },
             "delivery run skipped",
           );
@@ -239,14 +265,16 @@ const app = createAgentApp<
             durationMs: Date.now() - startedAt,
             ...hx,
             resendMessageIds: [],
-            recipientErrorSummary: "no_subscribers",
-            runSkipReason: "skipped_no_subscribers",
+            recipientErrorSummary: isTestEmailOverride
+              ? "no_test_recipients"
+              : "no_subscribers",
+            runSkipReason,
             recipients: [],
           });
-          report("Delivery skipped", "no subscribers with email", "completed");
+          report("Delivery skipped", skipMessage, "completed");
           return {
             success: true,
-            message: "Skipped: no subscribers with email",
+            message: skipMessage,
             details: { outcome: "skipped", runId },
           };
         }
@@ -258,8 +286,8 @@ const app = createAgentApp<
         report("Sending emails", `${pendingRecipients} recipients via Resend`);
         const sendResult = await deliverNewsletterToSubscribers(
           deliveryData.newsletter,
-          deliveryData.subscribers,
-          deliveryData.deliveredUserTickerIds,
+          subscribers,
+          deliveredUserTickerIds,
           config,
           { resend, logger },
         );
@@ -271,15 +299,17 @@ const app = createAgentApp<
         errorSummary = firstFail?.lastErrorMessage ?? null;
 
         stage = "persist_delivery_record";
-        for (const row of recipientRows) {
-          if (row.status === "success") {
-            await dataApiClient.delivery.create({
-              userTickerId: row.userTickerId,
-              newsletterId: deliveryData.newsletter.id,
-              ...(row.resendEmailId !== undefined
-                ? { resendEmailId: row.resendEmailId }
-                : {}),
-            });
+        if (!isTestEmailOverride) {
+          for (const row of recipientRows) {
+            if (row.status === "success") {
+              await dataApiClient.delivery.create({
+                userTickerId: row.userTickerId,
+                newsletterId: deliveryData.newsletter.id,
+                ...(row.resendEmailId !== undefined
+                  ? { resendEmailId: row.resendEmailId }
+                  : {}),
+              });
+            }
           }
         }
 
@@ -328,6 +358,7 @@ const app = createAgentApp<
             successCount,
             failureCount,
             skippedCount,
+            ...(isTestEmailOverride ? { testEmailOverride: true } : {}),
           },
           "delivery run outcome",
         );

--- a/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.test.ts
+++ b/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.test.ts
@@ -1,0 +1,106 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import type { DeliverySubscriber } from "./deliver-newsletter.js";
+import {
+  normalizeTestEmails,
+  resolveDeliveryRecipients,
+  syntheticTestRecipientUserTickerId,
+  testRecipientUserTickerId,
+} from "./resolve-delivery-recipients.js";
+
+const UT_A = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const UT_B = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+const DB_SUBSCRIBERS: DeliverySubscriber[] = [
+  { userTickerId: UT_A, email: "alice@example.com" },
+  { userTickerId: UT_B, email: "bob@example.com" },
+];
+
+describe("normalizeTestEmails", () => {
+  it("trims, lowercases, dedupes, and preserves order", () => {
+    expect(
+      normalizeTestEmails([
+        "  Alice@Example.COM ",
+        "bob@example.com",
+        "alice@example.com",
+      ]),
+    ).toEqual(["alice@example.com", "bob@example.com"]);
+  });
+
+  it("skips empty strings after trim", () => {
+    expect(normalizeTestEmails(["", "  ", "a@b.co"])).toEqual(["a@b.co"]);
+  });
+});
+
+describe("syntheticTestRecipientUserTickerId", () => {
+  it("returns a stable UUID for the same email", () => {
+    const a = syntheticTestRecipientUserTickerId("test@example.com");
+    const b = syntheticTestRecipientUserTickerId("test@example.com");
+    expect(a).toBe(b);
+    expect(a).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+  });
+
+  it("differs across emails", () => {
+    expect(syntheticTestRecipientUserTickerId("a@example.com")).not.toBe(
+      syntheticTestRecipientUserTickerId("b@example.com"),
+    );
+  });
+});
+
+describe("testRecipientUserTickerId", () => {
+  it("reuses subscriber userTickerId when email matches case-insensitively", () => {
+    expect(testRecipientUserTickerId("ALICE@example.com", DB_SUBSCRIBERS)).toBe(
+      UT_A,
+    );
+  });
+
+  it("uses synthetic id when email is not a subscriber", () => {
+    expect(testRecipientUserTickerId("other@example.com", DB_SUBSCRIBERS)).toBe(
+      syntheticTestRecipientUserTickerId("other@example.com"),
+    );
+  });
+});
+
+describe("resolveDeliveryRecipients", () => {
+  it("returns API subscribers when emails is omitted", () => {
+    expect(
+      resolveDeliveryRecipients(
+        { emails: undefined },
+        { subscribers: DB_SUBSCRIBERS },
+      ),
+    ).toEqual({
+      subscribers: DB_SUBSCRIBERS,
+      isTestEmailOverride: false,
+    });
+  });
+
+  it("maps override emails to subscribers with override flag", () => {
+    const resolved = resolveDeliveryRecipients(
+      { emails: ["other@example.com", "alice@example.com"] },
+      { subscribers: DB_SUBSCRIBERS },
+    );
+    expect(resolved.isTestEmailOverride).toBe(true);
+    expect(resolved.subscribers).toEqual([
+      {
+        userTickerId: syntheticTestRecipientUserTickerId("other@example.com"),
+        email: "other@example.com",
+      },
+      { userTickerId: UT_A, email: "alice@example.com" },
+    ]);
+  });
+
+  it("returns empty subscribers for empty override array", () => {
+    expect(
+      resolveDeliveryRecipients(
+        { emails: [] },
+        { subscribers: DB_SUBSCRIBERS },
+      ),
+    ).toEqual({
+      subscribers: [],
+      isTestEmailOverride: true,
+    });
+  });
+});

--- a/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.ts
+++ b/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.ts
@@ -1,0 +1,110 @@
+import { createHash } from "node:crypto";
+
+import type { DeliverySubscriber } from "./deliver-newsletter.js";
+
+/** Namespace UUID for deterministic test-recipient ids (RFC 4122 name-based). */
+const TEST_RECIPIENT_NAMESPACE = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+export type DeliveryDataForRecipients = {
+  subscribers: DeliverySubscriber[];
+};
+
+export type DeliveryInputForRecipients = {
+  emails?: string[] | undefined;
+};
+
+export type ResolvedDeliveryRecipients = {
+  subscribers: DeliverySubscriber[];
+  isTestEmailOverride: boolean;
+};
+
+/**
+ * Normalizes test override emails: trim, lowercase, dedupe, preserve first-seen order.
+ *
+ * @param emails - Raw email strings from invoke input.
+ * @returns Deduped normalized addresses.
+ */
+export function normalizeTestEmails(emails: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const raw of emails) {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === "" || seen.has(normalized)) {
+      continue;
+    }
+    seen.add(normalized);
+    out.push(normalized);
+  }
+  return out;
+}
+
+/**
+ * Builds a deterministic RFC-4122-style UUID from an email for test-only recipients.
+ *
+ * @param email - Normalized email address.
+ * @returns UUID string suitable for delivery-run diagnostics.
+ */
+export function syntheticTestRecipientUserTickerId(email: string): string {
+  const hash = createHash("sha256")
+    .update(`${TEST_RECIPIENT_NAMESPACE}:${email}`)
+    .digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20, 32),
+  ].join("-");
+}
+
+/**
+ * Resolves `userTickerId` for a test override email, reusing a DB subscriber when matched.
+ *
+ * @param email - Normalized email address.
+ * @param subscribers - Enabled subscribers from agent-data-api.
+ * @returns Existing `userTickerId` or a deterministic synthetic UUID.
+ */
+export function testRecipientUserTickerId(
+  email: string,
+  subscribers: readonly DeliverySubscriber[],
+): string {
+  const normalized = email.trim().toLowerCase();
+  const match = subscribers.find(
+    (s) => s.email.trim().toLowerCase() === normalized,
+  );
+  return match?.userTickerId ?? syntheticTestRecipientUserTickerId(normalized);
+}
+
+/**
+ * Chooses delivery recipients: all API subscribers, or test override emails only.
+ *
+ * @param input - Agent invoke input (`emails` optional).
+ * @param deliveryData - Payload from `delivery.get`.
+ * @returns Resolved subscriber rows and whether test override is active.
+ */
+export function resolveDeliveryRecipients(
+  input: DeliveryInputForRecipients,
+  deliveryData: DeliveryDataForRecipients,
+): ResolvedDeliveryRecipients {
+  if (input.emails === undefined) {
+    return {
+      subscribers: [...deliveryData.subscribers],
+      isTestEmailOverride: false,
+    };
+  }
+
+  const normalized = normalizeTestEmails(input.emails);
+  const subscribers = normalized.map((email) => ({
+    userTickerId: testRecipientUserTickerId(email, deliveryData.subscribers),
+    email,
+  }));
+
+  return {
+    subscribers,
+    isTestEmailOverride: true,
+  };
+}

--- a/dev-docs/docs/mediapulse/apps/agents/delivery.mdx
+++ b/dev-docs/docs/mediapulse/apps/agents/delivery.mdx
@@ -10,12 +10,37 @@ The delivery agent reads **newsletter content and subscribers** from agent-data-
 
 ## Features
 
-- **Input:** `tickerId` (UUID). Receives bearer token from Hermes.
+- **Input:** `tickerId` (Hermes ticker id). Optional **`emails`** (string array) for manual/test runs. Receives bearer token from Hermes.
 - **Fetches** delivery data from agent-data-api: newsletter (subject, content) and list of subscribers (email).
 - **Sends email** to each subscriber using the configured provider (e.g. Resend).
-- **Skips** cleanly if no newsletter or no subscribers.
-- **Marks completion** — POSTs to agent-data-api (e.g. `userTickerId`) so the pipeline can track delivery.
-- **Diagnostics** — Persists **delivery runs** with Hermes correlation when present (`X-Job-Id`, `X-Execution-Id`, `X-Schedule-Id`, execution/step ids), skip reasons (`skipped_no_newsletter`, `skipped_no_subscribers`), and per-recipient **`errorCategory`** (e.g. `resend_rate_limited`, `skipped_already_delivered`). Invalid **agent config** is rejected with **HTTP 400** before a run starts, so no delivery-run row is written for that case.
+- **Skips** cleanly if no newsletter or no recipients (subscribers, or test `emails` when override is set).
+- **Marks completion** — POSTs delivery checkpoints to agent-data-api per successful subscriber send (production runs only; see test override below).
+- **Diagnostics** — Persists **delivery runs** with Hermes correlation when present (`X-Job-Id`, `X-Execution-Id`, `X-Schedule-Id`, execution/step ids), skip reasons (`skipped_no_newsletter`, `skipped_no_subscribers`, `skipped_no_test_recipients`), and per-recipient **`errorCategory`** (e.g. `resend_rate_limited`, `skipped_already_delivered`). Invalid **agent config** is rejected with **HTTP 400** before a run starts, so no delivery-run row is written for that case.
+
+### Test recipient override (`input.emails`)
+
+For **manual or test invokes only**, you may pass `emails` on the invoke body. When present, the agent sends the latest newsletter **only** to those addresses (they need not be subscribed). Production pipeline steps should keep passing `tickerId` only.
+
+- Does **not** write **delivery checkpoints** (`POST /delivery`); production idempotency for real subscribers is unchanged.
+- Ignores existing delivery checkpoints for the send pass (always attempts each listed address).
+- If an address matches an enabled subscriber from agent-data-api, that subscriber’s `userTickerId` is reused in diagnostics; otherwise a deterministic synthetic id is used.
+- Empty `emails: []` skips with `skipped_no_test_recipients`.
+
+Example invoke body:
+
+```json
+{
+  "input": {
+    "tickerId": "11111111-1111-4111-a111-111111111111",
+    "emails": ["you@example.com"]
+  },
+  "config": {
+    "resendApiKey": "...",
+    "resend": { "from": "Newsletter <news@example.com>" },
+    "unsubscribe": { "secret": "...", "baseUrl": "https://example.com" }
+  }
+}
+```
 
 ### Newsletter `content` (plain text in storage)
 


### PR DESCRIPTION
## Summary

Adds optional `input.emails` on the delivery agent so manual test invokes can send the latest newsletter to specific addresses only. Override runs skip production delivery checkpoints and ignore replay skip semantics.

## Related issues

Closes #643

## Important changes

- `BodySchema` accepts optional `emails: string[]` (validated as email addresses).
- `resolve-delivery-recipients.ts` normalizes addresses, reuses DB `userTickerId` when matched, otherwise uses a deterministic synthetic UUID.
- When override is active: send to resolved list only, pass empty `deliveredUserTickerIds`, do not call `delivery.create`.
- Empty `emails: []` skips with `skipped_no_test_recipients`.

## Other changes

- Extended `index.test.ts` and new unit tests for recipient resolution.
- Documented test override in `dev-docs/docs/mediapulse/apps/agents/delivery.mdx`.

## Key files to review

- `apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.ts` — override recipient list and synthetic ids.
- `apps/mediapulse/agents/delivery/src/index.ts` — schema, wiring, checkpoint guard.
- `apps/mediapulse/agents/delivery/src/index.test.ts` — HTTP-level override cases.

## How to test

1. `pnpm --filter @workspace/utils build && pnpm --filter @mediapulse/delivery test`
2. `pnpm format:check`
3. POST to the delivery agent with `{ "input": { "tickerId": "...", "emails": ["you@example.com"] }, "config": { ... } }` and confirm only that address is sent and `delivery.create` is not called.
