### PR TITLE
Harden user-registration inbox queue draining

### DIFF
--- a/apps/mediapulse/agents/user-registration/src/config-schema.ts
+++ b/apps/mediapulse/agents/user-registration/src/config-schema.ts
@@ -32,6 +32,8 @@ export const ConfigSchema = z.object({
   newsletterDeliveryTimeLabel: z.string().optional(),
   inboxPageSize: z.number().int().min(1).max(1000).optional().default(50),
   inboxMaxPagesPerRun: z.number().int().positive().optional().default(20),
+  mailFolder: z.string().min(1).optional().default("inbox"),
+  maxMessageAttempts: z.number().int().positive().optional().default(5),
 });
 
 export type UserRegistrationConfig = z.input<typeof ConfigSchema>;

--- a/apps/mediapulse/agents/user-registration/src/index.ts
+++ b/apps/mediapulse/agents/user-registration/src/index.ts
@@ -58,8 +58,18 @@ async function callWithRetry<TResult>(params: {
   throw lastError;
 }
 
+/**
+ * Lower bound for messages processed per run. Oldest-first ordering means a
+ * single slow or failing message blocks all progress, so a value like 1 is
+ * pathological. The floor guarantees each run drains a real batch.
+ */
+const MIN_MAX_MESSAGES_PER_RUN = 10;
+
 const BodySchemaInner = z.object({
-  maxMessagesPerRun: z.number().default(20),
+  maxMessagesPerRun: z
+    .number()
+    .default(20)
+    .transform((value) => Math.max(value, MIN_MAX_MESSAGES_PER_RUN)),
   watermark: z.string().datetime().optional(),
 });
 const BodySchema = BodySchemaInner as unknown as z.ZodType<

--- a/apps/mediapulse/agents/user-registration/src/lib/watermark.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/watermark.ts
@@ -3,6 +3,7 @@ const TERMINAL_SUCCESS_STATUSES = new Set([
   "acknowledged_archived",
   "invalid_ticker_archived",
   "archived_unparseable",
+  "dead_lettered",
 ]);
 
 export type ProcessResult = {

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -124,6 +124,7 @@ describe("createRunHandler", () => {
       createInbox: () => ({
         listMessages: async () => makeListResult([]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -161,6 +162,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -209,6 +211,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -261,6 +264,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -309,6 +313,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -353,6 +358,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -394,6 +400,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -438,6 +445,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -482,6 +490,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -524,6 +533,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage: vi.fn().mockResolvedValue(undefined),
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -571,6 +581,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -608,6 +619,7 @@ describe("createRunHandler", () => {
       createInbox: () => ({
         listMessages: async () => makeListResult(messages),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -648,6 +660,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -696,6 +709,7 @@ describe("createRunHandler", () => {
             }),
           ]),
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -768,6 +782,7 @@ describe("createRunHandler", () => {
           };
         },
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -851,6 +866,7 @@ describe("createRunHandler", () => {
           };
         },
         archiveMessage,
+        markMessageRead: vi.fn(),
         processMessages: vi.fn(),
         deleteMessage: vi.fn(),
       }),
@@ -894,5 +910,117 @@ describe("createRunHandler", () => {
     expect(result.details.inboxScan.drained).toBe(false);
     expect(result.details.inboxScan.matchedMessages).toBe(10);
     expect(result.details.inboxScan.limit).toBe(10);
+  });
+
+  it("registers all new signups in one run despite an already-confirmed message at the head", async () => {
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+    const registerCreate = vi.fn(async (payload: any) => {
+      if (payload.email === "stuck@run-test.example") {
+        return { tickerKnown: true, isNewSubscription: false };
+      }
+
+      return {
+        tickerKnown: true,
+        isNewSubscription: true,
+        userTickerId: `ut-${payload.email}`,
+      };
+    });
+
+    const messages = [
+      makeMessage({
+        id: "stuck",
+        receivedDateTime: "2024-01-01T00:00:00Z",
+        from: { emailAddress: { address: "stuck@run-test.example" } },
+      }),
+      ...Array.from({ length: 4 }, (_, index) =>
+        makeMessage({
+          id: `new-${index + 1}`,
+          receivedDateTime: `2024-01-0${index + 2}T00:00:00Z`,
+          from: {
+            emailAddress: { address: `new${index + 1}@run-test.example` },
+          },
+        }),
+      ),
+    ];
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () => makeListResult(messages),
+        archiveMessage,
+        markMessageRead: vi.fn(),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn().mockResolvedValue({ data: { id: "e" } }) };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: { create: registerCreate },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    const result = (await run(
+      makeCtx({ input: { maxMessagesPerRun: 5 } }) as any,
+    )) as any;
+
+    const confirmed = result.details.results.filter(
+      (r: any) => r.status === "confirmed_archived",
+    );
+    const acknowledged = result.details.results.filter(
+      (r: any) => r.status === "acknowledged_archived",
+    );
+
+    expect(confirmed).toHaveLength(4);
+    expect(acknowledged).toHaveLength(1);
+    expect(archiveMessage).toHaveBeenCalledTimes(5);
+  });
+
+  it("dead-letters a message that fails every run after maxMessageAttempts", async () => {
+    const archiveMessage = vi.fn().mockResolvedValue(undefined);
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              id: "poison",
+              from: { emailAddress: { address: "poison@run-test.example" } },
+            }),
+          ]),
+        archiveMessage,
+        markMessageRead: vi.fn(),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn() };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: {
+            create: async () => {
+              throw new Error("permanent failure");
+            },
+          },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    // Runs 1–4: failed_retry, message left unarchived for retry
+    for (let attempt = 1; attempt <= 4; attempt++) {
+      const result = (await run(makeCtx() as any)) as any;
+      expect(result.details.results[0].status).toBe("failed_retry");
+    }
+    expect(archiveMessage).not.toHaveBeenCalled();
+
+    // Run 5: attempts reach the limit — dead-lettered and archived
+    const final = (await run(makeCtx() as any)) as any;
+
+    expect(final.details.results[0].status).toBe("dead_lettered");
+    expect(archiveMessage).toHaveBeenCalledWith("poison");
   });
 });

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -45,10 +45,21 @@ type RateLimitConfig = {
 const registrationAttempts = new Map<string, number[]>();
 
 /**
- * Clears in-memory per-sender rate-limit counters (for unit tests only).
+ * Per-message consecutive failure counts, keyed by Graph message id. Used to
+ * dead-letter a poison message after `maxMessageAttempts` failed runs so it
+ * cannot block the oldest slot forever under oldest-first ordering.
+ */
+const messageProcessingAttempts = new Map<string, number>();
+
+const DEFAULT_MAX_MESSAGE_ATTEMPTS = 5;
+
+/**
+ * Clears in-memory per-sender rate-limit and per-message attempt counters
+ * (for unit tests only).
  */
 export const resetRegistrationRateLimitsForTest = (): void => {
   registrationAttempts.clear();
+  messageProcessingAttempts.clear();
 };
 const DEFAULT_RATE_LIMIT_CONFIG: RateLimitConfig = {
   windowMs: 60 * 60 * 1000,
@@ -296,7 +307,11 @@ export const createRunHandler =
       clientSecret: config.outlookClientSecret,
       tenantId: config.outlookTenantId,
       userId: config.outlookUserId,
+      mailFolder: config.mailFolder,
     });
