### PR TITLE
Polish registration success UI and confirmation copy

### DIFF
--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -104,7 +104,7 @@ describe("RegistrationForm", () => {
     expect(screen.getByText(/Send/i)).toBeInTheDocument();
   });
 
-  it("shows spam/junk reassurance text and 'Add to contacts' button after submit", async () => {
+  it("shows spam/junk reassurance text and download contact card button after submit", async () => {
     // Setup
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
@@ -119,11 +119,11 @@ describe("RegistrationForm", () => {
     // Assert
     expect(screen.getByText(/spam|junk/i)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+      screen.getByRole("button", { name: /Download contact card/i }),
     ).toBeInTheDocument();
   });
 
-  it("triggers a vCard download when 'Add to contacts' is clicked", async () => {
+  it("triggers a vCard download when download contact card is clicked", async () => {
     // Setup
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
@@ -145,7 +145,7 @@ describe("RegistrationForm", () => {
 
     // Act
     await user.click(
-      screen.getByRole("button", { name: /Add MediaPulse to your contacts/i }),
+      screen.getByRole("button", { name: /Download contact card/i }),
     );
 
     // Assert

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -68,27 +68,25 @@ const RegistrationForm = ({
         <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
           <Mail className="size-8" aria-hidden />
         </div>
-        <div className="space-y-2">
+        <div className="space-y-1">
           <h1 className="text-xl font-bold">Almost done</h1>
           <p className="text-sm text-muted-foreground">
-            Open your email app if it did not open automatically. You should see
-            a draft addressed to MediaPulse. Tap <strong>Send</strong> from your
-            own mailbox so we can register you for{" "}
-            <strong>{selectedTicker?.KodeEmiten}</strong>.
-          </p>
-          <p className="text-xs text-muted-foreground">
-            A confirmation email is on the way. If it does not appear, check
-            your spam or junk folder.
+            Tap <strong>Send</strong> on the draft in your email app to
+            subscribe for <strong>{selectedTicker?.KodeEmiten}</strong>.
           </p>
         </div>
-        <div className="flex flex-col items-center gap-3">
-          <Button variant="outline" onClick={downloadVCard}>
-            Add MediaPulse to your contacts
-          </Button>
-          <Button variant="ghost" onClick={resetForm}>
-            Subscribe to another ticker
+        <div className="w-full rounded-lg border bg-muted/30 px-4 py-3 space-y-3">
+          <p className="text-sm text-muted-foreground">
+            Save MediaPulse to your contacts so newsletters land in your inbox,
+            not spam or junk.
+          </p>
+          <Button variant="outline" className="w-full" onClick={downloadVCard}>
+            Download contact card
           </Button>
         </div>
+        <Button variant="ghost" size="sm" onClick={resetForm}>
+          Subscribe to another ticker
+        </Button>
       </div>
     );
   }

--- a/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.test.tsx
@@ -13,12 +13,12 @@ describe("RegistrationConfirmationEmail", () => {
     expect(text).toMatch(/Subscription Confirmed/i);
   });
 
-  it("contains the add-to-contacts tip in HTML and text", async () => {
+  it("mentions the attached contact card in HTML and text", async () => {
     const { html, text } = await renderNewsletterEmail({
       variant: "registration-confirmation",
       tickerSymbol: "AAPL",
     });
-    expect(html).toMatch(/contacts/i);
-    expect(text).toMatch(/contacts/i);
+    expect(html).toMatch(/contact card/i);
+    expect(text).toMatch(/contact card/i);
   });
 });

--- a/packages/shared/email-templates/src/registration/registration-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.tsx
@@ -47,15 +47,15 @@ export const RegistrationConfirmationEmail = ({
               ? `\n\nYou will receive your first ${tickerSymbol} newsletter ${nextDeliveryLabel}.`
               : ""}
             {"\n\n"}
+            We've attached a contact card to this email. Open it to add
+            MediaPulse to your contacts and ensure future newsletters land in
+            your inbox, not spam or junk.
+            {"\n\n"}
             Thank you,
             {"\n"}
             MediaPulse Team
           </Text>
           <Hr style={hr} />
-          <Text style={footer}>
-            Add MediaPulse to your contacts so future newsletters land in your
-            inbox, not spam or junk.
-          </Text>
           <Text style={footer}>
             You are receiving this because you subscribed to updates on
             MediaPulse.


### PR DESCRIPTION
## Summary

Tightens the post-registration success screen and confirmation email so they match the vCard flow we shipped earlier. Copy is shorter, the download sits in its own card, and the email points at the attachment instead of repeating a footer tip.

Closes #647

## Related issues

Closes #647

## Important changes

- Success screen: shorter “Almost done” copy, bordered contact-card block with full-width **Download contact card** button, and **Subscribe to another ticker** moved to a smaller ghost action below.
- Confirmation email: body text references the attached contact card; redundant footer contacts tip removed.

## Other changes

- Unit test labels and assertions updated for the new button copy and email wording.

## Key files to review

- `apps/mediapulse/user-registration/components/registration-form.tsx` — success-state layout and copy.
- `packages/shared/email-templates/src/registration/registration-confirmation.tsx` — confirmation email body.
- `apps/mediapulse/user-registration/components/registration-form.test.tsx` — success UI and vCard download tests.
- `packages/shared/email-templates/src/registration/registration-confirmation.test.tsx` — HTML/text assertions for contact card wording.

## How to test

1. Run `pnpm --filter @mediapulse/user-registration test` and `pnpm --filter @workspace/email-templates test`.
2. Open the user-registration app, complete a ticker subscription, and confirm the success screen shows the bordered card and **Download contact card** triggers a vCard download.
3. Render a registration confirmation email (or trigger one in dev) and confirm HTML and plain text mention the attached contact card with no duplicate footer tip.
