### PR TITLE
Add curated SearchQuerySource and ensure-curated-listing-query endpoint

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -26,6 +26,7 @@ import {
   postDataCollectionDeadUrlsRecord,
 } from "./routes/data-collection-dead-url.js";
 import { getDataCollectionRecentSourceFingerprints } from "./routes/data-collection-recent-source-fingerprints.js";
+import { postDataCollectionCuratedListingQuery } from "./routes/data-collection-curated-listing-query.js";
 import {
   getDataCollection,
   postDataCollection,
@@ -119,6 +120,9 @@ const routeHandlers = {
   },
   dataCollectionRecentSourceFingerprints: {
     get: getDataCollectionRecentSourceFingerprints,
+  },
+  dataCollectionCuratedListingQuery: {
+    post: postDataCollectionCuratedListingQuery,
   },
   dataCollectionRun: {
     get: getDataCollectionRun,

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection-curated-listing-query.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection-curated-listing-query.ts
@@ -1,0 +1,29 @@
+import { postCuratedListingQueryBodySchema } from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+import { prisma } from "@mediapulse/database";
+import type { Context } from "hono";
+
+import { ensureCuratedListingQuery } from "../services/data-collection-curated-query.js";
+
+/**
+ * Returns the stable curated-listing SearchQuery id for a ticker, creating it if absent.
+ *
+ * @param context - Hono context; JSON body `{ tickerId }`.
+ * @returns JSON `{ searchQueryId }`.
+ */
+export async function postDataCollectionCuratedListingQuery(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed = postCuratedListingQueryBodySchema.parse(body);
+    const searchQueryId = await ensureCuratedListingQuery(
+      parsed.tickerId,
+      prisma.searchQuery,
+    );
+
+    return context.json({ searchQueryId }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.test.ts
@@ -1,0 +1,73 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  CURATED_LISTING_TEXT,
+  ensureCuratedListingQuery,
+} from "./data-collection-curated-query";
+
+const TICKER_A = "00000000-0000-0000-0000-000000000001";
+const TICKER_B = "00000000-0000-0000-0000-000000000002";
+const QUERY_ID_A = "aaaaaaaa-0000-0000-0000-000000000001";
+const QUERY_ID_B = "bbbbbbbb-0000-0000-0000-000000000001";
+
+describe("ensureCuratedListingQuery", () => {
+  it("creates a curated query on first call and returns its id", async () => {
+    const findFirst = vi.fn().mockResolvedValue(null);
+    const create = vi.fn().mockResolvedValue({ id: QUERY_ID_A });
+    const searchQuery = { findFirst, create };
+
+    const result = await ensureCuratedListingQuery(TICKER_A, searchQuery);
+
+    expect(result).toBe(QUERY_ID_A);
+    expect(findFirst).toHaveBeenCalledWith({
+      where: {
+        tickerId: TICKER_A,
+        source: "curated",
+        text: CURATED_LISTING_TEXT,
+      },
+      select: { id: true },
+    });
+    expect(create).toHaveBeenCalledWith({
+      data: {
+        tickerId: TICKER_A,
+        text: CURATED_LISTING_TEXT,
+        source: "curated",
+        setId: null,
+      },
+      select: { id: true },
+    });
+  });
+
+  it("returns the existing id on second call without creating a new row", async () => {
+    const findFirst = vi.fn().mockResolvedValue({ id: QUERY_ID_A });
+    const create = vi.fn();
+    const searchQuery = { findFirst, create };
+
+    const result = await ensureCuratedListingQuery(TICKER_A, searchQuery);
+
+    expect(result).toBe(QUERY_ID_A);
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it("returns distinct ids for two different tickers", async () => {
+    const findFirstA = vi.fn().mockResolvedValue({ id: QUERY_ID_A });
+    const findFirstB = vi.fn().mockResolvedValue({ id: QUERY_ID_B });
+    const create = vi.fn();
+
+    const resultA = await ensureCuratedListingQuery(TICKER_A, {
+      findFirst: findFirstA,
+      create,
+    });
+    const resultB = await ensureCuratedListingQuery(TICKER_B, {
+      findFirst: findFirstB,
+      create,
+    });
+
+    expect(resultA).toBe(QUERY_ID_A);
+    expect(resultB).toBe(QUERY_ID_B);
+    expect(resultA).not.toBe(resultB);
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.ts
+++ b/apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.ts
@@ -1,0 +1,44 @@
+import type { Prisma } from "@mediapulse/database";
+
+/** Reserved query text for all curated-listing synthetic queries. */
+export const CURATED_LISTING_TEXT = "[curated-listing]";
+
+type SearchQueryDb = Pick<
+  typeof import("@mediapulse/database").prisma.searchQuery,
+  "findFirst" | "create"
+>;
+
+/**
+ * Returns the id of the stable per-ticker curated SearchQuery, creating it on first call.
+ *
+ * @param tickerId - Ticker the curated query belongs to.
+ * @param searchQuery - Prisma delegate for `searchQuery`.
+ */
+export async function ensureCuratedListingQuery(
+  tickerId: string,
+  searchQuery: SearchQueryDb,
+): Promise<string> {
+  const findArgs = {
+    where: { tickerId, source: "curated", text: CURATED_LISTING_TEXT },
+    select: { id: true },
+  } satisfies Prisma.SearchQueryFindFirstArgs;
+
+  const existing = await searchQuery.findFirst(findArgs);
+  if (existing) {
+    return existing.id;
+  }
+
+  const createArgs = {
+    data: {
+      tickerId,
+      text: CURATED_LISTING_TEXT,
+      source: "curated",
+      setId: null,
+    },
+    select: { id: true },
+  } satisfies Prisma.SearchQueryCreateArgs;
+
+  const created = await searchQuery.create(createArgs);
+
+  return created.id;
+}

--- a/apps/mediapulse/domain-api/src/resources/search-queries/routes.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/search-queries/routes.test.ts
@@ -72,6 +72,7 @@ describe("searchQueriesRoutes", () => {
     expect(body.sourceOptions).toEqual([
       { value: "deterministic", label: "deterministic" },
       { value: "llm", label: "llm" },
+      { value: "curated", label: "curated" },
     ]);
   });
 

--- a/packages/mediapulse/database/prisma/migrations/20260608000001_add_curated_search_query_source/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260608000001_add_curated_search_query_source/migration.sql
@@ -1,0 +1,2 @@
+-- Add curated value to SearchQuerySource enum for synthetic per-ticker queries.
+ALTER TYPE "SearchQuerySource" ADD VALUE 'curated';

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -22,6 +22,7 @@ enum Sentiment {
 enum SearchQuerySource {
   deterministic
   llm
+  curated
 }
 
 enum SearchQueryIntent {

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -25,6 +25,8 @@ import {
   dataCollectionBodySchema,
   dataCollectionQuerySchema,
   getDataCollectionResponseSchema,
+  postCuratedListingQueryBodySchema,
+  postCuratedListingQueryResponseSchema,
   postDataCollectionExistingUrlsBodySchema,
   postDataCollectionExistingUrlsResponseSchema,
   postDataCollectionResponseSchema,
@@ -318,6 +320,22 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       get: {
         query: getDataCollectionRecentSourceFingerprintsQuerySchema,
         response: getDataCollectionRecentSourceFingerprintsResponseSchema,
+      },
+    },
+  },
+  dataCollectionCuratedListingQuery: {
+    v1: {
+      pathSegment: "/data-collection/curated-listing-query",
+      post: {
+        body: postCuratedListingQueryBodySchema,
+        response: postCuratedListingQueryResponseSchema,
+      },
+    },
+    v2: {
+      pathSegment: "/data-collection/curated-listing-query",
+      post: {
+        body: postCuratedListingQueryBodySchema,
+        response: postCuratedListingQueryResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/data-collection.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection.ts
@@ -103,3 +103,24 @@ export type GetDataCollectionRecentSourceFingerprintsResponse = z.infer<
   typeof getDataCollectionRecentSourceFingerprintsResponseSchema
 >;
 export type SourceFingerprint = z.infer<typeof sourceFingerprintSchema>;
+
+/**
+ * Body for POST `/data-collection/curated-listing-query`: ensures a per-ticker synthetic query.
+ */
+export const postCuratedListingQueryBodySchema = z.object({
+  tickerId: z.string().uuid(),
+});
+
+/**
+ * Response: the stable id of the curated SearchQuery row for the ticker.
+ */
+export const postCuratedListingQueryResponseSchema = z.object({
+  searchQueryId: z.string().uuid(),
+});
+
+export type PostCuratedListingQueryBody = z.infer<
+  typeof postCuratedListingQueryBodySchema
+>;
+export type PostCuratedListingQueryResponse = z.infer<
+  typeof postCuratedListingQueryResponseSchema
+>;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -79,6 +79,10 @@ export {
   type PostDataCollectionExistingUrlsResponse,
   type PostDataCollectionResponse,
   type SourceFingerprint,
+  postCuratedListingQueryBodySchema,
+  postCuratedListingQueryResponseSchema,
+  type PostCuratedListingQueryBody,
+  type PostCuratedListingQueryResponse,
 } from "./data-collection.js";
 export {
   computeDeadUrlExpiresAt,

--- a/packages/shared/agent-data-api-contract/src/query-analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.ts
@@ -59,7 +59,11 @@ export const DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS: Record<
   wildcard: 0,
 };
 
-export const queryAnalysisSourceSchema = z.enum(["deterministic", "llm"]);
+export const queryAnalysisSourceSchema = z.enum([
+  "deterministic",
+  "llm",
+  "curated",
+]);
 
 export const getQueryAnalysisQuerySchema = z.object({
   tickerId: z.string().trim().min(1),


### PR DESCRIPTION
## Summary

`DataSource.searchQueryId` is NOT-NULL, but curated listing articles have no real search query to attribute them to. This adds a `curated` value to the `SearchQuerySource` enum and a `POST /data-collection/curated-listing-query` endpoint that returns a stable per-ticker synthetic `SearchQuery` id, creating it on first call and reusing it on all subsequent calls.

## Related issues

Closes #679

## Important changes

- `SearchQuerySource` enum gets a `curated` value via migration `20260608000001_add_curated_search_query_source`.
- New `POST /data-collection/curated-listing-query` endpoint (registered under both v1 and v2) accepts `{ tickerId }` and returns `{ searchQueryId }`. The underlying `ensureCuratedListingQuery` service does a find-first then create, so two calls for the same ticker always return the same id.
- `queryAnalysisSourceSchema` in the contract now includes `"curated"`, which also surfaces it as a filter option in the Hermes search-queries dashboard.

## Other changes

- Updated `domain-api` search-queries `/meta` test to expect the new `curated` source option.

## Key files to review

- `packages/mediapulse/database/prisma/migrations/20260608000001_add_curated_search_query_source/migration.sql` — single `ALTER TYPE` statement; no unsafe-new-value pitfall since no default uses `curated`.
- `apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.ts` — find-first-then-create idempotency logic.
- `apps/mediapulse/agent-data-api/src/services/data-collection-curated-query.test.ts` — three cases: first call creates, second call reuses, two different tickers get distinct ids.
- `packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts` — new `dataCollectionCuratedListingQuery` resource with explicit `pathSegment`.

## How to test

1. Run `pnpm --filter @mediapulse/agent-data-api test` — all tests should pass, including the three idempotency cases in `data-collection-curated-query.test.ts`.
2. Run `pnpm --filter @mediapulse/domain-api test` — the search-queries `/meta` test should pass with the updated `sourceOptions`.
3. After deploying, `POST /api/v1/data-collection/curated-listing-query` with `{ "tickerId": "<uuid>" }` twice should return the same `searchQueryId` both times, and `SELECT * FROM search_query WHERE source = 'curated' AND ticker_id = '<uuid>'` should show exactly one row with `text = '[curated-listing]'` and `set_id = NULL`.