+
+    const maxMessageAttempts =
+      config.maxMessageAttempts ?? DEFAULT_MAX_MESSAGE_ATTEMPTS;
 
     const resend = new ResendClient(config.resendApiKey);
 
@@ -323,6 +338,7 @@ export const createRunHandler =
 
     const inboxPageSize = config.inboxPageSize ?? 50;
     const inboxMaxPagesPerRun = config.inboxMaxPagesPerRun ?? 20;
+    const mailFolder = config.mailFolder ?? "inbox";
 
     report(
       "Reading subscription inbox",
@@ -360,6 +376,18 @@ export const createRunHandler =
       `Found ${messages.length} subscription messages (scanned ${messagesScanned} across ${pagesScanned} pages, drained: ${drained}).`,
     );
 
+    // Regression alarm: with isUnread:true and Inbox scoping, processed mail
+    // should never reappear. A nonzero count means it is leaking back in.
+    const refetchedTerminal = messages.filter(
+      (msg) => msg.isRead === true,
+    ).length;
+    if (refetchedTerminal > 0) {
+      logger.warn(
+        { refetchedTerminal, mailFolder },
+        "Fetched already-read messages; processed mail may be leaking back into the unread queue.",
+      );
+    }
+
     report("Scanning subscription requests", `${messages.length} emails found`);
 
     if (messages.length === 0) {
@@ -379,6 +407,8 @@ export const createRunHandler =
             matchedMessages: 0,
             limit: input.maxMessagesPerRun,
             drained,
+            mailFolder,
+            refetchedTerminal,
           },
         },
       };
