### PR TITLE
Consume agent contract briefs in query and content agents

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -2286,10 +2286,15 @@ describe("generateNewsletterWithLlm — contract brief", () => {
   it("system prompt does not contain product_contract block when brief is absent (reversibility guarantee)", async () => {
     const generateObjectFn = makeSuccessfulGenerateFn();
 
-    const result = await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
-      generateObjectFn,
-      sleepFn: noopSleepFn,
-    });
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      testContext,
+      {
+        generateObjectFn,
+        sleepFn: noopSleepFn,
+      },
+    );
 
     expect(result.systemPrompt).not.toContain("<product_contract>");
   });
@@ -2311,10 +2316,15 @@ describe("generateNewsletterWithLlm — contract brief", () => {
   it("returned systemPrompt differs when brief is present so computePromptHash sees the full prompt", async () => {
     const generateObjectFn = makeSuccessfulGenerateFn();
 
-    const withoutBrief = await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
-      generateObjectFn,
-      sleepFn: noopSleepFn,
-    });
+    const withoutBrief = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      testContext,
+      {
+        generateObjectFn,
+        sleepFn: noopSleepFn,
+      },
+    );
     const withBrief = await generateNewsletterWithLlm(
       testSources,
       baseConfig,

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -2281,3 +2281,48 @@ describe("generateNewsletterWithLlm — reasoning effort", () => {
     });
   });
 });
+
+describe("generateNewsletterWithLlm — contract brief", () => {
+  it("system prompt does not contain product_contract block when brief is absent (reversibility guarantee)", async () => {
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    const result = await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+    });
+
+    expect(result.systemPrompt).not.toContain("<product_contract>");
+  });
+
+  it("system prompt contains product_contract block when brief is present", async () => {
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    const result = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      { ...testContext, brief: "Daily newsletter for executives." },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    expect(result.systemPrompt).toContain("<product_contract>");
+    expect(result.systemPrompt).toContain("Daily newsletter for executives.");
+  });
+
+  it("returned systemPrompt differs when brief is present so computePromptHash sees the full prompt", async () => {
+    const generateObjectFn = makeSuccessfulGenerateFn();
+
+    const withoutBrief = await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
+      generateObjectFn,
+      sleepFn: noopSleepFn,
+    });
+    const withBrief = await generateNewsletterWithLlm(
+      testSources,
+      baseConfig,
+      { ...testContext, brief: "Some brief." },
+      { generateObjectFn, sleepFn: noopSleepFn },
+    );
+
+    expect(withBrief.systemPrompt).toContain("<product_contract>");
+    expect(withBrief.systemPrompt).not.toBe(withoutBrief.systemPrompt);
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -3,6 +3,7 @@ import { generateObject, generateText } from "ai";
 import type { z } from "zod";
 
 import {
+  applyContractBrief,
   buildOpenAiReasoningProviderOptions,
   type OpenAiReasoningProviderOptions,
 } from "@workspace/agent-runtime";
@@ -697,6 +698,8 @@ export async function generateNewsletterWithLlm(
     competitors?: Array<{ name: string; relation: string }>;
     /** Issuer aliases from the content-generation API (plan 71). */
     issuerAliases?: string[];
+    /** Opaque product brief from the Agent Contract; appended to the system prompt when present. */
+    brief?: string;
   },
   deps: {
     generateObjectFn?: GenerateNewsletterObjectFn;
@@ -890,11 +893,15 @@ export async function generateNewsletterWithLlm(
   // Apply placeholder substitution to the system prompt so {{topNewsCount}},
   // {{tickerName}}, and {{tickerSymbol}} are resolved before the LLM call.
   const rawSystemPrompt = config.prompts?.systemPrompt || SYSTEM_PROMPT;
-  const systemPrompt = rawSystemPrompt
+  const substitutedSystemPrompt = rawSystemPrompt
     .replaceAll("{{topNewsCount}}", String(effectiveTopNewsCount))
     .replaceAll("{{tickerId}}", context.tickerId)
     .replaceAll("{{tickerName}}", context.tickerName ?? context.tickerId)
     .replaceAll("{{tickerSymbol}}", context.tickerSymbol ?? context.tickerId);
+  const systemPrompt = applyContractBrief(
+    substitutedSystemPrompt,
+    context.brief !== undefined ? { brief: context.brief } : undefined,
+  );
 
   const numericAnchors = config.inputs.numericAnchors;
   let numericAnchorSection = "";

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -134,6 +134,7 @@ export async function run({
   config,
   token,
   hermesCorrelation,
+  contract,
 }: AgentRunContext<Input, ContentGenerationConfig>): Promise<AgentRunResult> {
   const runStart = Date.now();
 
@@ -400,6 +401,7 @@ export async function run({
       recentBullets,
       competitors,
       issuerAliases,
+      ...(contract !== undefined ? { brief: contract.brief } : {}),
     });
   } catch (err) {
     const code = classifyLlmError(err);

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -507,3 +507,17 @@ describe("queryAnalysisConfigSchema languageQuotas", () => {
     }
   });
 });
