### PR TITLE
Implement page-collection run pipeline

### DIFF
--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -1,0 +1,364 @@
+/** @vitest-environment node */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentRunContext } from "@workspace/agent-runtime";
+
+import type { BodySchemaType } from "./utilities/body-schema";
+import { ConfigSchema, type ConfigSchemaType } from "./utilities/config-schema";
+import type {
+  FetchedWebSearchResult,
+  WebFetchFailure,
+  WebFetchOutcome,
+} from "@workspace/agent-ingestion";
+
+const TICKER_ID = "11111111-1111-4111-a111-111111111111";
+const CURATED_QUERY_ID = "22222222-2222-4222-a222-222222222222";
+
+const validArticleContent = [
+  "Bank Central Asia announced strategic expansion plans across regional markets.",
+  "The company reported improved margins, higher loan growth, and stronger risk controls.",
+  ...Array.from(
+    { length: 90 },
+    (_, index) =>
+      `Analyst note ${index} discusses lending trends and deposit growth in Indonesia.`,
+  ),
+].join(" ");
+
+const validArticleTitle = "Bank Central Asia expands regional operations";
+
+const baseConfig = ConfigSchema.parse({
+  curatedSources: [
+    {
+      listingUrl: "https://example.com/feed",
+      strategies: ["rss"],
+    },
+  ],
+  providers: {
+    fetch: {
+      providers: [
+        {
+          type: "jina",
+          baseUrl: "https://fetch.example",
+          authentication: { type: "bearer" },
+          rateLimit: { requests: 1, perSeconds: 1 },
+          concurrency: 4,
+        },
+      ],
+    },
+  },
+  runPolicy: {
+    minSuccessfulSources: 1,
+    failOnZeroSuccess: true,
+  },
+});
+
+const mockFetchSuccess = (
+  data: Omit<FetchedWebSearchResult, "provider"> &
+    Partial<Pick<FetchedWebSearchResult, "provider">>,
+): WebFetchOutcome => ({
+  success: { provider: "jina", ...data },
+  failures: [],
+});
+
+const mockFetchFailure = (
+  failure: Omit<WebFetchFailure, "provider"> &
+    Partial<Pick<WebFetchFailure, "provider">>,
+): WebFetchOutcome => ({
+  success: null,
+  failures: [{ provider: "jina", ...failure }],
+});
+
+vi.mock("@mediapulse/env/agents-page-collection", () => ({
+  env: {
+    AGENT_DATA_API_URL: "http://agent-data-api",
+    AGENT_AUTH_API_URL: "http://agent-auth-api",
+    AGENT_REGISTRY_URL: "http://agent-registry",
+  },
+}));
+
+const { mockRunLog } = vi.hoisted(() => ({
+  mockRunLog: { info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock("@workspace/logger", () => ({
+  logger: {
+    child: vi.fn(() => mockRunLog),
+  },
+}));
+
+const dataCollectionCreateMock = vi.fn();
+const existingUrlsCreateMock = vi.fn();
+const deadUrlsLookupMock = vi.fn();
+const deadUrlsRecordMock = vi.fn();
+const runCreateMock = vi.fn();
+const failureCreateMock = vi.fn();
+const tickerGetMock = vi.fn();
+const curatedListingQueryCreateMock = vi.fn();
+
+vi.mock("@workspace/agent-data-api-client", () => ({
+  createAgentDataApiClient: vi.fn(() => ({
+    dataCollection: {
+      create: dataCollectionCreateMock,
+    },
+    dataCollectionExistingUrls: {
+      create: existingUrlsCreateMock,
+    },
+    dataCollectionDeadUrlsLookup: {
+      create: deadUrlsLookupMock,
+    },
+    dataCollectionDeadUrlsRecord: {
+      create: deadUrlsRecordMock,
+    },
+    dataCollectionRun: {
+      create: runCreateMock,
+    },
+    dataCollectionFailure: {
+      create: failureCreateMock,
+    },
+    ticker: {
+      get: tickerGetMock,
+    },
+    dataCollectionCuratedListingQuery: {
+      create: curatedListingQueryCreateMock,
+    },
+  })),
+}));
+
+vi.mock("@workspace/agent-ingestion", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@workspace/agent-ingestion")>();
+  return {
+    ...actual,
+    runDiscovery: vi.fn(),
+    performWebFetch: vi.fn(),
+  };
+});
+
+import { runDiscovery, performWebFetch } from "@workspace/agent-ingestion";
+import { runPageCollection } from "./run";
+
+function createContext(
+  overrides?: Partial<AgentRunContext<BodySchemaType, ConfigSchemaType>>,
+): AgentRunContext<BodySchemaType, ConfigSchemaType> {
+  return {
+    input: { tickerId: TICKER_ID },
+    config: baseConfig,
+    token: "Bearer test-token",
+    ...overrides,
+  };
+}
+
+describe("runPageCollection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    tickerGetMock.mockResolvedValue({
+      id: TICKER_ID,
+      symbol: "BBCA",
+      name: "Bank Central Asia",
+      aliases: ["BCA"],
+      sector: "Keuangan",
+      industry: "Perbankan",
+    });
+
+    curatedListingQueryCreateMock.mockResolvedValue({
+      searchQueryId: CURATED_QUERY_ID,
+    });
+
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [
+        {
+          url: "https://example.com/article-1",
+          title: validArticleTitle,
+          publishedAt: "2026-06-08T00:00:00.000Z",
+        },
+      ],
+      failures: [],
+    });
+
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchSuccess({
+        url: "https://example.com/article-1",
+        title: validArticleTitle,
+        content: validArticleContent,
+        tickerId: TICKER_ID,
+        searchQueryId: CURATED_QUERY_ID,
+        searchQueryText: "",
+        serpIndex: 0,
+      }),
+    ]);
+
+    dataCollectionCreateMock.mockResolvedValue("{}");
+    existingUrlsCreateMock.mockResolvedValue({
+      existingUrls: [],
+      hostCounts: {},
+    });
+    deadUrlsLookupMock.mockResolvedValue({ deadUrls: [] });
+    deadUrlsRecordMock.mockResolvedValue({
+      message: "Dead URLs recorded",
+      recordedCount: 0,
+    });
+    runCreateMock.mockResolvedValue({});
+    failureCreateMock.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("persists gate-surviving sources attributed to the curated searchQueryId", async () => {
+    const result = await runPageCollection(createContext());
+
+    expect(result.success).toBe(true);
+    expect(dataCollectionCreateMock).toHaveBeenCalledOnce();
+
+    const persistedSource = dataCollectionCreateMock.mock.calls[0]![0][0];
+
+    expect(persistedSource.tickerId).toBe(TICKER_ID);
+    expect(persistedSource.searchQueryId).toBe(CURATED_QUERY_ID);
+    expect(persistedSource.url).toBe("https://example.com/article-1");
+    expect(persistedSource.title).toBe(validArticleTitle);
+  });
+
+  it("records a DataCollectionRun with the correct tickerId and runId", async () => {
+    await runPageCollection(createContext());
+
+    expect(runCreateMock).toHaveBeenCalledOnce();
+
+    const runPayload = runCreateMock.mock.calls[0]![0];
+
+    expect(runPayload.tickerId).toBe(TICKER_ID);
+    expect(typeof runPayload.id).toBe("string");
+    expect(runPayload.status).toBe("success");
+  });
+
+  it("returns a summary with totalSources count", async () => {
+    const result = await runPageCollection(createContext());
+
+    expect(result.success).toBe(true);
+    expect(
+      (result.details?.summary as { totalSources: number }).totalSources,
+    ).toBe(1);
+  });
+
+  it("records discovery failure in counters but does not abort the run", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [
+        {
+          url: "https://example.com/article-1",
+          title: validArticleTitle,
+          publishedAt: "2026-06-08T00:00:00.000Z",
+        },
+      ],
+      failures: [
+        {
+          sourceUrl: "https://example.com/bad-feed",
+          strategyType: "rss",
+          errorCategory: "network_error",
+          message: "Connection refused",
+          retryable: true,
+        },
+      ],
+    });
+
+    const result = await runPageCollection(createContext());
+
+    expect(result.success).toBe(true);
+    expect(dataCollectionCreateMock).toHaveBeenCalledOnce();
+
+    const runPayload = runCreateMock.mock.calls[0]![0];
+
+    expect(runPayload.counters.searchFailed).toBe(1);
+  });
+
+  it("drops items that fail the pre-filter alias check before fetching", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [
+        { url: "https://example.com/off-topic", title: "Sports news today" },
+      ],
+      failures: [],
+    });
+
+    const result = await runPageCollection(createContext());
+
+    expect(vi.mocked(performWebFetch)).not.toHaveBeenCalled();
+    expect(dataCollectionCreateMock).not.toHaveBeenCalled();
+
+    expect(result.success).toBe(false);
+  });
+
+  it("passes through title-less items without pre-filtering them", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [{ url: "https://example.com/no-title" }],
+      failures: [],
+    });
+
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchSuccess({
+        url: "https://example.com/no-title",
+        title: validArticleTitle,
+        content: validArticleContent,
+        tickerId: TICKER_ID,
+        searchQueryId: CURATED_QUERY_ID,
+        searchQueryText: "",
+        serpIndex: 0,
+      }),
+    ]);
+
+    const result = await runPageCollection(createContext());
+
+    expect(vi.mocked(performWebFetch)).toHaveBeenCalledOnce();
+    expect(result.success).toBe(true);
+  });
+
+  it("skips already-existing URLs and does not fetch them", async () => {
+    existingUrlsCreateMock.mockResolvedValue({
+      existingUrls: ["https://example.com/article-1"],
+      hostCounts: {},
+    });
+
+    const result = await runPageCollection(createContext());
+
+    expect(vi.mocked(performWebFetch)).not.toHaveBeenCalled();
+    expect(dataCollectionCreateMock).not.toHaveBeenCalled();
+    expect(result.success).toBe(false);
+  });
+
+  it("records fetch failures in the failures payload and persists them", async () => {
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchFailure({
+        url: "https://example.com/article-1",
+        queryId: CURATED_QUERY_ID,
+        tickerId: TICKER_ID,
+        errorCategory: "network_error",
+        message: "ECONNREFUSED",
+        retryable: true,
+      }),
+    ]);
+
+    const result = await runPageCollection(createContext());
+
+    expect(failureCreateMock).toHaveBeenCalledOnce();
+
+    const failurePayload = failureCreateMock.mock.calls[0]![0][0];
+
+    expect(failurePayload.stage).toBe("web-fetch");
+    expect(failurePayload.tickerId).toBe(TICKER_ID);
+    expect(result.success).toBe(false);
+  });
+
+  it("returns semantic failure when run policy is not met", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [],
+      failures: [],
+    });
+
+    const result = await runPageCollection(createContext());
+
+    expect(result.success).toBe(false);
+    expect(typeof result.message).toBe("string");
+    expect((result.details as { failureReason: string }).failureReason).toBe(
+      "insufficient_successful_sources",
+    );
+  });
+});

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -1,23 +1,593 @@
+import type { DataCollectionInput } from "@workspace/agent-types";
+import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
+import { env } from "@mediapulse/env/agents-page-collection";
+import { logger } from "@workspace/logger";
+import got from "got";
+import crypto from "node:crypto";
 
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
+import {
+  performWebFetch,
+  createEmptyQualityCounters,
+  runQualityGate,
+  resolveExistingDataSourceUrls,
+  resolveDeadUrls,
+  buildDeadUrlRecords,
+  HostErrorTracker,
+  hostFromUrl,
+  type QualityDropForDeadUrl,
+  buildTickerAliases,
+  buildIndustryAliases,
+  isRelevant,
+  deriveRunStatus,
+  type RunCounters,
+  extractPublishedDate,
+  isFresh,
+  runDiscovery,
+  RateLimiter,
+  type DiscoverySource,
+  type WebSearchResult,
+} from "@workspace/agent-ingestion";
+import { classifyNoisyUrl, type UrlNoiseReason } from "@workspace/utils";
+import { prefilterByAliases } from "./utilities/prefilter-by-aliases";
 
 /**
- * Stub run for the page-collection agent.
+ * Executes the page-collection pipeline: discover article links from curated listing
+ * sources, pre-filter by ticker/industry aliases, fetch survivors, apply quality/relevance/
+ * freshness gates, and persist new data sources under the ticker's curated listing query.
  *
- * The full pipeline is implemented in Plan 97. This stub returns an empty
- * success result so the agent scaffolding can be verified end-to-end.
- *
- * @param context - Agent run context carrying the input body and resolved config.
+ * @param context - Validated input and config, plus the bearer token for the Agent Data API.
+ * @returns Success with summary counts, or semantic failure when the run policy shortfall is hit.
  */
 export async function runPageCollection(
-  _context: AgentRunContext<BodySchemaType, ConfigSchemaType>,
+  context: AgentRunContext<BodySchemaType, ConfigSchemaType>,
 ): Promise<AgentRunResult> {
+  const { input, config, token, hermesCorrelation } = context;
+  const startedAt = new Date();
+  const runId = crypto.randomUUID();
+
+  const hermes = hermesCorrelation;
+  const log = logger.child({
+    component: "page-collection",
+    runId,
+    tickerId: input.tickerId,
+    ...(hermes?.scheduleId ? { scheduleId: hermes.scheduleId } : {}),
+    ...(hermes?.scheduleExecutionId
+      ? { scheduleExecutionId: hermes.scheduleExecutionId }
+      : {}),
+    ...(hermes?.pipelineStepId
+      ? { pipelineStepId: hermes.pipelineStepId }
+      : {}),
+  });
+
+  log.info({ runPolicy: config.runPolicy }, "page collection run started");
+
+  const runPolicy = config.runPolicy;
+  const webFetchConfig = config.providers.fetch;
+  const relevanceGateConfig = config.gates.relevance;
+  const deadUrlCacheConfig = config.resilience.deadUrlCache;
+  const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
+  const freshnessGateConfig = config.gates.freshness;
+  const hostErrorTracker = new HostErrorTracker(hostErrorBreakerConfig);
+
+  const dataApiClient = createAgentDataApiClient({
+    baseUrl: env.AGENT_DATA_API_URL,
+    version: "v1",
+    token,
+  });
+
+  const report = (
+    title: string,
+    description?: string,
+    status: "processing" | "completed" = "processing",
+  ) => {
+    const jobId = hermesCorrelation?.jobId;
+    if (jobId && token) {
+      void fetch(`${env.AGENT_REGISTRY_URL}/api/agent-activity`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Authorization: token },
+        body: JSON.stringify({ jobId, title, description, status }),
+      }).catch(() => {});
+    }
+  };
+
+  report("Loading ticker context", `ticker ${input.tickerId}`);
+
+  const tickerRecord = await dataApiClient.ticker.get({
+    tickerId: input.tickerId,
+  });
+  const tickerAliases = buildTickerAliases(
+    tickerRecord.symbol,
+    tickerRecord.name,
+    tickerRecord.aliases,
+  );
+  const industryAliases = buildIndustryAliases(
+    tickerRecord.sector,
+    tickerRecord.industry,
+  );
+
+  if (tickerAliases.length === 0 && industryAliases.length === 0) {
+    log.warn(
+      { tickerId: input.tickerId },
+      "ticker has no aliases or industry labels; relevance gate is a no-op for this run",
+    );
+  } else {
+    log.info(
+      {
+        aliasCount: tickerAliases.length,
+        industryAliasCount: industryAliases.length,
+      },
+      "loaded ticker and industry aliases for relevance gate",
+    );
+  }
+
+  const { searchQueryId } =
+    await dataApiClient.dataCollectionCuratedListingQuery.create({
+      tickerId: input.tickerId,
+    });
+
+  report(
+    "Loaded ticker context",
+    `${tickerAliases.length} ticker aliases, ${industryAliases.length} industry terms`,
+  );
+
+  const discoverySources: DiscoverySource[] = config.curatedSources.map(
+    (source) => ({
+      url: source.listingUrl,
+      strategies: source.strategies ?? config.defaultDiscoveryChain,
+      enabled: source.enabled,
+      maxItems: source.maxItems,
+    }),
+  );
+
+  report("Running discovery", `${discoverySources.length} curated sources`);
+
+  const discoveryRateLimiter = new RateLimiter(2, 1);
+  const discoveryDeps = {
+    gotClient: got,
+    rateLimiter: discoveryRateLimiter,
+    logger: log,
+  };
+
+  const { items: discoveredItems, failures: discoveryFailures } =
+    await runDiscovery(discoverySources, discoveryDeps);
+
+  log.info(
+    {
+      discoveredCount: discoveredItems.length,
+      discoveryFailureCount: discoveryFailures.length,
+    },
+    "discovery stage finished",
+  );
+
+  const prefilterDropCount =
+    discoveredItems.length -
+    prefilterByAliases(discoveredItems, {
+      tickerAliases,
+      industryAliases,
+    }).length;
+  const filteredItems = prefilterByAliases(discoveredItems, {
+    tickerAliases,
+    industryAliases,
+  });
+
+  log.info(
+    {
+      filteredCount: filteredItems.length,
+      prefilterDropCount,
+    },
+    "alias pre-filter applied",
+  );
+
+  const droppedByUrlReason: Record<UrlNoiseReason, number> = {
+    blocked_host: 0,
+    blocked_host_path: 0,
+    blocked_path: 0,
+    blocked_extension: 0,
+  };
+  let droppedByDuplicateCanonicalUrl = 0;
+  let droppedByExistingCanonicalUrl = 0;
+  const droppedByContentQuality = createEmptyQualityCounters();
+  let droppedByRelevance = 0;
+  let droppedByDeadUrlCache = 0;
+  let droppedByHostErrorRate = 0;
+  let droppedByFreshness = 0;
+  let fetchSuccessCount = 0;
+  let fetchFailedCount = 0;
+  let persistedCount = 0;
+
+  const fetchFailures: Array<
+    Awaited<ReturnType<typeof performWebFetch>>[number]["failures"][number]
+  > = [];
+
+  const canonicalItemMap = new Map<
+    string,
+    { searchResult: WebSearchResult; discoveryPublishedAt?: string }
+  >();
+  for (const item of filteredItems) {
+    const decision = classifyNoisyUrl(item.url);
+    if (decision.blocked) {
+      droppedByUrlReason[decision.reason] += 1;
+      continue;
+    }
+
+    if (canonicalItemMap.has(decision.canonicalUrl)) {
+      droppedByDuplicateCanonicalUrl += 1;
+      continue;
+    }
+
+    canonicalItemMap.set(decision.canonicalUrl, {
+      searchResult: {
+        url: decision.canonicalUrl,
+        title: item.title ?? "",
+        content: "",
+        tickerId: input.tickerId,
+        searchQueryId,
+        searchQueryText: "",
+        serpIndex: 0,
+      },
+      discoveryPublishedAt: item.publishedAt,
+    });
+  }
+
+  const candidateUrls = [...canonicalItemMap.keys()];
+  const { existingUrls: existingUrlSet } = await resolveExistingDataSourceUrls(
+    input.tickerId,
+    candidateUrls,
+    (body) => dataApiClient.dataCollectionExistingUrls.create(body),
+  );
+
+  let candidatesAfterExisting = candidateUrls.filter(
+    (url) => !existingUrlSet.has(url),
+  );
+  droppedByExistingCanonicalUrl =
+    candidateUrls.length - candidatesAfterExisting.length;
+
+  if (droppedByExistingCanonicalUrl > 0) {
+    log.info(
+      { droppedByExistingCanonicalUrl },
+      "skipped fetch for URLs already stored as data sources",
+    );
+  }
+
+  let candidatesAfterDeadUrl = candidatesAfterExisting;
+  if (deadUrlCacheConfig.enabled) {
+    const deadUrlSet = await resolveDeadUrls(
+      input.tickerId,
+      candidatesAfterExisting,
+      (body) => dataApiClient.dataCollectionDeadUrlsLookup.create(body),
+      deadUrlCacheConfig.skipLookupBatchSize,
+    );
+    if (deadUrlSet.size > 0) {
+      candidatesAfterDeadUrl = candidatesAfterDeadUrl.filter(
+        (url) => !deadUrlSet.has(url),
+      );
+      droppedByDeadUrlCache =
+        candidatesAfterExisting.length - candidatesAfterDeadUrl.length;
+      log.info(
+        { droppedByDeadUrlCache },
+        "skipped fetch for URLs in dead-url negative cache",
+      );
+    }
+  }
+
+  const candidatesAfterHostBreaker = candidatesAfterDeadUrl.filter((url) => {
+    const host = hostFromUrl(url);
+    if (hostErrorTracker.isSkipped(host)) {
+      droppedByHostErrorRate += 1;
+      return false;
+    }
+    return true;
+  });
+
+  if (droppedByHostErrorRate > 0) {
+    log.info(
+      { droppedByHostErrorRate },
+      "skipped fetch for hosts over error-rate threshold",
+    );
+  }
+
+  report(
+    "Fetching article content",
+    `${candidatesAfterHostBreaker.length} candidate URLs`,
+  );
+
+  const fetchInputs = candidatesAfterHostBreaker
+    .map((url) => canonicalItemMap.get(url)?.searchResult)
+    .filter((r): r is WebSearchResult => r !== undefined);
+
+  const fetchAttemptResults =
+    fetchInputs.length > 0
+      ? await performWebFetch(fetchInputs, {
+          config: webFetchConfig,
+          logger: log,
+          hostErrorTracker,
+        })
+      : [];
+
+  const roundFetchSuccesses = fetchAttemptResults
+    .filter((outcome) => outcome.success !== null)
+    .map((outcome) => outcome.success!);
+  const roundFetchFailures = fetchAttemptResults.flatMap(
+    (outcome) => outcome.failures,
+  );
+  const roundFailedUrlCount = fetchAttemptResults.filter(
+    (outcome) => outcome.success === null,
+  ).length;
+  fetchFailedCount += roundFailedUrlCount;
+  fetchFailures.push(...roundFetchFailures);
+
+  const roundQualityDrops: QualityDropForDeadUrl[] = [];
+
+  report(
+    "Saving sources to database",
+    `${roundFetchSuccesses.length} fetched pages`,
+  );
+
+  for (const page of roundFetchSuccesses) {
+    const urlDecision = classifyNoisyUrl(page.url);
+    if (urlDecision.blocked) {
+      droppedByUrlReason[urlDecision.reason] += 1;
+      continue;
+    }
+
+    const contentDecision = runQualityGate(page.title, page.content, page.url);
+    if (contentDecision.blocked) {
+      droppedByContentQuality[contentDecision.reason] += 1;
+      roundQualityDrops.push({
+        url: urlDecision.canonicalUrl,
+        reason: contentDecision.reason,
+      });
+      continue;
+    }
+
+    if (relevanceGateConfig.enabled) {
+      const relevanceDecision = isRelevant(
+        {
+          title: page.title,
+          content: page.content,
+          aliases: tickerAliases,
+          industryAliases,
+        },
+        {
+          headChars: relevanceGateConfig.headChars,
+          minMatches: relevanceGateConfig.minMatches,
+        },
+      );
+      if (!relevanceDecision.relevant) {
+        droppedByRelevance += 1;
+        log.info(
+          {
+            url: page.url.slice(0, 120),
+            reason: relevanceDecision.reason,
+          },
+          "dropped page that did not mention the target ticker or industry",
+        );
+        continue;
+      }
+    }
+
+    const extractedDate = extractPublishedDate({
+      fetchMetadata: page.fetchMetadata ?? page.jinaMetadata,
+      content: page.content,
+    });
+    const itemEntry = canonicalItemMap.get(urlDecision.canonicalUrl);
+    const discoveryPublishedAt = itemEntry?.discoveryPublishedAt;
+    const publishedAt =
+      extractedDate ??
+      (discoveryPublishedAt ? new Date(discoveryPublishedAt) : null);
+
+    if (freshnessGateConfig.enabled) {
+      const freshnessDecision = isFresh(publishedAt, {
+        maxAgeDays: freshnessGateConfig.maxAgeDays,
+        allowUnknown: freshnessGateConfig.allowUnknown,
+      });
+      if (!freshnessDecision.fresh) {
+        droppedByFreshness += 1;
+        log.info(
+          {
+            url: urlDecision.canonicalUrl.slice(0, 120),
+            publishedAt: publishedAt?.toISOString() ?? null,
+            reason: freshnessDecision.reason,
+          },
+          "dropped page outside freshness window",
+        );
+        continue;
+      }
+    }
+
+    const source: DataCollectionInput = {
+      url: urlDecision.canonicalUrl,
+      title: page.title,
+      content: page.content,
+      tickerId: input.tickerId,
+      searchQueryId,
+      ...(publishedAt ? { publishedAt: publishedAt.toISOString() } : {}),
+    };
+    log.info(
+      { url: urlDecision.canonicalUrl.slice(0, 120) },
+      "persisting collected source to Agent Data API",
+    );
+    await dataApiClient.dataCollection.create([source]);
+    persistedCount += 1;
+    fetchSuccessCount += 1;
+  }
+
+  log.info(
+    {
+      fetchSuccess: fetchSuccessCount,
+      fetchFailed: fetchFailedCount,
+      droppedByUrlReason,
+      droppedByDuplicateCanonicalUrl,
+      droppedByExistingCanonicalUrl,
+      droppedByContentQuality,
+      droppedByRelevance,
+      droppedByDeadUrlCache,
+      droppedByHostErrorRate,
+      droppedByFreshness,
+      prefilterDropCount,
+    },
+    "fetch stage finished",
+  );
+
+  if (deadUrlCacheConfig.enabled) {
+    const deadUrlFetchFailures = fetchAttemptResults
+      .filter((outcome) => outcome.success === null)
+      .flatMap((outcome) => outcome.failures);
+    const deadUrlRecords = buildDeadUrlRecords(
+      input.tickerId,
+      deadUrlFetchFailures,
+      roundQualityDrops,
+    );
+    if (deadUrlRecords.length > 0) {
+      try {
+        await dataApiClient.dataCollectionDeadUrlsRecord.create(deadUrlRecords);
+        log.info(
+          { deadUrlRecordCount: deadUrlRecords.length },
+          "recorded dead URLs to negative cache",
+        );
+      } catch (recordError) {
+        log.warn(
+          { deadUrlRecordCount: deadUrlRecords.length, err: recordError },
+          "failed to record dead URLs; continuing without negative cache write",
+        );
+      }
+    }
+  }
+
+  const failuresPayload = fetchFailures.map((f) => ({
+    id: crypto.randomUUID(),
+    runId,
+    tickerId: input.tickerId,
+    stage: "web-fetch" as const,
+    provider: f.provider,
+    searchQueryId: f.queryId,
+    url: f.url,
+    errorCategory: f.errorCategory,
+    retryable: f.retryable,
+    message: f.message,
+    httpStatus: f.httpStatus,
+    createdAt: new Date().toISOString(),
+  }));
+
+  const totalSources = persistedCount;
+  const status = deriveRunStatus({
+    totalSources,
+    failureCount: failuresPayload.length + discoveryFailures.length,
+    runPolicy,
+  });
+
+  const counters: RunCounters = {
+    queriesTotal: discoverySources.filter((s) => s.enabled !== false).length,
+    urlsTotal: discoveredItems.length,
+    searchSuccess: discoveredItems.length,
+    searchFailed: discoveryFailures.length,
+    fetchSuccess: fetchSuccessCount,
+    fetchFailed: fetchFailedCount,
+    retryCount: 0,
+    droppedByRelevance,
+    throttleEvents: 0,
+  };
+
+  const runPayload = {
+    id: runId,
+    tickerId: input.tickerId,
+    startedAt: startedAt.toISOString(),
+    completedAt: new Date().toISOString(),
+    status,
+    counters,
+  };
+
+  await dataApiClient.dataCollectionRun.create(runPayload);
+
+  if (failuresPayload.length > 0) {
+    log.warn(
+      { failureRecords: failuresPayload.length },
+      "recording run failures to Agent Data API",
+    );
+    await dataApiClient.dataCollectionFailure.create(failuresPayload);
+  }
+
+  const summary = {
+    totalSources,
+    status,
+    discoveredCount: discoveredItems.length,
+    discoveryFailureCount: discoveryFailures.length,
+    prefilterDropCount,
+    fetchSuccess: fetchSuccessCount,
+    droppedByRelevance,
+    droppedByDeadUrlCache,
+    droppedByHostErrorRate,
+    droppedByFreshness,
+  };
+
+  const durationMs = Date.now() - startedAt.getTime();
+
+  if (status === "failed") {
+    const minRequired = runPolicy.minSuccessfulSources;
+    const message =
+      totalSources === 0
+        ? `Page collection run failed: no sources were successfully collected, but the run policy requires at least ${minRequired} successful source${minRequired === 1 ? "" : "s"}.`
+        : `Page collection run failed: only ${totalSources} successful source${totalSources === 1 ? "" : "s"} collected, but the run policy requires at least ${minRequired}.`;
+
+    log.warn(
+      {
+        status,
+        durationMs,
+        totalSources,
+        minRequired,
+        failureCount: failuresPayload.length,
+        discoveryFailureCount: discoveryFailures.length,
+      },
+      "page collection run completed with policy failure (semantic failure response)",
+    );
+
+    report(
+      "Page collection complete",
+      `${totalSources} saved, ${failuresPayload.length} failed`,
+      "completed",
+    );
+
+    return {
+      success: false,
+      message,
+      details: {
+        summary,
+        failureReason: "insufficient_successful_sources" as const,
+        requiredSuccessfulSources: minRequired,
+        collectedSuccessfulSources: totalSources,
+      },
+    };
+  }
+
+  const completionMessage =
+    status === "partial_success"
+      ? "page collection run completed with partial success"
+      : "page collection run completed successfully";
+
+  log.info(
+    {
+      status,
+      durationMs,
+      totalSources,
+      failureCount: failuresPayload.length,
+      discoveryFailureCount: discoveryFailures.length,
+      droppedByRelevance,
+      droppedByFreshness,
+    },
+    completionMessage,
+  );
+
+  report(
+    "Page collection complete",
+    `${totalSources} saved, ${failuresPayload.length} failed`,
+    "completed",
+  );
+
   return {
     success: true,
-    details: {
-      summary: {},
-    },
+    details: { summary },
   };
 }

