### PR TITLE
Improve article-analysis LLM extraction observability and budget

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -3,6 +3,7 @@ import { RELEVANCE_BREAKDOWN_CANONICAL_KEYS_V1 } from "./analysis-relevance-scor
 import type {
   ArticleAnalysisExtractionFailureRecord,
   ArticleAnalysisPostFailureRecord,
+  ExtractionLlmFailureReason,
 } from "./article-analysis-run-policy.js";
 import type { QualityDropReason } from "./utilities/content-quality-gate.js";
 import { createEmptyQualityCounters } from "./utilities/content-quality-gate.js";
@@ -294,6 +295,12 @@ export type ExtractionRetryObservabilityAggregate = {
   exhausted: number;
 };
 
+/** Per-reason counts for `stage: "llm"` non-response failures. */
+export type ExtractionNonResponseBreakdown = Record<
+  ExtractionLlmFailureReason,
+  number
+>;
+
 /** Per-source latency samples collected during parallel extraction. */
 export type PerSourceLatencyObservability = {
   extractionMs: number[];
@@ -390,6 +397,7 @@ export type ArticleAnalysisRunSummaryInput = {
   parallelism?: ParallelismObservabilityAggregate;
   perSourceLatency?: PerSourceLatencyObservability;
   extractionRetries?: ExtractionRetryObservabilityAggregate;
+  extractionNonResponse?: ExtractionNonResponseBreakdown;
 };
 
 /**
@@ -412,6 +420,33 @@ export const percentileOf = (
     Math.max(0, Math.ceil(p * sorted.length) - 1),
   );
   return sorted[index] ?? null;
+};
+
+/**
+ * Aggregates `stage: "llm"` failure records by their `reason` field.
+ *
+ * @param failures - All per-source extraction failure records for the run.
+ * @returns Per-reason counts for the non-response breakdown dashboard bucket.
+ */
+export const aggregateExtractionNonResponseBreakdown = (
+  failures: readonly ArticleAnalysisExtractionFailureRecord[],
+): ExtractionNonResponseBreakdown => {
+  const breakdown: ExtractionNonResponseBreakdown = {
+    length_truncation: 0,
+    empty_stop: 0,
+    content_filter: 0,
+    timeout: 0,
+    other: 0,
+  };
+  for (const failure of failures) {
+    if (failure.stage === "llm" && failure.reason !== undefined) {
+      breakdown[failure.reason] += 1;
+    } else if (failure.stage === "llm") {
+      breakdown.other += 1;
+    }
+  }
+
+  return breakdown;
 };
 
 /**
@@ -750,6 +785,14 @@ export const buildArticleAnalysisRunSummaryPayload = (
 
   if (input.extractionRetries !== undefined) {
     base.extractionRetries = input.extractionRetries;
+  }
+
+  if (input.extractionNonResponse !== undefined) {
+    base.extractionNonResponse = input.extractionNonResponse;
+  } else if (llmFails > 0) {
+    base.extractionNonResponse = aggregateExtractionNonResponseBreakdown(
+      input.extractionFailures,
+    );
   }
 
   return base;

--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-run-policy.ts
@@ -8,11 +8,25 @@ export type ArticleAnalysisExtractionFailureStage =
   | "vocabulary"
   | "prefilter";
 
+/** Fine-grained cause of a `stage: "llm"` non-response. */
+export type ExtractionLlmFailureReason =
+  | "length_truncation"
+  | "empty_stop"
+  | "content_filter"
+  | "timeout"
+  | "other";
+
 /** One source that did not contribute to the merged extraction payload. */
 export type ArticleAnalysisExtractionFailureRecord = {
   dataSourceId: string;
   stage: ArticleAnalysisExtractionFailureStage;
   message: string;
+  /** Fine-grained cause for `stage: "llm"` failures — distinguishes starvation from model degradation. */
+  reason?: ExtractionLlmFailureReason;
+  /** Actual output tokens reported by the provider when truncation occurred. */
+  outputTokens?: number;
+  /** The `maxOutputTokens` cap that was active on the truncated attempt. */
+  maxOutputTokens?: number;
 };
 
 /** POST phase labels aligned with `run.ts` logging. */

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -35,6 +35,17 @@ export const articleAnalysisConfigSchema = z
     reasoningEffort: reasoningEffortSchema.optional(),
     /** Max output tokens for `generateObject`. */
     maxOutputTokens: z.number().int().positive().optional(),
+    /**
+     * Max output tokens for the extraction pass only. Covers reasoning tokens + JSON for reasoning
+     * models. Falls back to `maxOutputTokens` when unset.
+     */
+    extractionMaxOutputTokens: z.number().int().positive().optional(),
+    /**
+     * Reasoning effort for the extraction pass only. Falls back to `reasoningEffort` when unset.
+     * Tune together with `extractionMaxOutputTokens` — lowering effort saves budget but reduces
+     * extraction quality when brainstorm is disabled.
+     */
+    extractionReasoningEffort: reasoningEffortSchema.optional(),
     /** Truncate article text in the LLM user message (full text remains in DB). */
     maxContentChars: z.number().int().positive().optional(),
     /** When true, use structure-aware paragraph truncation instead of naive slice. */
@@ -208,6 +219,8 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   useBrainstormPass: boolean;
   brainstormModel: string;
   brainstormMaxOutputTokens: number;
+  /** Max output tokens for the extraction pass (falls back to `maxOutputTokens`). */
+  extractionMaxOutputTokens: number;
   /** Resolved reasoning effort for the extraction pass (falls back to `reasoningEffort`). */
   extractionReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
   /** Resolved reasoning effort for the brainstorm pass. */
@@ -269,7 +282,7 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
 /** Production-oriented defaults merged onto parsed Hermes config. */
 export const articleAnalysisConfigDefaults = {
   openaiModel: "gpt-4o-mini",
-  maxOutputTokens: 8192,
+  maxOutputTokens: 24576,
   maxContentChars: 12_000,
   useStructureAwareTruncation: false,
   truncationLeadParagraphsAlwaysKept: 2,
@@ -342,6 +355,10 @@ export const resolveArticleAnalysisConfig = (
     openaiModel,
     maxOutputTokens:
       config.maxOutputTokens ?? articleAnalysisConfigDefaults.maxOutputTokens,
+    extractionMaxOutputTokens:
+      config.extractionMaxOutputTokens ??
+      config.maxOutputTokens ??
+      articleAnalysisConfigDefaults.maxOutputTokens,
     maxContentChars:
       config.maxContentChars ?? articleAnalysisConfigDefaults.maxContentChars,
     useStructureAwareTruncation:
@@ -507,9 +524,11 @@ export const resolveArticleAnalysisConfig = (
     // Reasoning effort: per-pass overrides fall back to the agent-wide default.
     // All values remain undefined when the operator has not set reasoning effort
     // (safe for non-reasoning models such as gpt-4o-mini).
-    ...(defaultEffort !== undefined
-      ? { extractionReasoningEffort: defaultEffort }
-      : {}),
+    ...(config.extractionReasoningEffort !== undefined
+      ? { extractionReasoningEffort: config.extractionReasoningEffort }
+      : defaultEffort !== undefined
+        ? { extractionReasoningEffort: defaultEffort }
+        : {}),
     ...(config.brainstormReasoningEffort !== undefined
       ? { brainstormReasoningEffort: config.brainstormReasoningEffort }
       : defaultEffort !== undefined

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -20,6 +20,7 @@ import {
   buildRelationCritiqueUserContent,
   buildVocabularyRepairSystemContent,
   classifyLlmExtractionError,
+  classifyNoResponseSubtype,
   executeLlmCallWithTransientRetries,
   extractEntitiesAndRelationsForSource,
   repairExtractionVocabulary,
@@ -827,6 +828,77 @@ describe("classifyLlmExtractionError", () => {
     expect(classifyLlmExtractionError(new Error("unexpected error"))).toBe(
       "permanent",
     );
+  });
+});
+
+type FinishReason =
+  | "stop"
+  | "length"
+  | "content-filter"
+  | "tool-calls"
+  | "error"
+  | "other";
+
+const noObjectGeneratedErrorFixture = (
+  finishReason: FinishReason,
+  text?: string,
+): NoObjectGeneratedError =>
+  new NoObjectGeneratedError({
+    message: "No object generated: the model did not return a response.",
+    response: {
+      id: "test-id",
+      modelId: "gpt-4o-mini",
+      timestamp: new Date(),
+    },
+    usage: {
+      inputTokens: 100,
+      outputTokens: 8192,
+      totalTokens: 8292,
+      inputTokenDetails: {
+        noCacheTokens: undefined,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+      },
+      outputTokenDetails: {
+        textTokens: undefined,
+        reasoningTokens: undefined,
+      },
+    },
+    finishReason,
+    ...(text !== undefined ? { text } : {}),
+  });
+
+describe("classifyNoResponseSubtype", () => {
+  it("returns length_truncation for finishReason: length", () => {
+    const error = noObjectGeneratedErrorFixture("length");
+
+    expect(classifyNoResponseSubtype(error)).toBe("length_truncation");
+  });
+
+  it("returns content_filter for finishReason: content-filter", () => {
+    const error = noObjectGeneratedErrorFixture("content-filter");
+
+    expect(classifyNoResponseSubtype(error)).toBe("content_filter");
+  });
+
+  it("returns empty_stop for finishReason: stop", () => {
+    const error = noObjectGeneratedErrorFixture("stop");
+
+    expect(classifyNoResponseSubtype(error)).toBe("empty_stop");
+  });
+
+  it("returns empty_stop for unrecognized finishReason with empty text", () => {
+    const error = noObjectGeneratedErrorFixture("other", "");
+
+    expect(classifyNoResponseSubtype(error)).toBe("empty_stop");
+  });
+
+  it("returns other for a non-NoObjectGeneratedError", () => {
+    expect(classifyNoResponseSubtype(new Error("parse failure"))).toBe("other");
+  });
+
+  it("returns other for a plain object", () => {
+    expect(classifyNoResponseSubtype({ code: 500 })).toBe("other");
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -110,6 +110,45 @@ export type GenerateTextForBrainstorm = (args: {
   providerOptions?: OpenAiReasoningProviderOptions;
 }) => Promise<ArticleBrainstormCallResult>;
 
+/** Fine-grained sub-type for a `NoObjectGeneratedError` non-response. */
+export type NoResponseSubtype =
+  | "length_truncation"
+  | "empty_stop"
+  | "content_filter"
+  | "other";
+
+/**
+ * Returns the fine-grained sub-type of a `NoObjectGeneratedError` non-response.
+ *
+ * Used by instrumentation and by budget-escalation retry to distinguish starvation
+ * from genuinely empty completions.
+ *
+ * @param error - Thrown value from an LLM call.
+ * @returns Sub-type label; `"other"` for non-`NoObjectGeneratedError` errors.
+ */
+export const classifyNoResponseSubtype = (
+  error: unknown,
+): NoResponseSubtype => {
+  if (!NoObjectGeneratedError.isInstance(error)) {
+    return "other";
+  }
+  const finishReason = error.finishReason;
+  if (finishReason === "length") {
+    return "length_truncation";
+  }
+  if (finishReason === "content-filter") {
+    return "content_filter";
+  }
+  if (finishReason === "stop") {
+    return "empty_stop";
+  }
+  const text = error.text;
+  if (text === undefined || text.trim().length === 0) {
+    return "empty_stop";
+  }
+  return "other";
+};
+
 /**
  * Classifies an LLM extraction error as transient or permanent.
  *

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -2,6 +2,7 @@ import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
 import { buildOpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
+import { NoObjectGeneratedError } from "ai";
 
 import { applyPerArticleExtractionCaps } from "./analysis-caps-dedupe.js";
 import {
@@ -25,7 +26,10 @@ import {
   type RelationProposal,
 } from "./analysis-vocabulary.js";
 import { toSafeLogError } from "./article-analysis-observability.js";
-import type { ArticleAnalysisExtractionFailureRecord } from "./article-analysis-run-policy.js";
+import type {
+  ArticleAnalysisExtractionFailureRecord,
+  ExtractionLlmFailureReason,
+} from "./article-analysis-run-policy.js";
 import type { ResolvedArticleAnalysisConfig } from "./config-schema.js";
 import {
   buildArticleAnalysisExtractionUserContent,
@@ -34,6 +38,7 @@ import {
   applyRelationCritiqueDrops,
   buildRelationCritiqueModelMessages,
   classifyLlmExtractionError,
+  classifyNoResponseSubtype,
   critiqueExtractedRelations,
   executeLlmCallWithTransientRetries,
   relationCritiqueRowKey,
@@ -282,6 +287,8 @@ export const createProcessOneSource =
         ? source.content.slice(0, cfg.maxContentChars)
         : source.content;
 
+    let currentExtractionMaxOutputTokens = cfg.extractionMaxOutputTokens;
+
     try {
       const t0 = Date.now();
       const extractionUserContent = buildArticleAnalysisExtractionUserContent({
@@ -372,12 +379,13 @@ export const createProcessOneSource =
         cfg.extractionReasoningEffort,
       );
       let extractionRetryAttempts = 0;
+      const extractionBudgetCap = cfg.extractionMaxOutputTokens * 4;
       const extractedResult = await executeLlmCallWithTransientRetries(
         () =>
           extractEntitiesAndRelationsForSource({
             apiKey: cfg.openaiApiKey,
             model: cfg.openaiModel,
-            maxOutputTokens: cfg.maxOutputTokens,
+            maxOutputTokens: currentExtractionMaxOutputTokens,
             messages: [
               { role: "system", content: systemContent },
               {
@@ -402,11 +410,20 @@ export const createProcessOneSource =
           shouldAbort: isRunDeadlineElapsed,
           onRetry: (attempt, error) => {
             extractionRetryAttempts++;
+            const noResponseSubtype = classifyNoResponseSubtype(error);
+            if (noResponseSubtype === "length_truncation") {
+              currentExtractionMaxOutputTokens = Math.min(
+                extractionBudgetCap,
+                Math.ceil(currentExtractionMaxOutputTokens * 1.5),
+              );
+            }
             log.warn(
               {
                 dataSourceId: source.id,
                 stage: "extraction",
                 retryAttempt: attempt,
+                noResponseSubtype,
+                currentExtractionMaxOutputTokens,
                 err: toSafeLogError(error),
               },
               "article-analysis LLM extraction transient failure; retrying",
@@ -759,15 +776,44 @@ export const createProcessOneSource =
       };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      outcome.extractionFailures.push({
+      const noResponseSubtype = classifyNoResponseSubtype(err);
+      const isTimeout =
+        message.includes("timed out") ||
+        message.includes("ETIMEDOUT") ||
+        message.includes("ECONNRESET");
+      const llmFailureReason: ExtractionLlmFailureReason =
+        NoObjectGeneratedError.isInstance(err)
+          ? noResponseSubtype
+          : isTimeout
+            ? "timeout"
+            : "other";
+      const failureRecord: ArticleAnalysisExtractionFailureRecord = {
         dataSourceId: source.id,
         stage: "llm",
         message,
-      });
+        reason: llmFailureReason,
+      };
+      if (NoObjectGeneratedError.isInstance(err)) {
+        const outputTokens = err.usage?.outputTokens;
+        if (outputTokens !== undefined) {
+          failureRecord.outputTokens = outputTokens;
+        }
+        failureRecord.maxOutputTokens = currentExtractionMaxOutputTokens;
+      }
+      outcome.extractionFailures.push(failureRecord);
       log.warn(
         {
           dataSourceId: source.id,
           stage: "llm",
+          llmFailureReason,
+          ...(NoObjectGeneratedError.isInstance(err)
+            ? {
+                finishReason: err.finishReason,
+                outputTokens: err.usage?.outputTokens,
+                maxOutputTokens: currentExtractionMaxOutputTokens,
+                responseTextLength: err.text?.length,
+              }
+            : {}),
           err: toSafeLogError(err),
         },
         "article-analysis LLM extraction failed for source; skipping",

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -1490,9 +1490,10 @@ describe("run", () => {
       {
         dataSourceId: DS_ID,
         stage: "llm",
+        llmFailureReason: "other",
         err: { type: "Error", message: "provider timeout" },
       },
-      expect.any(String),
+      "article-analysis LLM extraction failed for source; skipping",
     );
   });
 
@@ -3034,5 +3035,105 @@ describe("run", () => {
       (summaryCall?.[0] as { extractionFailuresLlm: number })
         .extractionFailuresLlm,
     ).toBe(0);
+  });
+
+  it("recovers from length-truncation via budget escalation and reports recoveredByRetry", async () => {
+    // Setup
+    const { NoObjectGeneratedError } = await import("ai");
+    const lengthTruncationError = new NoObjectGeneratedError({
+      message: "No object generated: the model did not return a response.",
+      response: { id: "r", modelId: "gpt-4o-mini", timestamp: new Date() },
+      usage: {
+        inputTokens: 1000,
+        inputTokenDetails: {
+          noCacheTokens: undefined,
+          cacheReadTokens: undefined,
+          cacheWriteTokens: undefined,
+        },
+        outputTokens: 8192,
+        outputTokenDetails: {
+          textTokens: undefined,
+          reasoningTokens: undefined,
+        },
+        totalTokens: 9192,
+      },
+      finishReason: "length",
+    });
+    const goodResult = llmResult({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [],
+    });
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    const capturedMaxOutputTokens: number[] = [];
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockImplementation(
+      async (params) => {
+        capturedMaxOutputTokens.push(params.maxOutputTokens);
+        if (capturedMaxOutputTokens.length === 1) {
+          throw lengthTruncationError;
+        }
+
+        return goodResult;
+      },
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    // Act
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          extractionMaxOutputTokens: 8192,
+          extractionTransientRetries: 2,
+          extractionTransientRetryBaseDelayMs: 1,
+          extractionTransientRetryMaxDelayMs: 1,
+        },
+      }),
+    );
+
+    // Assert
+    expect(result.success).toBe(true);
+    expect(result.details?.extractionFailures).toHaveLength(0);
+    expect(capturedMaxOutputTokens).toHaveLength(2);
+    expect(capturedMaxOutputTokens[1]).toBeGreaterThan(
+      capturedMaxOutputTokens[0]!,
+    );
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect(
+      (summaryCall?.[0] as { extractionRetries?: { recoveredByRetry: number } })
+        .extractionRetries?.recoveredByRetry,
+    ).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

LLM extraction skips were lumped under a generic `stage: "llm"` label, which made it hard to tell starvation from timeouts or content filters. This PR classifies non-response failures, adds extraction-specific token budget config, escalates output tokens on length-truncation retries, and rolls up `extractionNonResponse` on run summaries.

## Related issues

Closes #671

## Important changes

- Add `extractionMaxOutputTokens` (falls back to `maxOutputTokens`; default now 24576) and honor explicit `extractionReasoningEffort`.
- Classify `NoObjectGeneratedError` into `length_truncation`, `empty_stop`, `content_filter`, or `other`.
- Escalate `currentExtractionMaxOutputTokens` by 1.5× on length-truncation transient retries, capped at 4× the configured extraction budget.
- Record `reason`, `outputTokens`, and `maxOutputTokens` on permanent LLM failure records.
- Emit `extractionNonResponse` breakdown in run summary payloads when LLM failures occur.

## Other changes

- Export `classifyNoResponseSubtype` and `aggregateExtractionNonResponseBreakdown` with unit tests.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts` - budget escalation and enriched failure records.
- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` - `classifyNoResponseSubtype`.
- `apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts` - `extractionNonResponse` rollup.
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` - `extractionMaxOutputTokens` resolution.
- `apps/mediapulse/agents/article-analysis/src/run.test.ts` - summary and retry behavior tests.

## How to test

1. `pnpm --filter @mediapulse/article-analysis test`
2. `pnpm --filter @mediapulse/article-analysis type:check`
3. Confirm `classifyNoResponseSubtype` and observability aggregation tests pass.
