### PR TITLE
Include ticker and source URLs in article-analysis run reports

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -701,7 +701,7 @@ export const run = async ({
     articlesProcessedForSummary = batch.length;
 
     report(
-      `Loaded article batch for ${input.tickerId}`,
+      "Loaded article batch",
       `${batch.length} sources\n${batch.map((s) => s.url).join("\n")}`,
     );
 
@@ -1401,7 +1401,7 @@ export const run = async ({
     if (!erPhaseFailed && perSourceSignals.length > 0) {
       const urlByDataSourceId = new Map(batch.map((s) => [s.id, s.url]));
       report(
-        `Scoring and posting article relevance for ${input.tickerId}`,
+        "Scoring and posting article relevance",
         `${perSourceSignals.length} sources\n${perSourceSignals.map((s) => urlByDataSourceId.get(s.dataSourceId) ?? s.dataSourceId).join("\n")}`,
       );
       const weightMap = toRelevanceWeightMapV1(cfg);

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -700,7 +700,10 @@ export const run = async ({
     const batch = applyMaxBatchSizeCap(sorted, effectiveMaxBatchSize);
     articlesProcessedForSummary = batch.length;
 
-    report("Loaded article batch", `${batch.length} sources`);
+    report(
+      `Loaded article batch for ${input.tickerId}`,
+      `${batch.length} sources\n${batch.map((s) => s.url).join("\n")}`,
+    );
 
     if (batch.length === 0) {
       const yieldSnapshot = emitRunSummaryAndYield({
@@ -1396,9 +1399,10 @@ export const run = async ({
     let relevancePostChunksCompleted = 0;
 
     if (!erPhaseFailed && perSourceSignals.length > 0) {
+      const urlByDataSourceId = new Map(batch.map((s) => [s.id, s.url]));
       report(
-        "Scoring and posting article relevance",
-        `${perSourceSignals.length} sources`,
+        `Scoring and posting article relevance for ${input.tickerId}`,
+        `${perSourceSignals.length} sources\n${perSourceSignals.map((s) => urlByDataSourceId.get(s.dataSourceId) ?? s.dataSourceId).join("\n")}`,
       );
       const weightMap = toRelevanceWeightMapV1(cfg);
       const relevanceDrafts = perSourceSignals.map((sig) =>


### PR DESCRIPTION
## Summary

Article-analysis run logs now name the ticker and list source URLs when a batch loads and when relevance scoring starts. Count-only messages were fine for happy paths but painful when you are trying to see which articles a run actually touched.

## Related issues

Closes #649

## Important changes

- Batch-load report title includes `input.tickerId`; body lists each source URL on its own line.
- Relevance-scoring report title includes the ticker; body lists URLs resolved from the batch (falls back to data source id when no URL is available).

## Other changes

- None.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` — two `report()` call sites around batch load and relevance posting.

## How to test

1. Run `pnpm --filter @mediapulse/article-analysis test` (and lint/typecheck if you want a quick scoped pass).
2. Trigger an article-analysis run in dev or staging and confirm progress reports show the ticker id and newline-separated URLs for batch load and relevance scoring.
