### PR TITLE
Add ticker and created-at filters to Data Sources list

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/data-sources/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/dashboard-page.ts
@@ -47,6 +47,7 @@ export const dataSourcesDashboardPage = {
     "tickerSymbol",
     "searchQueryText",
   ]),
+  listFilters: ["tickerId", "createdAt"],
   actions: { create: false, update: false, delete: false, view: true },
   customActions: dataSourcesCustomActionsForManifest,
 } satisfies DashboardPageInput;

--- a/apps/mediapulse/domain-api/src/resources/data-sources/list-filters.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/list-filters.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import { buildDataSourceListWhere } from "./list-filters";
+
+describe("buildDataSourceListWhere", () => {
+  it("returns an empty filter when no inputs are set", () => {
+    expect(buildDataSourceListWhere({})).toEqual({});
+  });
+
+  it("applies a case-insensitive multi-field substring search", () => {
+    const where = buildDataSourceListWhere({ q: "  apple " });
+    expect(where).toEqual({
+      OR: [
+        { title: { contains: "apple", mode: "insensitive" } },
+        { url: { contains: "apple", mode: "insensitive" } },
+        { content: { contains: "apple", mode: "insensitive" } },
+        {
+          ticker: {
+            symbol: { contains: "apple", mode: "insensitive" },
+          },
+        },
+        {
+          ticker: { name: { contains: "apple", mode: "insensitive" } },
+        },
+        {
+          searchQuery: {
+            text: { contains: "apple", mode: "insensitive" },
+          },
+        },
+      ],
+    });
+  });
+
+  it("ignores whitespace-only search input", () => {
+    expect(buildDataSourceListWhere({ q: "   " })).toEqual({});
+  });
+
+  it("filters by tickerId", () => {
+    expect(
+      buildDataSourceListWhere({
+        tickerId: "11111111-1111-4111-a111-111111111111",
+      }),
+    ).toEqual({ tickerId: "11111111-1111-4111-a111-111111111111" });
+  });
+
+  it("filters by a partial date range (from only)", () => {
+    const from = new Date("2026-05-01T00:00:00.000Z");
+    expect(buildDataSourceListWhere({ from })).toEqual({
+      createdAt: { gte: from },
+    });
+  });
+
+  it("filters by a partial date range (to only)", () => {
+    const to = new Date("2026-05-31T23:59:59.999Z");
+    expect(buildDataSourceListWhere({ to })).toEqual({
+      createdAt: { lte: to },
+    });
+  });
+
+  it("combines multiple filters under AND", () => {
+    const from = new Date("2026-05-01T00:00:00.000Z");
+    const where = buildDataSourceListWhere({
+      q: "earnings",
+      tickerId: "11111111-1111-4111-a111-111111111111",
+      from,
+    });
+    expect(where).toEqual({
+      AND: [
+        {
+          OR: [
+            { title: { contains: "earnings", mode: "insensitive" } },
+            { url: { contains: "earnings", mode: "insensitive" } },
+            { content: { contains: "earnings", mode: "insensitive" } },
+            {
+              ticker: {
+                symbol: { contains: "earnings", mode: "insensitive" },
+              },
+            },
+            {
+              ticker: { name: { contains: "earnings", mode: "insensitive" } },
+            },
+            {
+              searchQuery: {
+                text: { contains: "earnings", mode: "insensitive" },
+              },
+            },
+          ],
+        },
+        { tickerId: "11111111-1111-4111-a111-111111111111" },
+        { createdAt: { gte: from } },
+      ],
+    });
+  });
+
+  it("ignores invalid Date inputs", () => {
+    expect(buildDataSourceListWhere({ from: new Date("not-a-date") })).toEqual(
+      {},
+    );
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/data-sources/list-filters.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/list-filters.ts
@@ -1,0 +1,71 @@
+import { Prisma } from "@mediapulse/database";
+
+/**
+ * Input filters parsed from query string for the data-source list endpoint.
+ * All fields are optional; missing values mean "no filter".
+ */
+export type DataSourceListFilters = {
+  /** Case-insensitive substring search across title, url, content, ticker, and search query. */
+  q?: string;
+  /** UUID; restricts results to a single ticker. */
+  tickerId?: string;
+  /** Lower bound on `createdAt` (inclusive). */
+  from?: Date;
+  /** Upper bound on `createdAt` (inclusive). */
+  to?: Date;
+};
+
+/**
+ * Builds a Prisma `where` for the data-source list query from parsed filters.
+ *
+ * @param filters - Parsed filter values from the request.
+ * @returns A `Prisma.DataSourceWhereInput` (always returned, possibly empty).
+ */
+export const buildDataSourceListWhere = (
+  filters: DataSourceListFilters,
+): Prisma.DataSourceWhereInput => {
+  const parts: Prisma.DataSourceWhereInput[] = [];
+
+  if (filters.q && filters.q.trim().length > 0) {
+    const query = filters.q.trim();
+    parts.push({
+      OR: [
+        { title: { contains: query, mode: "insensitive" } },
+        { url: { contains: query, mode: "insensitive" } },
+        { content: { contains: query, mode: "insensitive" } },
+        {
+          ticker: {
+            symbol: { contains: query, mode: "insensitive" },
+          },
+        },
+        {
+          ticker: { name: { contains: query, mode: "insensitive" } },
+        },
+        {
+          searchQuery: {
+            text: { contains: query, mode: "insensitive" },
+          },
+        },
+      ],
+    });
+  }
+
+  if (filters.tickerId) {
+    parts.push({ tickerId: filters.tickerId });
+  }
+
+  const createdAt: { gte?: Date; lte?: Date } = {};
+  if (filters.from && !Number.isNaN(filters.from.getTime())) {
+    createdAt.gte = filters.from;
+  }
+  if (filters.to && !Number.isNaN(filters.to.getTime())) {
+    createdAt.lte = filters.to;
+  }
+  if (createdAt.gte !== undefined || createdAt.lte !== undefined) {
+    parts.push({ createdAt });
+  }
+
+  if (parts.length === 0) return {};
+  if (parts.length === 1) return parts[0] ?? {};
+  return { AND: parts };
+};

--- a/apps/mediapulse/domain-api/src/resources/data-sources/routes.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/routes.test.ts
@@ -13,7 +13,12 @@ vi.mock("@mediapulse/database", async (importOriginal) => {
       ...actual.prisma,
       dataSource: {
         ...actual.prisma.dataSource,
+        findMany: vi.fn(),
+        count: vi.fn(),
         deleteMany: vi.fn(),
+      },
+      ticker: {
+        findMany: vi.fn(),
       },
     },
   };
@@ -29,14 +34,60 @@ describe("dataSourcesRoutes", () => {
     vi.clearAllMocks();
   });
 
-  it("serves GET /meta with table-v1 meta JSON (not 404 from id lookup)", async () => {
+  it("serves GET /meta with table-v1 meta JSON and filter options", async () => {
+    vi.mocked(prisma.ticker.findMany).mockResolvedValue([
+      {
+        id: "11111111-1111-4111-a111-111111111111",
+        symbol: "AAPL",
+        name: "Apple",
+      },
+    ] as never);
+
     const res = await dataSourcesRoutes.request("http://localhost/meta", {
       method: "GET",
     });
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { title?: string };
+    const body = (await res.json()) as {
+      title?: string;
+      listFilters?: string[];
+      tickerOptions?: Array<{ value: string; label: string }>;
+    };
     expect(body.title).toBe("Data Sources");
+    expect(body.listFilters).toEqual(["tickerId", "createdAt"]);
+    expect(body.tickerOptions).toEqual([
+      {
+        value: "11111111-1111-4111-a111-111111111111",
+        label: "AAPL — Apple",
+      },
+    ]);
+  });
+
+  it("passes list filter query params to Prisma findMany", async () => {
+    vi.mocked(prisma.dataSource.findMany).mockResolvedValue([] as never);
+    vi.mocked(prisma.dataSource.count).mockResolvedValue(0);
+
+    const res = await dataSourcesRoutes.request(
+      "http://localhost/?tickerId=11111111-1111-4111-a111-111111111111&from=2026-05-01&to=2026-05-31",
+      { method: "GET" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(prisma.dataSource.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          AND: [
+            { tickerId: "11111111-1111-4111-a111-111111111111" },
+            {
+              createdAt: {
+                gte: new Date("2026-05-01T00:00:00.000Z"),
+                lte: new Date("2026-05-31T23:59:59.999Z"),
+              },
+            },
+          ],
+        },
+      }),
+    );
   });
 
   it("reset-all deletes every data source when confirm token matches", async () => {

--- a/apps/mediapulse/domain-api/src/resources/data-sources/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/routes.ts
@@ -5,10 +5,13 @@
 import { tableV1ListResponseSchema } from "@hermes/domain-contract";
 import { prisma, Prisma } from "@mediapulse/database";
 import { Hono } from "hono";
+import { z } from "zod";
 import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
 import { registerTableV1CustomActionRoutes } from "../../hermes-dashboard/templates/table-v1/register-table-v1-custom-actions";
+import { parseCreatedDateBound } from "../../lib/parse-created-date-bound";
 import { parsePagination } from "../../lib/list-pagination";
 import { dataSourcesTableV1CustomActionRegistrations } from "./custom-actions";
+import { buildDataSourceListWhere } from "./list-filters";
 import {
   listInclude,
   mapRowToDetailItem,
@@ -49,40 +52,28 @@ const resolveDataSourceListOrderBy = (
  */
 export const dataSourcesRoutes = new Hono();
 
-/** Paginated list of data sources for the Hermes dashboard (search `q`; sort `sortBy` / `sortDir`). */
+/** Paginated list of data sources for the Hermes dashboard (search `q`; filters; sort `sortBy` / `sortDir`). */
 dataSourcesRoutes.get("/", async (c) => {
   const { page, pageSize } = parsePagination(
     c.req.query("page"),
     c.req.query("pageSize"),
   );
-  const query = c.req.query("q")?.trim();
   const sortBy = c.req.query("sortBy");
   const sortDir: Prisma.SortOrder =
     c.req.query("sortDir") === "desc" ? "desc" : "asc";
   const skip = (page - 1) * pageSize;
 
-  const where = query
-    ? ({
-        OR: [
-          { title: { contains: query, mode: "insensitive" as const } },
-          { url: { contains: query, mode: "insensitive" as const } },
-          { content: { contains: query, mode: "insensitive" as const } },
-          {
-            ticker: {
-              symbol: { contains: query, mode: "insensitive" as const },
-            },
-          },
-          {
-            ticker: { name: { contains: query, mode: "insensitive" as const } },
-          },
-          {
-            searchQuery: {
-              text: { contains: query, mode: "insensitive" as const },
-            },
-          },
-        ],
-      } satisfies Prisma.DataSourceWhereInput)
-    : undefined;
+  const tickerFilter = z
+    .string()
+    .uuid()
+    .safeParse(c.req.query("tickerId")?.trim() ?? "");
+
+  const where = buildDataSourceListWhere({
+    q: c.req.query("q"),
+    tickerId: tickerFilter.success ? tickerFilter.data : undefined,
+    from: parseCreatedDateBound(c.req.query("from"), "start"),
+    to: parseCreatedDateBound(c.req.query("to"), "end"),
+  });
 
   const orderBy = resolveDataSourceListOrderBy(sortBy, sortDir);
 
@@ -113,12 +104,24 @@ dataSourcesRoutes.get("/", async (c) => {
  * Table-v1 metadata for Hermes. Registered **before** `GET /:id` so `/meta` is not captured as an id
  * (see {@link buildMetaPayloadForPathSegment}).
  */
-dataSourcesRoutes.get("/meta", (c) => {
-  const meta = buildMetaPayloadForPathSegment(DATA_SOURCES_PATH_SEGMENT);
-  if (!meta) {
+dataSourcesRoutes.get("/meta", async (c) => {
+  const base = buildMetaPayloadForPathSegment(DATA_SOURCES_PATH_SEGMENT);
+  if (!base) {
     return c.json({ message: "Unknown dashboard resource" }, 404);
   }
-  return c.json(meta);
+
+  const tickerOptions = await prisma.ticker.findMany({
+    select: { id: true, symbol: true, name: true },
+    orderBy: { symbol: "asc" },
+  } satisfies Prisma.TickerFindManyArgs);
+
+  return c.json({
+    ...base,
+    tickerOptions: tickerOptions.map((ticker) => ({
+      value: ticker.id,
+      label: `${ticker.symbol} — ${ticker.name}`,
+    })),
+  });
 });
 
 /** Returns one data source by id (full `content`) for the Hermes read-only detail page. */


### PR DESCRIPTION
## Summary

Admins can filter the Hermes Data Sources list by ticker and created date. The shared domain-table filter UI was already there for other mediapulse resources; this PR declares the filters on the data-sources manifest and applies them in domain-api.

## Related issues

Closes #651

## Important changes

- Added `listFilters: ["tickerId", "createdAt"]` to the data-sources dashboard manifest.
- New `buildDataSourceListWhere` handles text search, ticker FK, and UTC day bounds on `createdAt`.
- `GET /meta` now returns `tickerOptions` for the dropdown; `GET /` parses `tickerId`, `from`, and `to`.

## Other changes

- Route and list-filters unit tests cover meta options and Prisma where wiring.

## Key files to review

- `apps/mediapulse/domain-api/src/resources/data-sources/list-filters.ts` — where builder for q, tickerId, date range.
- `apps/mediapulse/domain-api/src/resources/data-sources/routes.ts` — list/meta filter wiring.
- `apps/mediapulse/domain-api/src/resources/data-sources/dashboard-page.ts` — manifest `listFilters`.

## How to test

1. Run `pnpm --filter @mediapulse/domain-api test -- data-sources/list-filters data-sources/routes`.
2. Open `/dashboard/mediapulse/data-sources?size=15&dir=asc` in Hermes.
3. Confirm ticker dropdown and From/To date fields appear; apply filters and check the URL and narrowed results.
4. Try From only, To only, and the same date in both fields for a single-day slice.
