### PR TITLE
Add listing discovery strategy chain to agent-ingestion

### DIFF
--- a/packages/shared/agent-ingestion/package.json
+++ b/packages/shared/agent-ingestion/package.json
@@ -18,6 +18,7 @@
     "@workspace/agent-types": "workspace:*",
     "@workspace/logger": "workspace:*",
     "@workspace/utils": "workspace:*",
+    "fast-xml-parser": "catalog:",
     "got": "catalog:",
     "zod": "catalog:"
   },

--- a/packages/shared/agent-ingestion/src/discovery/generic-links.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/generic-links.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+import { RequestError } from "got";
+import type got from "got";
+
+import { genericLinksStrategy } from "./generic-links";
+import { RateLimiter } from "../resilience";
+
+const LISTING_HTML = `<!DOCTYPE html>
+<html>
+<head><title>News</title></head>
+<body>
+  <nav>
+    <a href="/category/markets">Markets</a>
+    <a href="/tag/finance">Finance</a>
+    <a href="/">Home</a>
+  </nav>
+  <main>
+    <a href="/articles/apple-q4-results">Apple Q4 Results</a>
+    <a href="/articles/fed-rate-decision">Fed Rate Decision</a>
+    <a href="https://otherdomain.com/article/external">External Article</a>
+    <a href="/articles/apple-q4-results">Apple Q4 Results (duplicate)</a>
+  </main>
+</body>
+</html>`;
+
+const buildDeps = (html: string) => ({
+  gotClient: {
+    get: vi.fn().mockResolvedValue({ statusCode: 200, body: html }),
+  } as unknown as typeof got,
+  rateLimiter: new RateLimiter(100, 1),
+  logger: { info: vi.fn(), warn: vi.fn() },
+});
+
+describe("genericLinksStrategy", () => {
+  it("extracts same-host article links and drops nav/noisy paths", async () => {
+    const deps = buildDeps(LISTING_HTML);
+    const items = await genericLinksStrategy.discover(
+      "https://example.com/news",
+      deps,
+    );
+
+    const urls = items.map((item) => item.url);
+    expect(urls).toContain("https://example.com/articles/apple-q4-results");
+    expect(urls).toContain("https://example.com/articles/fed-rate-decision");
+    expect(urls.every((url) => url.startsWith("https://example.com"))).toBe(
+      true,
+    );
+  });
+
+  it("drops cross-origin links", async () => {
+    const deps = buildDeps(LISTING_HTML);
+    const items = await genericLinksStrategy.discover(
+      "https://example.com/news",
+      deps,
+    );
+
+    expect(items.some((item) => item.url.includes("otherdomain.com"))).toBe(
+      false,
+    );
+  });
+
+  it("drops noisy paths like /category/ and /tag/", async () => {
+    const deps = buildDeps(LISTING_HTML);
+    const items = await genericLinksStrategy.discover(
+      "https://example.com/news",
+      deps,
+    );
+
+    expect(items.some((item) => item.url.includes("/category/"))).toBe(false);
+    expect(items.some((item) => item.url.includes("/tag/"))).toBe(false);
+  });
+
+  it("deduplicates same URLs", async () => {
+    const deps = buildDeps(LISTING_HTML);
+    const items = await genericLinksStrategy.discover(
+      "https://example.com/news",
+      deps,
+    );
+
+    const appleUrls = items.filter((item) => item.url.includes("apple-q4"));
+    expect(appleUrls).toHaveLength(1);
+  });
+
+  it("returns items with url only (no title)", async () => {
+    const deps = buildDeps(LISTING_HTML);
+    const items = await genericLinksStrategy.discover(
+      "https://example.com/news",
+      deps,
+    );
+
+    for (const item of items) {
+      expect(item.title).toBeUndefined();
+      expect(item.publishedAt).toBeUndefined();
+    }
+  });
+
+  it("throws a classified error on HTTP failure", async () => {
+    const networkError = new RequestError(
+      "connection refused",
+      { code: "ECONNREFUSED" },
+      {} as never,
+    );
+    const deps = {
+      gotClient: {
+        get: vi.fn().mockRejectedValue(networkError),
+      } as unknown as typeof got,
+      rateLimiter: new RateLimiter(100, 1),
+      logger: { info: vi.fn(), warn: vi.fn() },
+    };
+
+    await expect(
+      genericLinksStrategy.discover("https://example.com/news", deps),
+    ).rejects.toMatchObject({ errorCategory: "network_error" });
+  });
+});