--- a/apps/mediapulse/agents/page-collection/src/utilities/prefilter-by-aliases.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/prefilter-by-aliases.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import type { DiscoveredItem } from "@workspace/agent-ingestion";
+
+import { prefilterByAliases, type AliasContext } from "./prefilter-by-aliases";
+
+const item = (
+  url: string,
+  title?: string,
+  summary?: string,
+): DiscoveredItem => ({ url, title, summary });
+
+describe("prefilterByAliases", () => {
+  it("keeps items whose title matches a ticker alias", () => {
+    const items = [
+      item("https://example.com/a", "Apple Earnings Report"),
+      item("https://example.com/b", "Unrelated news story"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: ["apple"],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe("https://example.com/a");
+  });
+
+  it("keeps items whose summary matches an industry alias", () => {
+    const items = [
+      item("https://example.com/a", "Market roundup", "Tech sector rally"),
+      item("https://example.com/b", "Weather report", "Rain expected"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: [],
+      industryAliases: ["tech"],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.url).toBe("https://example.com/a");
+  });
+
+  it("drops items with a title that mentions no alias", () => {
+    const items = [
+      item("https://example.com/a", "Sports roundup"),
+      item("https://example.com/b", "Cooking tips"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: ["tsla"],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("passes through title-less items regardless of aliases", () => {
+    const items = [
+      item("https://example.com/a"),
+      item("https://example.com/b"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: ["tsla"],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("returns all items when both alias lists are empty", () => {
+    const items = [
+      item("https://example.com/a", "Some title"),
+      item("https://example.com/b"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: [],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(2);
+  });
+
+  it("matches case-insensitively", () => {
+    const items = [item("https://example.com/a", "TESLA Q3 Results")];
+    const aliasContext: AliasContext = {
+      tickerAliases: ["tesla"],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(1);
+  });
+
+  it("mixes titled and title-less items correctly", () => {
+    const items = [
+      item("https://example.com/match", "Apple announces new products"),
+      item("https://example.com/no-match", "Sports news today"),
+      item("https://example.com/no-title"),
+    ];
+    const aliasContext: AliasContext = {
+      tickerAliases: ["apple"],
+      industryAliases: [],
+    };
+
+    const result = prefilterByAliases(items, aliasContext);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.url)).toEqual([
+      "https://example.com/match",
+      "https://example.com/no-title",
+    ]);
+  });
+});

--- a/apps/mediapulse/agents/page-collection/src/utilities/prefilter-by-aliases.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/prefilter-by-aliases.ts
@@ -1,0 +1,40 @@
+import type { DiscoveredItem } from "@workspace/agent-ingestion";
+
+export type AliasContext = {
+  tickerAliases: string[];
+  industryAliases: string[];
+};
+
+/**
+ * Pre-filters discovered items by ticker and industry aliases before fetch.
+ *
+ * Items with a title or summary are kept only when the lowercased title+summary
+ * text contains at least one alias. Items without a title pass through unchanged
+ * (e.g. generic-links items).
+ *
+ * @param items - Discovered items from the listing discovery stage.
+ * @param aliasContext - Ticker and industry aliases for the relevance check.
+ */
+export function prefilterByAliases(
+  items: DiscoveredItem[],
+  aliasContext: AliasContext,
+): DiscoveredItem[] {
+  const { tickerAliases, industryAliases } = aliasContext;
+  const allAliases = [...tickerAliases, ...industryAliases].map((alias) =>
+    alias.toLowerCase(),
+  );
+
+  if (allAliases.length === 0) {
+    return items;
+  }
+
+  return items.filter((item) => {
+    if (!item.title) {
+      return true;
+    }
+
+    const text = [item.title, item.summary ?? ""].join(" ").toLowerCase();
+
+    return allAliases.some((alias) => text.includes(alias));
+  });
+}


### PR DESCRIPTION
## Summary

Replaces the stub `runPageCollection` with the real pipeline. The agent discovers article URLs from curated listing sources, pre-filters them using ticker and industry aliases (to avoid fetching obviously off-topic items), runs candidates through the shared fetch and gate machinery, and persists survivors as DataSources under the ticker's synthetic curated-listing query. From `article-analysis`'s perspective the output is identical to what `data-collection` produces.

## Related issues

Closes #685

## Important changes

- `run.ts` — full pipeline: ticker load, curated query resolution, discovery, alias pre-filter, dedup, existing-URL and dead-URL checks, web fetch, quality/relevance/freshness gates, persist, run record, failure payload.
- `prefilter-by-aliases.ts` — new pure helper that drops titled items whose title+summary mentions no ticker or industry alias, while passing through title-less items (generic-links) unconditionally.

## Other changes

- `prefilter-by-aliases.test.ts` — unit tests for the alias pre-filter helper.
- `run.test.ts` — pipeline integration tests with mocked discovery, fetch, and data-api client; covers the happy path, discovery failures, pre-filter drop, existing-URL skip, fetch failure recording, and run policy shortfall.

## Key files to review

- `apps/mediapulse/agents/page-collection/src/run.ts` — core pipeline logic.
- `apps/mediapulse/agents/page-collection/src/utilities/prefilter-by-aliases.ts` — alias pre-filter helper.
- `apps/mediapulse/agents/page-collection/src/run.test.ts` — key assertions to verify pipeline behavior.

## How to test

1. Run `pnpm --filter @mediapulse/page-collection test` — all 31 tests should pass.
2. Run `pnpm --filter @mediapulse/page-collection type:check` — no type errors.
3. Run `pnpm code-quality` from repo root — format, lint, type, and test checks all pass.
