### PR TITLE
Add per-call timeout for article-analysis LLM extraction

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
+++ b/apps/mediapulse/agents/article-analysis/src/article-analysis-observability.ts
@@ -398,6 +398,7 @@ export type ArticleAnalysisRunSummaryInput = {
   perSourceLatency?: PerSourceLatencyObservability;
   extractionRetries?: ExtractionRetryObservabilityAggregate;
   extractionNonResponse?: ExtractionNonResponseBreakdown;
+  extractionCallTimeouts?: number;
 };
 
 /**
@@ -785,6 +786,13 @@ export const buildArticleAnalysisRunSummaryPayload = (
 
   if (input.extractionRetries !== undefined) {
     base.extractionRetries = input.extractionRetries;
+  }
+
+  if (
+    input.extractionCallTimeouts !== undefined &&
+    input.extractionCallTimeouts > 0
+  ) {
+    base.extractionCallTimeouts = input.extractionCallTimeouts;
   }
 
   if (input.extractionNonResponse !== undefined) {

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -168,6 +168,13 @@ export const articleAnalysisConfigSchema = z
     /** Cap on jittered backoff in ms for extraction retries. */
     extractionTransientRetryMaxDelayMs: z.number().int().positive().optional(),
     /**
+     * Per-call wall-clock timeout in ms applied to each `generateObject`/`generateText` attempt
+     * (extraction, brainstorm, critique, repair). A stuck call aborts after this interval and is
+     * retried by `executeLlmCallWithTransientRetries`. Default is generous — this is a hung-call
+     * backstop, not a latency SLA.
+     */
+    extractionCallTimeoutMs: z.number().int().positive().optional(),
+    /**
      * Cap on data sources loaded and processed per run
      * (also bounds `analysis.get` `limit` together with `analysisGetDataSourceLimitMax`).
      * Override in Hermes agent config; package default applies when omitted.
@@ -271,6 +278,7 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   extractionTransientRetries: number;
   extractionTransientRetryBaseDelayMs: number;
   extractionTransientRetryMaxDelayMs: number;
+  extractionCallTimeoutMs: number;
   debounceMinUnanalyzedCount: number;
   debounceMinMinutesSinceLastScore: number;
   /** Cap on sources per run (Hermes agent config). */