--- a/packages/shared/agent-ingestion/src/discovery/generic-links.ts
+++ b/packages/shared/agent-ingestion/src/discovery/generic-links.ts
@@ -1,0 +1,132 @@
+import { classifyNoisyUrl } from "@workspace/utils";
+
+import { classifyError } from "../error-classification";
+import type {
+  DiscoveredItem,
+  DiscoveryDeps,
+  ListingDiscoveryStrategy,
+} from "./types";
+
+/** Regex to extract href attribute values from anchor tags. */
+const HREF_REGEX = /<a\s[^>]*href\s*=\s*["']([^"']+)["'][^>]*>/gi;
+
+/**
+ * Extracts all href values from raw HTML.
+ *
+ * @param html - Raw HTML string.
+ */
+const extractHrefs = (html: string): string[] => {
+  const hrefs: string[] = [];
+  let match: RegExpExecArray | null;
+  HREF_REGEX.lastIndex = 0;
+
+  while ((match = HREF_REGEX.exec(html)) !== null) {
+    const href = match[1];
+    if (href) {
+      hrefs.push(href);
+    }
+  }
+
+  return hrefs;
+};
+
+/**
+ * Resolves a potentially relative href against the listing page origin.
+ *
+ * @param href - Raw href from an anchor tag.
+ * @param baseUrl - The listing page URL used as base for relative hrefs.
+ */
+const resolveHref = (href: string, baseUrl: string): string | undefined => {
+  try {
+    return new URL(href, baseUrl).toString();
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Returns true when the resolved URL is on the same host as the listing page.
+ *
+ * @param resolvedUrl - Fully resolved URL.
+ * @param listingHost - Hostname of the listing page.
+ */
+const isSameHost = (resolvedUrl: string, listingHost: string): boolean => {
+  try {
+    return new URL(resolvedUrl).hostname === listingHost;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Fetches a listing page and extracts same-host article links via classifyNoisyUrl.
+ *
+ * @param listingUrl - URL of the listing page.
+ * @param deps - Shared discovery dependencies.
+ */
+const discoverGenericLinks = async (
+  listingUrl: string,
+  deps: DiscoveryDeps,
+): Promise<DiscoveredItem[]> => {
+  const { gotClient, rateLimiter } = deps;
+
+  await rateLimiter.acquire();
+
+  let html: string;
+  let listingHost: string;
+  try {
+    listingHost = new URL(listingUrl).hostname;
+  } catch {
+    throw Object.assign(new Error(`Invalid listing URL: ${listingUrl}`), {
+      errorCategory: "internal_processing_error",
+    });
+  }
+
+  try {
+    const response = await gotClient.get(listingUrl, {
+      headers: { Accept: "text/html" },
+    });
+    rateLimiter.recordResponse(response.statusCode);
+    html = response.body;
+  } catch (error) {
+    const classified = classifyError(error);
+    throw Object.assign(new Error(classified.message), {
+      errorCategory: classified.category,
+    });
+  }
+
+  const hrefs = extractHrefs(html);
+  const seen = new Set<string>();
+  const items: DiscoveredItem[] = [];
+
+  for (const href of hrefs) {
+    const resolved = resolveHref(href, listingUrl);
+    if (!resolved) {
+      continue;
+    }
+    if (!isSameHost(resolved, listingHost)) {
+      continue;
+    }
+
+    const decision = classifyNoisyUrl(resolved);
+    if (decision.blocked) {
+      continue;
+    }
+
+    const canonical = decision.canonicalUrl;
+    if (seen.has(canonical)) {
+      continue;
+    }
+    seen.add(canonical);
+
+    items.push({ url: canonical });
+  }
+
+  return items;
+};
+
+/** Generic same-host link extraction listing discovery strategy. */
+export const genericLinksStrategy: ListingDiscoveryStrategy = {
+  type: "generic-links",
+  discover: discoverGenericLinks,
+};

--- a/packages/shared/agent-ingestion/src/discovery/registry.ts
+++ b/packages/shared/agent-ingestion/src/discovery/registry.ts
@@ -1,0 +1,30 @@
+import { genericLinksStrategy } from "./generic-links";
+import { rssStrategy } from "./rss";
+import { sitemapStrategy } from "./sitemap";
+import type { ListingDiscoveryStrategy } from "./types";
+
+/** Ordered default discovery chain tried for every source unless overridden. */
+export const DEFAULT_DISCOVERY_CHAIN: ReadonlyArray<
+  "rss" | "sitemap" | "generic-links"
+> = ["rss", "sitemap", "generic-links"];
+
+/**
+ * Returns the listing discovery strategy for the given type.
+ *
+ * @param type - Strategy type key.
+ * @throws When `type` is not a known discovery strategy.
+ */
+export const createListingDiscoveryStrategy = (
+  type: "rss" | "sitemap" | "generic-links",
+): ListingDiscoveryStrategy => {
+  switch (type) {
+    case "rss":
+      return rssStrategy;
+    case "sitemap":
+      return sitemapStrategy;
+    case "generic-links":
+      return genericLinksStrategy;
+    default:
+      throw new Error(`Unknown listing discovery strategy type: ${type}`);
+  }
+};

--- a/packages/shared/agent-ingestion/src/discovery/rss.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/rss.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from "vitest";
+import type got from "got";
+
+import { rssStrategy } from "./rss";
+import { RateLimiter } from "../resilience";
+
+const RSS_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Article One</title>
+      <link>https://example.com/articles/one</link>
+      <description>Summary of article one</description>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Article Two</title>
+      <link>https://example.com/articles/two</link>
+      <description>Summary of article two</description>
+      <pubDate>Tue, 02 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
+const ATOM_FIXTURE = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Atom Feed</title>
+  <entry>
+    <title>Atom Entry One</title>
+    <link href="https://example.com/atom/one" rel="alternate"/>
+    <summary>Summary of atom entry one</summary>
+    <updated>2024-03-15T10:00:00Z</updated>
+  </entry>
+  <entry>
+    <title>Atom Entry Two</title>
+    <link href="https://example.com/atom/two"/>
+    <updated>2024-03-16T12:00:00Z</updated>
+  </entry>
+</feed>`;
+
+const MALFORMED_XML = `<?xml version="1.0"?><unclosed>`;
+
+const buildDeps = (body: string) => ({
+  gotClient: {
+    get: vi.fn().mockResolvedValue({ statusCode: 200, body }),
+  } as unknown as typeof got,
+  rateLimiter: new RateLimiter(100, 1),
+  logger: { info: vi.fn(), warn: vi.fn() },
+});
+
+describe("rssStrategy", () => {
+  it("parses RSS 2.0 items with title, summary and publishedAt", async () => {
+    const deps = buildDeps(RSS_FIXTURE);
+    const items = await rssStrategy.discover(
+      "https://example.com/feed.rss",
+      deps,
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      url: "https://example.com/articles/one",
+      title: "Article One",
+      summary: "Summary of article one",
+    });
+    expect(items[0]?.publishedAt).toBe(
+      new Date("Mon, 01 Jan 2024 00:00:00 GMT").toISOString(),
+    );
+  });
+
+  it("parses Atom feed entries with title, summary and publishedAt", async () => {
+    const deps = buildDeps(ATOM_FIXTURE);
+    const items = await rssStrategy.discover(
+      "https://example.com/feed.atom",
+      deps,
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      url: "https://example.com/atom/one",
+      title: "Atom Entry One",
+      summary: "Summary of atom entry one",
+      publishedAt: "2024-03-15T10:00:00.000Z",
+    });
+    expect(items[1]).toMatchObject({
+      url: "https://example.com/atom/two",
+      title: "Atom Entry Two",
+      publishedAt: "2024-03-16T12:00:00.000Z",
+    });
+    expect(items[1]?.summary).toBeUndefined();
+  });
+
+  it("throws a classified error on malformed XML", async () => {
+    const deps = buildDeps(MALFORMED_XML);
+    await expect(
+      rssStrategy.discover("https://example.com/bad-feed.xml", deps),
+    ).rejects.toMatchObject({ errorCategory: "provider_data_invalid" });
+  });
+
+  it("throws a classified error when the XML is not an RSS or Atom feed", async () => {
+    const deps = buildDeps("<html><body>Not a feed</body></html>");
+    await expect(
+      rssStrategy.discover("https://example.com/not-feed", deps),
+    ).rejects.toMatchObject({ errorCategory: "provider_data_invalid" });
+  });
+});

--- a/packages/shared/agent-ingestion/src/discovery/rss.ts
+++ b/packages/shared/agent-ingestion/src/discovery/rss.ts
@@ -1,0 +1,196 @@
+import { XMLParser } from "fast-xml-parser";
+
+import { classifyError } from "../error-classification";
+import type {
+  DiscoveredItem,
+  DiscoveryDeps,
+  ListingDiscoveryStrategy,
+} from "./types";
+
+const XML_PARSER_OPTIONS = {
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  isArray: (tagName: string) => tagName === "item" || tagName === "entry",
+} as const;
+
+const xmlParser = new XMLParser(XML_PARSER_OPTIONS);
+
+/**
+ * Normalizes a raw date string to an ISO string, returning undefined when unparseable.
+ *
+ * @param raw - Raw date string from a feed field.
+ */
+const normalizeDate = (raw: unknown): string | undefined => {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return undefined;
+  }
+  const parsed = new Date(raw.trim());
+
+  return isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+/**
+ * Maps a string or object with #text to a plain string.
+ *
+ * @param value - Possibly wrapped text from the XML parser.
+ */
+const asText = (value: unknown): string | undefined => {
+  if (typeof value === "string") {
+    return value || undefined;
+  }
+  if (typeof value === "object" && value !== null && "#text" in value) {
+    const text = (value as Record<string, unknown>)["#text"];
+    return typeof text === "string" ? text || undefined : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Parses RSS 2.0 items from a parsed feed document.
+ *
+ * @param doc - Parsed XML document.
+ */
+const parseRssItems = (doc: Record<string, unknown>): DiscoveredItem[] => {
+  const channel = (doc["rss"] as Record<string, unknown>)?.["channel"] as
+    | Record<string, unknown>
+    | undefined;
+  if (!channel) {
+    return [];
+  }
+
+  const items = (channel["item"] as unknown[]) ?? [];
+
+  return items.flatMap((item) => {
+    const entry = item as Record<string, unknown>;
+    const url = asText(entry["link"]);
+    if (!url) {
+      return [];
+    }
+
+    return [
+      {
+        url,
+        ...(asText(entry["title"]) ? { title: asText(entry["title"]) } : {}),
+        ...(asText(entry["description"])
+          ? { summary: asText(entry["description"]) }
+          : {}),
+        ...(normalizeDate(entry["pubDate"])
+          ? { publishedAt: normalizeDate(entry["pubDate"]) }
+          : {}),
+      },
+    ];
+  });
+};
+
+/**
+ * Parses Atom feed entries from a parsed feed document.
+ *
+ * @param doc - Parsed XML document.
+ */
+const parseAtomEntries = (doc: Record<string, unknown>): DiscoveredItem[] => {
+  const feed = doc["feed"] as Record<string, unknown> | undefined;
+  if (!feed) {
+    return [];
+  }
+
+  const entries = (feed["entry"] as unknown[]) ?? [];
+
+  return entries.flatMap((entry) => {
+    const node = entry as Record<string, unknown>;
+
+    const linkNode = node["link"];
+    let url: string | undefined;
+    if (
+      typeof linkNode === "object" &&
+      linkNode !== null &&
+      "@_href" in linkNode
+    ) {
+      url = (linkNode as Record<string, string>)["@_href"];
+    } else if (Array.isArray(linkNode)) {
+      const alternate = (linkNode as Record<string, string>[]).find(
+        (link) => !link["@_rel"] || link["@_rel"] === "alternate",
+      );
+      url = alternate?.["@_href"];
+    } else {
+      url = asText(linkNode);
+    }
+
+    if (!url) {
+      return [];
+    }
+
+    const summaryNode = node["summary"] ?? node["content"];
+
+    return [
+      {
+        url,
+        ...(asText(node["title"]) ? { title: asText(node["title"]) } : {}),
+        ...(asText(summaryNode) ? { summary: asText(summaryNode) } : {}),
+        ...(normalizeDate(node["updated"] ?? node["published"])
+          ? { publishedAt: normalizeDate(node["updated"] ?? node["published"]) }
+          : {}),
+      },
+    ];
+  });
+};
+
+/**
+ * Fetches and parses an RSS or Atom feed into DiscoveredItem entries.
+ *
+ * @param listingUrl - URL of the RSS or Atom feed.
+ * @param deps - Shared discovery dependencies.
+ */
+const discoverRss = async (
+  listingUrl: string,
+  deps: DiscoveryDeps,
+): Promise<DiscoveredItem[]> => {
+  const { gotClient, rateLimiter } = deps;
+
+  await rateLimiter.acquire();
+
+  let body: string;
+  try {
+    const response = await gotClient.get(listingUrl, {
+      headers: {
+        Accept:
+          "application/rss+xml, application/atom+xml, application/xml, text/xml",
+      },
+    });
+    rateLimiter.recordResponse(response.statusCode);
+    body = response.body;
+  } catch (error) {
+    const classified = classifyError(error);
+    throw Object.assign(new Error(classified.message), {
+      errorCategory: classified.category,
+    });
+  }
+
+  let doc: Record<string, unknown>;
+  try {
+    doc = xmlParser.parse(body) as Record<string, unknown>;
+  } catch (error) {
+    throw Object.assign(
+      new Error(
+        `RSS/Atom XML parse failed: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+      { errorCategory: "provider_data_invalid" },
+    );
+  }
+
+  if (doc["rss"]) {
+    return parseRssItems(doc);
+  }
+  if (doc["feed"]) {
+    return parseAtomEntries(doc);
+  }
+
+  throw Object.assign(new Error("Not a recognized RSS or Atom feed"), {
+    errorCategory: "provider_data_invalid",
+  });
+};
+
+/** RSS/Atom listing discovery strategy. */
+export const rssStrategy: ListingDiscoveryStrategy = {
+  type: "rss",
+  discover: discoverRss,
+};

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type got from "got";
+
+import { discoverOneSource, runDiscovery } from "./run-discovery";
+import { rssStrategy } from "./rss";
+import { sitemapStrategy } from "./sitemap";
+import { genericLinksStrategy } from "./generic-links";
+import { RateLimiter } from "../resilience";
+
+vi.mock("./rss", () => ({
+  rssStrategy: { type: "rss", discover: vi.fn() },
+}));
+
+vi.mock("./sitemap", () => ({
+  sitemapStrategy: { type: "sitemap", discover: vi.fn() },
+}));
+
+vi.mock("./generic-links", () => ({
+  genericLinksStrategy: { type: "generic-links", discover: vi.fn() },
+}));
+
+const buildDeps = () => ({
+  gotClient: {} as typeof got,
+  rateLimiter: new RateLimiter(100, 1),
+  logger: { info: vi.fn(), warn: vi.fn() },
+});
+
+const RSS_ERROR = Object.assign(new Error("feed not found"), {
+  errorCategory: "provider_http_error",
+});
+
+describe("discoverOneSource", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns items from the first strategy that succeeds with non-empty results", async () => {
+    const rssItems = [{ url: "https://example.com/a" }];
+    vi.mocked(rssStrategy.discover).mockResolvedValue(rssItems);
+
+    const result = await discoverOneSource(
+      {
+        url: "https://example.com/feed",
+        strategies: ["rss", "sitemap", "generic-links"],
+      },
+      buildDeps(),
+    );
+
+    expect(result.items).toEqual(rssItems);
+    expect(result.failures).toHaveLength(0);
+    expect(vi.mocked(sitemapStrategy.discover)).not.toHaveBeenCalled();
+  });
+
+  it("falls through rss error → sitemap empty → generic-links succeeds", async () => {
+    const genericItems = [{ url: "https://example.com/article/one" }];
+    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
+    vi.mocked(sitemapStrategy.discover).mockResolvedValue([]);
+    vi.mocked(genericLinksStrategy.discover).mockResolvedValue(genericItems);
+
+    const result = await discoverOneSource(
+      {
+        url: "https://example.com/news",
+        strategies: ["rss", "sitemap", "generic-links"],
+      },
+      buildDeps(),
+    );
+
+    expect(result.items).toEqual(genericItems);
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures[0]?.strategyType).toBe("rss");
+    expect(result.failures[1]?.strategyType).toBe("sitemap");
+  });
+
+  it("returns empty items and all failures when the whole chain is exhausted", async () => {
+    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
+    vi.mocked(sitemapStrategy.discover).mockRejectedValue(
+      new Error("sitemap gone"),
+    );
+    vi.mocked(genericLinksStrategy.discover).mockRejectedValue(
+      new Error("403"),
+    );
+
+    const result = await discoverOneSource(
+      {
+        url: "https://example.com/news",
+        strategies: ["rss", "sitemap", "generic-links"],
+      },
+      buildDeps(),
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.failures).toHaveLength(3);
+  });
+
+  it("respects maxItems when the winning strategy returns too many", async () => {
+    const manyItems = Array.from({ length: 20 }, (_, index) => ({
+      url: `https://example.com/articles/${index}`,
+    }));
+    vi.mocked(rssStrategy.discover).mockResolvedValue(manyItems);
+
+    const result = await discoverOneSource(
+      { url: "https://example.com/feed", strategies: ["rss"], maxItems: 5 },
+      buildDeps(),
+    );
+
+    expect(result.items).toHaveLength(5);
+  });
+});
+
+describe("runDiscovery", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("skips sources with enabled: false", async () => {
+    vi.mocked(rssStrategy.discover).mockResolvedValue([
+      { url: "https://a.com/article" },
+    ]);
+
+    const result = await runDiscovery(
+      [
+        { url: "https://a.com/feed", strategies: ["rss"] },
+        { url: "https://b.com/feed", strategies: ["rss"], enabled: false },
+      ],
+      buildDeps(),
+    );
+
+    expect(vi.mocked(rssStrategy.discover)).toHaveBeenCalledTimes(1);
+    expect(result.items).toHaveLength(1);
+  });
+
+  it("deduplicates items with the same URL across sources", async () => {
+    const sharedItem = { url: "https://example.com/shared-article" };
+    vi.mocked(rssStrategy.discover).mockResolvedValue([sharedItem]);
+    vi.mocked(sitemapStrategy.discover).mockResolvedValue([sharedItem]);
+
+    const result = await runDiscovery(
+      [
+        { url: "https://example.com/feed.rss", strategies: ["rss"] },
+        { url: "https://example.com/sitemap.xml", strategies: ["sitemap"] },
+      ],
+      buildDeps(),
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.url).toBe("https://example.com/shared-article");
+  });
+
+  it("never throws even when all sources fail; captures failures", async () => {
+    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
+
+    const result = await runDiscovery(
+      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      buildDeps(),
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.failures).toHaveLength(1);
+  });
+});

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
@@ -1,0 +1,124 @@
+import { classifyError, isRetryableError } from "../error-classification";
+import {
+  createListingDiscoveryStrategy,
+  DEFAULT_DISCOVERY_CHAIN,
+} from "./registry";
+import type { DiscoveredItem, DiscoveryDeps } from "./types";
+
+/** A single listing source for discovery. */
+export type DiscoverySource = {
+  url: string;
+  /** Whether to include this source. Defaults to true when omitted. */
+  enabled?: boolean;
+  /** Ordered strategy chain override; falls back to DEFAULT_DISCOVERY_CHAIN. */
+  strategies?: ReadonlyArray<"rss" | "sitemap" | "generic-links">;
+  /** Maximum items to return from this source. */
+  maxItems?: number;
+};
+
+/** A per-strategy failure captured during discovery. */
+export type DiscoveryFailure = {
+  sourceUrl: string;
+  strategyType: string;
+  errorCategory: string;
+  message: string;
+  retryable: boolean;
+};
+
+/** Result of running discovery over a single source's strategy chain. */
+export type SourceDiscoveryOutcome = {
+  items: DiscoveredItem[];
+  failures: DiscoveryFailure[];
+};
+
+/** Aggregate result of running discovery over all sources. */
+export type RunDiscoveryResult = {
+  items: DiscoveredItem[];
+  failures: DiscoveryFailure[];
+};
+
+/**
+ * Runs a source through its ordered strategy chain with fallback.
+ *
+ * The first strategy that returns a non-empty list wins. An error or empty
+ * result falls through to the next strategy. Every per-strategy failure is
+ * collected; the source yields `{ items: [], failures }` only when the whole
+ * chain is exhausted — mirroring fetchOneResult's loop over the provider chain.
+ *
+ * @param source - Listing source configuration.
+ * @param deps - Shared discovery dependencies.
+ */
+export const discoverOneSource = async (
+  source: DiscoverySource,
+  deps: DiscoveryDeps,
+): Promise<SourceDiscoveryOutcome> => {
+  const chain = source.strategies ?? DEFAULT_DISCOVERY_CHAIN;
+  const failures: DiscoveryFailure[] = [];
+
+  for (const strategyType of chain) {
+    const strategy = createListingDiscoveryStrategy(strategyType);
+
+    try {
+      const items = await strategy.discover(source.url, deps);
+
+      if (items.length === 0) {
+        failures.push({
+          sourceUrl: source.url,
+          strategyType,
+          errorCategory: "provider_data_invalid",
+          message: "Strategy returned no items",
+          retryable: false,
+        });
+        continue;
+      }
+
+      const limited =
+        source.maxItems !== undefined ? items.slice(0, source.maxItems) : items;
+
+      return { items: limited, failures };
+    } catch (error) {
+      const classified = classifyError(error);
+      failures.push({
+        sourceUrl: source.url,
+        strategyType,
+        errorCategory: classified.category,
+        message: classified.message,
+        retryable: isRetryableError(error),
+      });
+    }
+  }
+
+  return { items: [], failures };
+};
+
+/**
+ * Runs discovery over all enabled sources, deduplicates by canonical URL, and returns
+ * the merged item list with all per-strategy failures captured (never thrown).
+ *
+ * @param sources - Listing sources to discover from.
+ * @param deps - Shared discovery dependencies.
+ */
+export const runDiscovery = async (
+  sources: DiscoverySource[],
+  deps: DiscoveryDeps,
+): Promise<RunDiscoveryResult> => {
+  const enabledSources = sources.filter((source) => source.enabled !== false);
+
+  const allItems: DiscoveredItem[] = [];
+  const allFailures: DiscoveryFailure[] = [];
+  const seen = new Set<string>();
+
+  for (const source of enabledSources) {
+    const { items, failures } = await discoverOneSource(source, deps);
+
+    for (const item of items) {
+      if (!seen.has(item.url)) {
+        seen.add(item.url);
+        allItems.push(item);
+      }
+    }
+    allFailures.push(...failures);
+  }
+
+  return { items: allItems, failures: allFailures };
+};

