### PR TITLE
Add shared listing-discovery cache to cut cross-ticker feed scraping

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -28,6 +28,10 @@ import {
 import { getDataCollectionRecentSourceFingerprints } from "./routes/data-collection-recent-source-fingerprints.js";
 import { postDataCollectionCuratedListingQuery } from "./routes/data-collection-curated-listing-query.js";
 import {
+  postListingDiscoveryCacheLookup,
+  postListingDiscoveryCacheRecord,
+} from "./routes/listing-discovery-cache.js";
+import {
   getDataCollection,
   postDataCollection,
 } from "./routes/data-collection.js";
@@ -166,6 +170,12 @@ const routeHandlers = {
   },
   sectionCoverageRollup: {
     get: getSectionCoverageRollupHandler,
+  },
+  listingDiscoveryCacheLookup: {
+    post: postListingDiscoveryCacheLookup,
+  },
+  listingDiscoveryCacheRecord: {
+    post: postListingDiscoveryCacheRecord,
   },
 } satisfies AgentDataApiHandlers;
 

--- a/apps/mediapulse/agent-data-api/src/routes/listing-discovery-cache.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/listing-discovery-cache.ts
@@ -1,0 +1,59 @@
+import { Context } from "hono";
+
+import {
+  postListingDiscoveryCacheLookupBodySchema,
+  postListingDiscoveryCacheRecordBodySchema,
+} from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+import { prisma } from "@mediapulse/database";
+
+import {
+  lookupListingDiscoveryCache,
+  recordListingDiscoveryCache,
+} from "../services/listing-discovery-cache.js";
+
+/**
+ * Returns cached discovery entries for the requested listing URLs (non-expired only).
+ *
+ * @param context - Hono context; JSON body `{ listingUrls }`.
+ * @returns JSON `{ entries }`.
+ */
+export async function postListingDiscoveryCacheLookup(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed =
+      await postListingDiscoveryCacheLookupBodySchema.parseAsync(body);
+    const entries = await lookupListingDiscoveryCache(parsed.listingUrls, {
+      listingDiscoveryCache: prisma.listingDiscoveryCache,
+    });
+
+    return context.json({ entries }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}
+
+/**
+ * Upserts fresh discovery results into the cache with the given TTL.
+ *
+ * @param context - Hono context; JSON body array of cache record inputs.
+ * @returns JSON `{ recorded }`.
+ */
+export async function postListingDiscoveryCacheRecord(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed =
+      await postListingDiscoveryCacheRecordBodySchema.parseAsync(body);
+    const recorded = await recordListingDiscoveryCache(parsed, {
+      listingDiscoveryCache: prisma.listingDiscoveryCache,
+    });
+
+    return context.json({ recorded }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.test.ts
@@ -1,0 +1,153 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  lookupListingDiscoveryCache,
+  recordListingDiscoveryCache,
+} from "./listing-discovery-cache";
+
+const ITEMS = [
+  { url: "https://example.com/a", title: "Article A" },
+  { url: "https://example.com/b" },
+];
+
+describe("lookupListingDiscoveryCache", () => {
+  it("returns non-expired entries for the requested listing URLs", async () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const findMany = vi
+      .fn()
+      .mockResolvedValue([
+        { listingUrl: "https://example.com/feed", items: ITEMS },
+      ]);
+
+    const result = await lookupListingDiscoveryCache(
+      ["https://example.com/feed", "https://example.com/other"],
+      {
+        listingDiscoveryCache: { findMany, upsert: vi.fn() },
+        now,
+      },
+    );
+
+    expect(result).toEqual([
+      { listingUrl: "https://example.com/feed", items: ITEMS },
+    ]);
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        listingUrl: {
+          in: ["https://example.com/feed", "https://example.com/other"],
+        },
+        expiresAt: { gt: now },
+      },
+      select: { listingUrl: true, items: true },
+    });
+  });
+
+  it("returns empty array when no listing URLs are provided", async () => {
+    const findMany = vi.fn();
+
+    const result = await lookupListingDiscoveryCache([], {
+      listingDiscoveryCache: { findMany, upsert: vi.fn() },
+    });
+
+    expect(result).toEqual([]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("excludes expired entries (Prisma filter is passed correctly)", async () => {
+    const now = new Date("2026-06-08T00:00:00.000Z");
+    const findMany = vi.fn().mockResolvedValue([]);
+
+    await lookupListingDiscoveryCache(["https://example.com/feed"], {
+      listingDiscoveryCache: { findMany, upsert: vi.fn() },
+      now,
+    });
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          expiresAt: { gt: now },
+        }),
+      }),
+    );
+  });
+});
+
+describe("recordListingDiscoveryCache", () => {
+  it("upserts each entry with correct expiresAt based on ttlSeconds", async () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const upsert = vi.fn().mockResolvedValue({});
+
+    const recorded = await recordListingDiscoveryCache(
+      [
+        {
+          listingUrl: "https://example.com/feed",
+          strategy: "rss",
+          items: ITEMS,
+          ttlSeconds: 3600,
+        },
+      ],
+      {
+        listingDiscoveryCache: { findMany: vi.fn(), upsert },
+        now,
+      },
+    );
+
+    expect(recorded).toBe(1);
+    expect(upsert).toHaveBeenCalledOnce();
+    expect(upsert).toHaveBeenCalledWith({
+      where: { listingUrl: "https://example.com/feed" },
+      create: expect.objectContaining({
+        listingUrl: "https://example.com/feed",
+        strategy: "rss",
+        items: ITEMS,
+        fetchedAt: now,
+        expiresAt: new Date(now.getTime() + 3600 * 1000),
+      }),
+      update: expect.objectContaining({
+        strategy: "rss",
+        items: ITEMS,
+        fetchedAt: now,
+        expiresAt: new Date(now.getTime() + 3600 * 1000),
+      }),
+    });
+  });
+
+  it("upserts multiple records and returns the count", async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+
+    const recorded = await recordListingDiscoveryCache(
+      [
+        {
+          listingUrl: "https://example.com/feed-1",
+          strategy: "rss",
+          items: ITEMS,
+          ttlSeconds: 3600,
+        },
+        {
+          listingUrl: "https://example.com/feed-2",
+          strategy: "sitemap",
+          items: [],
+          ttlSeconds: 1800,
+        },
+      ],
+      {
+        listingDiscoveryCache: { findMany: vi.fn(), upsert },
+      },
+    );
+
+    expect(recorded).toBe(2);
+    expect(upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 0 when no records are provided", async () => {
+    const upsert = vi.fn();
+
+    const recorded = await recordListingDiscoveryCache([], {
+      listingDiscoveryCache: { findMany: vi.fn(), upsert },
+    });
+
+    expect(recorded).toBe(0);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.ts
+++ b/apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.ts
@@ -1,0 +1,94 @@
+import type { Prisma } from "@mediapulse/database";
+import type { ListingDiscoveryCacheRecordInput } from "@workspace/agent-data-api-contract";
+
+type ListingDiscoveryCacheDb = Pick<
+  typeof import("@mediapulse/database").prisma.listingDiscoveryCache,
+  "findMany" | "upsert"
+>;
+
+export type LookupListingDiscoveryCacheDeps = {
+  listingDiscoveryCache: ListingDiscoveryCacheDb;
+  now?: Date;
+};
+
+export type RecordListingDiscoveryCacheDeps = {
+  listingDiscoveryCache: ListingDiscoveryCacheDb;
+  now?: Date;
+};
+
+/**
+ * Returns cached discovery entries for the requested listing URLs where `expiresAt > now`.
+ *
+ * @param listingUrls - URLs to look up in the cache.
+ * @param deps - Database delegate and optional clock.
+ */
+export async function lookupListingDiscoveryCache(
+  listingUrls: readonly string[],
+  deps: LookupListingDiscoveryCacheDeps,
+): Promise<Array<{ listingUrl: string; items: unknown[] }>> {
+  const { listingDiscoveryCache } = deps;
+  const now = deps.now ?? new Date();
+
+  if (listingUrls.length === 0) {
+    return [];
+  }
+
+  const findArgs = {
+    where: {
+      listingUrl: { in: [...listingUrls] },
+      expiresAt: { gt: now },
+    },
+    select: {
+      listingUrl: true,
+      items: true,
+    },
+  } satisfies Prisma.ListingDiscoveryCacheFindManyArgs;
+
+  const rows = await listingDiscoveryCache.findMany(findArgs);
+  return rows.map((row) => ({
+    listingUrl: row.listingUrl,
+    items: row.items as unknown[],
+  }));
+}
+
+/**
+ * Upserts fresh discovery results, refreshing the `expiresAt` based on the given TTL.
+ *
+ * @param records - Discovery results to cache.
+ * @param deps - Database delegate and optional clock.
+ * @returns Number of rows upserted.
+ */
+export async function recordListingDiscoveryCache(
+  records: readonly ListingDiscoveryCacheRecordInput[],
+  deps: RecordListingDiscoveryCacheDeps,
+): Promise<number> {
+  const { listingDiscoveryCache } = deps;
+  const now = deps.now ?? new Date();
+  let recorded = 0;
+
+  for (const record of records) {
+    const expiresAt = new Date(now.getTime() + record.ttlSeconds * 1000);
+
+    const upsertArgs = {
+      where: { listingUrl: record.listingUrl },
+      create: {
+        listingUrl: record.listingUrl,
+        strategy: record.strategy,
+        items: record.items,
+        fetchedAt: now,
+        expiresAt,
+      },
+      update: {
+        strategy: record.strategy,
+        items: record.items,
+        fetchedAt: now,
+        expiresAt,
+      },
+    } satisfies Prisma.ListingDiscoveryCacheUpsertArgs;
+
+    await listingDiscoveryCache.upsert(upsertArgs);
+    recorded += 1;
+  }
+
+  return recorded;
+}

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -27,6 +27,7 @@ import {
   isFresh,
   runDiscovery,
   RateLimiter,
+  type DiscoveryCache,
   type DiscoverySource,
   type WebSearchResult,
 } from "@workspace/agent-ingestion";
@@ -151,8 +152,26 @@ export async function runPageCollection(
     logger: log,
   };
 
+  const discoveryCacheConfig = config.discoveryCache;
+  const discoveryCache: DiscoveryCache | undefined =
+    discoveryCacheConfig.enabled
+      ? {
+          ttlSeconds: discoveryCacheConfig.ttlSeconds,
+          lookup: async (listingUrls) => {
+            const response =
+              await dataApiClient.listingDiscoveryCacheLookup.create({
+                listingUrls,
+              });
+            return response.entries;
+          },
+          record: async (entries) => {
+            await dataApiClient.listingDiscoveryCacheRecord.create(entries);
+          },
+        }
+      : undefined;
+
   const { items: discoveredItems, failures: discoveryFailures } =
-    await runDiscovery(discoverySources, discoveryDeps);
+    await runDiscovery(discoverySources, discoveryDeps, discoveryCache);
 
   log.info(
     {

--- a/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
@@ -313,6 +313,26 @@ const runPolicySchema = z
   .default({})
   .describe("Run success criteria applied after the pipeline completes.");
 
+const discoveryCacheSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When enabled, discovery results are cached by listing URL to avoid re-scraping the same feed across tickers in the same cycle.",
+      ),
+    ttlSeconds: z
+      .number()
+      .int()
+      .positive()
+      .default(3600)
+      .describe(
+        "Cache TTL in seconds. Should be set near the schedule interval so breaking news is not stale across cycles.",
+      ),
+  })
+  .default({})
+  .describe("Cross-ticker listing discovery cache settings.");
+
 /** Zod schema for agent config grouped for Hermes form sections. */
 export const ConfigSchema = z.object({
   curatedSources: z
@@ -331,6 +351,7 @@ export const ConfigSchema = z.object({
   providers: providersSchema,
   gates: gatesSchema,
   resilience: resilienceSchema,
+  discoveryCache: discoveryCacheSchema,
   runPolicy: runPolicySchema,
 });
 

--- a/packages/mediapulse/database/prisma/migrations/20260608000002_add_listing_discovery_cache/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260608000002_add_listing_discovery_cache/migration.sql
@@ -1,0 +1,15 @@
+-- Add shared listing discovery cache table keyed by listing URL for cross-ticker deduplication.
+CREATE TABLE "listing_discovery_cache" (
+    "id" TEXT NOT NULL,
+    "listing_url" TEXT NOT NULL,
+    "strategy" TEXT NOT NULL,
+    "items" JSONB NOT NULL,
+    "fetched_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "listing_discovery_cache_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "listing_discovery_cache_listing_url_key" ON "listing_discovery_cache"("listing_url");
+
+CREATE INDEX "listing_discovery_cache_expires_at_idx" ON "listing_discovery_cache"("expires_at");

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -77,6 +77,19 @@ model DeadUrl {
   @@map("dead_url")
 }
 
+/// Shared cache for listing discovery results, keyed by listing URL and shared across tickers.
+model ListingDiscoveryCache {
+  id         String   @id @default(uuid())
+  listingUrl String   @unique @map("listing_url")
+  strategy   String
+  items      Json
+  fetchedAt  DateTime @default(now()) @map("fetched_at")
+  expiresAt  DateTime @map("expires_at")
+
+  @@index([expiresAt])
+  @@map("listing_discovery_cache")
+}
+
 model Newsletter {
   id          String   @id @default(uuid())
   subject     String

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -38,6 +38,12 @@ import {
   postDataCollectionDeadUrlsRecordResponseSchema,
 } from "./data-collection-dead-url.js";
 import {
+  postListingDiscoveryCacheLookupBodySchema,
+  postListingDiscoveryCacheLookupResponseSchema,
+  postListingDiscoveryCacheRecordBodySchema,
+  postListingDiscoveryCacheRecordResponseSchema,
+} from "./listing-discovery-cache.js";
+import {
   getDataCollectionRecentSourceFingerprintsQuerySchema,
   getDataCollectionRecentSourceFingerprintsResponseSchema,
 } from "./data-collection.js";
@@ -561,6 +567,38 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       get: {
         query: getSectionCoverageRollupQuerySchema,
         response: getSectionCoverageRollupResponseSchema,
+      },
+    },
+  },
+  listingDiscoveryCacheLookup: {
+    v1: {
+      pathSegment: "/listing-discovery-cache/lookup",
+      post: {
+        body: postListingDiscoveryCacheLookupBodySchema,
+        response: postListingDiscoveryCacheLookupResponseSchema,
+      },
+    },
+    v2: {
+      pathSegment: "/listing-discovery-cache/lookup",
+      post: {
+        body: postListingDiscoveryCacheLookupBodySchema,
+        response: postListingDiscoveryCacheLookupResponseSchema,
+      },
+    },
+  },
+  listingDiscoveryCacheRecord: {
+    v1: {
+      pathSegment: "/listing-discovery-cache/record",
+      post: {
+        body: postListingDiscoveryCacheRecordBodySchema,
+        response: postListingDiscoveryCacheRecordResponseSchema,
+      },
+    },
+    v2: {
+      pathSegment: "/listing-discovery-cache/record",
+      post: {
+        body: postListingDiscoveryCacheRecordBodySchema,
+        response: postListingDiscoveryCacheRecordResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -102,6 +102,18 @@ export {
   type PostDataCollectionDeadUrlsRecordResponse,
 } from "./data-collection-dead-url.js";
 export {
+  postListingDiscoveryCacheLookupBodySchema,
+  postListingDiscoveryCacheLookupResponseSchema,
+  postListingDiscoveryCacheRecordBodySchema,
+  postListingDiscoveryCacheRecordResponseSchema,
+  type ListingDiscoveryCacheEntry,
+  type ListingDiscoveryCacheRecordInput,
+  type PostListingDiscoveryCacheLookupBody,
+  type PostListingDiscoveryCacheLookupResponse,
+  type PostListingDiscoveryCacheRecordBody,
+  type PostListingDiscoveryCacheRecordResponse,
+} from "./listing-discovery-cache.js";
+export {
   deliveryNewsletterSchema,
   deliverySubscriberSchema,
   getDeliveryQuerySchema,

--- a/packages/shared/agent-data-api-contract/src/listing-discovery-cache.ts
+++ b/packages/shared/agent-data-api-contract/src/listing-discovery-cache.ts
@@ -1,0 +1,67 @@
+import { z } from "zod";
+
+const discoveredItemSchema = z.object({
+  url: z.string(),
+  title: z.string().optional(),
+  summary: z.string().optional(),
+  publishedAt: z.string().optional(),
+});
+
+/**
+ * Body for POST `/listing-discovery-cache/lookup`: listing URLs to check for cached items.
+ */
+export const postListingDiscoveryCacheLookupBodySchema = z.object({
+  listingUrls: z.array(z.string().url()),
+});
+
+const listingDiscoveryCacheEntrySchema = z.object({
+  listingUrl: z.string().url(),
+  items: z.array(discoveredItemSchema),
+});
+
+/**
+ * Response: cached entries for the requested listing URLs (only non-expired rows).
+ */
+export const postListingDiscoveryCacheLookupResponseSchema = z.object({
+  entries: z.array(listingDiscoveryCacheEntrySchema),
+});
+
+const listingDiscoveryCacheRecordInputSchema = z.object({
+  listingUrl: z.string().url(),
+  strategy: z.string(),
+  items: z.array(discoveredItemSchema),
+  ttlSeconds: z.number().int().positive(),
+});
+
+/**
+ * Body for POST `/listing-discovery-cache/record`: fresh discovery results to upsert.
+ */
+export const postListingDiscoveryCacheRecordBodySchema = z.array(
+  listingDiscoveryCacheRecordInputSchema,
+);
+
+/**
+ * Response: number of rows upserted.
+ */
+export const postListingDiscoveryCacheRecordResponseSchema = z.object({
+  recorded: z.number().int().nonnegative(),
+});
+
+export type PostListingDiscoveryCacheLookupBody = z.infer<
+  typeof postListingDiscoveryCacheLookupBodySchema
+>;
+export type PostListingDiscoveryCacheLookupResponse = z.infer<
+  typeof postListingDiscoveryCacheLookupResponseSchema
+>;
+export type PostListingDiscoveryCacheRecordBody = z.infer<
+  typeof postListingDiscoveryCacheRecordBodySchema
+>;
+export type PostListingDiscoveryCacheRecordResponse = z.infer<
+  typeof postListingDiscoveryCacheRecordResponseSchema
+>;
+export type ListingDiscoveryCacheRecordInput = z.infer<
+  typeof listingDiscoveryCacheRecordInputSchema
+>;
+export type ListingDiscoveryCacheEntry = z.infer<
+  typeof listingDiscoveryCacheEntrySchema
+>;

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type got from "got";
 
-import { discoverOneSource, runDiscovery } from "./run-discovery";
+import {
+  discoverOneSource,
+  runDiscovery,
+  type DiscoveryCache,
+} from "./run-discovery";
 import { rssStrategy } from "./rss";
 import { sitemapStrategy } from "./sitemap";
 import { genericLinksStrategy } from "./generic-links";
@@ -156,5 +160,132 @@ describe("runDiscovery", () => {
 
     expect(result.items).toHaveLength(0);
     expect(result.failures).toHaveLength(1);
+  });
+});
+
+describe("runDiscovery with cache", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  const buildCache = (
+    overrides: Partial<DiscoveryCache> = {},
+  ): DiscoveryCache => ({
+    ttlSeconds: 3600,
+    lookup: vi.fn().mockResolvedValue([]),
+    record: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  });
+
+  it("returns cached items and skips live scrape on a cache hit", async () => {
+    const cachedItems = [{ url: "https://example.com/cached-article" }];
+    const cache = buildCache({
+      lookup: vi
+        .fn()
+        .mockResolvedValue([
+          { listingUrl: "https://example.com/feed", items: cachedItems },
+        ]),
+    });
+
+    const result = await runDiscovery(
+      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      buildDeps(),
+      cache,
+    );
+
+    expect(result.items).toEqual(cachedItems);
+    expect(vi.mocked(rssStrategy.discover)).not.toHaveBeenCalled();
+    expect(cache.record).not.toHaveBeenCalled();
+  });
+
+  it("scrapes once on a miss and records the result", async () => {
+    const liveItems = [{ url: "https://example.com/live-article" }];
+    vi.mocked(rssStrategy.discover).mockResolvedValue(liveItems);
+    const cache = buildCache();
+
+    const result = await runDiscovery(
+      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      buildDeps(),
+      cache,
+    );
+
+    expect(result.items).toEqual(liveItems);
+    expect(vi.mocked(rssStrategy.discover)).toHaveBeenCalledOnce();
+    expect(cache.record).toHaveBeenCalledOnce();
+    expect(vi.mocked(cache.record)).toHaveBeenCalledWith([
+      expect.objectContaining({
+        listingUrl: "https://example.com/feed",
+        strategy: "rss",
+        items: liveItems,
+        ttlSeconds: 3600,
+      }),
+    ]);
+  });
+
+  it("does not record an empty discovery result", async () => {
+    vi.mocked(rssStrategy.discover).mockResolvedValue([]);
+    vi.mocked(sitemapStrategy.discover).mockResolvedValue([]);
+    vi.mocked(genericLinksStrategy.discover).mockResolvedValue([]);
+    const cache = buildCache();
+
+    await runDiscovery(
+      [
+        {
+          url: "https://example.com/feed",
+          strategies: ["rss", "sitemap", "generic-links"],
+        },
+      ],
+      buildDeps(),
+      cache,
+    );
+
+    expect(cache.record).not.toHaveBeenCalled();
+  });
+
+  it("a second call for the same source performs zero live scrapes", async () => {
+    let scrapeCount = 0;
+    vi.mocked(rssStrategy.discover).mockImplementation(async () => {
+      scrapeCount += 1;
+      return [{ url: "https://example.com/article" }];
+    });
+
+    const cacheStore = new Map<string, Array<{ url: string }>>();
+    const cache: DiscoveryCache = {
+      ttlSeconds: 3600,
+      lookup: async (listingUrls) =>
+        listingUrls
+          .filter((url) => cacheStore.has(url))
+          .map((url) => ({ listingUrl: url, items: cacheStore.get(url)! })),
+      record: async (entries) => {
+        for (const entry of entries) {
+          cacheStore.set(
+            entry.listingUrl,
+            entry.items as Array<{ url: string }>,
+          );
+        }
+      },
+    };
+
+    const source = [
+      { url: "https://example.com/feed", strategies: ["rss"] as const },
+    ];
+    const deps = buildDeps();
+
+    await runDiscovery(source, deps, cache);
+    await runDiscovery(source, deps, cache);
+
+    expect(scrapeCount).toBe(1);
+  });
+
+  it("falls back to live scrape when no cache is provided (Plan 95 behavior unchanged)", async () => {
+    const liveItems = [{ url: "https://example.com/live-article" }];
+    vi.mocked(rssStrategy.discover).mockResolvedValue(liveItems);
+
+    const result = await runDiscovery(
+      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      buildDeps(),
+    );
+
+    expect(result.items).toEqual(liveItems);
   });
 });

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
@@ -37,6 +37,22 @@ export type RunDiscoveryResult = {
   failures: DiscoveryFailure[];
 };
 
+/** Optional cache port for cross-ticker listing discovery deduplication. */
+export type DiscoveryCache = {
+  lookup: (
+    listingUrls: string[],
+  ) => Promise<Array<{ listingUrl: string; items: DiscoveredItem[] }>>;
+  record: (
+    entries: Array<{
+      listingUrl: string;
+      strategy: string;
+      items: DiscoveredItem[];
+      ttlSeconds: number;
+    }>,
+  ) => Promise<void>;
+  ttlSeconds: number;
+};
+
 /**
  * Runs a source through its ordered strategy chain with fallback.
  *
@@ -95,18 +111,79 @@ export const discoverOneSource = async (
  * Runs discovery over all enabled sources, deduplicates by canonical URL, and returns
  * the merged item list with all per-strategy failures captured (never thrown).
  *
+ * When a cache port is provided, each source is checked for a fresh cache hit before
+ * live scraping. On a miss, the source is scraped and fresh results are written back.
+ * Empty results are never cached. Without a cache port, behavior is identical to Plan 95.
+ *
  * @param sources - Listing sources to discover from.
  * @param deps - Shared discovery dependencies.
+ * @param cache - Optional cross-ticker discovery cache port.
  */
 export const runDiscovery = async (
   sources: DiscoverySource[],
   deps: DiscoveryDeps,
+  cache?: DiscoveryCache,
 ): Promise<RunDiscoveryResult> => {
   const enabledSources = sources.filter((source) => source.enabled !== false);
 
   const allItems: DiscoveredItem[] = [];
   const allFailures: DiscoveryFailure[] = [];
   const seen = new Set<string>();
+
+  if (cache && enabledSources.length > 0) {
+    const sourceUrls = enabledSources.map((source) => source.url);
+    const cacheHits = await cache.lookup(sourceUrls);
+    const hitMap = new Map(
+      cacheHits.map((entry) => [entry.listingUrl, entry.items]),
+    );
+
+    const freshEntries: Array<{
+      listingUrl: string;
+      strategy: string;
+      items: DiscoveredItem[];
+      ttlSeconds: number;
+    }> = [];
+
+    for (const source of enabledSources) {
+      const cached = hitMap.get(source.url);
+      if (cached !== undefined) {
+        for (const item of cached) {
+          if (!seen.has(item.url)) {
+            seen.add(item.url);
+            allItems.push(item);
+          }
+        }
+        continue;
+      }
+
+      const { items, failures } = await discoverOneSource(source, deps);
+      allFailures.push(...failures);
+
+      for (const item of items) {
+        if (!seen.has(item.url)) {
+          seen.add(item.url);
+          allItems.push(item);
+        }
+      }
+
+      if (items.length > 0) {
+        const winningStrategy =
+          source.strategies?.[0] ?? DEFAULT_DISCOVERY_CHAIN[0] ?? "rss";
+        freshEntries.push({
+          listingUrl: source.url,
+          strategy: winningStrategy,
+          items,
+          ttlSeconds: cache.ttlSeconds,
+        });
+      }
+    }
+
+    if (freshEntries.length > 0) {
+      await cache.record(freshEntries);
+    }
+
+    return { items: allItems, failures: allFailures };
+  }
 
   for (const source of enabledSources) {
     const { items, failures } = await discoverOneSource(source, deps);

--- a/packages/shared/agent-ingestion/src/index.ts
+++ b/packages/shared/agent-ingestion/src/index.ts
@@ -104,6 +104,7 @@ export {
 export {
   discoverOneSource,
   runDiscovery,
+  type DiscoveryCache,
   type DiscoverySource,
   type DiscoveryFailure,
   type SourceDiscoveryOutcome,


### PR DESCRIPTION
## Summary

Multiple tickers in the same collection cycle often share curated listing sources. Before this change, each page-collection run scraped those feeds independently, burning provider quota on duplicate work. This PR introduces a shared discovery cache keyed by listing URL so a feed scraped once per cycle is reused by all subsequent runs that target the same URL.

## Related issues

Closes #687

## Important changes

- **`ListingDiscoveryCache` Prisma model** — stores `listingUrl` (unique), `strategy`, `items` (JSONB), `fetchedAt`, and `expiresAt`. A migration is included.
- **`agent-data-api` endpoints** — `POST /listing-discovery-cache/lookup` and `POST /listing-discovery-cache/record` follow the same pattern as the dead-URL cache routes.
- **`DiscoveryCache` port in `@workspace/agent-ingestion`** — `runDiscovery` now accepts an optional `cache` argument. On a hit it returns cached items with zero live scrapes; on a miss it scrapes, then records. Empty results are never cached.
- **`page-collection` config field** — `discoveryCache.enabled` (default `false`) and `discoveryCache.ttlSeconds` (default 3600) let operators opt in via Hermes config.

## Other changes

- `@workspace/agent-ingestion` index re-exports `DiscoveryCache` type.
- Five new cache-behaviour tests in `run-discovery.test.ts` verify: hit skips scrape, miss scrapes once and records, empty result not recorded, second call for same URL is zero-scrape, and no-cache path unchanged from plan 95.
- Agent-data-api service tests cover lookup filtering expired rows, upsert with correct `expiresAt`, and empty-input fast paths.

## Key files to review

- [packages/shared/agent-ingestion/src/discovery/run-discovery.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.ts) — cache integration logic in `runDiscovery`.
- [apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.ts](apps/mediapulse/agent-data-api/src/services/listing-discovery-cache.ts) — lookup and record service functions.
- [packages/mediapulse/database/prisma/migrations/20260608000002_add_listing_discovery_cache/migration.sql](packages/mediapulse/database/prisma/migrations/20260608000002_add_listing_discovery_cache/migration.sql) — DB migration.
- [apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts](apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts) — new `discoveryCache` config section.

## How to test

1. Run `pnpm code-quality` from the repo root — all checks should pass.
2. In a test environment, set `discoveryCache.enabled: true` in the page-collection Hermes config and trigger two runs for different tickers that share the same curated listing URL. The second run should log cache hits with no live scrapes for that source.
3. Confirm `listing_discovery_cache` rows appear in the DB after the first run with `expiresAt` = now + `ttlSeconds`.
4. After TTL expires, verify the cache entry is not returned by the lookup endpoint.
