### PR TITLE
Add transient retries for article-analysis LLM extraction

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -287,6 +287,13 @@ export type ParallelismObservabilityAggregate = {
   deadlineFiredAtMs?: number;
 };
 
+export type ExtractionRetryObservabilityAggregate = {
+  sourcesRetried: number;
+  totalRetryAttempts: number;
+  recoveredByRetry: number;
+  exhausted: number;
+};
+
 /** Per-source latency samples collected during parallel extraction. */
 export type PerSourceLatencyObservability = {
   extractionMs: number[];
@@ -382,6 +389,7 @@ export type ArticleAnalysisRunSummaryInput = {
   llmPromptFingerprint?: string;
   parallelism?: ParallelismObservabilityAggregate;
   perSourceLatency?: PerSourceLatencyObservability;
+  extractionRetries?: ExtractionRetryObservabilityAggregate;
 };
 
 /**
@@ -738,6 +746,10 @@ export const buildArticleAnalysisRunSummaryPayload = (
 
   if (input.parallelism !== undefined) {
     base.parallelism = input.parallelism;
+  }
+
+  if (input.extractionRetries !== undefined) {
+    base.extractionRetries = input.extractionRetries;
   }
 
   return base;

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -148,6 +148,15 @@ export const articleAnalysisConfigSchema = z
     /** Initial backoff in ms; delay doubles each retry (`base * 2^attempt`). */
     postTransientRetryBaseDelayMs: z.number().int().positive().optional(),
     /**
+     * Retries after the first LLM extraction attempt when a transient error is classified
+     * (rate limit, empty completion, timeout, 5xx). 0 disables retries.
+     */
+    extractionTransientRetries: z.number().int().min(0).max(5).optional(),
+    /** Initial backoff in ms for extraction retries (full-jitter exponential). */
+    extractionTransientRetryBaseDelayMs: z.number().int().positive().optional(),
+    /** Cap on jittered backoff in ms for extraction retries. */
+    extractionTransientRetryMaxDelayMs: z.number().int().positive().optional(),
+    /**
      * Cap on data sources loaded and processed per run
      * (also bounds `analysis.get` `limit` together with `analysisGetDataSourceLimitMax`).
      * Override in Hermes agent config; package default applies when omitted.
@@ -246,6 +255,9 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   runPolicy: ArticleAnalysisRunPolicy;
   postTransientRetries: number;
   postTransientRetryBaseDelayMs: number;
+  extractionTransientRetries: number;
+  extractionTransientRetryBaseDelayMs: number;
+  extractionTransientRetryMaxDelayMs: number;
   debounceMinUnanalyzedCount: number;
   debounceMinMinutesSinceLastScore: number;
   /** Cap on sources per run (Hermes agent config). */
@@ -301,6 +313,9 @@ export const articleAnalysisConfigDefaults = {
   },
   postTransientRetries: 0,
   postTransientRetryBaseDelayMs: 500,
+  extractionTransientRetries: 2,
+  extractionTransientRetryBaseDelayMs: 500,
+  extractionTransientRetryMaxDelayMs: 8000,
   debounceMinUnanalyzedCount: 0,
   debounceMinMinutesSinceLastScore: 0,
   maxBatchSize: 10,
@@ -469,6 +484,15 @@ export const resolveArticleAnalysisConfig = (
     postTransientRetryBaseDelayMs:
       config.postTransientRetryBaseDelayMs ??
       articleAnalysisConfigDefaults.postTransientRetryBaseDelayMs,
+    extractionTransientRetries:
+      config.extractionTransientRetries ??
+      articleAnalysisConfigDefaults.extractionTransientRetries,
+    extractionTransientRetryBaseDelayMs:
+      config.extractionTransientRetryBaseDelayMs ??
+      articleAnalysisConfigDefaults.extractionTransientRetryBaseDelayMs,
+    extractionTransientRetryMaxDelayMs:
+      config.extractionTransientRetryMaxDelayMs ??
+      articleAnalysisConfigDefaults.extractionTransientRetryMaxDelayMs,
     debounceMinUnanalyzedCount:
       config.debounceMinUnanalyzedCount ??
       articleAnalysisConfigDefaults.debounceMinUnanalyzedCount,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -1,5 +1,6 @@
 /** @vitest-environment node */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { APICallError, NoObjectGeneratedError } from "ai";
 
 import type { ResolvedExemplar } from "./exemplars/default-extraction-exemplars.js";
 import {
@@ -18,6 +19,8 @@ import {
   buildRelationCritiqueSystemContent,
   buildRelationCritiqueUserContent,
   buildVocabularyRepairSystemContent,
+  classifyLlmExtractionError,
+  executeLlmCallWithTransientRetries,
   extractEntitiesAndRelationsForSource,
   repairExtractionVocabulary,
   vocabularyRepairPreservesIdentity,
@@ -733,5 +736,228 @@ describe("normalizeLlmUsageFromSdk", () => {
       outputTokens: 1,
       totalTokens: 99,
     });
+  });
+});
+
+describe("classifyLlmExtractionError", () => {
+  it("classifies APICallError with status 429 as transient", () => {
+    const error = new APICallError({
+      message: "rate limited",
+      url: "https://api.openai.com",
+      requestBodyValues: {},
+      statusCode: 429,
+      isRetryable: false,
+    });
+
+    expect(classifyLlmExtractionError(error)).toBe("transient");
+  });
+
+  it("classifies APICallError with status 503 as transient", () => {
+    const error = new APICallError({
+      message: "service unavailable",
+      url: "https://api.openai.com",
+      requestBodyValues: {},
+      statusCode: 503,
+      isRetryable: false,
+    });
+
+    expect(classifyLlmExtractionError(error)).toBe("transient");
+  });
+
+  it("classifies APICallError with isRetryable=true as transient regardless of status", () => {
+    const error = new APICallError({
+      message: "retryable error",
+      url: "https://api.openai.com",
+      requestBodyValues: {},
+      isRetryable: true,
+    });
+
+    expect(classifyLlmExtractionError(error)).toBe("transient");
+  });
+
+  it("classifies NoObjectGeneratedError with no-response message as transient", () => {
+    const error = new NoObjectGeneratedError({
+      message: "No object generated: the model did not return a response.",
+      response: {
+        id: "test-id",
+        modelId: "gpt-4o-mini",
+        timestamp: new Date(),
+      },
+      usage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+      },
+      finishReason: "stop",
+    });
+
+    expect(classifyLlmExtractionError(error)).toBe("transient");
+  });
+
+  it("classifies timeout message strings as transient", () => {
+    expect(classifyLlmExtractionError(new Error("request timed out"))).toBe(
+      "transient",
+    );
+    expect(classifyLlmExtractionError(new Error("ETIMEDOUT"))).toBe(
+      "transient",
+    );
+    expect(classifyLlmExtractionError(new Error("ECONNRESET"))).toBe(
+      "transient",
+    );
+  });
+
+  it("classifies parse failure message as permanent", () => {
+    expect(
+      classifyLlmExtractionError(
+        new Error("could not parse the response from OpenAI"),
+      ),
+    ).toBe("permanent");
+  });
+
+  it("classifies generic Error as permanent", () => {
+    expect(classifyLlmExtractionError(new Error("unexpected error"))).toBe(
+      "permanent",
+    );
+  });
+});
+
+describe("executeLlmCallWithTransientRetries", () => {
+  it("resolves immediately when operation succeeds on first attempt", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const operation = vi.fn().mockResolvedValue("ok");
+
+    const result = await executeLlmCallWithTransientRetries(operation, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+      maxDelayMs: 1000,
+      sleep: fakeSleep,
+      classify: () => "transient",
+    });
+
+    expect(result).toBe("ok");
+    expect(operation).toHaveBeenCalledOnce();
+    expect(fakeSleep).not.toHaveBeenCalled();
+  });
+
+  it("retries transient failures and resolves when the operation eventually succeeds", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const transientError = new Error("rate limited");
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(transientError)
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValue("recovered");
+    let retryCallCount = 0;
+
+    const result = await executeLlmCallWithTransientRetries(operation, {
+      maxRetries: 2,
+      baseDelayMs: 100,
+      maxDelayMs: 1000,
+      sleep: fakeSleep,
+      classify: () => "transient",
+      onRetry: () => {
+        retryCallCount++;
+      },
+    });
+
+    expect(result).toBe("recovered");
+    expect(fakeSleep).toHaveBeenCalledTimes(2);
+    expect(retryCallCount).toBe(2);
+    const firstDelay = fakeSleep.mock.calls[0]?.[0] as number;
+    const secondDelay = fakeSleep.mock.calls[1]?.[0] as number;
+    expect(firstDelay).toBeGreaterThanOrEqual(0);
+    expect(firstDelay).toBeLessThanOrEqual(100);
+    expect(secondDelay).toBeGreaterThanOrEqual(0);
+    expect(secondDelay).toBeLessThanOrEqual(200);
+  });
+
+  it("rethrows after exhausting maxRetries", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const transientError = new Error("still failing");
+    const operation = vi.fn().mockRejectedValue(transientError);
+
+    await expect(
+      executeLlmCallWithTransientRetries(operation, {
+        maxRetries: 1,
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        sleep: fakeSleep,
+        classify: () => "transient",
+      }),
+    ).rejects.toThrow("still failing");
+
+    expect(operation).toHaveBeenCalledTimes(2);
+    expect(fakeSleep).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows immediately without sleeping when classification is permanent", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const permanentError = new Error("could not parse");
+    const operation = vi.fn().mockRejectedValue(permanentError);
+
+    await expect(
+      executeLlmCallWithTransientRetries(operation, {
+        maxRetries: 2,
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        sleep: fakeSleep,
+        classify: () => "permanent",
+      }),
+    ).rejects.toThrow("could not parse");
+
+    expect(operation).toHaveBeenCalledOnce();
+    expect(fakeSleep).not.toHaveBeenCalled();
+  });
+
+  it("stops retrying when shouldAbort returns true before sleep", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const transientError = new Error("transient");
+    const operation = vi.fn().mockRejectedValue(transientError);
+    const shouldAbort = vi.fn().mockReturnValue(true);
+
+    await expect(
+      executeLlmCallWithTransientRetries(operation, {
+        maxRetries: 3,
+        baseDelayMs: 100,
+        maxDelayMs: 1000,
+        sleep: fakeSleep,
+        classify: () => "transient",
+        shouldAbort,
+      }),
+    ).rejects.toThrow("transient");
+
+    expect(fakeSleep).not.toHaveBeenCalled();
+  });
+
+  it("delays are bounded by maxDelayMs", async () => {
+    const fakeSleep = vi.fn().mockResolvedValue(undefined);
+    const transientError = new Error("rate limited");
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(transientError)
+      .mockRejectedValueOnce(transientError)
+      .mockRejectedValueOnce(transientError)
+      .mockResolvedValue("ok");
+
+    await executeLlmCallWithTransientRetries(operation, {
+      maxRetries: 3,
+      baseDelayMs: 10000,
+      maxDelayMs: 50,
+      sleep: fakeSleep,
+      classify: () => "transient",
+    });
+
+    for (const call of fakeSleep.mock.calls) {
+      expect(call[0] as number).toBeLessThanOrEqual(50);
+    }
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -1,5 +1,11 @@
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateObject, generateText, type ModelMessage } from "ai";
+import {
+  generateObject,
+  generateText,
+  APICallError,
+  NoObjectGeneratedError,
+  type ModelMessage,
+} from "ai";
 import {
   buildOpenAiReasoningProviderOptions,
   type OpenAiReasoningProviderOptions,
@@ -103,6 +109,93 @@ export type GenerateTextForBrainstorm = (args: {
   messages: ModelMessage[];
   providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<ArticleBrainstormCallResult>;
+
+/**
+ * Classifies an LLM extraction error as transient or permanent.
+ *
+ * Transient errors are safe to retry (rate limits, empty completions, timeouts, 5xx).
+ * Permanent errors should not be retried (parse failures, unknown categories).
+ *
+ * @param error - Thrown value from an LLM extraction call.
+ * @returns Classification driving retry vs. immediate failure.
+ */
+export const classifyLlmExtractionError = (
+  error: unknown,
+): "transient" | "permanent" => {
+  if (APICallError.isInstance(error)) {
+    const statusCode = error.statusCode;
+    if (
+      error.isRetryable ||
+      statusCode === 429 ||
+      (statusCode !== undefined && statusCode >= 500 && statusCode <= 599)
+    ) {
+      return "transient";
+    }
+  }
+  if (NoObjectGeneratedError.isInstance(error)) {
+    if (error.message.includes("the model did not return a response")) {
+      return "transient";
+    }
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  if (
+    message.includes("timed out") ||
+    message.includes("ETIMEDOUT") ||
+    message.includes("ECONNRESET")
+  ) {
+    return "transient";
+  }
+  return "permanent";
+};
+
+/**
+ * Runs an async LLM operation with transient-error retry and jittered exponential backoff.
+ *
+ * Delay formula: `random() * min(maxDelayMs, baseDelayMs * 2^attempt)` (full jitter).
+ * Full jitter prevents concurrent extractions (plan 36) from retrying in lockstep.
+ *
+ * @param operation - Async LLM call to attempt.
+ * @param deps - Retry limits, injectable sleep, classifier, and optional abort predicate.
+ * @returns The fulfilled result from `operation`.
+ * @throws The last error when retries are exhausted, classification is permanent, or shouldAbort fires.
+ */
+export const executeLlmCallWithTransientRetries = async <T>(
+  operation: () => Promise<T>,
+  deps: {
+    maxRetries: number;
+    baseDelayMs: number;
+    maxDelayMs: number;
+    sleep: (ms: number) => Promise<void>;
+    classify: (error: unknown) => "transient" | "permanent";
+    onRetry?: (attempt: number, error: unknown) => void;
+    shouldAbort?: () => boolean;
+  },
+): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= deps.maxRetries; attempt++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error;
+      const mayRetry =
+        attempt < deps.maxRetries && deps.classify(error) === "transient";
+      if (!mayRetry) {
+        throw error;
+      }
+      deps.onRetry?.(attempt + 1, error);
+      const exponentialCap = Math.min(
+        deps.maxDelayMs,
+        deps.baseDelayMs * 2 ** attempt,
+      );
+      const jitteredDelay = Math.random() * exponentialCap;
+      if (deps.shouldAbort?.()) {
+        throw error;
+      }
+      await deps.sleep(jitteredDelay);
+    }
+  }
+  throw lastError;
+};
 
 /**
  * Maps OpenAI wire payload to the normalized extraction shape (null = none).

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -33,7 +33,9 @@ import {
   buildBrainstormUserContent,
   applyRelationCritiqueDrops,
   buildRelationCritiqueModelMessages,
+  classifyLlmExtractionError,
   critiqueExtractedRelations,
+  executeLlmCallWithTransientRetries,
   relationCritiqueRowKey,
   extractEntitiesAndRelationsForSource,
   fetchArticleBrainstorm,
@@ -123,6 +125,8 @@ export type SourceProcessingOutcome = {
   sourceQualityTier?: HostTier;
   sourceQualityRecencyHours?: number | null;
   sourceQualityScore?: number;
+  extractionRetryAttempts: number;
+  extractionRetrySucceeded: boolean;
 };
 
 /** Returns an empty per-source outcome for early-return paths. */
@@ -152,6 +156,8 @@ export const createEmptySourceProcessingOutcome =
     relationsCritiqueSkippedDueToDeadline: 0,
     relationsDroppedByCritique: 0,
     relationCritiqueCalls: 0,
+    extractionRetryAttempts: 0,
+    extractionRetrySucceeded: false,
   });
 
 export type ProcessOneSourceDeps = {
@@ -165,6 +171,7 @@ export type ProcessOneSourceDeps = {
   sourceQualityHostTiers: SourceQualityComputeCtx["hostTiers"];
   runStart: number;
   isRunDeadlineElapsed: () => boolean;
+  sleep: (ms: number) => Promise<void>;
   resolveAgainstExistingEntities: (
     entities: readonly EntityProposal[],
     relations: readonly RelationProposal[],
@@ -204,6 +211,7 @@ export const createProcessOneSource =
       dataApiClient,
       log,
       hardDeleteDataSource,
+      sleep,
     } = deps;
 
     const outcome = createEmptySourceProcessingOutcome();
@@ -298,30 +306,41 @@ export const createProcessOneSource =
           const brainstormProviderOptions = buildOpenAiReasoningProviderOptions(
             cfg.brainstormReasoningEffort,
           );
-          const brainstormResult = await fetchArticleBrainstorm({
-            apiKey: cfg.openaiApiKey,
-            model: cfg.brainstormModel,
-            maxOutputTokens: cfg.brainstormMaxOutputTokens,
-            messages: [
-              {
-                role: "system",
-                content: buildBrainstormSystemContent(ctx),
-              },
-              {
-                role: "user",
-                content: buildBrainstormUserContent({
-                  tickerId,
-                  tickerSymbol: ctx.ticker.symbol,
-                  tickerName: ctx.ticker.name,
-                  title: source.title,
-                  contentTruncated: truncated,
-                }),
-              },
-            ],
-            ...(brainstormProviderOptions !== undefined
-              ? { providerOptions: brainstormProviderOptions }
-              : {}),
-          });
+          const brainstormResult = await executeLlmCallWithTransientRetries(
+            () =>
+              fetchArticleBrainstorm({
+                apiKey: cfg.openaiApiKey,
+                model: cfg.brainstormModel,
+                maxOutputTokens: cfg.brainstormMaxOutputTokens,
+                messages: [
+                  {
+                    role: "system",
+                    content: buildBrainstormSystemContent(ctx),
+                  },
+                  {
+                    role: "user",
+                    content: buildBrainstormUserContent({
+                      tickerId,
+                      tickerSymbol: ctx.ticker.symbol,
+                      tickerName: ctx.ticker.name,
+                      title: source.title,
+                      contentTruncated: truncated,
+                    }),
+                  },
+                ],
+                ...(brainstormProviderOptions !== undefined
+                  ? { providerOptions: brainstormProviderOptions }
+                  : {}),
+              }),
+            {
+              maxRetries: cfg.extractionTransientRetries,
+              baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
+              maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+              sleep,
+              classify: classifyLlmExtractionError,
+              shouldAbort: isRunDeadlineElapsed,
+            },
+          );
           outcome.brainstormCalls = 1;
           outcome.brainstormLatencyMs = Date.now() - brainstormStartedAt;
           outcome.brainstormUsage = brainstormResult.usage;
@@ -352,28 +371,54 @@ export const createProcessOneSource =
       const extractionProviderOptions = buildOpenAiReasoningProviderOptions(
         cfg.extractionReasoningEffort,
       );
-      const extractedResult = await extractEntitiesAndRelationsForSource({
-        apiKey: cfg.openaiApiKey,
-        model: cfg.openaiModel,
-        maxOutputTokens: cfg.maxOutputTokens,
-        messages: [
-          { role: "system", content: systemContent },
-          {
-            role: "user",
-            content: extractionUserContent,
+      let extractionRetryAttempts = 0;
+      const extractedResult = await executeLlmCallWithTransientRetries(
+        () =>
+          extractEntitiesAndRelationsForSource({
+            apiKey: cfg.openaiApiKey,
+            model: cfg.openaiModel,
+            maxOutputTokens: cfg.maxOutputTokens,
+            messages: [
+              { role: "system", content: systemContent },
+              {
+                role: "user",
+                content: extractionUserContent,
+              },
+            ],
+            ...(resolvedExemplars.length > 0
+              ? { exemplars: resolvedExemplars }
+              : {}),
+            ...(brainstormText !== undefined ? { brainstormText } : {}),
+            ...(extractionProviderOptions !== undefined
+              ? { providerOptions: extractionProviderOptions }
+              : {}),
+          }),
+        {
+          maxRetries: cfg.extractionTransientRetries,
+          baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
+          maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+          sleep,
+          classify: classifyLlmExtractionError,
+          shouldAbort: isRunDeadlineElapsed,
+          onRetry: (attempt, error) => {
+            extractionRetryAttempts++;
+            log.warn(
+              {
+                dataSourceId: source.id,
+                stage: "extraction",
+                retryAttempt: attempt,
+                err: toSafeLogError(error),
+              },
+              "article-analysis LLM extraction transient failure; retrying",
+            );
           },
-        ],
-        ...(resolvedExemplars.length > 0
-          ? { exemplars: resolvedExemplars }
-          : {}),
-        ...(brainstormText !== undefined ? { brainstormText } : {}),
-        ...(extractionProviderOptions !== undefined
-          ? { providerOptions: extractionProviderOptions }
-          : {}),
-      });
+        },
+      );
       outcome.extractionLatencyMs = Date.now() - t0;
       outcome.extractionCalls = 1;
       outcome.extractionUsage = extractedResult.usage;
+      outcome.extractionRetryAttempts = extractionRetryAttempts;
+      outcome.extractionRetrySucceeded = extractionRetryAttempts > 0;
       const extracted = extractedResult.object;
 
       let entitiesForPipeline: EntityProposal[] = [...extracted.entities];
@@ -555,19 +600,30 @@ export const createProcessOneSource =
           const critiqueProviderOptions = buildOpenAiReasoningProviderOptions(
             cfg.relationCritiqueReasoningEffort,
           );
-          const critiqueResult = await critiqueExtractedRelations({
-            apiKey: cfg.openaiApiKey,
-            model: cfg.relationCritiqueModel,
-            maxOutputTokens: cfg.maxOutputTokens,
-            messages: buildRelationCritiqueModelMessages(ctx, {
-              articleTitle: source.title,
-              articleBody: source.content,
-              candidates: resolved.relations,
-            }),
-            ...(critiqueProviderOptions !== undefined
-              ? { providerOptions: critiqueProviderOptions }
-              : {}),
-          });
+          const critiqueResult = await executeLlmCallWithTransientRetries(
+            () =>
+              critiqueExtractedRelations({
+                apiKey: cfg.openaiApiKey,
+                model: cfg.relationCritiqueModel,
+                maxOutputTokens: cfg.maxOutputTokens,
+                messages: buildRelationCritiqueModelMessages(ctx, {
+                  articleTitle: source.title,
+                  articleBody: source.content,
+                  candidates: resolved.relations,
+                }),
+                ...(critiqueProviderOptions !== undefined
+                  ? { providerOptions: critiqueProviderOptions }
+                  : {}),
+              }),
+            {
+              maxRetries: cfg.extractionTransientRetries,
+              baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
+              maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+              sleep,
+              classify: classifyLlmExtractionError,
+              shouldAbort: isRunDeadlineElapsed,
+            },
+          );
           outcome.relationCritiqueCalls = 1;
           outcome.critiqueLatencyMs = Date.now() - critiqueStartedAt;
           outcome.relationsCritiquedSources = 1;

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -2926,4 +2926,113 @@ describe("run", () => {
       batchSize: 2,
     });
   });
+
+  it("recovers a transient extraction failure via retry and reports recoveredByRetry in the run summary", async () => {
+    // Setup
+    const { NoObjectGeneratedError } = await import("ai");
+    const noResponseError = new NoObjectGeneratedError({
+      message: "No object generated: the model did not return a response.",
+      response: { id: "r", modelId: "gpt-4o-mini", timestamp: new Date() },
+      usage: {
+        inputTokens: 0,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: 0,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: 0,
+      },
+      finishReason: "stop",
+    });
+    const goodResult = llmResult({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [],
+    });
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_2,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+          {
+            id: DS_ID_3,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource")
+      .mockResolvedValueOnce(goodResult)
+      .mockRejectedValueOnce(noResponseError)
+      .mockResolvedValueOnce(goodResult)
+      .mockResolvedValueOnce(goodResult);
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    // Act
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          extractionTransientRetries: 2,
+          extractionTransientRetryBaseDelayMs: 1,
+          extractionTransientRetryMaxDelayMs: 1,
+        },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(result.details?.extractionFailures).toHaveLength(0);
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect(
+      (summaryCall?.[0] as { extractionRetries?: { recoveredByRetry: number } })
+        .extractionRetries?.recoveredByRetry,
+    ).toBe(1);
+    expect(
+      (summaryCall?.[0] as { extractionFailuresLlm: number })
+        .extractionFailuresLlm,
+    ).toBe(0);
+  });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -61,8 +61,7 @@ import {
   type ChunkBuildParseCounts,
   type ExemplarsObservabilityAggregate,
   type LlmUsageTotals,
-  type RelationCritiqueObservabilityAggregate,
-  type VocabularyPartitioningObservabilityAggregate,
+  type ExtractionRetryObservabilityAggregate,
   type YieldSnapshot,
 } from "./article-analysis-observability.js";
 import {
@@ -385,6 +384,16 @@ export const run = async ({
               : {}),
           }
         : undefined),
+    extractionRetries:
+      summary.extractionRetries ??
+      (extractionRetriesSourcesRetried > 0
+        ? ({
+            sourcesRetried: extractionRetriesSourcesRetried,
+            totalRetryAttempts: extractionRetriesTotalAttempts,
+            recoveredByRetry: extractionRetriesRecoveredByRetry,
+            exhausted: extractionRetriesExhausted,
+          } satisfies ExtractionRetryObservabilityAggregate)
+        : undefined),
   });
 
   /**
@@ -536,6 +545,10 @@ export const run = async ({
   let articlesScoredTotal = 0;
   let articlesSelectedTotal = 0;
   let extractionSkippedDueToDeadline = 0;
+  let extractionRetriesSourcesRetried = 0;
+  let extractionRetriesTotalAttempts = 0;
+  let extractionRetriesRecoveredByRetry = 0;
+  let extractionRetriesExhausted = 0;
   let parallelPeakInFlight = 0;
   let parallelDeadlineFiredAtMs: number | undefined;
   const perSourceExtractionLatencyMs: number[] = [];
@@ -903,6 +916,15 @@ export const run = async ({
         sourceQualityRecencyHoursSum += outcome.sourceQualityRecencyHours;
         sourceQualityRecencyHoursCount += 1;
       }
+      if (outcome.extractionRetryAttempts > 0) {
+        extractionRetriesSourcesRetried += 1;
+        extractionRetriesTotalAttempts += outcome.extractionRetryAttempts;
+        if (outcome.extractionRetrySucceeded) {
+          extractionRetriesRecoveredByRetry += 1;
+        } else {
+          extractionRetriesExhausted += 1;
+        }
+      }
     };
 
     const processOneSource = createProcessOneSource({
@@ -920,6 +942,7 @@ export const run = async ({
       dataApiClient,
       log,
       hardDeleteDataSource: hardDeleteDataSourceById,
+      sleep: sleepMs,
     });
 
     const extractionDeadlineAtMs =


### PR DESCRIPTION
## Summary

Article-analysis runs now retry LLM extraction when the provider hiccups (rate limits, empty completions, timeouts, 5xx) instead of failing the source on the first transient error. Retries use full-jitter exponential backoff so parallel sources do not stampede, and the run summary reports how often retries recovered work vs gave up.

## Related issues

Closes #663

## Important changes

- `classifyLlmExtractionError` and `executeLlmCallWithTransientRetries` centralize transient vs permanent handling with jittered delays.
- Hermes config adds `extractionTransientRetries`, `extractionTransientRetryBaseDelayMs`, and `extractionTransientRetryMaxDelayMs` (defaults: 2 retries, 500ms base, 8000ms cap).
- Brainstorm, structured extraction, and relation critique LLM calls run through the retry helper in `run-process-one-source`.
- Run summary includes `extractionRetries`: sources retried, attempts, recovered, exhausted.

## Other changes

- `article-analysis-observability` types extended for extraction retry aggregates.
- Unit tests for classification, retry helper, and an integration path that recovers a transient failure.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` — classifier and retry executor.
- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts` — transient/permanent cases and retry behavior.
- `apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts` — wiring into extraction passes.
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` — new config fields and defaults.
- `apps/mediapulse/agents/article-analysis/src/run.test.ts` — end-to-end recovery assertion.

## How to test

1. Run `pnpm --filter @mediapulse/article-analysis type:check` and `test`.
2. Trigger an article-analysis run with default config against sources that occasionally rate-limit; confirm logs show retry warnings then success.
3. Inspect run summary JSON for `extractionRetries` when retries occurred.