--- a/packages/shared/agent-ingestion/src/discovery/sitemap.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/sitemap.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from "vitest";
+import type got from "got";
+
+import { sitemapStrategy } from "./sitemap";
+import { RateLimiter } from "../resilience";
+
+const STANDARD_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://example.com/articles/first</loc>
+    <lastmod>2024-04-01</lastmod>
+  </url>
+  <url>
+    <loc>https://example.com/articles/second</loc>
+    <lastmod>2024-04-02</lastmod>
+  </url>
+</urlset>`;
+
+const NEWS_SITEMAP = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+        xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
+  <url>
+    <loc>https://example.com/news/breaking</loc>
+    <lastmod>2024-05-10</lastmod>
+    <news:news>
+      <news:title>Breaking News Today</news:title>
+      <news:publication_date>2024-05-10T08:00:00Z</news:publication_date>
+    </news:news>
+  </url>
+</urlset>`;
+
+const buildDeps = (body: string) => ({
+  gotClient: {
+    get: vi.fn().mockResolvedValue({ statusCode: 200, body }),
+  } as unknown as typeof got,
+  rateLimiter: new RateLimiter(100, 1),
+  logger: { info: vi.fn(), warn: vi.fn() },
+});
+
+describe("sitemapStrategy", () => {
+  it("parses a standard sitemap with loc and lastmod", async () => {
+    const deps = buildDeps(STANDARD_SITEMAP);
+    const items = await sitemapStrategy.discover(
+      "https://example.com/sitemap.xml",
+      deps,
+    );
+
+    expect(items).toHaveLength(2);
+    expect(items[0]).toMatchObject({
+      url: "https://example.com/articles/first",
+      publishedAt: "2024-04-01T00:00:00.000Z",
+    });
+    expect(items[0]?.title).toBeUndefined();
+  });
+
+  it("parses a news sitemap using news:title and lastmod", async () => {
+    const deps = buildDeps(NEWS_SITEMAP);
+    const items = await sitemapStrategy.discover(
+      "https://example.com/news-sitemap.xml",
+      deps,
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      url: "https://example.com/news/breaking",
+      title: "Breaking News Today",
+      publishedAt: "2024-05-10T00:00:00.000Z",
+    });
+  });
+
+  it("throws a classified error on malformed XML", async () => {
+    const deps = buildDeps("<broken><unclosed>");
+    await expect(
+      sitemapStrategy.discover("https://example.com/sitemap.xml", deps),
+    ).rejects.toMatchObject({ errorCategory: "provider_data_invalid" });
+  });
+
+  it("throws a classified error when XML has no urlset", async () => {
+    const deps = buildDeps(
+      "<notasitemap><url><loc>x</loc></url></notasitemap>",
+    );
+    await expect(
+      sitemapStrategy.discover("https://example.com/sitemap.xml", deps),
+    ).rejects.toMatchObject({ errorCategory: "provider_data_invalid" });
+  });
+});

