### PR TITLE
Centralize newsletter sections and add queryMaxWords config

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -2,6 +2,8 @@ import { z } from "zod";
 
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import { reasoningEffortSchema } from "@workspace/agent-runtime";
+import { NEWSLETTER_SECTION_IDS } from "@workspace/agent-data-api-contract";
+import type { NewsletterSectionId } from "@workspace/agent-data-api-contract";
 
 /** Maximum length for each optional `prompts.*` string (Hermes JSON config). */
 export const CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
@@ -354,14 +356,9 @@ const crossRunDedupSchema = z
   .default({})
   .describe("Cross-run semantic dedup against recent newsletter bullets.");
 
-const requireCitationSectionEnum = z.enum([
-  "industryPulse",
-  "competitiveLandscape",
-  "dealsAndMovements",
-  "regulatoryPolicyWatch",
-  "disruptorsOrTech",
-  "quickHits",
-]);
+const requireCitationSectionEnum = z.enum(
+  NEWSLETTER_SECTION_IDS as [NewsletterSectionId, ...NewsletterSectionId[]],
+);
 
 const requireCitationSchema = z
   .object({

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import { NEWSLETTER_SECTION_IDS } from "@workspace/agent-data-api-contract";
 
 import {
   industryNewsletterStructureLlmSchema,
@@ -114,6 +115,16 @@ describe("industryNewsletterStructureSchema", () => {
         },
       }),
     ).toThrow();
+  });
+});
+
+describe("industryNewsletterStructureSchema section drift guard", () => {
+  it("has exactly the same section keys as NEWSLETTER_SECTION_IDS", () => {
+    const schemaKeys = Object.keys(
+      industryNewsletterStructureSchema.shape,
+    ).filter((key) => key !== "subject");
+
+    expect(new Set(schemaKeys)).toEqual(new Set(NEWSLETTER_SECTION_IDS));
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -47,6 +47,7 @@ describe("queryAnalysisConfigSchema grouped layout", () => {
       personas: ["analyst", "retail", "regulator", "esg", "short_seller"],
       perPersonaQuotaCount: 3,
       fewShotExemplarCount: 3,
+      queryMaxWords: 2,
     });
     expect(parsed.creativity).toEqual({
       wildcardFraction: 0.1,

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -154,9 +154,18 @@ const promptingSchema = z
       .describe(
         "Number of curated few-shot exemplars to inject. Set 0 to disable exemplars.",
       ),
+    queryMaxWords: z
+      .number()
+      .int()
+      .min(1)
+      .max(10)
+      .default(2)
+      .describe(
+        "Target maximum words per generated keyword phrase. Default 2 produces short, punchy queries. Set to 5 for the classic '2–5 word' range.",
+      ),
   })
   .default({})
-  .describe("Persona fan-out and few-shot prompting.");
+  .describe("Persona fan-out, few-shot prompting, and phrase length.");
 
 const creativitySchema = z
   .object({

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -70,6 +70,8 @@ export type LlmQueryStrategyPrompt = {
   allowedLanguages?: string[];
   minDeterministicCount: number;
   intentWeights: QueryAnalysisIntentWeights;
+  /** Maximum words per generated keyword phrase. Defaults to 5 when omitted. */
+  queryMaxWords?: number;
 };
 
 const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_STANDARD_INTENTS.map(
@@ -116,11 +118,16 @@ export const buildQueryAnalysisSystemContent = (
   const intentTargetLines = QUERY_ANALYSIS_STANDARD_INTENTS.map(
     (intent) => `- ${intent}: ${String(targets[intent])}`,
   ).join("\n");
+  const maxWords = strategy.queryMaxWords ?? 5;
+  const phraseLengthHint =
+    maxWords === 5
+      ? "Prefer 2–5 word keyword phrases."
+      : `Prefer ${String(maxWords)}-word keyword phrases.`;
 
   return [
     "You generate short keyword search queries for news monitoring.",
     `Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": ${QUERY_ANALYSIS_INTENT_JSON_UNION} } ] }.`,
-    "Prefer 2–5 word keyword phrases. Do not write full sentences, questions, or analyst-style commentary.",
+    `${phraseLengthHint} Do not write full sentences, questions, or analyst-style commentary.`,
     `All queries must be in ${strategy.language} (BCP-47). Do not code-mix or translate ticker symbols and proper nouns.`,
     "Do not translate ticker symbols or proper nouns into other languages.",
     "Include the company name or ticker symbol in at most 2 queries — the rest should be bare topic keywords, industry terms, or regulatory terms that stand alone without the company name.",
@@ -524,15 +531,19 @@ export const fetchLlmQueryCandidates = async (
 export const resolveWildcardSystemContent = (
   wildcardCount: number,
   allowedLanguages: string[],
-): string =>
-  [
+  queryMaxWords?: number,
+): string => {
+  const maxWords = queryMaxWords ?? 5;
+  const wordsHint = maxWords === 5 ? "2–5 words" : `${String(maxWords)} words`;
+  return [
     `Generate ${String(wildcardCount)} short search queries unlike anything an institutional analyst would typically search for.`,
     "Lateral, surprising, second-order, contrarian, or culturally-grounded angles welcome.",
     "Do not use the standard intent taxonomy — these queries are deliberately unconventional.",
-    "Keep queries short — 2–5 words. Prefer unusual keyword combinations over full questions or sentences.",
+    `Keep queries short — ${wordsHint}. Prefer unusual keyword combinations over full questions or sentences.`,
     'Return ONLY a JSON object: { "queries": [ { "text": string } ] }.',
     `Write in these languages when natural (BCP-47 codes): ${allowedLanguages.join(", ")}.`,
   ].join("\n\n");
+};
 
 /**
  * Builds the wildcard user prompt from serialized GET context.
@@ -585,6 +596,7 @@ export const fetchWildcardCandidates = async (
     allowedLanguages: string[];
     sampling: LlmQuerySampling;
     avoidTexts?: string[];
+    queryMaxWords?: number;
   },
   deps: { generateObjectForWildcards: GenerateObjectForWildcards } = {
     generateObjectForWildcards: generateObject,
@@ -594,6 +606,7 @@ export const fetchWildcardCandidates = async (
   const systemContent = resolveWildcardSystemContent(
     params.count,
     params.allowedLanguages,
+    params.queryMaxWords,
   );
   const userContent = buildWildcardUserContentWithAvoidNudge(
     resolveWildcardUserContent(params.context),

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -364,6 +364,7 @@ type LanguageSliceSharedConfig = {
   useBrainstormPass: boolean;
   brainstormModel: string;
   fewShotExemplarCount: number;
+  queryMaxWords: number;
   useSelfCritique: boolean;
   critiqueDropFraction: number;
   critiqueModel: string;
@@ -427,6 +428,7 @@ export const runLanguageQuerySlice = async (params: {
     language,
     minDeterministicCount: params.minDeterministicCount,
     intentWeights: shared.intentWeights,
+    queryMaxWords: shared.queryMaxWords,
   };
 
   const systemContent = buildQueryAnalysisSystemContent(strategyPrompt);
@@ -712,6 +714,7 @@ export const runQueryAnalysis = async (
   const { seed } = sampling;
   const useBrainstormPass = creativity.useBrainstormPass;
   const fewShotExemplarCount = prompting.fewShotExemplarCount;
+  const queryMaxWords = prompting.queryMaxWords;
   const brainstormModel = creativity.brainstormModel ?? openaiModel;
   const useSelfCritique = quality.useSelfCritique;
   const critiqueDropFraction = quality.critiqueDropFraction;
@@ -775,6 +778,7 @@ export const runQueryAnalysis = async (
       language: primaryLanguage,
       minDeterministicCount,
       intentWeights,
+      queryMaxWords,
     }),
     buildQueryAnalysisUserContent(queryContext, primaryLanguage),
   );
@@ -789,6 +793,7 @@ export const runQueryAnalysis = async (
     useBrainstormPass,
     brainstormModel,
     fewShotExemplarCount,
+    queryMaxWords,
     useSelfCritique,
     critiqueDropFraction,
     critiqueModel,
@@ -908,6 +913,7 @@ export const runQueryAnalysis = async (
         context: queryContext,
         allowedLanguages: wildcardLanguages,
         sampling: llmSampling,
+        queryMaxWords,
       });
     } catch (error) {
       logger.warn(
@@ -932,6 +938,7 @@ export const runQueryAnalysis = async (
                   allowedLanguages: wildcardLanguages,
                   sampling: llmSampling,
                   avoidTexts,
+                  queryMaxWords,
                 });
               } catch (error) {
                 logger.warn(

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -202,3 +202,10 @@ export {
   type GetTickerResponse,
 } from "./ticker.js";
 export * from "./user-registration.js";
+export {
+  MEDIAPULSE_NEWSLETTER_SECTIONS,
+  NEWSLETTER_SECTION_IDS,
+  SECTION_BY_INTENT,
+  sectionsWithoutDedicatedIntent,
+  type NewsletterSectionId,
+} from "./newsletter-sections.js";

--- a/packages/shared/agent-data-api-contract/src/newsletter-sections.test.ts
+++ b/packages/shared/agent-data-api-contract/src/newsletter-sections.test.ts
@@ -1,0 +1,109 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { QUERY_ANALYSIS_INTENTS } from "./query-analysis.js";
+import {
+  NEWSLETTER_SECTION_IDS,
+  SECTION_BY_INTENT,
+  sectionsWithoutDedicatedIntent,
+} from "./newsletter-sections.js";
+
+describe("SECTION_BY_INTENT", () => {
+  it("covers every QueryAnalysisIntent as a key", () => {
+    for (const intent of QUERY_ANALYSIS_INTENTS) {
+      expect(
+        Object.prototype.hasOwnProperty.call(SECTION_BY_INTENT, intent),
+        `SECTION_BY_INTENT missing key: ${intent}`,
+      ).toBe(true);
+    }
+  });
+
+  it("has no keys beyond the known intent list", () => {
+    const intentSet = new Set<string>(QUERY_ANALYSIS_INTENTS);
+    for (const key of Object.keys(SECTION_BY_INTENT)) {
+      expect(
+        intentSet.has(key),
+        `unexpected key in SECTION_BY_INTENT: ${key}`,
+      ).toBe(true);
+    }
+  });
+
+  it("every non-null value is a valid NewsletterSectionId", () => {
+    const sectionSet = new Set<string>(NEWSLETTER_SECTION_IDS);
+    for (const [intent, sectionId] of Object.entries(SECTION_BY_INTENT)) {
+      if (sectionId !== null) {
+        expect(
+          sectionSet.has(sectionId),
+          `SECTION_BY_INTENT['${intent}'] = '${sectionId}' is not a valid NewsletterSectionId`,
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("maps competitor to competitiveLandscape", () => {
+    expect(SECTION_BY_INTENT.competitor).toBe("competitiveLandscape");
+  });
+
+  it("maps regulatory to regulatoryPolicyWatch", () => {
+    expect(SECTION_BY_INTENT.regulatory).toBe("regulatoryPolicyWatch");
+  });
+
+  it("maps technology_trend and technical to disruptorsOrTech", () => {
+    expect(SECTION_BY_INTENT.technology_trend).toBe("disruptorsOrTech");
+    expect(SECTION_BY_INTENT.technical).toBe("disruptorsOrTech");
+  });
+
+  it("maps industry_trend to industryPulse", () => {
+    expect(SECTION_BY_INTENT.industry_trend).toBe("industryPulse");
+  });
+
+  it("maps homeless intents to null", () => {
+    const homelessIntents = [
+      "breaking",
+      "kg_change",
+      "fundamental",
+      "sentiment",
+      "supply_chain",
+      "esg",
+      "macro",
+      "geopolitical",
+      "wildcard",
+    ] as const;
+    for (const intent of homelessIntents) {
+      expect(SECTION_BY_INTENT[intent]).toBeNull();
+    }
+  });
+});
+
+describe("sectionsWithoutDedicatedIntent", () => {
+  it("includes dealsAndMovements", () => {
+    expect(sectionsWithoutDedicatedIntent()).toContain("dealsAndMovements");
+  });
+
+  it("excludes competitiveLandscape", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain(
+      "competitiveLandscape",
+    );
+  });
+
+  it("excludes regulatoryPolicyWatch", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain(
+      "regulatoryPolicyWatch",
+    );
+  });
+
+  it("excludes disruptorsOrTech", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain("disruptorsOrTech");
+  });
+
+  it("excludes industryPulse", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain("industryPulse");
+  });
+
+  it("returns only valid NewsletterSectionIds", () => {
+    const sectionSet = new Set<string>(NEWSLETTER_SECTION_IDS);
+    for (const sectionId of sectionsWithoutDedicatedIntent()) {
+      expect(sectionSet.has(sectionId)).toBe(true);
+    }
+  });
+});

--- a/packages/shared/agent-data-api-contract/src/newsletter-sections.ts
+++ b/packages/shared/agent-data-api-contract/src/newsletter-sections.ts
@@ -1,0 +1,87 @@
+import type { QueryAnalysisIntent } from "./query-analysis.js";
+
+/** Canonical newsletter sections in display order. */
+export const MEDIAPULSE_NEWSLETTER_SECTIONS = [
+  {
+    id: "industryPulse",
+    label: "Industry Pulse",
+    description:
+      "Lead prose section summarising the most significant macro or sector-wide development of the day.",
+  },
+  {
+    id: "competitiveLandscape",
+    label: "Competitive Landscape",
+    description:
+      "Bullets covering peer positioning, share shifts, and competitive threats relevant to the issuer.",
+  },
+  {
+    id: "dealsAndMovements",
+    label: "Deals & Movements",
+    description:
+      "Bullets covering M&A, funding rounds, leadership changes, and notable corporate actions.",
+  },
+  {
+    id: "regulatoryPolicyWatch",
+    label: "Regulatory & Policy Watch",
+    description:
+      "Bullets covering licensing, compliance, policy enforcement, and rulemaking that affects the issuer or its sector.",
+  },
+  {
+    id: "disruptorsOrTech",
+    label: "Disruptors / Tech",
+    description:
+      "Prose or bullets covering digital disruption, AI adoption, and technology shifts reshaping the sector.",
+  },
+  {
+    id: "quickHits",
+    label: "Quick Hits",
+    description:
+      "Short cited items that do not fit the main sections but are worth surfacing to the reader.",
+  },
+] as const;
+
+export type NewsletterSectionId =
+  (typeof MEDIAPULSE_NEWSLETTER_SECTIONS)[number]["id"];
+
+/** Ordered list of all newsletter section ids — use this wherever a section list is needed. */
+export const NEWSLETTER_SECTION_IDS: readonly NewsletterSectionId[] =
+  MEDIAPULSE_NEWSLETTER_SECTIONS.map((section) => section.id);
+
+/**
+ * Maps every QueryAnalysisIntent to the newsletter section it primarily feeds.
+ * `null` means the intent has no dedicated section and flows to industryPulse or quickHits at
+ * generation time. This is the authoritative record of the current intent→section alignment.
+ */
+export const SECTION_BY_INTENT: Record<
+  QueryAnalysisIntent,
+  NewsletterSectionId | null
+> = {
+  competitor: "competitiveLandscape",
+  regulatory: "regulatoryPolicyWatch",
+  technology_trend: "disruptorsOrTech",
+  technical: "disruptorsOrTech",
+  industry_trend: "industryPulse",
+  breaking: null,
+  kg_change: null,
+  fundamental: null,
+  sentiment: null,
+  supply_chain: null,
+  esg: null,
+  macro: null,
+  geopolitical: null,
+  wildcard: null,
+};
+
+/**
+ * Returns every section id that no intent maps to via {@link SECTION_BY_INTENT}.
+ * These are structurally required sections the upstream search pipeline does not cover by default —
+ * e.g. `dealsAndMovements` has no dedicated intent and will be starved unless explicitly budgeted.
+ */
+export const sectionsWithoutDedicatedIntent = (): NewsletterSectionId[] => {
+  const covered = new Set(
+    Object.values(SECTION_BY_INTENT).filter(
+      (sectionId): sectionId is NewsletterSectionId => sectionId !== null,
+    ),
+  );
+  return NEWSLETTER_SECTION_IDS.filter((sectionId) => !covered.has(sectionId));
+};


### PR DESCRIPTION
## Summary

Newsletter section IDs lived in more than one place, and query-analysis had no way to tune how long generated keyword phrases should be. This PR adds a shared newsletter-sections module in the agent-data-api contract, points content-generation at it, and introduces `prompting.queryMaxWords` (default 2) for shorter queries.

## Related issues

Closes #653

## Important changes

- New `@workspace/agent-data-api-contract` module with `NEWSLETTER_SECTION_IDS`, `SECTION_BY_INTENT`, and `sectionsWithoutDedicatedIntent()`.
- Content-generation `requireCitation.sections` now validates against the shared section list instead of a local enum.
- Query-analysis accepts `prompting.queryMaxWords` (1–10, default 2) and passes it into standard and wildcard LLM prompts. Set to 5 to get the old "2–5 word" wording back.

## Other changes

- Drift guard test ensures the industry newsletter Zod schema keys match `NEWSLETTER_SECTION_IDS`.
- Config schema test fixture updated for the new `queryMaxWords` default.

## Key files to review

- `packages/shared/agent-data-api-contract/src/newsletter-sections.ts` — canonical section IDs and intent→section map.
- `packages/shared/agent-data-api-contract/src/newsletter-sections.test.ts` — intent coverage and section helper tests.
- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — new `queryMaxWords` field and description.
- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — phrase-length hints in system and wildcard prompts.
- `apps/mediapulse/agents/query-analysis/src/run.ts` — threads `queryMaxWords` through the run pipeline.
- `apps/mediapulse/agents/content-generation/src/config-schema.ts` — uses shared section enum.

## How to test

1. `pnpm --filter @workspace/agent-data-api-contract build test`
2. `pnpm --filter @mediapulse/query-analysis type:check test`
3. `pnpm --filter @mediapulse/content-generation type:check test`
4. Confirm query-analysis config with default `prompting.queryMaxWords: 2` produces "Prefer 2-word keyword phrases" in the system prompt (see `llm-queries.test.ts` or inspect `buildQueryAnalysisSystemContent` output).
5. Confirm setting `queryMaxWords: 5` restores "Prefer 2–5 word keyword phrases."