+
+describe("queryAnalysisConfigSchema — sectionCoverage", () => {
+  it("defaults sectionCoverage.enabled to false", () => {
+    const parsed = queryAnalysisConfigSchema.parse({});
+    expect(parsed.output.sectionCoverage.enabled).toBe(false);
+  });
+
+  it("accepts sectionCoverage.enabled: true", () => {
+    const parsed = queryAnalysisConfigSchema.parse({
+      output: { sectionCoverage: { enabled: true } },
+    });
+    expect(parsed.output.sectionCoverage.enabled).toBe(true);
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -87,6 +87,19 @@ const outputSchema = z
       .describe(
         "Relative weights keyed by intent for merge ordering and LLM target counts. Omitted keys use contract defaults.",
       ),
+    sectionCoverage: z
+      .object({
+        enabled: z
+          .boolean()
+          .default(false)
+          .describe(
+            "When true, reserve at least one query per newsletter section that has a dedicated intent, and inject keyword guidance for sections with no dedicated intent (e.g. Deals & Movements).",
+          ),
+      })
+      .default({})
+      .describe(
+        "Optional section-coverage path: ensures every newsletter section has upstream search budget. Off by default.",
+      ),
   })
   .default({})
   .describe("Query set size, language mix, and intent weighting.");

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -1077,7 +1077,10 @@ describe("buildQueryAnalysisSystemContent — contract brief", () => {
 
   it("returns identical output with no brief (reversibility guarantee)", () => {
     const withoutBrief = buildQueryAnalysisSystemContent(baseStrategy);
-    const withUndefinedBrief = buildQueryAnalysisSystemContent({ ...baseStrategy, brief: undefined });
+    const withUndefinedBrief = buildQueryAnalysisSystemContent({
+      ...baseStrategy,
+      brief: undefined,
+    });
     expect(withoutBrief).toBe(withUndefinedBrief);
   });
 
@@ -1115,14 +1118,20 @@ describe("buildQueryAnalysisSystemContent — section coverage", () => {
   };
 
   it("does not include deals/M&A guidance when sectionCoverageEnabled is false", () => {
-    const result = buildQueryAnalysisSystemContent({ ...baseStrategy, sectionCoverageEnabled: false });
+    const result = buildQueryAnalysisSystemContent({
+      ...baseStrategy,
+      sectionCoverageEnabled: false,
+    });
 
     expect(result).not.toContain("Deals & Movements");
     expect(result).not.toContain("M&A");
   });
 
   it("injects deals/M&A keyword guidance when sectionCoverageEnabled is true", () => {
-    const result = buildQueryAnalysisSystemContent({ ...baseStrategy, sectionCoverageEnabled: true });
+    const result = buildQueryAnalysisSystemContent({
+      ...baseStrategy,
+      sectionCoverageEnabled: true,
+    });
 
     expect(result).toContain("M&A");
     expect(result).toContain("Deals & Movements");
@@ -1137,7 +1146,10 @@ describe("computeQueryAnalysisIntentTargetCounts — section coverage floor", ()
 
     const counts = computeQueryAnalysisIntentTargetCounts({
       queryCount: 10,
-      intentWeights: { ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS, competitor: 0 },
+      intentWeights: {
+        ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+        competitor: 0,
+      },
       sectionCoverageEnabled: false,
     });
 
@@ -1185,7 +1197,10 @@ describe("buildBrainstormPrompt — contract brief", () => {
   };
 
   it("does not include product_contract block when no brief", () => {
-    const { system } = buildBrainstormPrompt(baseStrategy, emptyContext as never);
+    const { system } = buildBrainstormPrompt(
+      baseStrategy,
+      emptyContext as never,
+    );
     expect(system).not.toContain("<product_contract>");
   });
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -1066,3 +1066,135 @@ describe("llmSamplingOptions — reasoning effort", () => {
     });
   });
 });
+
+describe("buildQueryAnalysisSystemContent — contract brief", () => {
+  const baseStrategy = {
+    queryCount: 10,
+    language: "en",
+    minDeterministicCount: 3,
+    intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+  };
+
+  it("returns identical output with no brief (reversibility guarantee)", () => {
+    const withoutBrief = buildQueryAnalysisSystemContent(baseStrategy);
+    const withUndefinedBrief = buildQueryAnalysisSystemContent({ ...baseStrategy, brief: undefined });
+    expect(withoutBrief).toBe(withUndefinedBrief);
+  });
+
+  it("appends product_contract block when brief is present", () => {
+    const result = buildQueryAnalysisSystemContent({
+      ...baseStrategy,
+      brief: "Daily industry newsletter for executives.",
+    });
+
+    expect(result).toContain("<product_contract>");
+    expect(result).toContain("Daily industry newsletter for executives.");
+    expect(result).toContain("</product_contract>");
+  });
+
+  it("prompt fingerprint differs when brief is present vs absent", () => {
+    const fingerprintWithout = computeLlmPromptFingerprint(
+      buildQueryAnalysisSystemContent(baseStrategy),
+      "user content",
+    );
+    const fingerprintWith = computeLlmPromptFingerprint(
+      buildQueryAnalysisSystemContent({ ...baseStrategy, brief: "A brief." }),
+      "user content",
+    );
+
+    expect(fingerprintWith).not.toBe(fingerprintWithout);
+  });
+});
+
+describe("buildQueryAnalysisSystemContent — section coverage", () => {
+  const baseStrategy = {
+    queryCount: 10,
+    language: "en",
+    minDeterministicCount: 3,
+    intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+  };
+
+  it("does not include deals/M&A guidance when sectionCoverageEnabled is false", () => {
+    const result = buildQueryAnalysisSystemContent({ ...baseStrategy, sectionCoverageEnabled: false });
+
+    expect(result).not.toContain("Deals & Movements");
+    expect(result).not.toContain("M&A");
+  });
+
+  it("injects deals/M&A keyword guidance when sectionCoverageEnabled is true", () => {
+    const result = buildQueryAnalysisSystemContent({ ...baseStrategy, sectionCoverageEnabled: true });
+
+    expect(result).toContain("M&A");
+    expect(result).toContain("Deals & Movements");
+  });
+});
+
+describe("computeQueryAnalysisIntentTargetCounts — section coverage floor", () => {
+  it("does not change counts when sectionCoverageEnabled is false", () => {
+    const zeroWeights = Object.fromEntries(
+      QUERY_ANALYSIS_STANDARD_INTENTS.map((intent) => [intent, 0]),
+    ) as Record<(typeof QUERY_ANALYSIS_STANDARD_INTENTS)[number], number>;
+
+    const counts = computeQueryAnalysisIntentTargetCounts({
+      queryCount: 10,
+      intentWeights: { ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS, competitor: 0 },
+      sectionCoverageEnabled: false,
+    });
+
+    expect(counts.competitor).toBe(0);
+  });
+
+  it("bumps intents that map to a section to at least 1 when sectionCoverageEnabled", () => {
+    const withZeroCompetitor = {
+      ...DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+      competitor: 0,
+      industry_trend: 0,
+    };
+
+    const counts = computeQueryAnalysisIntentTargetCounts({
+      queryCount: 10,
+      intentWeights: withZeroCompetitor,
+      sectionCoverageEnabled: true,
+    });
+
+    expect(counts.competitor).toBeGreaterThanOrEqual(1);
+    expect(counts.industry_trend).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe("buildBrainstormPrompt — contract brief", () => {
+  const baseStrategy = {
+    queryCount: 10,
+    language: "en",
+    minDeterministicCount: 3,
+    intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+  };
+  const emptyContext = {
+    ticker: { id: "t1", symbol: "ACME", name: "Acme Co", metadata: null },
+    topEntities: [] as never[],
+    recentThemes: [] as never[],
+    headlineSamples: [] as never[],
+    kgNeighborhood: [] as never[],
+    peers: [] as never[],
+    calendar: { recentEventTypes: [] as never[] },
+    recentRelationDeltas: [] as never[],
+    sources: [] as never[],
+    priorYield: undefined,
+    competitors: [] as never[],
+    issuerAliases: [] as never[],
+  };
+
+  it("does not include product_contract block when no brief", () => {
+    const { system } = buildBrainstormPrompt(baseStrategy, emptyContext as never);
+    expect(system).not.toContain("<product_contract>");
+  });
+
+  it("appends product_contract block when brief is present", () => {
+    const { system } = buildBrainstormPrompt(
+      { ...baseStrategy, brief: "Newsletter for executives." },
+      emptyContext as never,
+    );
+    expect(system).toContain("<product_contract>");
+    expect(system).toContain("Newsletter for executives.");
+  });
+});

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -8,11 +8,14 @@ import type {
 } from "@workspace/agent-runtime";
 import {
   QUERY_ANALYSIS_STANDARD_INTENTS,
+  SECTION_BY_INTENT,
   queryAnalysisIntentSchema,
+  sectionsWithoutDedicatedIntent,
   type GetQueryAnalysisResponse,
   type QueryAnalysisIntent,
   type QueryAnalysisIntentWeights,
 } from "@workspace/agent-data-api-contract";
+import { applyContractBrief } from "@workspace/agent-runtime";
 import { z } from "zod";
 
 import {
@@ -72,6 +75,10 @@ export type LlmQueryStrategyPrompt = {
   intentWeights: QueryAnalysisIntentWeights;
   /** Maximum words per generated keyword phrase. Defaults to 5 when omitted. */
   queryMaxWords?: number;
+  /** When true, reserves intent budget per newsletter section and injects keyword guidance for starved sections. */
+  sectionCoverageEnabled?: boolean;
+  /** Opaque product brief from the Agent Contract; appended to the system prompt when present. */
+  brief?: string;
 };
 
 const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_STANDARD_INTENTS.map(
@@ -81,11 +88,15 @@ const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_STANDARD_INTENTS.map(
 /**
  * Computes approximate LLM target counts per standard intent from strategy weights.
  *
+ * When `sectionCoverageEnabled` is true, intents that map to a newsletter section via
+ * {@link SECTION_BY_INTENT} are guaranteed at least 1 query, so every section with a
+ * dedicated intent has upstream search budget.
+ *
  * @param strategy - Query budget and relative intent weights for the language slice.
  * @returns Rounded target count per standard intent label.
  */
 export const computeQueryAnalysisIntentTargetCounts = (
-  strategy: Pick<LlmQueryStrategyPrompt, "queryCount" | "intentWeights">,
+  strategy: Pick<LlmQueryStrategyPrompt, "queryCount" | "intentWeights" | "sectionCoverageEnabled">,
 ): Record<(typeof QUERY_ANALYSIS_STANDARD_INTENTS)[number], number> => {
   const sum = QUERY_ANALYSIS_STANDARD_INTENTS.reduce(
     (total, intent) => total + strategy.intentWeights[intent],
@@ -102,13 +113,26 @@ export const computeQueryAnalysisIntentTargetCounts = (
         : 1 / QUERY_ANALYSIS_STANDARD_INTENTS.length;
     counts[intent] = Math.round(ratio * strategy.queryCount);
   }
+  if (strategy.sectionCoverageEnabled) {
+    for (const intent of QUERY_ANALYSIS_STANDARD_INTENTS) {
+      if (SECTION_BY_INTENT[intent] !== null && counts[intent] < 1) {
+        counts[intent] = 1;
+      }
+    }
+  }
   return counts;
 };
 
 /**
  * Builds the query-analysis system prompt with inline strategy interpolation.
  *
- * @param strategy - Strategy knobs for language lock, intent targets, and deterministic floor.
+ * When `strategy.sectionCoverageEnabled` is true, appends explicit keyword guidance
+ * for newsletter sections that have no dedicated intent (e.g. Deals & Movements).
+ *
+ * When `strategy.brief` is set, the opaque product contract brief is appended via
+ * {@link applyContractBrief} so the LLM knows the end artifact it is feeding.
+ *
+ * @param strategy - Strategy knobs for language lock, intent targets, deterministic floor, and optional contract brief.
  * @returns System message content for the chat model.
  */
 export const buildQueryAnalysisSystemContent = (
@@ -124,7 +148,7 @@ export const buildQueryAnalysisSystemContent = (
       ? "Prefer 2–5 word keyword phrases."
       : `Prefer ${String(maxWords)}-word keyword phrases.`;
 
-  return [
+  const sections: string[] = [
     "You generate short keyword search queries for news monitoring.",
     `Return ONLY a JSON object matching the schema: { "queries": [ { "text": string, "intent": ${QUERY_ANALYSIS_INTENT_JSON_UNION} } ] }.`,
     `${phraseLengthHint} Do not write full sentences, questions, or analyst-style commentary.`,
@@ -152,7 +176,19 @@ export const buildQueryAnalysisSystemContent = (
       "- geopolitical: trade, sanctions, cross-border dynamics affecting the sector",
       "- industry_trend: sector outlook, analyst views on the industry overall",
     ].join("\n"),
-  ].join("\n\n");
+  ];
+
+  if (strategy.sectionCoverageEnabled) {
+    const homelessSections = sectionsWithoutDedicatedIntent();
+    if (homelessSections.includes("dealsAndMovements")) {
+      sections.push(
+        "Section coverage: Reserve 1–2 queries specifically for M&A deals, funding rounds, leadership appointments, and notable corporate actions — these feed the Deals & Movements section of the end product. Tag such queries with intent: \"breaking\" when time-sensitive or \"kg_change\" when structural.",
+      );
+    }
+  }
+
+  const base = sections.join("\n\n");
+  return applyContractBrief(base, strategy.brief !== undefined ? { brief: strategy.brief } : undefined);
 };
 
 /**
@@ -290,6 +326,9 @@ const BRAINSTORM_SYSTEM_PROMPT = [
 /**
  * Builds the system and user messages for the brainstorm pass.
  *
+ * When `strategy.brief` is set, appends the product contract brief to the brainstorm
+ * system prompt so the brainstorm angles are oriented toward the end artifact.
+ *
  * @param strategy - Strategy knobs (languages inform phrasing expectations).
  * @param context - Live GET /query-analysis payload.
  * @returns System and user content for `generateText`.
@@ -297,13 +336,16 @@ const BRAINSTORM_SYSTEM_PROMPT = [
 export const buildBrainstormPrompt = (
   strategy: LlmQueryStrategyPrompt,
   context: GetQueryAnalysisResponse,
-): { system: string; user: string } => ({
-  system: [
+): { system: string; user: string } => {
+  const baseSystem = [
     BRAINSTORM_SYSTEM_PROMPT,
     `Write angles in ${strategy.language}. Do not translate ticker symbols or proper nouns.`,
-  ].join("\n\n"),
-  user: serializeQueryAnalysisContextBlock(context, strategy.language),
-});
+  ].join("\n\n");
+  return {
+    system: applyContractBrief(baseSystem, strategy.brief !== undefined ? { brief: strategy.brief } : undefined),
+    user: serializeQueryAnalysisContextBlock(context, strategy.language),
+  };
+};
 
 /**
  * Parses brainstorm model output into trimmed bullet strings.

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -96,7 +96,10 @@ const QUERY_ANALYSIS_INTENT_JSON_UNION = QUERY_ANALYSIS_STANDARD_INTENTS.map(
  * @returns Rounded target count per standard intent label.
  */
 export const computeQueryAnalysisIntentTargetCounts = (
-  strategy: Pick<LlmQueryStrategyPrompt, "queryCount" | "intentWeights" | "sectionCoverageEnabled">,
+  strategy: Pick<
+    LlmQueryStrategyPrompt,
+    "queryCount" | "intentWeights" | "sectionCoverageEnabled"
+  >,
 ): Record<(typeof QUERY_ANALYSIS_STANDARD_INTENTS)[number], number> => {
   const sum = QUERY_ANALYSIS_STANDARD_INTENTS.reduce(
     (total, intent) => total + strategy.intentWeights[intent],
@@ -182,13 +185,16 @@ export const buildQueryAnalysisSystemContent = (
     const homelessSections = sectionsWithoutDedicatedIntent();
     if (homelessSections.includes("dealsAndMovements")) {
       sections.push(
-        "Section coverage: Reserve 1–2 queries specifically for M&A deals, funding rounds, leadership appointments, and notable corporate actions — these feed the Deals & Movements section of the end product. Tag such queries with intent: \"breaking\" when time-sensitive or \"kg_change\" when structural.",
+        'Section coverage: Reserve 1–2 queries specifically for M&A deals, funding rounds, leadership appointments, and notable corporate actions — these feed the Deals & Movements section of the end product. Tag such queries with intent: "breaking" when time-sensitive or "kg_change" when structural.',
       );
     }
   }
 
   const base = sections.join("\n\n");
-  return applyContractBrief(base, strategy.brief !== undefined ? { brief: strategy.brief } : undefined);
+  return applyContractBrief(
+    base,
+    strategy.brief !== undefined ? { brief: strategy.brief } : undefined,
+  );
 };
 
 /**
@@ -342,7 +348,10 @@ export const buildBrainstormPrompt = (
     `Write angles in ${strategy.language}. Do not translate ticker symbols or proper nouns.`,
   ].join("\n\n");
   return {
-    system: applyContractBrief(baseSystem, strategy.brief !== undefined ? { brief: strategy.brief } : undefined),
+    system: applyContractBrief(
+      baseSystem,
+      strategy.brief !== undefined ? { brief: strategy.brief } : undefined,
+    ),
     user: serializeQueryAnalysisContextBlock(context, strategy.language),
   };
 };

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -434,7 +434,9 @@ export const runLanguageQuerySlice = async (params: {
     intentWeights: shared.intentWeights,
     queryMaxWords: shared.queryMaxWords,
     sectionCoverageEnabled: shared.sectionCoverageEnabled,
-    ...(shared.contractBrief !== undefined ? { brief: shared.contractBrief } : {}),
+    ...(shared.contractBrief !== undefined
+      ? { brief: shared.contractBrief }
+      : {}),
   };
 
   const systemContent = buildQueryAnalysisSystemContent(strategyPrompt);

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -381,6 +381,10 @@ type LanguageSliceSharedConfig = {
     description?: string,
     status?: "processing" | "completed",
   ) => void;
+  /** Opaque product brief from the Agent Contract; threaded into every system prompt. */
+  contractBrief?: string;
+  /** When true, enables the section-coverage path in query generation. */
+  sectionCoverageEnabled: boolean;
 };
 
 /**
@@ -429,6 +433,8 @@ export const runLanguageQuerySlice = async (params: {
     minDeterministicCount: params.minDeterministicCount,
     intentWeights: shared.intentWeights,
     queryMaxWords: shared.queryMaxWords,
+    sectionCoverageEnabled: shared.sectionCoverageEnabled,
+    ...(shared.contractBrief !== undefined ? { brief: shared.contractBrief } : {}),
   };
 
   const systemContent = buildQueryAnalysisSystemContent(strategyPrompt);
@@ -642,7 +648,7 @@ export const concatenateLanguageMergedRows = (
 export const runQueryAnalysis = async (
   context: AgentRunContext<QueryAnalysisInput, QueryAnalysisConfig>,
 ): Promise<AgentRunResult> => {
-  const { input, config, token, hermesCorrelation } = context;
+  const { input, config, token, hermesCorrelation, contract } = context;
   const runStartMs = Date.now();
   const client = createAgentDataApiClient({
     baseUrl: env.AGENT_DATA_API_URL,
@@ -687,6 +693,7 @@ export const runQueryAnalysis = async (
 
   const templatePack = templates.templatePack;
   const kgTemplateCap = templates.kgTemplateCap;
+  const sectionCoverageEnabled = output.sectionCoverage.enabled;
   const queryCount = output.queryCount;
   const wildcardFraction = creativity.wildcardFraction;
   const wildcardCount = computeWildcardCount(queryCount, wildcardFraction);
@@ -779,6 +786,8 @@ export const runQueryAnalysis = async (
       minDeterministicCount,
       intentWeights,
       queryMaxWords,
+      sectionCoverageEnabled,
+      ...(contract !== undefined ? { brief: contract.brief } : {}),
     }),
     buildQueryAnalysisUserContent(queryContext, primaryLanguage),
   );
@@ -806,6 +815,8 @@ export const runQueryAnalysis = async (
     yieldFeedback,
     priorYield: yieldFeedback.enabled ? queryContext.priorYield : undefined,
     reportActivity: report,
+    sectionCoverageEnabled,
+    ...(contract !== undefined ? { contractBrief: contract.brief } : {}),
   };
 
   const deterministicCount = distributedStandard.reduce(
@@ -967,6 +978,8 @@ export const runQueryAnalysis = async (
     languageQuotas,
     minDeterministicCount,
     intentWeights,
+    ...(contract !== undefined ? { contractVersion: contract.version } : {}),
+    ...(sectionCoverageEnabled ? { sectionCoverageEnabled: true } : {}),
     ...(appliedEventBias !== undefined
       ? {
           appliedEventBias: {


### PR DESCRIPTION
## Summary

Pipeline steps can already attach an agent contract, but query-analysis and content-generation were not using the brief in their prompts. This PR threads the contract into both agents via `applyContractBrief`, and adds an optional `output.sectionCoverage` flag so query-analysis can reserve search budget for newsletter sections that normally get starved (especially Deals & Movements).

## Related issues

Closes #657

## Important changes

- **Query-analysis:** `contract.brief` flows into the main system prompt and brainstorm system prompt; prompt fingerprints change only when a brief is present.
- **Query-analysis:** New `output.sectionCoverage.enabled` (default `false`). When on, each intent that maps to a newsletter section gets at least one query target, and the system prompt adds M&A / Deals & Movements keyword guidance.
- **Content-generation:** `contract.brief` is passed into `generateNewsletterWithLlm` and appended to the substituted system prompt so `computePromptHash` reflects the full prompt.

## Other changes

- Run output may include `contractVersion` and `sectionCoverageEnabled` when those paths are active.
- Reversibility tests assert prompts are unchanged when no contract brief is supplied.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/llm-queries.ts` — `applyContractBrief`, section coverage prompt block, intent target floor.
- `apps/mediapulse/agents/query-analysis/src/run.ts` — threads contract and `sectionCoverageEnabled` through the run.
- `apps/mediapulse/agents/query-analysis/src/config-schema.ts` — `output.sectionCoverage` schema.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — brief on system prompt.
- `apps/mediapulse/agents/content-generation/src/run.ts` — passes `contract.brief` from `AgentRunContext`.
- `apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts` — brief and section coverage tests.

## How to test

1. `pnpm --filter @mediapulse/query-analysis test` and `pnpm --filter @mediapulse/content-generation test`
2. Attach a contract to a pipeline step in Hermes (see PR #656), run query-analysis with `output.sectionCoverage.enabled: true`, and confirm generated queries include M&A-style phrases and intent targets cover mapped sections.
3. Run content-generation on the same pipeline and inspect logs or returned `systemPrompt` for a `<product_contract>` block containing the contract brief.
4. Run both agents without a contract and confirm prompts do not contain `<product_contract>` (reversibility tests cover this in CI).