--- a/packages/shared/agent-ingestion/src/discovery/sitemap.ts
+++ b/packages/shared/agent-ingestion/src/discovery/sitemap.ts
@@ -1,0 +1,143 @@
+import { XMLParser } from "fast-xml-parser";
+
+import { classifyError } from "../error-classification";
+import type {
+  DiscoveredItem,
+  DiscoveryDeps,
+  ListingDiscoveryStrategy,
+} from "./types";
+
+const XML_PARSER_OPTIONS = {
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  isArray: (tagName: string) => tagName === "url",
+} as const;
+
+const xmlParser = new XMLParser(XML_PARSER_OPTIONS);
+
+/**
+ * Normalizes a raw date string to an ISO string, returning undefined when unparseable.
+ *
+ * @param raw - Raw date string from a sitemap field.
+ */
+const normalizeDate = (raw: unknown): string | undefined => {
+  if (typeof raw !== "string" || raw.trim() === "") {
+    return undefined;
+  }
+  const parsed = new Date(raw.trim());
+
+  return isNaN(parsed.getTime()) ? undefined : parsed.toISOString();
+};
+
+/**
+ * Maps a string or object with #text to a plain string.
+ *
+ * @param value - Possibly wrapped text from the XML parser.
+ */
+const asText = (value: unknown): string | undefined => {
+  if (typeof value === "string") {
+    return value || undefined;
+  }
+  if (typeof value === "object" && value !== null && "#text" in value) {
+    const text = (value as Record<string, unknown>)["#text"];
+    return typeof text === "string" ? text || undefined : undefined;
+  }
+  return undefined;
+};
+
+/**
+ * Parses a sitemap urlset into DiscoveredItem entries.
+ *
+ * @param doc - Parsed XML document.
+ */
+const parseSitemapUrls = (doc: Record<string, unknown>): DiscoveredItem[] => {
+  const urlset = doc["urlset"] as Record<string, unknown> | undefined;
+  if (!urlset) {
+    return [];
+  }
+
+  const urls = (urlset["url"] as unknown[]) ?? [];
+
+  return urls.flatMap((urlNode) => {
+    const node = urlNode as Record<string, unknown>;
+    const loc = asText(node["loc"]);
+    if (!loc) {
+      return [];
+    }
+
+    const newsNode = node["news:news"] as Record<string, unknown> | undefined;
+    const newsTitle = newsNode
+      ? asText((newsNode["news:title"] ?? newsNode["title"]) as unknown)
+      : undefined;
+
+    const rawDate =
+      node["lastmod"] ??
+      newsNode?.["news:publication_date"] ??
+      newsNode?.["publication_date"];
+    const publishedAt = normalizeDate(rawDate);
+
+    return [
+      {
+        url: loc,
+        ...(newsTitle ? { title: newsTitle } : {}),
+        ...(publishedAt ? { publishedAt } : {}),
+      },
+    ];
+  });
+};
+
+/**
+ * Fetches and parses a sitemap (standard or news) into DiscoveredItem entries.
+ *
+ * @param listingUrl - URL of the sitemap.
+ * @param deps - Shared discovery dependencies.
+ */
+const discoverSitemap = async (
+  listingUrl: string,
+  deps: DiscoveryDeps,
+): Promise<DiscoveredItem[]> => {
+  const { gotClient, rateLimiter } = deps;
+
+  await rateLimiter.acquire();
+
+  let body: string;
+  try {
+    const response = await gotClient.get(listingUrl, {
+      headers: { Accept: "application/xml, text/xml" },
+    });
+    rateLimiter.recordResponse(response.statusCode);
+    body = response.body;
+  } catch (error) {
+    const classified = classifyError(error);
+    throw Object.assign(new Error(classified.message), {
+      errorCategory: classified.category,
+    });
+  }
+
+  let doc: Record<string, unknown>;
+  try {
+    doc = xmlParser.parse(body) as Record<string, unknown>;
+  } catch (error) {
+    throw Object.assign(
+      new Error(
+        `Sitemap XML parse failed: ${error instanceof Error ? error.message : String(error)}`,
+      ),
+      { errorCategory: "provider_data_invalid" },
+    );
+  }
+
+  if (!doc["urlset"]) {
+    throw Object.assign(
+      new Error("Not a recognized sitemap (missing <urlset>)"),
+      { errorCategory: "provider_data_invalid" },
+    );
+  }
+
+  return parseSitemapUrls(doc);
+};
+
+/** Sitemap listing discovery strategy. */
+export const sitemapStrategy: ListingDiscoveryStrategy = {
+  type: "sitemap",
+  discover: discoverSitemap,
+};