@@ -403,6 +433,7 @@ export const createRunHandler =
               config,
               rateLimitConfig,
               retryConfig,
+              maxMessageAttempts,
             });
             return { ...result, receivedDateTime: msg.receivedDateTime };
           } catch (error) {
@@ -448,6 +479,8 @@ export const createRunHandler =
           matchedMessages: messages.length,
           limit: input.maxMessagesPerRun,
           drained,
+          mailFolder,
+          refetchedTerminal,
         },
       },
     };
@@ -478,6 +511,7 @@ async function processMessage({
   config,
   rateLimitConfig,
   retryConfig,
+  maxMessageAttempts,
 }: {
   msg: GraphMessage;
   inboxClient: any;
@@ -486,6 +520,7 @@ async function processMessage({
   config: Config;
   rateLimitConfig: RateLimitConfig;
   retryConfig: RetryConfig;
+  maxMessageAttempts: number;
 }) {
   const senderEmail = extractSenderEmail(msg);
   const tickerSymbol = extractTickerSymbol(msg.subject, msg.body?.content);
@@ -503,6 +538,7 @@ async function processMessage({
       retryConfig,
       isRetryable,
     );
+    if (msg.id) messageProcessingAttempts.delete(msg.id);
     return { id: msg.id, status: "archived_unparseable" };
   }
 
@@ -568,6 +604,7 @@ async function processMessage({
         retryConfig,
         isRetryable,
       );
+      if (msg.id) messageProcessingAttempts.delete(msg.id);
       return { id: msg.id, status: "invalid_ticker_archived" };
     }
 
@@ -645,6 +682,7 @@ async function processMessage({
       retryConfig,
       isRetryable,
     );
+    if (msg.id) messageProcessingAttempts.delete(msg.id);
     return {
       id: msg.id,
       status: isNewSubscription
@@ -652,15 +690,49 @@ async function processMessage({
         : "acknowledged_archived",
     };
   } catch (error) {
+    const errorDetails =
+      error instanceof Error
+        ? { message: error.message, name: error.name, stack: error.stack }
+        : error;
+
+    // Head-of-line guard: a message that fails every run must not block the
+    // oldest slot forever under oldest-first ordering. After maxMessageAttempts
+    // consecutive failures, dead-letter it (archive + mark read) so the queue
+    // can advance. Counters reset on any terminal success above.
+    const attempts = msg.id
+      ? (messageProcessingAttempts.get(msg.id) ?? 0) + 1
+      : 1;
+
+    if (msg.id && attempts >= maxMessageAttempts) {
+      try {
+        await withRetry(
+          () => inboxClient.archiveMessage(msg.id!),
+          retryConfig,
+          isRetryable,
+        );
+        messageProcessingAttempts.delete(msg.id);
+        logger.warn(
+          { messageId: msg.id, senderEmail, tickerSymbol, attempts },
+          "Dead-lettering message after repeated failures.",
+        );
+        return { id: msg.id, status: "dead_lettered" };
+      } catch (deadLetterError) {
+        logger.error(
+          { messageId: msg.id, err: deadLetterError },
+          "Failed to dead-letter message after repeated failures.",
+        );
+      }
+    }
+
+    if (msg.id) messageProcessingAttempts.set(msg.id, attempts);
+
     logger.error(
       {
         messageId: msg.id,
         senderEmail,
         tickerSymbol,
-        err:
-          error instanceof Error
-            ? { message: error.message, name: error.name, stack: error.stack }
-            : error,
+        attempts,
+        err: errorDetails,
       },
       "Failed processing message during agent run. Leaving unarchived for retry.",
     );

--- a/dev-docs/docs/mediapulse/apps/user-registration.mdx
+++ b/dev-docs/docs/mediapulse/apps/user-registration.mdx
@@ -44,3 +44,13 @@ Because MediaPulse supports login-less registration over email, the flow works l
 - **Archive on completion**: When a message is fully handled (including unparseable/invalid cases), the agent archives it to keep the inbox clear.
 - **Confirm is best-effort**: If the confirm API fails after registration, the agent still archives the message (confirmation is retried implicitly on subsequent runs via idempotent register/confirm behavior).
 - **Bounded retry for register**: The agent retries the register API once on transient failures (429/5xx or network errors). If it still fails, the message is left in the inbox so the next scheduled run can retry.
+
+### Message lifecycle (how a message leaves the queue)
+
+The agent reads **unread** messages and a message must actually leave that unread set once handled, or oldest-first ordering will keep re-fetching it and never reach newer signups.
+
+- **Folder-scoped fetch**: The list query is scoped to a single folder (`mailFolder`, default `inbox`) via `/mailFolders/{folder}/messages`, not the whole mailbox. Moving a handled message to Archive therefore removes it from the result set. Set `mailFolder: ""` to query the whole mailbox.
+- **Mark read, then move**: Archiving marks the message read (`PATCH isRead: true`) and then moves it to Archive. Read is set first so that even if the move fails, the message no longer matches the `isRead eq false` filter and is not reprocessed. A re-listed same-id message is harmless anyway because register is idempotent.
+- **Oldest-first, batched**: Messages are processed oldest-first so the backlog drains in arrival order. `maxMessagesPerRun` caps how many subscription emails are processed per run and is floored (minimum 10) because a value like 1 lets a single slow or failing message block all progress.
+- **Dead-letter guard**: A message that throws on every run is archived (marked read and moved) after `maxMessageAttempts` consecutive failures (default 5) so a poison message cannot hold the oldest slot forever. Rate-limited messages are not counted toward this and are simply retried on a later run.
+- **Coverage signal**: `details.inboxScan` reports `{ pagesScanned, messagesScanned, matchedMessages, limit, drained, mailFolder, refetchedTerminal }`. `drained: false` means signups remain beyond this run's `limit` (expected when volume exceeds `maxMessagesPerRun`, converging over runs). `refetchedTerminal > 0` is a regression alarm: it means already-read mail is leaking back into the unread queue.

--- a/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.test.ts
+++ b/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.test.ts
@@ -86,7 +86,7 @@ describe("createOutlookInboxClient", () => {
       // Assert
       expect(getFn.mock.calls[0]).toBeDefined();
       expect((getFn.mock.calls[0] as [string])[0]).toContain(
-        "/users/me/messages",
+        "/users/me/mailFolders/inbox/messages",
       );
       expect(result.messages).toHaveLength(1);
       expect(result.messages[0]).toBeDefined();
@@ -111,8 +111,29 @@ describe("createOutlookInboxClient", () => {
       // Assert
       expect(getFn.mock.calls[0]).toBeDefined();
       expect((getFn.mock.calls[0] as [string])[0]).toContain(
-        "/users/user-123/messages",
+        "/users/user-123/mailFolders/inbox/messages",
       );
+    });
+
+    it("listMessages queries the whole mailbox when mailFolder is empty", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createOutlookInboxClient(
+        { getAccessToken, mailFolder: "" },
+        { graphClientOptions: { getFn, postFn: vi.fn() } },
+      );
+
+      // Act
+      await client.listMessages({});
+
+      // Assert
+      const [url] = getFn.mock.calls[0] as [string];
+      expect(url).toContain("/users/me/messages");
+      expect(url).not.toContain("mailFolders");
     });
 
     it("processMessages defaults to archive and moves to archive folder", async () => {
@@ -267,9 +288,18 @@ describe("createOutlookInboxClient", () => {
       expect(postFn).toHaveBeenCalledTimes(2);
     });
 
-    it("archiveMessage moves single message to archive", async () => {
+    it("archiveMessage marks the message read then moves it to archive", async () => {
       // Setup
       const getAccessToken = vi.fn().mockResolvedValue("t");
+      const patchFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          id: "single",
+          subject: "Read",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: true,
+        }),
+      });
       const postFn = vi.fn().mockResolvedValue({
         statusCode: 200,
         body: JSON.stringify({
@@ -281,25 +311,71 @@ describe("createOutlookInboxClient", () => {
       });
       const client = createOutlookInboxClient(
         { getAccessToken },
-        { graphClientOptions: { getFn: vi.fn(), postFn } },
+        { graphClientOptions: { getFn: vi.fn(), postFn, patchFn } },
       );
 
       // Act
       const result = await client.archiveMessage("single");
 
-      // Assert
+      // Assert: mark read happened, and it moved to archive
       expect(result).toHaveLength(1);
-      expect(result[0]).toBeDefined();
       expect((result[0] as { id: string }).id).toBe("single");
+      expect(patchFn).toHaveBeenCalledWith(
+        expect.stringContaining("/messages/single"),
+        expect.objectContaining({ json: { isRead: true } }),
+      );
       expect(postFn).toHaveBeenCalledWith(
         expect.stringContaining("/messages/single/move"),
         expect.objectContaining({ json: { destinationId: "archive" } }),
       );
     });
 
+    it("markMessageRead PATCHes each id as read", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const patchFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          id: "r1",
+          subject: "Read",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: true,
+        }),
+      });
+      const client = createOutlookInboxClient(
+        { getAccessToken },
+        { graphClientOptions: { getFn: vi.fn(), postFn: vi.fn(), patchFn } },
+      );
+
+      // Act
+      await client.markMessageRead(["r1", "r2"]);
+
+      // Assert
+      expect(patchFn).toHaveBeenCalledTimes(2);
+      expect(patchFn).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining("/messages/r1"),
+        expect.objectContaining({ json: { isRead: true } }),
+      );
+      expect(patchFn).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining("/messages/r2"),
+        expect.objectContaining({ json: { isRead: true } }),
+      );
+    });
+
     it("archiveMessage accepts array of ids and moves each to archive", async () => {
       // Setup
       const getAccessToken = vi.fn().mockResolvedValue("t");
+      const patchFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          id: "r",
+          subject: "Read",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: true,
+        }),
+      });
       const postFn = vi
         .fn()
         .mockResolvedValueOnce({
@@ -322,13 +398,14 @@ describe("createOutlookInboxClient", () => {
         });
       const client = createOutlookInboxClient(
         { getAccessToken },
-        { graphClientOptions: { getFn: vi.fn(), postFn } },
+        { graphClientOptions: { getFn: vi.fn(), postFn, patchFn } },
       );
 
       // Act
       const result = await client.archiveMessage(["a1", "a2"]);
 
       // Assert
+      expect(patchFn).toHaveBeenCalledTimes(2);
       expect(result).toHaveLength(2);
       expect((result[0] as { id: string }).id).toBe("a1");
       expect((result[1] as { id: string }).id).toBe("a2");

--- a/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.ts
+++ b/packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.ts
@@ -49,6 +49,9 @@ export function createOutlookInboxClient(
 ) {
   const getAccessToken = resolveTokenGetter(config, options);
   const userId = config.userId ?? "me";
+  // Scope listing to a single folder (default Inbox) so a message moved to
+  // Archive leaves the result set. "" opts into a whole-mailbox query.
+  const mailFolder = config.mailFolder ?? "inbox";
   const graph = createGraphClient(
     getAccessToken,
     options.graphClientOptions ?? {},
@@ -73,6 +76,7 @@ export function createOutlookInboxClient(
         pageSize: listOptions?.pageSize,
         orderBy: listOptions?.orderBy,
         maxPages: listOptions?.maxPages,
+        mailFolder,
       });
     },
 
@@ -91,6 +95,7 @@ export function createOutlookInboxClient(
       const maxMessages = processOptions.maxMessages;
       const { messages } = await graph.listMessages(userId, filter, {
         orderBy: "receivedDateTime desc",
+        mailFolder,
         ...(maxMessages !== undefined && { limit: maxMessages }),
       });
       const destinationId =
@@ -105,7 +110,25 @@ export function createOutlookInboxClient(
     },
 
     /**
-     * Archives one or more messages (moves to Archive folder).
+     * Marks a message read so it stops matching an `isRead eq false` filter.
+     *
+     * @param messageIdOrIds - Single message ID or array of message IDs.
+     */
+    async markMessageRead(messageIdOrIds: string | string[]): Promise<void> {
+      const ids = Array.isArray(messageIdOrIds)
+        ? messageIdOrIds
+        : [messageIdOrIds];
+      for (const id of ids) {
+        await graph.markMessageRead(userId, id);
+      }
+    },
+
+    /**
+     * Archives one or more messages: marks each read, then moves it to the
+     * Archive folder.
+     *
+     * - Important: Read is set before the move so that even if the move fails,
+     *   the message no longer matches an unread filter and is not reprocessed.
      *
      * @param messageIdOrIds - Single message ID or array of message IDs.
      * @returns Array of moved messages (one per ID).
@@ -118,6 +141,7 @@ export function createOutlookInboxClient(
         : [messageIdOrIds];
       const results: GraphMessage[] = [];
       for (const id of ids) {
+        await graph.markMessageRead(userId, id);
         const moved = await graph.moveMessage(userId, id, ARCHIVE_FOLDER);
         results.push(moved);
       }

--- a/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.test.ts
@@ -4,7 +4,7 @@ import { createGraphClient } from "./graph-client.js";
 import type { MessageFilter } from "./types.js";
 
 vi.mock("got", () => ({
-  default: { get: vi.fn(), post: vi.fn() },
+  default: { get: vi.fn(), post: vi.fn(), patch: vi.fn() },
 }));
 
 describe("createGraphClient", () => {
@@ -58,6 +58,51 @@ describe("createGraphClient", () => {
       expect(result.messages[0]!.subject).toBe("Test");
       expect(result.drained).toBe(true);
       expect(result.pagesScanned).toBe(1);
+    });
+
+    it("scopes the query to a mail folder when paging.mailFolder is set", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.listMessages(
+        "me",
+        { isUnread: true },
+        { mailFolder: "inbox" },
+      );
+
+      // Assert
+      const [url] = getFn.mock.calls[0] as [string];
+      expect(url).toContain("/users/me/mailFolders/inbox/messages");
+    });
+
+    it("queries the whole mailbox when mailFolder is omitted", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const getFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({ value: [] }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn,
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.listMessages("me", { isUnread: true });
+
+      // Assert
+      const [url] = getFn.mock.calls[0] as [string];
+      expect(url).toContain("/users/me/messages");
+      expect(url).not.toContain("mailFolders");
     });
 
     it("encodes userId in URL", async () => {
@@ -575,6 +620,85 @@ describe("createGraphClient", () => {
       await expect(
         client.moveMessage("me", "msg-1", "archive"),
       ).rejects.toThrow();
+    });
+  });
+
+  describe("markMessageRead", () => {
+    it("PATCHes isRead: true to the message URL", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("token");
+      const patchFn = vi.fn().mockResolvedValue({
+        statusCode: 200,
+        body: JSON.stringify({
+          id: "msg-1",
+          subject: "Read",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: true,
+        }),
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn: vi.fn(),
+        postFn: vi.fn(),
+        patchFn,
+      });
+
+      // Act
+      await client.markMessageRead("me", "msg-1");
+
+      // Assert
+      expect(patchFn).toHaveBeenCalledTimes(1);
+      const [url, opts] = patchFn.mock.calls[0] as [
+        string,
+        { json: unknown; headers: Record<string, string> },
+      ];
+      expect(url).toContain("/users/me/messages/msg-1");
+      expect(url).not.toContain("/move");
+      expect(opts.json).toEqual({ isRead: true });
+      expect(opts.headers.Authorization).toBe("Bearer token");
+    });
+
+    it("throws when PATCH returns non-2xx", async () => {
+      // Setup
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const patchFn = vi.fn().mockResolvedValue({
+        statusCode: 404,
+        body: "Not found",
+      });
+      const client = createGraphClient(getAccessToken, {
+        getFn: vi.fn(),
+        postFn: vi.fn(),
+        patchFn,
+      });
+
+      // Act & Assert
+      await expect(client.markMessageRead("me", "bad-id")).rejects.toThrow(
+        "Graph mark message read failed: 404",
+      );
+    });
+
+    it("uses default patch when patchFn not provided", async () => {
+      // Setup
+      const got = await import("got");
+      vi.mocked(got.default.patch).mockResolvedValue({
+        body: JSON.stringify({
+          id: "m1",
+          subject: "Read",
+          receivedDateTime: "2024-01-01T00:00:00Z",
+          isRead: true,
+        }),
+        statusCode: 200,
+      } as never);
+      const getAccessToken = vi.fn().mockResolvedValue("t");
+      const client = createGraphClient(getAccessToken, {
+        getFn: vi.fn(),
+        postFn: vi.fn(),
+      });
+
+      // Act
+      await client.markMessageRead("me", "m1");
+
+      // Assert
+      expect(got.default.patch).toHaveBeenCalled();
     });
   });
 

--- a/packages/mediapulse/outlook-inbox/src/graph-client.ts
+++ b/packages/mediapulse/outlook-inbox/src/graph-client.ts
@@ -21,6 +21,12 @@ export type GraphPostFn = (
   options?: { json?: unknown; headers?: Record<string, string> },
 ) => Promise<{ body: string; statusCode: number }>;
 
+/** HTTP PATCH function for DI. */
+export type GraphPatchFn = (
+  url: string,
+  options?: { json?: unknown; headers?: Record<string, string> },
+) => Promise<{ body: string; statusCode: number }>;
+
 /** Options for the Graph client (DI). */
 export type GraphClientOptions = {
   /** Base URL for Graph API (default https://graph.microsoft.com/v1.0). */
@@ -29,6 +35,8 @@ export type GraphClientOptions = {
   getFn?: GraphGetFn;
   /** POST implementation; defaults to got.post. */
   postFn?: GraphPostFn;
+  /** PATCH implementation; defaults to got.patch. */
+  patchFn?: GraphPatchFn;
 };
 
 /** Pagination options for listMessages. */
@@ -41,6 +49,13 @@ export type ListMessagesPaging = {
   orderBy?: string;
   /** Runaway-pagination backstop (default 20). */
   maxPages?: number;
+  /**
+   * Well-known folder name or folder id to scope the query to (e.g. "inbox").
+   * When set, lists from `/mailFolders/{folder}/messages` so that moving a
+   * message out of the folder removes it from the result set. When omitted,
+   * lists from the whole mailbox `/messages`.
+   */
+  mailFolder?: string;
 };
 
 /** Result returned by listMessages including pagination metadata. */
@@ -73,11 +88,14 @@ export function createGraphClient(
   const baseUrl = options.baseUrl ?? DEFAULT_GRAPH_BASE;
   const getFn = options.getFn ?? defaultGet;
   const postFn = options.postFn ?? defaultPost;
+  const patchFn = options.patchFn ?? defaultPatch;
 
   return {
     /**
-     * Lists messages in the user's inbox matching the filter, following
-     * @odata.nextLink pagination until the limit, maxPages, or inbox end is reached.
+     * Lists messages matching the filter, following @odata.nextLink pagination
+     * until the limit, maxPages, or end of results is reached. When paging.mailFolder
+     * is set, scopes to `/mailFolders/{folder}/messages` so messages moved out of
+     * the folder (e.g. archived) drop out of the result set.
      * When filter.subjectContains is set and no other ($filter) criteria apply,
      * adds $search subject scoping so fewer pages are scanned; $orderby is then
      * applied client-side after collection. Graph rejects $search together with
@@ -108,9 +126,12 @@ export function createGraphClient(
         filter.subjectContains !== "" &&
         filterStr === "";
 
-      const initialUrl = new URL(
-        `${baseUrl}/users/${encodeURIComponent(userId)}/messages`,
-      );
+      const mailFolder = paging?.mailFolder;
+      const messagesPath =
+        mailFolder !== undefined && mailFolder !== ""
+          ? `/users/${encodeURIComponent(userId)}/mailFolders/${encodeURIComponent(mailFolder)}/messages`
+          : `/users/${encodeURIComponent(userId)}/messages`;
+      const initialUrl = new URL(`${baseUrl}${messagesPath}`);
       if (filterStr) initialUrl.searchParams.set("$filter", filterStr);
       initialUrl.searchParams.set("$top", String(pageSize));
       if (useSearch) {
@@ -220,6 +241,34 @@ export function createGraphClient(
       const parsed = JSON.parse(res.body) as unknown;
       return graphMessageSchema.parse(parsed);
     },
+
+    /**
+     * Marks a message as read (PATCH isRead: true).
+     *
+     * A read message no longer matches an `isRead eq false` filter, so this is
+     * how a processed message leaves the unread work queue regardless of folder.
+     *
+     * @param userId - User ID or "me".
+     * @param messageId - Message ID.
+     */
+    async markMessageRead(userId: string, messageId: string): Promise<void> {
+      const token = await getAccessToken();
+      const url = `${baseUrl}/users/${encodeURIComponent(userId)}/messages/${encodeURIComponent(messageId)}`;
+
+      const res = await patchFn(url, {
+        json: { isRead: true },
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      if (res.statusCode < 200 || res.statusCode >= 300) {
+        throw new Error(
+          `Graph mark message read failed: ${res.statusCode} - ${res.body}`,
+        );
+      }
+    },
   };
 }
 
@@ -241,6 +290,20 @@ async function defaultPost(
   opts?: { json?: unknown; headers?: Record<string, string> },
 ): Promise<{ body: string; statusCode: number }> {
   const res = await got.post(url, {
+    json: opts?.json,
+    headers: opts?.headers,
+    throwHttpErrors: false,
+  });
+  const bodyStr =
+    typeof res.body === "string" ? res.body : JSON.stringify(res.body);
+  return { body: bodyStr, statusCode: res.statusCode ?? 0 };
+}
+
+async function defaultPatch(
+  url: string,
+  opts?: { json?: unknown; headers?: Record<string, string> },
+): Promise<{ body: string; statusCode: number }> {
+  const res = await got.patch(url, {
     json: opts?.json,
     headers: opts?.headers,
     throwHttpErrors: false,

--- a/packages/mediapulse/outlook-inbox/src/index.ts
+++ b/packages/mediapulse/outlook-inbox/src/index.ts
@@ -14,6 +14,7 @@ export type {
   GraphClientOptions,
   GraphGetFn,
   GraphPostFn,
+  GraphPatchFn,
   ListMessagesPaging,
   ListMessagesResult,
 } from "./graph-client.js";

--- a/packages/mediapulse/outlook-inbox/src/types.ts
+++ b/packages/mediapulse/outlook-inbox/src/types.ts
@@ -13,6 +13,12 @@ export type OutlookInboxConfig = {
   tenantId?: string;
   /** User ID or "me" for delegated auth; for app-only, the mailbox to access. Default "me". */
   userId?: string;
+  /**
+   * Well-known folder name or folder id to list from (default "inbox"). Scoping
+   * to a folder ensures archived messages leave the result set. Set to "" to
+   * query the whole mailbox.
+   */
+  mailFolder?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Oldest-first inbox draining can still stall when handled mail shows up again as unread or one message fails every run. This PR scopes list queries to a mail folder, marks messages read before archive, dead-letters poison messages after repeated failures, floors `maxMessagesPerRun` at 10, and adds `refetchedTerminal` to `inboxScan` as a regression alarm.

## Related issues

Closes #669

## Important changes

- List from `/mailFolders/{mailFolder}/messages` (default `inbox`) so archived mail drops out of the work queue.
- `archiveMessage` marks read via Graph PATCH before moving to Archive.
- Dead-letter path after `maxMessageAttempts` consecutive failures (status `dead_lettered`).
- Request body floors `maxMessagesPerRun` at 10 so a single stuck message cannot block the whole run.
- `inboxScan` now includes `mailFolder` and `refetchedTerminal`.

## Other changes

- Document message lifecycle and inbox scan fields in dev-docs.
- Export `markMessageRead` on the outlook-inbox client.

## Key files to review

- `packages/mediapulse/outlook-inbox/src/graph-client.ts` - folder-scoped list path and `markMessageRead`.
- `packages/mediapulse/outlook-inbox/src/create-outlook-inbox-client.ts` - read-before-archive in `archiveMessage`.
- `apps/mediapulse/agents/user-registration/src/run.ts` - dead-letter guard and `refetchedTerminal` warning.
- `apps/mediapulse/agents/user-registration/src/run.test.ts` - dead-letter and inbox scan tests.
- `dev-docs/docs/mediapulse/apps/user-registration.mdx` - lifecycle documentation.

## How to test

1. `pnpm --filter @mediapulse/outlook-inbox test`
2. `pnpm --filter @mediapulse/user-registration-agent test`
3. Confirm dead-letter and `refetchedTerminal` tests pass in `run.test.ts`.
