### PR TITLE
Add Serper scrape provider to data-collection fetch chain

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -8,6 +8,7 @@ import {
   defaultFetchProviders,
   defaultFirecrawlFetchProvider,
   defaultJinaFetchProvider,
+  defaultSerperFetchProvider,
   getConfigSchema,
   isUnresolvedVariablePlaceholder,
 } from "./config-schema";
@@ -66,14 +67,17 @@ describe("dataCollectionAgentConfigSchema", () => {
     });
     expect(
       parsed.providers.fetch.providers.map((provider) => provider.type),
-    ).toEqual(["diffbot", "firecrawl", "jina"]);
+    ).toEqual(["serper", "diffbot", "firecrawl", "jina"]);
     expect(parsed.providers.fetch.providers[0]).toMatchObject(
-      defaultDiffbotFetchProvider,
+      defaultSerperFetchProvider,
     );
     expect(parsed.providers.fetch.providers[1]).toMatchObject(
-      defaultFirecrawlFetchProvider,
+      defaultDiffbotFetchProvider,
     );
     expect(parsed.providers.fetch.providers[2]).toMatchObject(
+      defaultFirecrawlFetchProvider,
+    );
+    expect(parsed.providers.fetch.providers[3]).toMatchObject(
       defaultJinaFetchProvider,
     );
     expect(parsed.collection).toEqual({
@@ -121,12 +125,15 @@ describe("dataCollectionAgentConfigSchema", () => {
       "{{SERPER_API_KEY}}",
     );
     expect(parsed.providers.fetch.providers[0]?.authentication.apiKey).toBe(
-      "{{DIFFBOT_API_KEY}}",
+      "{{SERPER_API_KEY}}",
     );
     expect(parsed.providers.fetch.providers[1]?.authentication.apiKey).toBe(
-      "{{FIRECRAWL_API_KEY}}",
+      "{{DIFFBOT_API_KEY}}",
     );
     expect(parsed.providers.fetch.providers[2]?.authentication.apiKey).toBe(
+      "{{FIRECRAWL_API_KEY}}",
+    );
+    expect(parsed.providers.fetch.providers[3]?.authentication.apiKey).toBe(
       "{{JINA_API_KEY}}",
     );
     expect(parsed.deduplication.openaiApiKey).toBe("{{OPENAI_API_KEY}}");
@@ -145,7 +152,7 @@ describe("dataCollectionAgentConfigSchema", () => {
     expect(parsed.collection.perRunFetchBudget).toBe(12);
     expect(parsed.collection.perQueryFetchBudget).toBe(5);
     expect(parsed.collection.targetDailySuccessfulSources).toBe(5);
-    expect(parsed.providers.fetch.providers).toHaveLength(3);
+    expect(parsed.providers.fetch.providers).toHaveLength(4);
     expect(parsed.runPolicy.failOnZeroSuccess).toBe(false);
   });
 
@@ -243,6 +250,7 @@ describe("dataCollectionAgentConfigSchema", () => {
 
   it("exports the default fetch chain in recommended order", () => {
     expect(defaultFetchProviders.map((provider) => provider.type)).toEqual([
+      "serper",
       "diffbot",
       "firecrawl",
       "jina",

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -117,7 +117,9 @@ const searchProviderSchema = z.object({
 export const fetchProviderConfigSchema = z.object({
   type: z
     .string()
-    .describe("Fetch adapter identifier such as diffbot, firecrawl, or jina."),
+    .describe(
+      "Fetch adapter identifier such as serper, diffbot, firecrawl, or jina.",
+    ),
   baseUrl: z.string().describe("Provider base URL for this adapter."),
   authentication: authenticationSchema.describe(
     "Provider credentials or Hermes variable placeholders.",
@@ -135,6 +137,21 @@ export const fetchProviderConfigSchema = z.object({
     .describe("HTTP request timeout in milliseconds."),
   retry: retrySchema.default(fetchDefaultRetry).optional(),
 });
+
+/** Recommended Serper scrape provider defaults for the fetch chain. */
+export const defaultSerperFetchProvider = {
+  type: "serper",
+  baseUrl: "https://scrape.serper.dev",
+  authentication: {
+    type: "none" as const,
+    apiKey: "{{SERPER_API_KEY}}",
+    headerName: "X-API-KEY",
+  },
+  rateLimit: { requests: 1, perSeconds: 1 },
+  concurrency: 1,
+  timeoutMs: 45_000,
+  retry: fetchDefaultRetry,
+};
 
 /** Recommended Diffbot provider defaults for the fetch chain. */
 export const defaultDiffbotFetchProvider = {
@@ -180,8 +197,9 @@ export const defaultJinaFetchProvider = {
   retry: fetchDefaultRetry,
 };
 
-/** Default ordered fetch-provider chain: Diffbot, then Firecrawl, then Jina. */
+/** Default ordered fetch-provider chain: Serper, then Diffbot, then Firecrawl, then Jina. */
 export const defaultFetchProviders = [
+  defaultSerperFetchProvider,
   defaultDiffbotFetchProvider,
   defaultFirecrawlFetchProvider,
   defaultJinaFetchProvider,

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/registry.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/registry.ts
@@ -1,6 +1,7 @@
 import { createDiffbotFetchProvider } from "./diffbot";
 import { createFirecrawlFetchProvider } from "./firecrawl";
 import { createJinaFetchProvider } from "./jina";
+import { createSerperFetchProvider } from "./serper";
 
 import type { FetchProvider, FetchProviderConfig } from "./types";
 
@@ -15,6 +16,8 @@ export const createFetchProvider = (
   config: FetchProviderConfig,
 ): FetchProvider => {
   switch (config.type) {
+    case "serper":
+      return createSerperFetchProvider(config);
     case "jina":
       return createJinaFetchProvider(config);
     case "firecrawl":

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.test.ts
@@ -1,0 +1,129 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type got from "got";
+
+import { createSerperFetchProvider } from "./serper";
+import type { FetchProviderConfig } from "./types";
+import { mockRateLimiter } from "./test-fixtures";
+
+const defaultConfig: FetchProviderConfig = {
+  type: "serper",
+  baseUrl: "https://scrape.serper.dev",
+  authentication: {
+    type: "none",
+    apiKey: "serper-key",
+    headerName: "X-API-KEY",
+  },
+  rateLimit: { requests: 2, perSeconds: 1 },
+  concurrency: 4,
+};
+
+/** Builds a got POST response stub with HTTP status metadata. */
+const mockGotPostResponse = (jsonValue: unknown, statusCode = 200) => ({
+  statusCode,
+  body: JSON.stringify(jsonValue),
+});
+
+describe("createSerperFetchProvider", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parses and normalizes a successful Serper response", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        text: "Article body",
+        metadata: {
+          title: "Article title",
+          "article:published_time": "2026-04-12T08:00:00.000Z",
+        },
+      }),
+    );
+    const provider = createSerperFetchProvider(defaultConfig);
+
+    // Act
+    const result = await provider.fetchOne("http://example.com", {
+      gotClient: { post: postMock } as unknown as typeof got,
+      rateLimiter: mockRateLimiter(),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(postMock).toHaveBeenCalledWith(
+      "https://scrape.serper.dev",
+      expect.objectContaining({
+        json: { url: "http://example.com" },
+        headers: expect.objectContaining({
+          "X-API-KEY": "serper-key",
+        }),
+      }),
+    );
+    expect(result).toEqual({
+      content: "Article body",
+      title: "Article title",
+      publishedTime: "2026-04-12T08:00:00.000Z",
+    });
+  });
+
+  it("normalizes a response without metadata", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        text: "Article body",
+      }),
+    );
+    const provider = createSerperFetchProvider(defaultConfig);
+
+    // Act
+    const result = await provider.fetchOne("http://example.com", {
+      gotClient: { post: postMock } as unknown as typeof got,
+      rateLimiter: mockRateLimiter(),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(result).toEqual({
+      content: "Article body",
+    });
+  });
+
+  it("throws on schema mismatch", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        text: 123,
+      }),
+    );
+    const provider = createSerperFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: mockRateLimiter(),
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("throws when text is empty", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        text: "  ",
+      }),
+    );
+    const provider = createSerperFetchProvider(defaultConfig);
+
+    // Act + Assert
+    await expect(
+      provider.fetchOne("http://example.com", {
+        gotClient: { post: postMock } as unknown as typeof got,
+        rateLimiter: mockRateLimiter(),
+        logger: { info: vi.fn(), warn: vi.fn() },
+      }),
+    ).rejects.toThrow("Semantic validation failed");
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+
+import { withRetry } from "../resilience";
+import { isRetryableError } from "../error-classification";
+
+import type {
+  FetchProvider,
+  FetchProviderConfig,
+  NormalizedFetchData,
+  ProviderRequestContext,
+} from "./types";
+
+/** Zod schema for the Serper scrape API response. */
+const serperResponseSchema = z.object({
+  text: z.string().optional(),
+  metadata: z
+    .object({
+      title: z.string().optional(),
+      "article:published_time": z.string().optional(),
+      "article:modified_time": z.string().optional(),
+    })
+    .passthrough()
+    .optional(),
+});
+
+/**
+ * Builds the API-key header from provider authentication config.
+ *
+ * @param config - Serper provider configuration.
+ */
+const buildAuthHeaders = (
+  config: FetchProviderConfig,
+): Record<string, string> => {
+  const headers: Record<string, string> = {};
+  if (config.authentication.apiKey && config.authentication.headerName) {
+    headers[config.authentication.headerName] = config.authentication.apiKey;
+  }
+  return headers;
+};
+
+/**
+ * Parses and validates a Serper scrape response body.
+ *
+ * @param raw - Parsed JSON body from the HTTP response.
+ */
+const parseSerperResponse = (raw: unknown): NormalizedFetchData => {
+  const parsed = serperResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw parsed.error;
+  }
+
+  const text = parsed.data.text;
+  if (!text || text.trim() === "") {
+    throw new Error("Semantic validation failed");
+  }
+
+  const metadata = parsed.data.metadata;
+  const publishedTime = metadata?.["article:published_time"];
+  return {
+    content: text,
+    ...(metadata?.title ? { title: metadata.title } : {}),
+    ...(publishedTime ? { publishedTime } : {}),
+  };
+};
+
+/**
+ * Executes one Serper scrape for a URL.
+ *
+ * @param url - Target page URL.
+ * @param config - Serper provider configuration.
+ * @param ctx - Shared request context.
+ */
+const fetchOneSerper = async (
+  url: string,
+  config: FetchProviderConfig,
+  ctx: ProviderRequestContext,
+): Promise<NormalizedFetchData> => {
+  await ctx.rateLimiter.acquire();
+
+  const fetchTask = async () => {
+    const response = await ctx.gotClient.post(config.baseUrl, {
+      json: { url },
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...buildAuthHeaders(config),
+      },
+      timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+    });
+    ctx.rateLimiter.recordResponse(response.statusCode);
+    const raw = JSON.parse(response.body) as unknown;
+    return parseSerperResponse(raw);
+  };
+
+  return config.retry
+    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    : await fetchTask();
+};
+
+/**
+ * Creates a Serper scrape fetch provider adapter.
+ *
+ * @param config - Serper provider configuration.
+ */
+export const createSerperFetchProvider = (
+  config: FetchProviderConfig,
+): FetchProvider => ({
+  type: "serper",
+  fetchOne: (url, ctx) => fetchOneSerper(url, config, ctx),
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-fetch.ts
@@ -19,7 +19,7 @@ import { hostFromUrl } from "./host-error-tracker";
 
 export type WebFetchProviderName = Extract<
   DataCollectionFailure["provider"],
-  "jina" | "firecrawl" | "diffbot"
+  "serper" | "jina" | "firecrawl" | "diffbot"
 >;
 
 export type FetchedWebSearchResult = WebSearchResult & {
@@ -66,6 +66,7 @@ type ProviderChainEntry = {
 };
 
 const WEB_FETCH_PROVIDER_NAMES = new Set<WebFetchProviderName>([
+  "serper",
   "jina",
   "firecrawl",
   "diffbot",


### PR DESCRIPTION
## Summary

Data collection can now scrape article pages through Serper before trying Diffbot, Firecrawl, or Jina. The agent already talks to Serper for search; this wires the scrape API into the fetch provider chain so Hermes configs can reuse `{{SERPER_API_KEY}}` and get a first-pass fetch without turning on another vendor.

## Related issues

Closes #661

## Important changes

- New `createSerperFetchProvider` posts to `https://scrape.serper.dev`, validates the JSON body, and maps text plus Open Graph dates into normalized fetch data.
- Fetch registry recognizes `serper`; default provider order is Serper → Diffbot → Firecrawl → Jina.
- Config schema exports `defaultSerperFetchProvider` (1 req/s rate limit, 45s timeout, fail-fast retry) and documents `serper` in fetch provider types.

## Other changes

- `web-fetch` provider union includes `serper`.
- Config schema tests assert the new default chain order.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.ts` — scrape adapter and response parsing.
- `apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/serper.test.ts` — auth header, success path, empty body error.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — defaults and chain ordering.
- `apps/mediapulse/agents/data-collection/src/utilities/fetch-providers/registry.ts` — provider wiring.

## How to test

1. Run `pnpm --filter @mediapulse/data-collection test` and `type:check`.
2. In Hermes, set `SERPER_API_KEY` on a data-collection pipeline step and run a collection with default fetch providers.
3. Confirm logs show Serper attempted first; on scrape failure, later providers in the chain still run.