--- a/packages/shared/agent-ingestion/src/discovery/types.ts
+++ b/packages/shared/agent-ingestion/src/discovery/types.ts
@@ -1,0 +1,32 @@
+import type got from "got";
+import type { RateLimiter } from "../resilience";
+
+/** One article item yielded by a listing discovery strategy. */
+export type DiscoveredItem = {
+  url: string;
+  title?: string;
+  summary?: string;
+  publishedAt?: string;
+};
+
+/** Minimal structured logger passed to discovery strategies. */
+export type DiscoveryLogger = {
+  info: (obj: object, msg?: string) => void;
+  warn: (obj: object, msg?: string) => void;
+};
+
+/** Shared dependencies for listing discovery strategies. */
+export type DiscoveryDeps = {
+  gotClient: typeof got;
+  rateLimiter: RateLimiter;
+  logger: DiscoveryLogger;
+};
+
+/** Contract implemented by every listing discovery strategy. */
+export type ListingDiscoveryStrategy = {
+  readonly type: "rss" | "sitemap" | "generic-links";
+  discover: (
+    listingUrl: string,
+    deps: DiscoveryDeps,
+  ) => Promise<DiscoveredItem[]>;
+};

--- a/packages/shared/agent-ingestion/src/index.ts
+++ b/packages/shared/agent-ingestion/src/index.ts
@@ -95,3 +95,24 @@ export {
   type RunPolicy,
   type RunCounters,
 } from "./run-status";
