### PR TITLE
Omit Graph $search when outlook inbox $filter criteria apply

### DIFF
--- a/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
@@ -38,7 +38,7 @@ describe("createGraphClient", () => {
       // Act
       const result = await client.listMessages("me", filter, { pageSize: 50 });
 
-      // Assert: URL has only Graph-safe OData filter (no subject), plus $search for subject
+      // Assert: URL has only Graph-safe OData filter (no subject); subject applied client-side
       expect(getAccessToken).toHaveBeenCalledTimes(1);
       expect(getFn).toHaveBeenCalledTimes(1);
       expect(getFn.mock.calls[0]).toBeDefined();
@@ -50,6 +50,7 @@ describe("createGraphClient", () => {
       expect(url).toContain("isRead");
       expect(url).toContain("false");
       expect(url).not.toContain("contains(subject"); // subject filter applied client-side
+      expect(url).not.toContain("search="); // $search omitted when $filter applies
       expect(url).toContain("top=50");
       expect(opts.headers.Authorization).toBe("Bearer bearer-token");
       expect(result.messages).toHaveLength(1);
@@ -368,8 +369,10 @@ describe("createGraphClient", () => {
       expect(result.drained).toBe(false);
     });
 
-    it("adds $search and ConsistencyLevel header when subjectContains is set, omits $orderby", async () => {
-      // Setup
+    it("omits $search when a $filter applies, avoiding the SearchWithFilter 400", async () => {
+      // Setup: subjectContains combined with isUnread/receivedAfter. Graph rejects
+      // $search + $filter (SearchWithFilter), so $filter wins and subject is applied
+      // client-side; $orderby is then allowed server-side alongside $filter.
       const getAccessToken = vi.fn().mockResolvedValue("t");
       const getFn = vi.fn().mockResolvedValue({
         statusCode: 200,
@@ -397,11 +400,43 @@ describe("createGraphClient", () => {
         string,
         { headers: Record<string, string> },
       ];
+      expect(url).not.toContain("search="); // $search dropped to avoid SearchWithFilter
+      expect(url).not.toContain("contains(subject"); // subject applied client-side
+      expect(url).toContain("isRead"); // $filter has isRead
+      expect(url).toContain("receivedDateTime"); // $filter has receivedDateTime bound
+      expect(url).toContain("orderby"); // $orderby allowed alongside $filter
+      expect(opts.headers["ConsistencyLevel"]).toBeUndefined();
+      expect(opts.headers.Authorization).toBe("Bearer t");
+    });
+
+    it("uses $search and ConsistencyLevel header when subjectContains is the only criterion", async () => {
+      // Setup: no $filter criteria, so $search subject scoping is safe to use
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.listMessages(
+        "me",
+        { subjectContains: "Newsletter" },
+        { orderBy: "receivedDateTime asc" },
+      );
+
+      // Assert
+      expect(getFn).toHaveBeenCalledTimes(1);
+      const [url, opts] = getFn.mock.calls[0] as [
+        string,
+        { headers: Record<string, string> },
+      ];
       expect(url).toContain("search="); // $search present
       expect(url).toContain("Newsletter"); // scoped to subject
-      expect(url).not.toContain("orderby"); // $orderby absent with $search
-      expect(url).toContain("isRead"); // $filter still has isRead
-      expect(url).toContain("receivedDateTime"); // $filter still has receivedDateTime bound
+      expect(url).not.toContain("orderby"); // $orderby absent with $search (sorted client-side)
       expect(opts.headers["ConsistencyLevel"]).toBe("eventual");
       expect(opts.headers.Authorization).toBe("Bearer t");
     });

--- a/packages/mediapulse/outlook-inbox/src/graph-client.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.ts
@@ -78,8 +78,11 @@ export function createGraphClient(
     /**
      * Lists messages in the user's inbox matching the filter, following
      * @odata.nextLink pagination until the limit, maxPages, or inbox end is reached.
-     * When filter.subjectContains is set, adds $search subject scoping so fewer
-     * pages are scanned; $orderby is then applied client-side after collection.
+     * When filter.subjectContains is set and no other ($filter) criteria apply,
+     * adds $search subject scoping so fewer pages are scanned; $orderby is then
+     * applied client-side after collection. Graph rejects $search together with
+     * $filter, so when both would apply the $filter (received watermark, isRead)
+     * wins and the subject match is applied client-side.
      *
      * @param userId - User ID or "me".
      * @param filter - Filter criteria (subject, received, isUnread).
@@ -96,8 +99,14 @@ export function createGraphClient(
       const pageSize = Math.min(Math.max(paging?.pageSize ?? 50, 1), 1000);
       const limit = paging?.limit;
       const maxPages = paging?.maxPages ?? 20;
+      // Graph rejects $search combined with $filter (SearchWithFilter) or
+      // $orderby. Only use $search when there is no $filter to conflict with;
+      // otherwise rely on the server-side $filter (received watermark, isRead)
+      // and apply the subject match client-side via applySubjectFilter.
       const useSearch =
-        filter.subjectContains !== undefined && filter.subjectContains !== "";
+        filter.subjectContains !== undefined &&
+        filter.subjectContains !== "" &&
+        filterStr === "";
 
       const initialUrl = new URL(
         `${baseUrl}/users/${encodeURIComponent(userId)}/messages`,


### PR DESCRIPTION
## Summary

Graph rejects `$search` and `$filter` in the same request (SearchWithFilter 400). The user-registration agent always sends subject plus unread and watermark filters, so inbox listing could fail after the pagination work in #666. This PR uses `$search` only when subject is the sole criterion and keeps subject matching client-side otherwise.

## Related issues

Closes #667

## Important changes

- Gate `$search` on an empty `$filter` string so `isUnread` / `receivedAfter` queries never combine search and filter.
- Allow server-side `$orderby` when `$filter` applies (subject-only `$search` paths still sort client-side).
- Split tests for mixed-filter vs subject-only query shapes.

## Other changes

- Update JSDoc on `listMessages` to document the SearchWithFilter constraint.

## Key files to review

- `packages/mediapulse/outlook-inbox/src/graph-client.ts` - `useSearch` guard against non-empty `filterStr`.
- `packages/mediapulse/outlook-inbox/src/graph-client.test.ts` - mixed-filter and subject-only assertions.

## How to test

1. `pnpm --filter @mediapulse/outlook-inbox test`
2. Confirm the test named "omits $search when a $filter applies" passes and the subject-only `$search` test still expects `ConsistencyLevel: eventual`.