@@ -329,6 +337,7 @@ export const articleAnalysisConfigDefaults = {
   extractionTransientRetries: 2,
   extractionTransientRetryBaseDelayMs: 500,
   extractionTransientRetryMaxDelayMs: 8000,
+  extractionCallTimeoutMs: 60_000,
   debounceMinUnanalyzedCount: 0,
   debounceMinMinutesSinceLastScore: 0,
   maxBatchSize: 10,
@@ -510,6 +519,9 @@ export const resolveArticleAnalysisConfig = (
     extractionTransientRetryMaxDelayMs:
       config.extractionTransientRetryMaxDelayMs ??
       articleAnalysisConfigDefaults.extractionTransientRetryMaxDelayMs,
+    extractionCallTimeoutMs:
+      config.extractionCallTimeoutMs ??
+      articleAnalysisConfigDefaults.extractionCallTimeoutMs,
     debounceMinUnanalyzedCount:
       config.debounceMinUnanalyzedCount ??
       articleAnalysisConfigDefaults.debounceMinUnanalyzedCount,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -21,6 +21,7 @@ import {
   buildVocabularyRepairSystemContent,
   classifyLlmExtractionError,
   classifyNoResponseSubtype,
+  isCallTimeoutError,
   executeLlmCallWithTransientRetries,
   extractEntitiesAndRelationsForSource,
   repairExtractionVocabulary,
@@ -828,6 +829,58 @@ describe("classifyLlmExtractionError", () => {
     expect(classifyLlmExtractionError(new Error("unexpected error"))).toBe(
       "permanent",
     );
+  });
+
+  it("classifies a DOMException TimeoutError as transient", () => {
+    const timeoutError = Object.assign(new Error("The operation timed out"), {
+      name: "TimeoutError",
+    });
+
+    expect(classifyLlmExtractionError(timeoutError)).toBe("transient");
+  });
+
+  it("classifies an AbortError whose cause is a TimeoutError as transient", () => {
+    const cause = Object.assign(new Error("timeout"), { name: "TimeoutError" });
+    const abortError = Object.assign(new Error("The operation was aborted"), {
+      name: "AbortError",
+      cause,
+    });
+
+    expect(classifyLlmExtractionError(abortError)).toBe("transient");
+  });
+});
+
+describe("isCallTimeoutError", () => {
+  it("returns true for an error named TimeoutError", () => {
+    const error = Object.assign(new Error("timed out"), {
+      name: "TimeoutError",
+    });
+
+    expect(isCallTimeoutError(error)).toBe(true);
+  });
+
+  it("returns true for an error whose cause is named TimeoutError", () => {
+    const cause = Object.assign(new Error("timeout"), { name: "TimeoutError" });
+    const error = Object.assign(new Error("aborted"), {
+      name: "AbortError",
+      cause,
+    });
+
+    expect(isCallTimeoutError(error)).toBe(true);
+  });
+
+  it("returns false for a generic Error", () => {
+    expect(isCallTimeoutError(new Error("network error"))).toBe(false);
+  });
+
+  it("returns false for an AbortError with no cause", () => {
+    const error = Object.assign(new Error("aborted"), { name: "AbortError" });
+
+    expect(isCallTimeoutError(error)).toBe(false);
+  });
+
+  it("returns false for a plain object", () => {
+    expect(isCallTimeoutError({ message: "timeout" })).toBe(false);
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -108,6 +108,7 @@ export type GenerateTextForBrainstorm = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   providerOptions?: OpenAiReasoningProviderOptions;
+  timeoutMs?: number;
 }) => Promise<ArticleBrainstormCallResult>;
 
 /** Fine-grained sub-type for a `NoObjectGeneratedError` non-response. */
@@ -150,6 +151,32 @@ export const classifyNoResponseSubtype = (
 };
 
 /**
+ * Returns true when the error originates from an `AbortSignal.timeout` per-call ceiling.
+ *
+ * `AbortSignal.timeout(ms)` aborts with a `DOMException` whose `name` is `"TimeoutError"`.
+ * The HTTP client may surface this as the thrown error itself or wrap it in an `AbortError`
+ * with the `TimeoutError` DOMException as `cause`.
+ *
+ * Distinguishes a *per-call* timeout (retryable) from a *run-deadline* abort (governed by
+ * `shouldAbort: isRunDeadlineElapsed`) which is NOT a `TimeoutError`.
+ *
+ * @param error - Thrown value from an LLM call.
+ */
+export const isCallTimeoutError = (error: unknown): boolean => {
+  if ((error as { name?: unknown }).name === "TimeoutError") {
+    return true;
+  }
+  const cause = (error as { cause?: unknown }).cause;
+  if (cause !== null && cause !== undefined) {
+    if ((cause as { name?: unknown }).name === "TimeoutError") {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+/**
  * Classifies an LLM extraction error as transient or permanent.
  *
  * Transient errors are safe to retry (rate limits, empty completions, timeouts, 5xx).
@@ -161,6 +188,9 @@ export const classifyNoResponseSubtype = (
 export const classifyLlmExtractionError = (
   error: unknown,
 ): "transient" | "permanent" => {
+  if (isCallTimeoutError(error)) {
+    return "transient";
+  }
   if (APICallError.isInstance(error)) {
     const statusCode = error.statusCode;
     if (
@@ -306,6 +336,7 @@ export type GenerateObjectForRelationCritique = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   providerOptions?: OpenAiReasoningProviderOptions;
+  timeoutMs?: number;
 }) => Promise<{
   object: LlmRelationCritiqueWireOutput;
   usage: LlmExtractionUsage | null;
@@ -317,6 +348,7 @@ export type GenerateObjectForExtraction = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   providerOptions?: OpenAiReasoningProviderOptions;
+  timeoutMs?: number;
 }) => Promise<{
   object: LlmExtractionWireOutput;
   usage: LlmExtractionUsage | null;
@@ -357,6 +389,7 @@ export type GenerateObjectForVocabularyRepair = (args: {
   maxOutputTokens: number;
   messages: ModelMessage[];
   providerOptions?: OpenAiReasoningProviderOptions;
+  timeoutMs?: number;
 }) => Promise<{
   object: LlmVocabularyRepairWireOutput;
   usage: LlmExtractionUsage | null;
@@ -391,9 +424,13 @@ export const normalizeLlmUsageFromSdk = (usage: {
 const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
   args,
 ) => {
-  const { providerOptions, ...rest } = args;
+  const { providerOptions, timeoutMs, ...rest } = args;
   const result = await generateObject({
     ...rest,
+    maxRetries: 0,
+    ...(timeoutMs !== undefined
+      ? { abortSignal: AbortSignal.timeout(timeoutMs) }
+      : {}),
     ...(providerOptions !== undefined ? { providerOptions } : {}),
   });
   return {
@@ -405,9 +442,13 @@ const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
 const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
   args,
 ) => {
-  const { providerOptions, ...rest } = args;
+  const { providerOptions, timeoutMs, ...rest } = args;
   const result = await generateText({
     ...rest,
+    maxRetries: 0,
+    ...(timeoutMs !== undefined
+      ? { abortSignal: AbortSignal.timeout(timeoutMs) }
+      : {}),
     ...(providerOptions !== undefined ? { providerOptions } : {}),
   });
   return {
@@ -418,9 +459,13 @@ const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
 
 const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritique =
   async (args) => {
-    const { providerOptions, ...rest } = args;
+    const { providerOptions, timeoutMs, ...rest } = args;
     const result = await generateObject({
       ...rest,
+      maxRetries: 0,
+      ...(timeoutMs !== undefined
+        ? { abortSignal: AbortSignal.timeout(timeoutMs) }
+        : {}),
       ...(providerOptions !== undefined ? { providerOptions } : {}),
     });
     return {
@@ -431,9 +476,13 @@ const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritiqu
 
 const defaultGenerateObjectForVocabularyRepair: GenerateObjectForVocabularyRepair =
   async (args) => {
-    const { providerOptions, ...rest } = args;
+    const { providerOptions, timeoutMs, ...rest } = args;
     const result = await generateObject({
       ...rest,
+      maxRetries: 0,
+      ...(timeoutMs !== undefined
+        ? { abortSignal: AbortSignal.timeout(timeoutMs) }
+        : {}),
       ...(providerOptions !== undefined ? { providerOptions } : {}),
     });
     return {
@@ -609,6 +658,7 @@ export const fetchArticleBrainstorm = async (
     maxOutputTokens: number;
     messages: ModelMessage[];
     providerOptions?: OpenAiReasoningProviderOptions;
+    timeoutMs?: number;
   },
   deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
     generateTextForBrainstorm: defaultGenerateTextForBrainstorm,
@@ -622,6 +672,7 @@ export const fetchArticleBrainstorm = async (
     ...(params.providerOptions !== undefined
       ? { providerOptions: params.providerOptions }
       : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
 };
 
@@ -688,6 +739,7 @@ export const extractEntitiesAndRelationsForSource = async (
     exemplars?: readonly ResolvedExemplar[];
     brainstormText?: string;
     providerOptions?: OpenAiReasoningProviderOptions;
+    timeoutMs?: number;
   },
   deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
     generateObjectForExtraction: defaultGenerateObjectForExtraction,
@@ -718,6 +770,7 @@ export const extractEntitiesAndRelationsForSource = async (
     ...(params.providerOptions !== undefined
       ? { providerOptions: params.providerOptions }
       : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
   return {
     object: normalizeLlmExtractionWire(raw.object),
@@ -888,6 +941,7 @@ export const critiqueExtractedRelations = async (
     maxOutputTokens: number;
     messages: ModelMessage[];
     providerOptions?: OpenAiReasoningProviderOptions;
+    timeoutMs?: number;
   },
   deps: {
     generateObjectForRelationCritique: GenerateObjectForRelationCritique;
@@ -904,6 +958,7 @@ export const critiqueExtractedRelations = async (
     ...(params.providerOptions !== undefined
       ? { providerOptions: params.providerOptions }
       : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
   return {
     ratings: raw.object.ratings,
@@ -1053,6 +1108,7 @@ export const repairExtractionVocabulary = async (
     badEntities: readonly BadEntityRecord[];
     badRelations: readonly BadRelationRecord[];
     providerOptions?: OpenAiReasoningProviderOptions;
+    timeoutMs?: number;
   },
   deps: {
     generateObjectForVocabularyRepair: GenerateObjectForVocabularyRepair;
@@ -1073,6 +1129,7 @@ export const repairExtractionVocabulary = async (
     ...(params.providerOptions !== undefined
       ? { providerOptions: params.providerOptions }
       : {}),
+    ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
 
   if (

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -39,6 +39,7 @@ import {
   buildRelationCritiqueModelMessages,
   classifyLlmExtractionError,
   classifyNoResponseSubtype,
+  isCallTimeoutError,
   critiqueExtractedRelations,
   executeLlmCallWithTransientRetries,
   relationCritiqueRowKey,
@@ -132,6 +133,7 @@ export type SourceProcessingOutcome = {
   sourceQualityScore?: number;
   extractionRetryAttempts: number;
   extractionRetrySucceeded: boolean;
+  extractionCallTimeouts: number;
 };
 
 /** Returns an empty per-source outcome for early-return paths. */
@@ -163,6 +165,7 @@ export const createEmptySourceProcessingOutcome =
     relationCritiqueCalls: 0,
     extractionRetryAttempts: 0,
     extractionRetrySucceeded: false,
+    extractionCallTimeouts: 0,
   });
 
 export type ProcessOneSourceDeps = {
@@ -319,6 +322,7 @@ export const createProcessOneSource =
                 apiKey: cfg.openaiApiKey,
                 model: cfg.brainstormModel,
                 maxOutputTokens: cfg.brainstormMaxOutputTokens,
+                timeoutMs: cfg.extractionCallTimeoutMs,
                 messages: [
                   {
                     role: "system",
@@ -346,6 +350,11 @@ export const createProcessOneSource =
               sleep,
               classify: classifyLlmExtractionError,
               shouldAbort: isRunDeadlineElapsed,
+              onRetry: (_attempt, error) => {
+                if (isCallTimeoutError(error)) {
+                  outcome.extractionCallTimeouts += 1;
+                }
+              },
             },
           );
           outcome.brainstormCalls = 1;
@@ -386,6 +395,7 @@ export const createProcessOneSource =
             apiKey: cfg.openaiApiKey,
             model: cfg.openaiModel,
             maxOutputTokens: currentExtractionMaxOutputTokens,
+            timeoutMs: cfg.extractionCallTimeoutMs,
             messages: [
               { role: "system", content: systemContent },
               {
@@ -410,6 +420,9 @@ export const createProcessOneSource =
           shouldAbort: isRunDeadlineElapsed,
           onRetry: (attempt, error) => {
             extractionRetryAttempts++;
+            if (isCallTimeoutError(error)) {
+              outcome.extractionCallTimeouts += 1;
+            }
             const noResponseSubtype = classifyNoResponseSubtype(error);
             if (noResponseSubtype === "length_truncation") {
               currentExtractionMaxOutputTokens = Math.min(
@@ -491,6 +504,7 @@ export const createProcessOneSource =
               apiKey: cfg.openaiApiKey,
               model: cfg.vocabularyRepairModel,
               maxOutputTokens: cfg.maxOutputTokens,
+              timeoutMs: cfg.extractionCallTimeoutMs,
               ctx,
               badEntities: partitioned.badEntities,
               badRelations: partitioned.badRelations,
@@ -623,6 +637,7 @@ export const createProcessOneSource =
                 apiKey: cfg.openaiApiKey,
                 model: cfg.relationCritiqueModel,
                 maxOutputTokens: cfg.maxOutputTokens,
+                timeoutMs: cfg.extractionCallTimeoutMs,
                 messages: buildRelationCritiqueModelMessages(ctx, {
                   articleTitle: source.title,
                   articleBody: source.content,
@@ -639,6 +654,11 @@ export const createProcessOneSource =
               sleep,
               classify: classifyLlmExtractionError,
               shouldAbort: isRunDeadlineElapsed,
+              onRetry: (_attempt, error) => {
+                if (isCallTimeoutError(error)) {
+                  outcome.extractionCallTimeouts += 1;
+                }
+              },
             },
           );
           outcome.relationCritiqueCalls = 1;

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -3136,4 +3136,126 @@ describe("run", () => {
         .extractionRetries?.recoveredByRetry,
     ).toBe(1);
   });
+
+  it("recovers from a call timeout and reports extractionCallTimeouts in the run summary", async () => {
+    const timeoutError = Object.assign(new Error("The operation timed out"), {
+      name: "TimeoutError",
+    });
+    const goodResult = llmResult({
+      entities: [{ canonicalName: "A", typeId: TYPE_ID, aliases: [] }],
+      relations: [],
+      articleMentions: [],
+    });
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    let extractionCallCount = 0;
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockImplementation(
+      async (_params) => {
+        extractionCallCount++;
+        if (extractionCallCount === 1) {
+          throw timeoutError;
+        }
+
+        return goodResult;
+      },
+    );
+    analysisCreate.mockResolvedValue({
+      entitiesCreated: 1,
+      entitiesReused: 0,
+      relationsCreated: 0,
+      articlesScored: 1,
+      articlesSelected: 1,
+    });
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          extractionTransientRetries: 2,
+          extractionTransientRetryBaseDelayMs: 1,
+          extractionTransientRetryMaxDelayMs: 1,
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.details?.extractionFailures).toHaveLength(0);
+
+    const summaryCall = mockLog.info.mock.calls.find(
+      (call) =>
+        typeof call[0] === "object" &&
+        call[0] !== null &&
+        (call[0] as { event?: string }).event ===
+          ARTICLE_ANALYSIS_RUN_SUMMARY_MESSAGE,
+    );
+    expect(summaryCall).toBeDefined();
+    expect(
+      (summaryCall?.[0] as { extractionCallTimeouts?: number })
+        .extractionCallTimeouts,
+    ).toBe(1);
+  });
+
+  it("surfaces a source as an llm failure when every extraction attempt times out", async () => {
+    const timeoutError = Object.assign(new Error("The operation timed out"), {
+      name: "TimeoutError",
+    });
+    analysisGet.mockResolvedValue(
+      analysisGetOk({
+        dataSources: [
+          {
+            id: DS_ID,
+            url: VALID_SOURCE_URL,
+            title: VALID_SOURCE_TITLE,
+            content: validSourceContent(),
+            tickerId: "ticker-1",
+            createdAt: new Date(),
+          },
+        ],
+        entityTypes: [{ id: TYPE_ID, name: "Co", description: null }],
+        relationTypes: [{ id: REL_ID, name: "r", description: null }],
+        existingEntities: [],
+        relevanceSelectionState,
+        lastRelevanceScoredAtIso: null,
+      }),
+    );
+    vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockRejectedValue(
+      timeoutError,
+    );
+
+    const result = await run(
+      runContext({
+        input: { tickerId: "ticker-1" },
+        config: {
+          extractionTransientRetries: 1,
+          extractionTransientRetryBaseDelayMs: 1,
+          extractionTransientRetryMaxDelayMs: 1,
+          runPolicy: { minSuccessfulSources: 0 },
+        },
+      }),
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.details?.extractionFailures).toHaveLength(1);
+    expect(result.details?.extractionFailures?.[0]?.stage).toBe("llm");
+    expect(
+      (result.details?.extractionFailures?.[0] as { reason?: string })?.reason,
+    ).toBe("timeout");
+  });
 });

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -394,6 +394,11 @@ export const run = async ({
             exhausted: extractionRetriesExhausted,
           } satisfies ExtractionRetryObservabilityAggregate)
         : undefined),
+    extractionCallTimeouts:
+      summary.extractionCallTimeouts ??
+      (extractionCallTimeoutsTotal > 0
+        ? extractionCallTimeoutsTotal
+        : undefined),
   });
 
   /**
@@ -549,6 +554,7 @@ export const run = async ({
   let extractionRetriesTotalAttempts = 0;
   let extractionRetriesRecoveredByRetry = 0;
   let extractionRetriesExhausted = 0;
+  let extractionCallTimeoutsTotal = 0;
   let parallelPeakInFlight = 0;
   let parallelDeadlineFiredAtMs: number | undefined;
   const perSourceExtractionLatencyMs: number[] = [];
@@ -924,6 +930,9 @@ export const run = async ({
         } else {
           extractionRetriesExhausted += 1;
         }
+      }
+      if (outcome.extractionCallTimeouts > 0) {
+        extractionCallTimeoutsTotal += outcome.extractionCallTimeouts;
       }
     };
 


### PR DESCRIPTION
## Summary

A stuck `generateObject` or `generateText` call can block article-analysis extraction with no timeout signal. This PR adds `extractionCallTimeoutMs`, aborts hung calls via `AbortSignal.timeout`, retries `TimeoutError` as transient, and reports `extractionCallTimeouts` on run summaries.

## Related issues

Closes #673

## Important changes

- Add `extractionCallTimeoutMs` config (default 60s) and pass `timeoutMs` through extraction, brainstorm, critique, and repair calls.
- Set SDK `maxRetries: 0` so `executeLlmCallWithTransientRetries` owns retry policy.
- Add `isCallTimeoutError` and classify per-call timeouts as transient.
- Track per-source `extractionCallTimeouts` and include the total in run summary payloads.

## Other changes

- Tests for timeout recovery, exhausted-timeout failure, and `isCallTimeoutError` classification.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts` - timeout wiring and `isCallTimeoutError`.
- `apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts` - timeout param and counter on retries.
- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` - `extractionCallTimeoutMs` resolution.
- `apps/mediapulse/agents/article-analysis/src/run.test.ts` - timeout recovery and failure tests.

## How to test

1. `pnpm --filter @mediapulse/article-analysis test`
2. `pnpm --filter @mediapulse/article-analysis type:check`
3. Confirm the timeout recovery and exhausted-timeout tests in `run.test.ts` pass.