+
+export {
+  DEFAULT_DISCOVERY_CHAIN,
+  createListingDiscoveryStrategy,
+} from "./discovery/registry";
+
+export {
+  discoverOneSource,
+  runDiscovery,
+  type DiscoverySource,
+  type DiscoveryFailure,
+  type SourceDiscoveryOutcome,
+  type RunDiscoveryResult,
+} from "./discovery/run-discovery";
+
+export {
+  type DiscoveredItem,
+  type ListingDiscoveryStrategy,
+  type DiscoveryDeps,
+  type DiscoveryLogger,
+} from "./discovery/types";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ catalogs:
     eslint:
       specifier: ^9.32.0
       version: 9.39.2
+    fast-xml-parser:
+      specifier: ^4.5.4
+      version: 4.5.4
     got:
       specifier: ^14.0.0
       version: 14.6.6
@@ -1561,6 +1564,9 @@ importers:
       '@workspace/utils':
         specifier: workspace:*
         version: link:../utils
+      fast-xml-parser:
+        specifier: 'catalog:'
+        version: 4.5.4
       got:
         specifier: 'catalog:'
         version: 14.6.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,3 +44,4 @@ catalog:
   "hono-pino": "^0.6"
   "vitest": "^4.0.18"
   "@vitest/coverage-v8": "^4.0.18"
