### PR TITLE
Fix user-registration inbox watermark and paginate Outlook scans

### DIFF
--- a/apps/mediapulse/agents/user-registration/src/config-schema.ts
+++ b/apps/mediapulse/agents/user-registration/src/config-schema.ts
@@ -30,6 +30,8 @@ export const ConfigSchema = z.object({
   newsletterDeliveryHour: z.number().int().min(0).max(23).optional(),
   newsletterDeliveryTimezone: z.string().optional(),
   newsletterDeliveryTimeLabel: z.string().optional(),
+  inboxPageSize: z.number().int().min(1).max(1000).optional().default(50),
+  inboxMaxPagesPerRun: z.number().int().positive().optional().default(20),
 });
 
 export type UserRegistrationConfig = z.input<typeof ConfigSchema>;

--- a/apps/mediapulse/agents/user-registration/src/index.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.test.ts
@@ -112,7 +112,12 @@ describe("user-registration agent – improved run loop", () => {
 
   it("returns success and new watermark for new subscription", async () => {
     const msg = makeMessage({ receivedDateTime: "2024-01-01T12:00:00Z" });
-    listMessagesMock.mockResolvedValue([msg]);
+    listMessagesMock.mockResolvedValue({
+      messages: [msg],
+      pagesScanned: 1,
+      messagesScanned: 1,
+      drained: true,
+    });
     registerCreateMock.mockResolvedValue({
       tickerKnown: true,
       isNewSubscription: true,
@@ -135,10 +140,15 @@ describe("user-registration agent – improved run loop", () => {
   });
 
   it("updates watermark to the latest processed message", async () => {
-    listMessagesMock.mockResolvedValue([
-      makeMessage({ id: "msg-1", receivedDateTime: "2024-01-01T10:00:00Z" }),
-      makeMessage({ id: "msg-2", receivedDateTime: "2024-01-01T11:00:00Z" }),
-    ]);
+    listMessagesMock.mockResolvedValue({
+      messages: [
+        makeMessage({ id: "msg-1", receivedDateTime: "2024-01-01T10:00:00Z" }),
+        makeMessage({ id: "msg-2", receivedDateTime: "2024-01-01T11:00:00Z" }),
+      ],
+      pagesScanned: 1,
+      messagesScanned: 2,
+      drained: true,
+    });
     registerCreateMock.mockResolvedValue({
       tickerKnown: true,
       isNewSubscription: false,
@@ -152,32 +162,37 @@ describe("user-registration agent – improved run loop", () => {
   });
 
   it("handles rate limiting by leaving message unarchived", async () => {
-    listMessagesMock.mockResolvedValue([
-      makeMessage({
-        id: "msg-1",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-      makeMessage({
-        id: "msg-2",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-      makeMessage({
-        id: "msg-3",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-      makeMessage({
-        id: "msg-4",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-      makeMessage({
-        id: "msg-5",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-      makeMessage({
-        id: "msg-6",
-        from: { emailAddress: { address: "spammer@example.com" } },
-      }),
-    ]);
+    listMessagesMock.mockResolvedValue({
+      messages: [
+        makeMessage({
+          id: "msg-1",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+        makeMessage({
+          id: "msg-2",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+        makeMessage({
+          id: "msg-3",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+        makeMessage({
+          id: "msg-4",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+        makeMessage({
+          id: "msg-5",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+        makeMessage({
+          id: "msg-6",
+          from: { emailAddress: { address: "spammer@example.com" } },
+        }),
+      ],
+      pagesScanned: 1,
+      messagesScanned: 6,
+      drained: true,
+    });
 
     registerCreateMock.mockResolvedValue({
       tickerKnown: true,
@@ -201,7 +216,12 @@ describe("user-registration agent – improved run loop", () => {
       subject: "No ticker here",
       body: { content: "Nothing useful" },
     });
-    listMessagesMock.mockResolvedValue([msg]);
+    listMessagesMock.mockResolvedValue({
+      messages: [msg],
+      pagesScanned: 1,
+      messagesScanned: 1,
+      drained: true,
+    });
 
     const res = await post({ input: {}, config: VALID_CONFIG });
     const body = (await res.json()) as any;
@@ -213,7 +233,12 @@ describe("user-registration agent – improved run loop", () => {
 
   it("handles unknown ticker selection by sending invalid-ticker email", async () => {
     const msg = makeMessage({ receivedDateTime: "2024-01-01T12:00:00Z" });
-    listMessagesMock.mockResolvedValue([msg]);
+    listMessagesMock.mockResolvedValue({
+      messages: [msg],
+      pagesScanned: 1,
+      messagesScanned: 1,
+      drained: true,
+    });
     registerCreateMock.mockResolvedValue({
       tickerKnown: false,
     });
@@ -235,7 +260,12 @@ describe("user-registration agent – improved run loop", () => {
 
   it("does not confirm when Resend returns an error envelope for a new subscription", async () => {
     const msg = makeMessage({ receivedDateTime: "2024-01-01T12:00:00Z" });
-    listMessagesMock.mockResolvedValue([msg]);
+    listMessagesMock.mockResolvedValue({
+      messages: [msg],
+      pagesScanned: 1,
+      messagesScanned: 1,
+      drained: true,
+    });
     registerCreateMock.mockResolvedValue({
       tickerKnown: true,
       isNewSubscription: true,
@@ -256,7 +286,12 @@ describe("user-registration agent – improved run loop", () => {
 
   it("returns failed_retry on unexpected error during processing", async () => {
     const msg = makeMessage();
-    listMessagesMock.mockResolvedValue([msg]);
+    listMessagesMock.mockResolvedValue({
+      messages: [msg],
+      pagesScanned: 1,
+      messagesScanned: 1,
+      drained: true,
+    });
     registerCreateMock.mockRejectedValue(new Error("Network Error"));
 
     const res = await post({ input: {}, config: VALID_CONFIG });

--- a/apps/mediapulse/agents/user-registration/src/lib/watermark.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/watermark.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { computeSafeWatermark } from "./watermark.js";
+
+const makeResult = (status: string, receivedDateTime?: string) => ({
+  status,
+  ...(receivedDateTime !== undefined && { receivedDateTime }),
+});
+
+describe("computeSafeWatermark", () => {
+  it("returns the newest receivedDateTime when all results are terminal successes", () => {
+    const results = [
+      makeResult("confirmed_archived", "2024-01-01T10:00:00Z"),
+      makeResult("acknowledged_archived", "2024-01-01T12:00:00Z"),
+      makeResult("archived_unparseable", "2024-01-01T11:00:00Z"),
+    ];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-01-01T12:00:00.000Z",
+    );
+  });
+
+  it("halts the prefix at the first failed_retry and returns the boundary below it", () => {
+    const results = [
+      makeResult("confirmed_archived", "2024-01-01T10:00:00Z"),
+      makeResult("failed_retry", "2024-01-01T11:00:00Z"),
+      makeResult("confirmed_archived", "2024-01-01T12:00:00Z"),
+    ];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-01-01T10:00:00.000Z",
+    );
+  });
+
+  it("returns previousWatermark unchanged when the oldest result is failed_retry", () => {
+    const results = [
+      makeResult("failed_retry", "2024-01-01T10:00:00Z"),
+      makeResult("confirmed_archived", "2024-01-01T11:00:00Z"),
+    ];
+
+    expect(computeSafeWatermark(results, "2024-01-01T09:00:00.000Z")).toBe(
+      "2024-01-01T09:00:00.000Z",
+    );
+  });
+
+  it("returns undefined when the oldest result is failed_retry and previousWatermark is undefined", () => {
+    const results = [makeResult("failed_retry", "2024-01-01T10:00:00Z")];
+
+    expect(computeSafeWatermark(results, undefined)).toBeUndefined();
+  });
+
+  it("sorts out-of-order input before walking the prefix", () => {
+    const results = [
+      makeResult("confirmed_archived", "2024-01-01T12:00:00Z"),
+      makeResult("confirmed_archived", "2024-01-01T10:00:00Z"),
+      makeResult("failed_retry", "2024-01-01T11:00:00Z"),
+    ];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-01-01T10:00:00.000Z",
+    );
+  });
+
+  it("does not extend the boundary past a result missing receivedDateTime", () => {
+    const results = [
+      makeResult("confirmed_archived", "2024-01-01T10:00:00Z"),
+      makeResult("confirmed_archived"),
+    ];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-01-01T10:00:00.000Z",
+    );
+  });
+
+  it("returns previousWatermark when results is empty", () => {
+    expect(computeSafeWatermark([], "2024-01-01T09:00:00.000Z")).toBe(
+      "2024-01-01T09:00:00.000Z",
+    );
+  });
+
+  it("returns undefined when results is empty and previousWatermark is undefined", () => {
+    expect(computeSafeWatermark([], undefined)).toBeUndefined();
+  });
+
+  it("accepts all four terminal success statuses in the prefix", () => {
+    const results = [
+      makeResult("confirmed_archived", "2024-01-01T10:00:00Z"),
+      makeResult("acknowledged_archived", "2024-01-01T11:00:00Z"),
+      makeResult("invalid_ticker_archived", "2024-01-01T12:00:00Z"),
+      makeResult("archived_unparseable", "2024-01-01T13:00:00Z"),
+    ];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-01-01T13:00:00.000Z",
+    );
+  });
+
+  it("normalises receivedDateTime to a full ISO-8601 string with milliseconds", () => {
+    const results = [makeResult("confirmed_archived", "2024-06-15T08:30:00Z")];
+
+    expect(computeSafeWatermark(results, undefined)).toBe(
+      "2024-06-15T08:30:00.000Z",
+    );
+  });
+});

--- a/apps/mediapulse/agents/user-registration/src/lib/watermark.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/watermark.ts
@@ -1,0 +1,47 @@
+const TERMINAL_SUCCESS_STATUSES = new Set([
+  "confirmed_archived",
+  "acknowledged_archived",
+  "invalid_ticker_archived",
+  "archived_unparseable",
+]);
+
+export type ProcessResult = {
+  status: string;
+  receivedDateTime?: string;
+};
+
+/**
+ * Returns the safe watermark boundary after a batch run.
+ *
+ * Sorts results oldest-first, then walks the longest contiguous prefix where
+ * every result is a terminal success with a known timestamp. The boundary is
+ * the timestamp of the last message in that prefix. Results with no
+ * `receivedDateTime` sort last and stop the prefix walk without extending it.
+ *
+ * - If no prefix exists (oldest result is `failed_retry` or has no timestamp),
+ *   returns `previousWatermark` unchanged so no already-seen messages are skipped.
+ * - Returns `undefined` when `previousWatermark` is `undefined` and no prefix exists.
+ */
+export function computeSafeWatermark(
+  results: ProcessResult[],
+  previousWatermark: string | undefined,
+): string | undefined {
+  const sorted = [...results].sort((a, b) => {
+    if (!a.receivedDateTime && !b.receivedDateTime) return 0;
+    if (!a.receivedDateTime) return 1;
+    if (!b.receivedDateTime) return -1;
+    return (
+      new Date(a.receivedDateTime).getTime() -
+      new Date(b.receivedDateTime).getTime()
+    );
+  });
+
+  let boundary: string | undefined;
+  for (const result of sorted) {
+    if (!result.receivedDateTime) break;
+    if (!TERMINAL_SUCCESS_STATUSES.has(result.status)) break;
+    boundary = new Date(result.receivedDateTime).toISOString();
+  }
+
+  return boundary ?? previousWatermark;
+}

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -735,6 +735,7 @@ describe("createRunHandler", () => {
 
     const archiveMessage = vi.fn(async (id: string) => {
       archivedIds.add(id);
+      return [];
     });
 
     const run = createRunHandler({

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -36,7 +36,12 @@ vi.mock("@workspace/logger", () => ({
 // Fallback mocks for default DI values that are never called in these tests.
 vi.mock("@mediapulse/outlook-inbox", () => ({
   createOutlookInboxClient: () => ({
-    listMessages: async () => [],
+    listMessages: async () => ({
+      messages: [],
+      pagesScanned: 0,
+      messagesScanned: 0,
+      drained: true,
+    }),
     archiveMessage: async () => {},
     processMessages: vi.fn(),
     deleteMessage: vi.fn(),
@@ -68,6 +73,21 @@ const makeMessage = (overrides: Record<string, unknown> = {}) => ({
   body: { content: "Ticker: AAPL", contentType: "text" },
   from: { emailAddress: { address: "user@run-test.example", name: "User" } },
   ...overrides,
+});
+
+/** Wraps messages in the ListMessagesResult shape returned by the inbox client. */
+const makeListResult = (
+  messages: ReturnType<typeof makeMessage>[],
+  extra: {
+    pagesScanned?: number;
+    messagesScanned?: number;
+    drained?: boolean;
+  } = {},
+) => ({
+  messages,
+  pagesScanned: extra.pagesScanned ?? 1,
+  messagesScanned: extra.messagesScanned ?? messages.length,
+  drained: extra.drained ?? true,
 });
 
 /**
@@ -102,7 +122,7 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [],
+        listMessages: async () => makeListResult([]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -134,11 +154,12 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "new@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: { emailAddress: { address: "new@run-test.example" } },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -181,11 +202,12 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "vcf@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: { emailAddress: { address: "vcf@run-test.example" } },
+            }),
+          ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -230,11 +252,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "resend-fail@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: {
+                emailAddress: { address: "resend-fail@run-test.example" },
+              },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -272,16 +297,17 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            subject: "[MediaPulse] Newsletter Subscription - BBCA",
-            body: {
-              content: "Name: Kevin Hermawan\nTicker: BBCA",
-              contentType: "text",
-            },
-            from: { emailAddress: { address: "k@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              subject: "[MediaPulse] Newsletter Subscription - BBCA",
+              body: {
+                content: "Name: Kevin Hermawan\nTicker: BBCA",
+                contentType: "text",
+              },
+              from: { emailAddress: { address: "k@run-test.example" } },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -318,13 +344,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            subject: "Newsletter Subscription - AAPL",
-            body: { content: oneLineBody, contentType: "text" },
-            from: { emailAddress: { address: "blob@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              subject: "Newsletter Subscription - AAPL",
+              body: { content: oneLineBody, contentType: "text" },
+              from: { emailAddress: { address: "blob@run-test.example" } },
+            }),
+          ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -358,11 +385,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "existing@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: {
+                emailAddress: { address: "existing@run-test.example" },
+              },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -399,11 +429,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "reenable@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: {
+                emailAddress: { address: "reenable@run-test.example" },
+              },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -440,11 +473,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "badticker@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: {
+                emailAddress: { address: "badticker@run-test.example" },
+              },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -479,13 +515,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: {
-              emailAddress: { address: "nowrap@run-test.example" },
-            },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: {
+                emailAddress: { address: "nowrap@run-test.example" },
+              },
+            }),
+          ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -525,13 +562,14 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            subject: "Hello there",
-            body: { content: "Nothing useful", contentType: "text" },
-            from: { emailAddress: { address: "noticker@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              subject: "Hello there",
+              body: { content: "Nothing useful", contentType: "text" },
+              from: { emailAddress: { address: "noticker@run-test.example" } },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -568,7 +606,7 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => messages,
+        listMessages: async () => makeListResult(messages),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -603,11 +641,12 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            from: { emailAddress: { address: "error@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              from: { emailAddress: { address: "error@run-test.example" } },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -638,23 +677,24 @@ describe("createRunHandler", () => {
 
     const run = createRunHandler({
       createInbox: () => ({
-        listMessages: async () => [
-          makeMessage({
-            id: "wm-1",
-            receivedDateTime: "2024-01-01T10:00:00Z",
-            from: { emailAddress: { address: "wm1@run-test.example" } },
-          }),
-          makeMessage({
-            id: "wm-2",
-            receivedDateTime: "2024-01-01T12:00:00Z",
-            from: { emailAddress: { address: "wm2@run-test.example" } },
-          }),
-          makeMessage({
-            id: "wm-3",
-            receivedDateTime: "2024-01-01T11:00:00Z",
-            from: { emailAddress: { address: "wm3@run-test.example" } },
-          }),
-        ],
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              id: "wm-1",
+              receivedDateTime: "2024-01-01T10:00:00Z",
+              from: { emailAddress: { address: "wm1@run-test.example" } },
+            }),
+            makeMessage({
+              id: "wm-2",
+              receivedDateTime: "2024-01-01T12:00:00Z",
+              from: { emailAddress: { address: "wm2@run-test.example" } },
+            }),
+            makeMessage({
+              id: "wm-3",
+              receivedDateTime: "2024-01-01T11:00:00Z",
+              from: { emailAddress: { address: "wm3@run-test.example" } },
+            }),
+          ]),
         archiveMessage,
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
@@ -678,5 +718,180 @@ describe("createRunHandler", () => {
     const result = (await run(makeCtx() as any)) as any;
 
     expect(result.details.newWatermark).toBe("2024-01-01T12:00:00.000Z");
+  });
+
+  it("drains all 12 subscription emails across two runs using the safe watermark", async () => {
+    const archivedIds = new Set<string>();
+
+    const allMessages = Array.from({ length: 12 }, (_, index) =>
+      makeMessage({
+        id: `drain-${index + 1}`,
+        receivedDateTime: `2024-01-${String(index + 1).padStart(2, "0")}T00:00:00Z`,
+        from: {
+          emailAddress: { address: `drain${index + 1}@run-test.example` },
+        },
+      }),
+    );
+
+    const archiveMessage = vi.fn(async (id: string) => {
+      archivedIds.add(id);
+    });
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async (filter: any, options: any) => {
+          const limit = options?.limit ?? allMessages.length;
+          const watermarkTime =
+            filter?.receivedAfter instanceof Date
+              ? filter.receivedAfter.getTime()
+              : 0;
+
+          const available = allMessages.filter((msg) => {
+            if (archivedIds.has(msg.id as string)) return false;
+            const msgTime = new Date(msg.receivedDateTime as string).getTime();
+            return msgTime >= watermarkTime;
+          });
+
+          const sorted = [...available].sort((a, b) => {
+            const timeA = new Date(a.receivedDateTime as string).getTime();
+            const timeB = new Date(b.receivedDateTime as string).getTime();
+            return timeA - timeB;
+          });
+
+          const messages = sorted.slice(0, limit);
+          return {
+            messages,
+            pagesScanned: 1,
+            messagesScanned: available.length,
+            drained: messages.length >= available.length,
+          };
+        },
+        archiveMessage,
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn().mockResolvedValue({ data: { id: "e" } }) };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: false,
+            }),
+          },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    // Run 1: no watermark — processes the 10 oldest messages
+    const result1 = (await run(
+      makeCtx({ input: { maxMessagesPerRun: 10 } }) as any,
+    )) as any;
+
+    expect(result1.details.processed).toBe(10);
+    expect(result1.details.inboxScan.drained).toBe(false);
+    expect(result1.details.newWatermark).toBe("2024-01-10T00:00:00.000Z");
+
+    // Run 2: feed the watermark from run 1 — picks up exactly the remaining 2
+    const result2 = (await run(
+      makeCtx({
+        input: {
+          maxMessagesPerRun: 10,
+          watermark: result1.details.newWatermark,
+        },
+      }) as any,
+    )) as any;
+
+    expect(result2.details.processed).toBe(2);
+    expect(result2.details.inboxScan.drained).toBe(true);
+
+    // All 12 archived — no gaps and no duplicates
+    expect(archivedIds.size).toBe(12);
+    for (let index = 1; index <= 12; index++) {
+      expect(archivedIds).toContain(`drain-${index}`);
+    }
+  });
+
+  it("processes the 10 oldest subscription emails when inbox has 12 and reports drained: false", async () => {
+    // Setup: fake inbox with 12 messages ordered oldest to newest
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+
+    const allMessages = Array.from({ length: 12 }, (_, index) =>
+      makeMessage({
+        id: `collect-${index + 1}`,
+        receivedDateTime: `2024-01-${String(index + 1).padStart(2, "0")}T00:00:00Z`,
+        from: {
+          emailAddress: { address: `user${index + 1}@run-test.example` },
+        },
+      }),
+    );
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        // Fake listMessages that honours limit and orderBy to simulate real pagination behaviour.
+        listMessages: async (_filter: any, options: any) => {
+          const limit = options?.limit ?? options?.top ?? allMessages.length;
+          const orderBy = options?.orderBy ?? "";
+          const sorted = [...allMessages].sort((a, b) => {
+            const timeA = new Date(a.receivedDateTime as string).getTime();
+            const timeB = new Date(b.receivedDateTime as string).getTime();
+
+            return orderBy.includes("asc") ? timeA - timeB : timeB - timeA;
+          });
+          const messages = sorted.slice(0, limit);
+          return {
+            messages,
+            pagesScanned: 1,
+            messagesScanned: allMessages.length,
+            drained: messages.length < allMessages.length ? false : true,
+          };
+        },
+        archiveMessage,
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = {
+          send: vi.fn().mockResolvedValue({ data: { id: "e" } }),
+        };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => ({
+              tickerKnown: true,
+              isNewSubscription: false,
+            }),
+          },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    const result = (await run(
+      makeCtx({ input: { maxMessagesPerRun: 10 } }) as any,
+    )) as any;
+
+    // Exactly 10 processed (oldest 10 since orderBy asc)
+    expect(result.details.processed).toBe(10);
+    expect(archiveMessage).toHaveBeenCalledTimes(10);
+
+    // Messages 11 and 12 were not processed
+    const archivedIds: string[] = archiveMessage.mock.calls.map(
+      (call: any) => call[0] as string,
+    );
+    expect(archivedIds).not.toContain("collect-11");
+    expect(archivedIds).not.toContain("collect-12");
+    for (let index = 1; index <= 10; index++) {
+      expect(archivedIds).toContain(`collect-${index}`);
+    }
+
+    // Backlog surfaced explicitly
+    expect(result.details.inboxScan.drained).toBe(false);
+    expect(result.details.inboxScan.matchedMessages).toBe(10);
+    expect(result.details.inboxScan.limit).toBe(10);
   });
 });

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -26,6 +26,8 @@ import {
   resolveSubscriberDisplayName,
 } from "./lib/parser.js";
 
+import { computeSafeWatermark } from "./lib/watermark.js";
+
 export type Input = { maxMessagesPerRun: number; watermark?: string };
 export type Config = UserRegistrationConfig;
 
@@ -319,29 +321,44 @@ export const createRunHandler =
       }
     };
 
+    const inboxPageSize = config.inboxPageSize ?? 50;
+    const inboxMaxPagesPerRun = config.inboxMaxPagesPerRun ?? 20;
+
     report(
       "Reading subscription inbox",
       `up to ${input.maxMessagesPerRun} messages`,
     );
 
-    // Step 0: List messages
-    const messages = await withRetry(
-      () =>
-        inboxClient.listMessages(
-          {
-            subjectContains: "[MediaPulse] Newsletter Subscription",
-            isUnread: true,
-            ...(input.watermark
-              ? { receivedAfter: new Date(input.watermark) }
-              : {}),
-          },
-          { top: input.maxMessagesPerRun },
-        ),
-      retryConfig,
-      isRetryable,
-    );
+    // Step 0: List messages — paginate oldest-first, capped at maxMessagesPerRun matches.
+    // receivedAfter is an inclusive `ge` filter. The boundary message was already archived
+    // last run, so it is no longer unread and won't be re-listed. Same-timestamp siblings
+    // are safe because userRegistrationRegister.create is idempotent (returns
+    // isNewSubscription: false, triggering only an acknowledge-and-archive path).
+    const { messages, pagesScanned, messagesScanned, drained } =
+      await withRetry(
+        () =>
+          inboxClient.listMessages(
+            {
+              subjectContains: "[MediaPulse] Newsletter Subscription",
+              isUnread: true,
+              ...(input.watermark
+                ? { receivedAfter: new Date(input.watermark) }
+                : {}),
+            },
+            {
+              limit: input.maxMessagesPerRun,
+              pageSize: inboxPageSize,
+              orderBy: "receivedDateTime asc",
+              maxPages: inboxMaxPagesPerRun,
+            },
+          ),
+        retryConfig,
+        isRetryable,
+      );
 
-    logger.info(`Found ${messages.length} messages to process.`);
+    logger.info(
+      `Found ${messages.length} subscription messages (scanned ${messagesScanned} across ${pagesScanned} pages, drained: ${drained}).`,
+    );
 
     report("Scanning subscription requests", `${messages.length} emails found`);
 
@@ -351,7 +368,20 @@ export const createRunHandler =
         "0 registered, 0 skipped",
         "completed",
       );
-      return { success: true, details: { processed: 0, results: [] } };
+      return {
+        success: true,
+        details: {
+          processed: 0,
+          results: [],
+          inboxScan: {
+            pagesScanned,
+            messagesScanned,
+            matchedMessages: 0,
+            limit: input.maxMessagesPerRun,
+            drained,
+          },
+        },
+      };
     }
 
     report("Processing registrations", `${messages.length} eligible requests`);
@@ -359,7 +389,6 @@ export const createRunHandler =
     // Process messages in parallel with a concurrency limit of 5.
     const CONCURRENCY = 5;
     const results: any[] = [];
-    let latestProcessedDate: string | undefined = input.watermark;
 
     for (let i = 0; i < messages.length; i += CONCURRENCY) {
       const batch = messages.slice(i, i + CONCURRENCY);
@@ -375,33 +404,24 @@ export const createRunHandler =
               rateLimitConfig,
               retryConfig,
             });
-
-            if (result.status !== "failed_retry") {
-              // Track the latest receivedDateTime for watermark management.
-              if (msg.receivedDateTime) {
-                const msgTime = new Date(msg.receivedDateTime).getTime();
-                const latestTime = latestProcessedDate
-                  ? new Date(latestProcessedDate).getTime()
-                  : 0;
-
-                if (!latestProcessedDate || msgTime > latestTime) {
-                  latestProcessedDate = new Date(msgTime).toISOString();
-                }
-              }
-            }
-
-            return result;
+            return { ...result, receivedDateTime: msg.receivedDateTime };
           } catch (error) {
             logger.error(
               { error, messageId: msg.id },
               "Unexpected error processing message.",
             );
-            return { id: msg.id, status: "failed_retry" };
+            return {
+              id: msg.id,
+              status: "failed_retry",
+              receivedDateTime: msg.receivedDateTime,
+            };
           }
         }),
       );
       results.push(...batchResults);
     }
+
+    const newWatermark = computeSafeWatermark(results, input.watermark);
 
     const registeredCount = results.filter(
       (result) =>
@@ -412,7 +432,7 @@ export const createRunHandler =
 
     report(
       "Registration run complete",
-      `${registeredCount} registered, ${skippedCount} skipped`,
+      `${registeredCount} registered, ${skippedCount} skipped (drained: ${drained})`,
       "completed",
     );
 
@@ -421,7 +441,14 @@ export const createRunHandler =
       details: {
         processed: results.length,
         results,
-        newWatermark: latestProcessedDate,
+        newWatermark,
+        inboxScan: {
+          pagesScanned,
+          messagesScanned,
+          matchedMessages: messages.length,
+          limit: input.maxMessagesPerRun,
+          drained,
+        },
       },
     };
   };

--- a/packages/mediapulse/outlook-inbox/script/test-lib.ts
+++ b/packages/mediapulse/outlook-inbox/script/test-lib.ts
@@ -21,7 +21,7 @@ async function main(): Promise<void> {
     userId,
   });
 
-  const messages = await client.listMessages(
+  const { messages } = await client.listMessages(
     {
       subjectContains: "New Registration",
     },

--- a/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.test.ts
+++ b/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.test.ts
@@ -88,9 +88,9 @@ describe("createOutlookInboxClient", () => {
       expect((getFn.mock.calls[0] as [string])[0]).toContain(
         "/users/me/messages",
       );
-      expect(result).toHaveLength(1);
-      expect(result[0]).toBeDefined();
-      expect((result[0] as { id: string }).id).toBe("m1");
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]).toBeDefined();
+      expect(result.messages[0]!.id).toBe("m1");
     });
 
     it("listMessages uses custom userId when provided", async () => {

--- a/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.ts
+++ b/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.ts
@@ -1,4 +1,5 @@
 import { createGraphClient } from "./graph-client.js";
+import type { ListMessagesResult } from "./graph-client.js";
 import { getAccessTokenFromClientCredentials } from "./get-access-token.js";
 import type {
   GraphMessage,
@@ -18,6 +19,20 @@ export type CreateOutlookInboxClientOptions = {
   getAccessTokenOptions?: Parameters<
     typeof getAccessTokenFromClientCredentials
   >[1];
+};
+
+/** Options for listMessages on the inbox client. */
+export type ListMessagesOptions = {
+  /** Backward-compat alias for limit. */
+  top?: number;
+  /** Max subject-matching messages to return (defaults to top). */
+  limit?: number;
+  /** Per-page Graph $top (default 50). */
+  pageSize?: number;
+  /** OData $orderby; omitted when $search is active. */
+  orderBy?: string;
+  /** Runaway-pagination backstop (default 20). */
+  maxPages?: number;
 };
 
 /**
@@ -41,19 +56,23 @@ export function createOutlookInboxClient(
 
   return {
     /**
-     * Lists messages in the inbox matching the filter.
+     * Lists messages in the inbox matching the filter, paging until the limit
+     * or inbox end is reached. Returns messages plus scan metadata.
      *
      * @param filter - Subject, received date, unread criteria.
-     * @param listOptions - Optional top (page size).
-     * @returns Array of messages.
+     * @param listOptions - Optional limit, pageSize, orderBy, maxPages.
+     * @returns Messages and pagination metadata.
      */
     async listMessages(
       filter: MessageFilter,
-      listOptions?: { top?: number },
-    ): Promise<GraphMessage[]> {
+      listOptions?: ListMessagesOptions,
+    ): Promise<ListMessagesResult> {
+      const limit = listOptions?.limit ?? listOptions?.top;
       return graph.listMessages(userId, filter, {
-        top: listOptions?.top,
-        orderBy: "receivedDateTime desc",
+        limit,
+        pageSize: listOptions?.pageSize,
+        orderBy: listOptions?.orderBy,
+        maxPages: listOptions?.maxPages,
       });
     },
 
@@ -70,17 +89,15 @@ export function createOutlookInboxClient(
     ): Promise<GraphMessage[]> {
       const action = processOptions.action ?? "archive";
       const maxMessages = processOptions.maxMessages;
-      const messages = await graph.listMessages(userId, filter, {
+      const { messages } = await graph.listMessages(userId, filter, {
         orderBy: "receivedDateTime desc",
-        ...(maxMessages !== undefined && { top: maxMessages }),
+        ...(maxMessages !== undefined && { limit: maxMessages }),
       });
-      const toProcess =
-        maxMessages !== undefined ? messages.slice(0, maxMessages) : messages;
       const destinationId =
         action === "archive" ? ARCHIVE_FOLDER : DELETED_ITEMS_FOLDER;
 
       const processed: GraphMessage[] = [];
-      for (const msg of toProcess) {
+      for (const msg of messages) {
         await graph.moveMessage(userId, msg.id, destinationId);
         processed.push(msg);
       }

--- a/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
@@ -36,9 +36,9 @@ describe("createGraphClient", () => {
       const filter: MessageFilter = { subjectContains: "Test", isUnread: true };
 
       // Act
-      const result = await client.listMessages("me", filter, { top: 50 });
+      const result = await client.listMessages("me", filter, { pageSize: 50 });
 
-      // Assert: URL has only Graph-safe filter (receivedDateTime, isRead), no subject
+      // Assert: URL has only Graph-safe OData filter (no subject), plus $search for subject
       expect(getAccessToken).toHaveBeenCalledTimes(1);
       expect(getFn).toHaveBeenCalledTimes(1);
       expect(getFn.mock.calls[0]).toBeDefined();
@@ -52,11 +52,11 @@ describe("createGraphClient", () => {
       expect(url).not.toContain("contains(subject"); // subject filter applied client-side
       expect(url).toContain("top=50");
       expect(opts.headers.Authorization).toBe("Bearer bearer-token");
-      expect(result).toHaveLength(1);
-      expect((result[0] as { id: string; subject: string }).id).toBe("msg-1");
-      expect((result[0] as { id: string; subject: string }).subject).toBe(
-        "Test",
-      );
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages[0]!.id).toBe("msg-1");
+      expect(result.messages[0]!.subject).toBe("Test");
+      expect(result.drained).toBe(true);
+      expect(result.pagesScanned).toBe(1);
     });
 
     it("encodes userId in URL", async () => {
@@ -99,7 +99,7 @@ describe("createGraphClient", () => {
       );
     });
 
-    it("returns empty array when value is missing in response", async () => {
+    it("returns empty messages and drained: true when value is missing in response", async () => {
       // Setup
       const getAccessToken = vi.fn().mockResolvedValue("t");
       const getFn = vi.fn().mockResolvedValue({
@@ -115,7 +115,8 @@ describe("createGraphClient", () => {
       const result = await client.listMessages("me", {});
 
       // Assert
-      expect(result).toEqual([]);
+      expect(result.messages).toEqual([]);
+      expect(result.drained).toBe(true);
     });
 
     it("throws when list response has invalid value shape", async () => {
@@ -132,6 +133,341 @@ describe("createGraphClient", () => {
 
       // Act & Assert
       await expect(client.listMessages("me", {})).rejects.toThrow();
+    });
+
+    it("follows @odata.nextLink across multiple pages and collects all matching messages", async () => {
+      // Setup: 3 pages, subscription messages interleaved with non-matching subjects.
+      // Page 1 alone has fewer matches than limit — the scenario the production bug dropped.
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const PAGE1_NEXT =
+        "https://graph.microsoft.com/v1.0/users/me/messages?$skiptoken=page2";
+      const PAGE2_NEXT =
+        "https://graph.microsoft.com/v1.0/users/me/messages?$skiptoken=page3";
+
+      const makeMsg = (id: string, subject: string, day: string) => ({
+        id,
+        subject,
+        receivedDateTime: `2024-01-${day}T00:00:00Z`,
+        isRead: false,
+      });
+
+      const getFn = vi
+        .fn()
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: JSON.stringify({
+            value: [
+              makeMsg(
+                "01",
+                "[MediaPulse] Newsletter Subscription - AAPL",
+                "01",
+              ),
+              makeMsg("02", "Unrelated email", "02"),
+              makeMsg(
+                "03",
+                "[MediaPulse] Newsletter Subscription - BBCA",
+                "03",
+              ),
+            ],
+            "@odata.nextLink": PAGE1_NEXT,
+          }),
+        })
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: JSON.stringify({
+            value: [
+              makeMsg("04", "Another unrelated", "04"),
+              makeMsg(
+                "05",
+                "[MediaPulse] Newsletter Subscription - TSLA",
+                "05",
+              ),
+              makeMsg(
+                "06",
+                "[MediaPulse] Newsletter Subscription - MSFT",
+                "06",
+              ),
+            ],
+            "@odata.nextLink": PAGE2_NEXT,
+          }),
+        })
+        .mockResolvedValueOnce({
+          statusCode: 200,
+          body: JSON.stringify({
+            value: [
+              makeMsg(
+                "07",
+                "[MediaPulse] Newsletter Subscription - GOOG",
+                "07",
+              ),
+              makeMsg("08", "Spam", "08"),
+            ],
+          }),
+        });
+
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+      const filter: MessageFilter = {
+        subjectContains: "[MediaPulse] Newsletter Subscription",
+        isUnread: true,
+      };
+
+      // Act
+      const result = await client.listMessages("me", filter, {
+        pageSize: 3,
+        limit: 10,
+        maxPages: 5,
+      });
+
+      // Assert: all 5 matching messages collected across 3 pages
+      expect(result.messages).toHaveLength(5);
+      expect(result.messages.map((m) => m.id)).toEqual([
+        "01",
+        "03",
+        "05",
+        "06",
+        "07",
+      ]);
+      expect(result.pagesScanned).toBe(3);
+      expect(result.messagesScanned).toBe(8);
+      expect(result.drained).toBe(true);
+
+      // Each subsequent page used the nextLink URL verbatim
+      expect(getFn).toHaveBeenCalledTimes(3);
+      expect((getFn.mock.calls[1] as [string])[0]).toBe(PAGE1_NEXT);
+      expect((getFn.mock.calls[2] as [string])[0]).toBe(PAGE2_NEXT);
+    });
+
+    it("stops at maxPages and returns drained: false", async () => {
+      // Setup: infinite pages (every response has a nextLink)
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const NEXT =
+        "https://graph.microsoft.com/v1.0/users/me/messages?$skiptoken=next";
+
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          value: [
+            {
+              id: "m1",
+              subject: "Test",
+              receivedDateTime: "2024-01-01T00:00:00Z",
+              isRead: false,
+            },
+          ],
+          "@odata.nextLink": NEXT,
+        }),
+      });
+
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      const result = await client.listMessages(
+        "me",
+        { subjectContains: "Test", isUnread: true },
+        { pageSize: 10, limit: 100, maxPages: 2 },
+      );
+
+      // Assert: stopped at maxPages
+      expect(result.pagesScanned).toBe(2);
+      expect(result.drained).toBe(false);
+      expect(getFn).toHaveBeenCalledTimes(2);
+    });
+
+    it("returns drained: true when all pages are exhausted before limit", async () => {
+      // Setup: only 2 matches, limit is 10
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+
+      const getFn = vi.fn().mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          value: [
+            {
+              id: "m1",
+              subject: "Test",
+              receivedDateTime: "2024-01-01T00:00:00Z",
+              isRead: false,
+            },
+            {
+              id: "m2",
+              subject: "Test",
+              receivedDateTime: "2024-01-02T00:00:00Z",
+              isRead: false,
+            },
+          ],
+        }),
+      });
+
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      const result = await client.listMessages(
+        "me",
+        { subjectContains: "Test", isUnread: true },
+        { limit: 10 },
+      );
+
+      // Assert: all matches collected, no nextLink — fully drained
+      expect(result.messages).toHaveLength(2);
+      expect(result.drained).toBe(true);
+      expect(getFn).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns drained: false when limit is hit before pages run out", async () => {
+      // Setup: 3 messages on one page, limit 2 — last message on page is skipped
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+
+      const getFn = vi.fn().mockResolvedValueOnce({
+        statusCode: 200,
+        body: JSON.stringify({
+          value: [
+            {
+              id: "m1",
+              subject: "Test",
+              receivedDateTime: "2024-01-01T00:00:00Z",
+              isRead: false,
+            },
+            {
+              id: "m2",
+              subject: "Test",
+              receivedDateTime: "2024-01-02T00:00:00Z",
+              isRead: false,
+            },
+            {
+              id: "m3",
+              subject: "Test",
+              receivedDateTime: "2024-01-03T00:00:00Z",
+              isRead: false,
+            },
+          ],
+        }),
+      });
+
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      const result = await client.listMessages(
+        "me",
+        { subjectContains: "Test", isUnread: true },
+        { limit: 2 },
+      );
+
+      // Assert: limit hit; m3 was on the same page but not collected
+      expect(result.messages).toHaveLength(2);
+      expect(result.drained).toBe(false);
+    });
+
+    it("adds $search and ConsistencyLevel header when subjectContains is set, omits $orderby", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.listMessages(
+        "me",
+        {
+          subjectContains: "Newsletter",
+          isUnread: true,
+          receivedAfter: new Date("2024-01-01T00:00:00Z"),
+        },
+        { orderBy: "receivedDateTime asc" },
+      );
+
+      // Assert
+      expect(getFn).toHaveBeenCalledTimes(1);
+      const [url, opts] = getFn.mock.calls[0] as [
+        string,
+        { headers: Record<string, string> },
+      ];
+      expect(url).toContain("search="); // $search present
+      expect(url).toContain("Newsletter"); // scoped to subject
+      expect(url).not.toContain("orderby"); // $orderby absent with $search
+      expect(url).toContain("isRead"); // $filter still has isRead
+      expect(url).toContain("receivedDateTime"); // $filter still has receivedDateTime bound
+      expect(opts.headers["ConsistencyLevel"]).toBe("eventual");
+      expect(opts.headers.Authorization).toBe("Bearer t");
+    });
+
+    it("uses $orderby and no $search when subjectContains is not set", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.listMessages(
+        "me",
+        { isUnread: true },
+        { orderBy: "receivedDateTime desc" },
+      );
+
+      // Assert
+      const [url] = getFn.mock.calls[0] as [string];
+      expect(url).toContain("orderby");
+      expect(url).not.toContain("search=");
+    });
+
+    it("sorts client-side by orderBy when $search is active", async () => {
+      // Setup: two messages returned in reverse order; expect sorted oldest-first
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          value: [
+            {
+              id: "newer",
+              subject: "Test",
+              receivedDateTime: "2024-01-02T00:00:00Z",
+              isRead: false,
+            },
+            {
+              id: "older",
+              subject: "Test",
+              receivedDateTime: "2024-01-01T00:00:00Z",
+              isRead: false,
+            },
+          ],
+        }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      const result = await client.listMessages(
+        "me",
+        { subjectContains: "Test" },
+        { orderBy: "receivedDateTime asc" },
+      );
+
+      // Assert: sorted ascending — older first
+      expect(result.messages[0]!.id).toBe("older");
+      expect(result.messages[1]!.id).toBe("newer");
     });
   });
 
@@ -254,9 +590,8 @@ describe("createGraphClient", () => {
 
     // Assert
     expect(got.default.get).toHaveBeenCalled();
-    expect(result).toHaveLength(1);
-    expect(result[0]).toBeDefined();
-    expect((result[0] as { id: string }).id).toBe("m1");
+    expect(result.messages).toHaveLength(1);
+    expect(result.messages[0]!.id).toBe("m1");
   });
 
   it("uses default post when postFn not provided", async () => {

--- a/packages/mediapulse/outlook-inbox/src/graph-client.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.ts
@@ -31,6 +31,33 @@ export type GraphClientOptions = {
   postFn?: GraphPostFn;
 };
 
+/** Pagination options for listMessages. */
+export type ListMessagesPaging = {
+  /** Per-page Graph $top (default 50, clamped 1–1000). */
+  pageSize?: number;
+  /** Max subject-matching messages to collect. Default: no limit. */
+  limit?: number;
+  /** OData $orderby; skipped when $search is active (client-side sort used instead). */
+  orderBy?: string;
+  /** Runaway-pagination backstop (default 20). */
+  maxPages?: number;
+};
+
+/** Result returned by listMessages including pagination metadata. */
+export type ListMessagesResult = {
+  messages: GraphMessage[];
+  /** Number of Graph pages fetched. */
+  pagesScanned: number;
+  /** Total messages seen across all pages (before subject filtering). */
+  messagesScanned: number;
+  /**
+   * True when all pages were consumed and the limit was not hit —
+   * the full matching set was collected. False when stopped early
+   * at limit or maxPages (more matching mail may remain).
+   */
+  drained: boolean;
+};
+
 /**
  * Creates a Graph API client for mailbox operations.
  * Uses the provided getAccessToken for Bearer auth on each request.
@@ -49,42 +76,106 @@ export function createGraphClient(
 
   return {
     /**
-     * Lists messages in the user's inbox matching the filter.
+     * Lists messages in the user's inbox matching the filter, following
+     * @odata.nextLink pagination until the limit, maxPages, or inbox end is reached.
+     * When filter.subjectContains is set, adds $search subject scoping so fewer
+     * pages are scanned; $orderby is then applied client-side after collection.
      *
      * @param userId - User ID or "me".
      * @param filter - Filter criteria (subject, received, isUnread).
-     * @param paging - Optional top (max 1000) and orderBy.
-     * @returns Array of messages.
+     * @param paging - Optional pageSize, limit, orderBy, maxPages.
+     * @returns Matched messages plus scan metadata.
      */
     async listMessages(
       userId: string,
       filter: MessageFilter,
-      paging?: { top?: number; orderBy?: string },
-    ): Promise<GraphMessage[]> {
+      paging?: ListMessagesPaging,
+    ): Promise<ListMessagesResult> {
       const token = await getAccessToken();
       const filterStr = buildFilterForGraph(filter);
-      const url = new URL(
+      const pageSize = Math.min(Math.max(paging?.pageSize ?? 50, 1), 1000);
+      const limit = paging?.limit;
+      const maxPages = paging?.maxPages ?? 20;
+      const useSearch =
+        filter.subjectContains !== undefined && filter.subjectContains !== "";
+
+      const initialUrl = new URL(
         `${baseUrl}/users/${encodeURIComponent(userId)}/messages`,
       );
-      if (filterStr) url.searchParams.set("$filter", filterStr);
-      if (paging?.top !== undefined)
-        url.searchParams.set("$top", String(paging.top));
-      if (paging?.orderBy) url.searchParams.set("$orderby", paging.orderBy);
-
-      const res = await getFn(url.toString(), {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        throw new Error(
-          `Graph list messages failed: ${res.statusCode} - ${res.body}`,
+      if (filterStr) initialUrl.searchParams.set("$filter", filterStr);
+      initialUrl.searchParams.set("$top", String(pageSize));
+      if (useSearch) {
+        // Graph rejects $search + $orderby on messages; sort client-side instead.
+        initialUrl.searchParams.set(
+          "$search",
+          `"subject:${filter.subjectContains}"`,
         );
+      } else if (paging?.orderBy) {
+        initialUrl.searchParams.set("$orderby", paging.orderBy);
       }
 
-      const parsed = JSON.parse(res.body) as unknown;
-      const data = listMessagesResponseSchema.parse(parsed);
-      const messages = data.value ?? [];
-      return applySubjectFilter(messages, filter);
+      const accumulatedMessages: GraphMessage[] = [];
+      let pagesScanned = 0;
+      let messagesScanned = 0;
+      let limitReached = false;
+      let nextUrl: string | undefined = initialUrl.toString();
+
+      while (
+        nextUrl !== undefined &&
+        !limitReached &&
+        pagesScanned < maxPages
+      ) {
+        const headers: Record<string, string> = {
+          Authorization: `Bearer ${token}`,
+        };
+        if (useSearch) headers["ConsistencyLevel"] = "eventual";
+
+        const res = await getFn(nextUrl, { headers });
+
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          throw new Error(
+            `Graph list messages failed: ${res.statusCode} - ${res.body}`,
+          );
+        }
+
+        const parsed = JSON.parse(res.body) as unknown;
+        const data = listMessagesResponseSchema.parse(parsed);
+        const pageMessages = data.value ?? [];
+
+        pagesScanned++;
+        messagesScanned += pageMessages.length;
+
+        const matching = applySubjectFilter(pageMessages, filter);
+        for (const msg of matching) {
+          if (limit !== undefined && accumulatedMessages.length >= limit) {
+            limitReached = true;
+            break;
+          }
+          accumulatedMessages.push(msg);
+        }
+
+        nextUrl = data["@odata.nextLink"];
+      }
+
+      // When $search is active, $orderby cannot be used server-side; sort here instead.
+      if (useSearch && paging?.orderBy) {
+        const descending = paging.orderBy.toLowerCase().includes("desc");
+        accumulatedMessages.sort((a, b) => {
+          const timeA = new Date(a.receivedDateTime).getTime();
+          const timeB = new Date(b.receivedDateTime).getTime();
+
+          return descending ? timeB - timeA : timeA - timeB;
+        });
+      }
+
+      const drained = nextUrl === undefined && !limitReached;
+
+      return {
+        messages: accumulatedMessages,
+        pagesScanned,
+        messagesScanned,
+        drained,
+      };
     },
 
     /**

--- a/packages/mediapulse/outlook-inbox/src/index.ts
+++ b/packages/mediapulse/outlook-inbox/src/index.ts
@@ -1,5 +1,8 @@
 export { createOutlookInboxClient } from "./create-outlook-inbox-client.js";
-export type { CreateOutlookInboxClientOptions } from "./create-outlook-inbox-client.js";
+export type {
+  CreateOutlookInboxClientOptions,
+  ListMessagesOptions,
+} from "./create-outlook-inbox-client.js";
 export { getAccessTokenFromClientCredentials } from "./get-access-token.js";
 export type {
   ClientCredentialsConfig,
@@ -11,6 +14,8 @@ export type {
   GraphClientOptions,
   GraphGetFn,
   GraphPostFn,
+  ListMessagesPaging,
+  ListMessagesResult,
 } from "./graph-client.js";
 export type {
   GraphMessage,


### PR DESCRIPTION
## Summary

Subscription mail could be skipped when a user-registration run hit its per-run cap or when a retryable failure still moved the watermark forward. This PR scans the inbox oldest-first with Graph pagination, advances the watermark only across a contiguous block of terminal successes, and surfaces inbox scan stats on each run.

## Related issues

Closes #665

## Important changes

- Add `computeSafeWatermark` so failed or out-of-order results do not advance the cursor past unprocessed mail.
- Paginate `@mediapulse/outlook-inbox` `listMessages` via `@odata.nextLink` with `limit`, `pageSize`, `orderBy`, and `maxPages`; return `pagesScanned`, `messagesScanned`, and `drained`.
- User-registration agent lists subscription mail ascending, respects `inboxPageSize` / `inboxMaxPagesPerRun`, and includes `inboxScan` in run details.

## Other changes

- Export `ListMessagesResult` and `ListMessagesOptions` from the outlook-inbox package barrel.
- Update the outlook-inbox manual test script for the new `listMessages` return shape.

## Key files to review

- `apps/mediapulse/agents/user-registration/src/lib/watermark.ts` - safe watermark prefix walk.
- `apps/mediapulse/agents/user-registration/src/run.ts` - oldest-first scan wiring and `newWatermark` / `inboxScan` output.
- `apps/mediapulse/agents/user-registration/src/run.test.ts` - 12-message two-run drain scenario.
- `packages/mediapulse/outlook-inbox/src/graph-client.ts` - pagination loop and metadata.
- `packages/mediapulse/outlook-inbox/src/graph-client.test.ts` - pagination and limit behavior.

## How to test

1. `pnpm --filter @mediapulse/outlook-inbox test`
2. `pnpm --filter @mediapulse/user-registration-agent test`
3. Confirm the drain test in `run.test.ts` processes 12 messages across two runs with the watermark from run 1.