+  "fast-xml-parser": "^4.5.4"


### PR DESCRIPTION
## Summary

Adds a listing discovery layer to `@workspace/agent-ingestion` so the ingestion pipeline can collect article URLs from curated listing sources without web search. Three strategies — rss, sitemap, generic-links — are wired into a registry and run as an ordered fallback chain per source, mirroring the existing fetch-provider chain idiom.

## Related issues

Closes #681

## Important changes

- New `discovery/` subdirectory in `@workspace/agent-ingestion` with `types.ts`, `rss.ts`, `sitemap.ts`, `generic-links.ts`, `registry.ts`, and `run-discovery.ts`.
- `discoverOneSource` mirrors `fetchOneResult`: each strategy runs in order; empty or error falls through to the next; failures accumulate rather than throwing.
- `runDiscovery` deduplicates by canonical URL across all enabled sources and never throws — all per-strategy failures are captured and returned.
- `fast-xml-parser` added as a direct dependency (was already a transitive dep at 4.5.4).

## Other changes

- All new discovery symbols exported from `packages/shared/agent-ingestion/src/index.ts`.
- `DEFAULT_DISCOVERY_CHAIN = ["rss", "sitemap", "generic-links"]` exported constant for consumers that want the default order.

## Key files to review

- [packages/shared/agent-ingestion/src/discovery/run-discovery.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.ts) — fallback chain logic; compare to `fetchOneResult` in `web-fetch.ts`.
- [packages/shared/agent-ingestion/src/discovery/registry.ts](packages/shared/agent-ingestion/src/discovery/registry.ts) — single switch enumerating all strategy types.
- [packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts) — chain-fallback test: rss throws → sitemap empty → generic-links succeeds.

## How to test

1. `pnpm --filter @workspace/agent-ingestion test` — all 108 tests pass, including the new discovery suite.
2. `pnpm --filter @workspace/agent-ingestion type:check` — no type errors.
