### PR TITLE
Harden page-collection run — bounded discovery, timeouts, caps, and deadline

### DIFF
--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -94,6 +94,8 @@ const runCreateMock = vi.fn();
 const failureCreateMock = vi.fn();
 const tickerGetMock = vi.fn();
 const curatedListingQueryCreateMock = vi.fn();
+const listingDiscoveryCacheLookupMock = vi.fn();
+const listingDiscoveryCacheRecordMock = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
@@ -120,6 +122,12 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     },
     dataCollectionCuratedListingQuery: {
       create: curatedListingQueryCreateMock,
+    },
+    listingDiscoveryCacheLookup: {
+      create: listingDiscoveryCacheLookupMock,
+    },
+    listingDiscoveryCacheRecord: {
+      create: listingDiscoveryCacheRecordMock,
     },
   })),
 }));
@@ -200,6 +208,8 @@ describe("runPageCollection", () => {
     });
     runCreateMock.mockResolvedValue({});
     failureCreateMock.mockResolvedValue({});
+    listingDiscoveryCacheLookupMock.mockResolvedValue({ entries: [] });
+    listingDiscoveryCacheRecordMock.mockResolvedValue({});
   });
 
   afterEach(() => {
@@ -360,5 +370,134 @@ describe("runPageCollection", () => {
     expect((result.details as { failureReason: string }).failureReason).toBe(
       "insufficient_successful_sources",
     );
+  });
+
+  it("truncates discovered items at maxDiscoveredItemsPerRun and logs the dropped count", async () => {
+    const manyItems = Array.from({ length: 10 }, (_, index) => ({
+      url: `https://example.com/article-${index}`,
+      title: validArticleTitle,
+    }));
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: manyItems,
+      failures: [],
+    });
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchSuccess({
+        url: "https://example.com/article-0",
+        title: validArticleTitle,
+        content: validArticleContent,
+        tickerId: TICKER_ID,
+        searchQueryId: CURATED_QUERY_ID,
+        searchQueryText: "",
+        serpIndex: 0,
+      }),
+    ]);
+
+    const ctx = createContext({
+      config: ConfigSchema.parse({
+        ...baseConfig,
+        collection: { maxDiscoveredItemsPerRun: 1, perRunFetchBudget: 50 },
+        runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+      }),
+    });
+
+    await runPageCollection(ctx);
+
+    const warnCalls = (mockRunLog.warn as ReturnType<typeof vi.fn>).mock.calls;
+    const capWarn = warnCalls.find(
+      (args: unknown[]) =>
+        typeof args[1] === "string" && args[1].includes("per-run cap"),
+    );
+
+    expect(capWarn).toBeDefined();
+    expect(
+      (capWarn![0] as { droppedByRunItemCap: number }).droppedByRunItemCap,
+    ).toBe(9);
+  });
+
+  it("stops fetching and returns partial_success when the run deadline is exceeded", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000_000);
+
+    vi.mocked(runDiscovery).mockImplementation(async () => {
+      vi.setSystemTime(1_100_000);
+
+      return {
+        items: [
+          {
+            url: "https://example.com/article-1",
+            title: validArticleTitle,
+          },
+        ],
+        failures: [],
+      };
+    });
+
+    const ctx = createContext({
+      config: ConfigSchema.parse({
+        ...baseConfig,
+        run: { maxDurationMs: 1 },
+        runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+      }),
+    });
+
+    let result;
+    try {
+      result = await runPageCollection(ctx);
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(vi.mocked(performWebFetch)).not.toHaveBeenCalled();
+    expect(result!.success).toBe(true);
+    expect(
+      (result!.details?.summary as { deadlineHit: boolean }).deadlineHit,
+    ).toBe(true);
+
+    const runRecord = runCreateMock.mock.calls[0]![0];
+
+    expect(runRecord.status).toBe("partial_success");
+  });
+
+  it("strips tracking params from discovered URLs before dedup via classifyNoisyUrl", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [
+        {
+          url: "https://example.com/article-1?utm_source=feed&utm_medium=rss",
+          title: validArticleTitle,
+        },
+        {
+          url: "https://example.com/article-1?utm_source=newsletter",
+          title: validArticleTitle,
+        },
+      ],
+      failures: [],
+    });
+
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchSuccess({
+        url: "https://example.com/article-1",
+        title: validArticleTitle,
+        content: validArticleContent,
+        tickerId: TICKER_ID,
+        searchQueryId: CURATED_QUERY_ID,
+        searchQueryText: "",
+        serpIndex: 0,
+      }),
+    ]);
+
+    const ctx = createContext({
+      config: ConfigSchema.parse({
+        ...baseConfig,
+        runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
+      }),
+    });
+
+    await runPageCollection(ctx);
+
+    const fetchInputs = vi.mocked(performWebFetch).mock.calls[0]![0];
+
+    expect(fetchInputs).toHaveLength(1);
+    expect(fetchInputs[0]!.url).toBe("https://example.com/article-1");
   });
 });

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -145,11 +145,20 @@ export async function runPageCollection(
 
   report("Running discovery", `${discoverySources.length} curated sources`);
 
+  const discoveryConfig = config.discovery;
+  const collectionConfig = config.collection;
+  const runConfig = config.run;
+  const deadline = startedAt.getTime() + runConfig.maxDurationMs;
+  let deadlineHit = false;
+
   const discoveryRateLimiter = new RateLimiter(2, 1);
   const discoveryDeps = {
     gotClient: got,
     rateLimiter: discoveryRateLimiter,
     logger: log,
+    hostErrorTracker,
+    timeoutMs: discoveryConfig.timeoutMs,
+    concurrency: discoveryConfig.concurrency,
   };
 
   const discoveryCacheConfig = config.discoveryCache;
@@ -181,13 +190,26 @@ export async function runPageCollection(
     "discovery stage finished",
   );
 
+  const maxDiscoveredItems = collectionConfig.maxDiscoveredItemsPerRun;
+  const droppedByRunItemCap = Math.max(
+    0,
+    discoveredItems.length - maxDiscoveredItems,
+  );
+  const cappedDiscoveredItems = discoveredItems.slice(0, maxDiscoveredItems);
+  if (droppedByRunItemCap > 0) {
+    log.warn(
+      { droppedByRunItemCap, maxDiscoveredItemsPerRun: maxDiscoveredItems },
+      "discovered items truncated by per-run cap",
+    );
+  }
+
   const prefilterDropCount =
-    discoveredItems.length -
-    prefilterByAliases(discoveredItems, {
+    cappedDiscoveredItems.length -
+    prefilterByAliases(cappedDiscoveredItems, {
       tickerAliases,
       industryAliases,
     }).length;
-  const filteredItems = prefilterByAliases(discoveredItems, {
+  const filteredItems = prefilterByAliases(cappedDiscoveredItems, {
     tickerAliases,
     industryAliases,
   });
@@ -308,14 +330,40 @@ export async function runPageCollection(
     );
   }
 
+  const perRunFetchBudget = collectionConfig.perRunFetchBudget;
+  const droppedByFetchBudget = Math.max(
+    0,
+    candidatesAfterHostBreaker.length - perRunFetchBudget,
+  );
+  const candidatesAfterBudget = candidatesAfterHostBreaker.slice(
+    0,
+    perRunFetchBudget,
+  );
+  if (droppedByFetchBudget > 0) {
+    log.warn(
+      { droppedByFetchBudget, perRunFetchBudget },
+      "fetch candidates truncated by per-run fetch budget",
+    );
+  }
+
   report(
     "Fetching article content",
-    `${candidatesAfterHostBreaker.length} candidate URLs`,
+    `${candidatesAfterBudget.length} candidate URLs`,
   );
 
-  const fetchInputs = candidatesAfterHostBreaker
-    .map((url) => canonicalItemMap.get(url)?.searchResult)
-    .filter((r): r is WebSearchResult => r !== undefined);
+  if (Date.now() > deadline) {
+    deadlineHit = true;
+    log.warn(
+      { maxDurationMs: runConfig.maxDurationMs },
+      "run deadline exceeded before fetch; finalizing with partial_success",
+    );
+  }
+
+  const fetchInputs = !deadlineHit
+    ? candidatesAfterBudget
+        .map((url) => canonicalItemMap.get(url)?.searchResult)
+        .filter((r): r is WebSearchResult => r !== undefined)
+    : [];
 
   const fetchAttemptResults =
     fetchInputs.length > 0
@@ -339,6 +387,7 @@ export async function runPageCollection(
   fetchFailures.push(...roundFetchFailures);
 
   const roundQualityDrops: QualityDropForDeadUrl[] = [];
+  const sourcesToPersist: DataCollectionInput[] = [];
 
   report(
     "Saving sources to database",
@@ -417,21 +466,24 @@ export async function runPageCollection(
       }
     }
 
-    const source: DataCollectionInput = {
+    sourcesToPersist.push({
       url: urlDecision.canonicalUrl,
       title: page.title,
       content: page.content,
       tickerId: input.tickerId,
       searchQueryId,
       ...(publishedAt ? { publishedAt: publishedAt.toISOString() } : {}),
-    };
-    log.info(
-      { url: urlDecision.canonicalUrl.slice(0, 120) },
-      "persisting collected source to Agent Data API",
-    );
-    await dataApiClient.dataCollection.create([source]);
-    persistedCount += 1;
+    });
     fetchSuccessCount += 1;
+  }
+
+  if (sourcesToPersist.length > 0) {
+    log.info(
+      { persistCount: sourcesToPersist.length },
+      "persisting collected sources to Agent Data API",
+    );
+    await dataApiClient.dataCollection.create(sourcesToPersist);
+    persistedCount += sourcesToPersist.length;
   }
 
   log.info(
@@ -446,6 +498,8 @@ export async function runPageCollection(
       droppedByDeadUrlCache,
       droppedByHostErrorRate,
       droppedByFreshness,
+      droppedByRunItemCap,
+      droppedByFetchBudget,
       prefilterDropCount,
     },
     "fetch stage finished",
@@ -492,15 +546,19 @@ export async function runPageCollection(
   }));
 
   const totalSources = persistedCount;
-  const status = deriveRunStatus({
+  const derivedStatus = deriveRunStatus({
     totalSources,
     failureCount: failuresPayload.length + discoveryFailures.length,
     runPolicy,
   });
+  const status =
+    deadlineHit && derivedStatus === "success"
+      ? "partial_success"
+      : derivedStatus;
 
   const counters: RunCounters = {
     queriesTotal: discoverySources.filter((s) => s.enabled !== false).length,
-    urlsTotal: discoveredItems.length,
+    urlsTotal: cappedDiscoveredItems.length,
     searchSuccess: discoveredItems.length,
     searchFailed: discoveryFailures.length,
     fetchSuccess: fetchSuccessCount,
@@ -540,6 +598,9 @@ export async function runPageCollection(
     droppedByDeadUrlCache,
     droppedByHostErrorRate,
     droppedByFreshness,
+    droppedByRunItemCap,
+    droppedByFetchBudget,
+    deadlineHit,
   };
 
   const durationMs = Date.now() - startedAt.getTime();

--- a/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
@@ -333,6 +333,63 @@ const discoveryCacheSchema = z
   .default({})
   .describe("Cross-ticker listing discovery cache settings.");
 
+const discoverySchema = z
+  .object({
+    concurrency: z
+      .number()
+      .int()
+      .min(1)
+      .max(16)
+      .default(4)
+      .describe("Maximum number of listing sources scraped concurrently."),
+    timeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(30_000)
+      .describe(
+        "Per-strategy HTTP timeout in milliseconds. A hung request is aborted and falls through the strategy chain.",
+      ),
+  })
+  .default({})
+  .describe("Discovery stage concurrency and timeout settings.");
+
+const collectionSchema = z
+  .object({
+    maxDiscoveredItemsPerRun: z
+      .number()
+      .int()
+      .positive()
+      .default(500)
+      .describe(
+        "Maximum candidate URLs taken from discovery before fetch. Excess items are dropped and logged.",
+      ),
+    perRunFetchBudget: z
+      .number()
+      .int()
+      .positive()
+      .default(50)
+      .describe(
+        "Maximum URLs sent to the fetch stage in a single run. Applied after dead-URL and host-breaker filtering.",
+      ),
+  })
+  .default({})
+  .describe("Per-run collection caps.");
+
+const runTimingSchema = z
+  .object({
+    maxDurationMs: z
+      .number()
+      .int()
+      .positive()
+      .default(300_000)
+      .describe(
+        "Overall run deadline in milliseconds. When exceeded the run stops starting new fetches and finalizes with partial_success.",
+      ),
+  })
+  .default({})
+  .describe("Run-level timing and deadline settings.");
+
 /** Zod schema for agent config grouped for Hermes form sections. */
 export const ConfigSchema = z.object({
   curatedSources: z
@@ -352,6 +409,9 @@ export const ConfigSchema = z.object({
   gates: gatesSchema,
   resilience: resilienceSchema,
   discoveryCache: discoveryCacheSchema,
+  discovery: discoverySchema,
+  collection: collectionSchema,
+  run: runTimingSchema,
   runPolicy: runPolicySchema,
 });
 

--- a/packages/shared/agent-ingestion/src/discovery/generic-links.ts
+++ b/packages/shared/agent-ingestion/src/discovery/generic-links.ts
@@ -68,7 +68,7 @@ const discoverGenericLinks = async (
   listingUrl: string,
   deps: DiscoveryDeps,
 ): Promise<DiscoveredItem[]> => {
-  const { gotClient, rateLimiter } = deps;
+  const { gotClient, rateLimiter, timeoutMs } = deps;
 
   await rateLimiter.acquire();
 
@@ -85,6 +85,7 @@ const discoverGenericLinks = async (
   try {
     const response = await gotClient.get(listingUrl, {
       headers: { Accept: "text/html" },
+      ...(timeoutMs ? { timeout: { request: timeoutMs } } : {}),
     });
     rateLimiter.recordResponse(response.statusCode);
     html = response.body;

--- a/packages/shared/agent-ingestion/src/discovery/rss.ts
+++ b/packages/shared/agent-ingestion/src/discovery/rss.ts
@@ -50,7 +50,10 @@ const asText = (value: unknown): string | undefined => {
  *
  * @param doc - Parsed XML document.
  */
-const parseRssItems = (doc: Record<string, unknown>): DiscoveredItem[] => {
+const parseRssItems = (
+  doc: Record<string, unknown>,
+  listingUrl: string,
+): DiscoveredItem[] => {
   const channel = (doc["rss"] as Record<string, unknown>)?.["channel"] as
     | Record<string, unknown>
     | undefined;
@@ -62,8 +65,14 @@ const parseRssItems = (doc: Record<string, unknown>): DiscoveredItem[] => {
 
   return items.flatMap((item) => {
     const entry = item as Record<string, unknown>;
-    const url = asText(entry["link"]);
-    if (!url) {
+    const rawUrl = asText(entry["link"]);
+    if (!rawUrl) {
+      return [];
+    }
+    let url: string;
+    try {
+      url = new URL(rawUrl, listingUrl).toString();
+    } catch {
       return [];
     }
 
@@ -87,7 +96,10 @@ const parseRssItems = (doc: Record<string, unknown>): DiscoveredItem[] => {
  *
  * @param doc - Parsed XML document.
  */
-const parseAtomEntries = (doc: Record<string, unknown>): DiscoveredItem[] => {
+const parseAtomEntries = (
+  doc: Record<string, unknown>,
+  listingUrl: string,
+): DiscoveredItem[] => {
   const feed = doc["feed"] as Record<string, unknown> | undefined;
   if (!feed) {
     return [];
@@ -99,23 +111,30 @@ const parseAtomEntries = (doc: Record<string, unknown>): DiscoveredItem[] => {
     const node = entry as Record<string, unknown>;
 
     const linkNode = node["link"];
-    let url: string | undefined;
+    let rawUrl: string | undefined;
     if (
       typeof linkNode === "object" &&
       linkNode !== null &&
       "@_href" in linkNode
     ) {
-      url = (linkNode as Record<string, string>)["@_href"];
+      rawUrl = (linkNode as Record<string, string>)["@_href"];
     } else if (Array.isArray(linkNode)) {
       const alternate = (linkNode as Record<string, string>[]).find(
         (link) => !link["@_rel"] || link["@_rel"] === "alternate",
       );
-      url = alternate?.["@_href"];
+      rawUrl = alternate?.["@_href"];
     } else {
-      url = asText(linkNode);
+      rawUrl = asText(linkNode);
     }
 
-    if (!url) {
+    if (!rawUrl) {
+      return [];
+    }
+
+    let url: string;
+    try {
+      url = new URL(rawUrl, listingUrl).toString();
+    } catch {
       return [];
     }
 
@@ -144,7 +163,7 @@ const discoverRss = async (
   listingUrl: string,
   deps: DiscoveryDeps,
 ): Promise<DiscoveredItem[]> => {
-  const { gotClient, rateLimiter } = deps;
+  const { gotClient, rateLimiter, timeoutMs } = deps;
 
   await rateLimiter.acquire();
 
@@ -155,6 +174,7 @@ const discoverRss = async (
         Accept:
           "application/rss+xml, application/atom+xml, application/xml, text/xml",
       },
+      ...(timeoutMs ? { timeout: { request: timeoutMs } } : {}),
     });
     rateLimiter.recordResponse(response.statusCode);
     body = response.body;
@@ -178,10 +198,10 @@ const discoverRss = async (
   }
 
   if (doc["rss"]) {
-    return parseRssItems(doc);
+    return parseRssItems(doc, listingUrl);
   }
   if (doc["feed"]) {
-    return parseAtomEntries(doc);
+    return parseAtomEntries(doc, listingUrl);
   }
 
   throw Object.assign(new Error("Not a recognized RSS or Atom feed"), {

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
@@ -1,9 +1,13 @@
 import { classifyError, isRetryableError } from "../error-classification";
+import { hostFromUrl } from "../host-error-tracker";
+import { pMap } from "../p-map";
 import {
   createListingDiscoveryStrategy,
   DEFAULT_DISCOVERY_CHAIN,
 } from "./registry";
 import type { DiscoveredItem, DiscoveryDeps } from "./types";
+
+const DEFAULT_DISCOVERY_CONCURRENCY = 4;
 
 /** A single listing source for discovery. */
 export type DiscoverySource = {
@@ -125,10 +129,44 @@ export const runDiscovery = async (
   cache?: DiscoveryCache,
 ): Promise<RunDiscoveryResult> => {
   const enabledSources = sources.filter((source) => source.enabled !== false);
+  const concurrency = deps.concurrency ?? DEFAULT_DISCOVERY_CONCURRENCY;
 
   const allItems: DiscoveredItem[] = [];
   const allFailures: DiscoveryFailure[] = [];
   const seen = new Set<string>();
+
+  const tryDiscover = async (
+    source: DiscoverySource,
+  ): Promise<SourceDiscoveryOutcome> => {
+    const host = hostFromUrl(source.url);
+    if (deps.hostErrorTracker?.isSkipped(host)) {
+      return {
+        items: [],
+        failures: [
+          {
+            sourceUrl: source.url,
+            strategyType: "host-breaker",
+            errorCategory: "provider_http_error",
+            message: `Host ${host} is over the error-rate threshold; skipped in discovery`,
+            retryable: false,
+          },
+        ],
+      };
+    }
+    const outcome = await discoverOneSource(source, deps);
+    deps.hostErrorTracker?.record(host, outcome.items.length > 0);
+
+    return outcome;
+  };
+
+  const addItems = (items: DiscoveredItem[]) => {
+    for (const item of items) {
+      if (!seen.has(item.url)) {
+        seen.add(item.url);
+        allItems.push(item);
+      }
+    }
+  };
 
   if (cache && enabledSources.length > 0) {
     const sourceUrls = enabledSources.map((source) => source.url);
@@ -137,64 +175,55 @@ export const runDiscovery = async (
       cacheHits.map((entry) => [entry.listingUrl, entry.items]),
     );
 
-    const freshEntries: Array<{
-      listingUrl: string;
-      strategy: string;
-      items: DiscoveredItem[];
-      ttlSeconds: number;
-    }> = [];
+    const missedSources = enabledSources.filter(
+      (source) => !hitMap.has(source.url),
+    );
 
-    for (const source of enabledSources) {
-      const cached = hitMap.get(source.url);
-      if (cached !== undefined) {
-        for (const item of cached) {
-          if (!seen.has(item.url)) {
-            seen.add(item.url);
-            allItems.push(item);
-          }
-        }
-        continue;
-      }
-
-      const { items, failures } = await discoverOneSource(source, deps);
-      allFailures.push(...failures);
-
-      for (const item of items) {
-        if (!seen.has(item.url)) {
-          seen.add(item.url);
-          allItems.push(item);
-        }
-      }
-
-      if (items.length > 0) {
-        const winningStrategy =
-          source.strategies?.[0] ?? DEFAULT_DISCOVERY_CHAIN[0] ?? "rss";
-        freshEntries.push({
-          listingUrl: source.url,
-          strategy: winningStrategy,
-          items,
-          ttlSeconds: cache.ttlSeconds,
-        });
-      }
+    for (const [, cachedItems] of hitMap) {
+      addItems(cachedItems);
     }
 
-    if (freshEntries.length > 0) {
-      await cache.record(freshEntries);
+    if (missedSources.length > 0) {
+      const missOutcomes = await pMap(missedSources, tryDiscover, {
+        concurrency,
+      });
+
+      const freshEntries: Array<{
+        listingUrl: string;
+        strategy: string;
+        items: DiscoveredItem[];
+        ttlSeconds: number;
+      }> = [];
+
+      for (let index = 0; index < missedSources.length; index += 1) {
+        const source = missedSources[index]!;
+        const outcome = missOutcomes[index]!;
+        allFailures.push(...outcome.failures);
+        addItems(outcome.items);
+        if (outcome.items.length > 0) {
+          const winningStrategy =
+            source.strategies?.[0] ?? DEFAULT_DISCOVERY_CHAIN[0] ?? "rss";
+          freshEntries.push({
+            listingUrl: source.url,
+            strategy: winningStrategy,
+            items: outcome.items,
+            ttlSeconds: cache.ttlSeconds,
+          });
+        }
+      }
+
+      if (freshEntries.length > 0) {
+        await cache.record(freshEntries);
+      }
     }
 
     return { items: allItems, failures: allFailures };
   }
 
-  for (const source of enabledSources) {
-    const { items, failures } = await discoverOneSource(source, deps);
-
-    for (const item of items) {
-      if (!seen.has(item.url)) {
-        seen.add(item.url);
-        allItems.push(item);
-      }
-    }
-    allFailures.push(...failures);
+  const outcomes = await pMap(enabledSources, tryDiscover, { concurrency });
+  for (const outcome of outcomes) {
+    allFailures.push(...outcome.failures);
+    addItems(outcome.items);
   }
 
   return { items: allItems, failures: allFailures };

--- a/packages/shared/agent-ingestion/src/discovery/sitemap.ts
+++ b/packages/shared/agent-ingestion/src/discovery/sitemap.ts
@@ -50,7 +50,10 @@ const asText = (value: unknown): string | undefined => {
  *
  * @param doc - Parsed XML document.
  */
-const parseSitemapUrls = (doc: Record<string, unknown>): DiscoveredItem[] => {
+const parseSitemapUrls = (
+  doc: Record<string, unknown>,
+  listingUrl: string,
+): DiscoveredItem[] => {
   const urlset = doc["urlset"] as Record<string, unknown> | undefined;
   if (!urlset) {
     return [];
@@ -60,8 +63,14 @@ const parseSitemapUrls = (doc: Record<string, unknown>): DiscoveredItem[] => {
 
   return urls.flatMap((urlNode) => {
     const node = urlNode as Record<string, unknown>;
-    const loc = asText(node["loc"]);
-    if (!loc) {
+    const rawLoc = asText(node["loc"]);
+    if (!rawLoc) {
+      return [];
+    }
+    let loc: string;
+    try {
+      loc = new URL(rawLoc, listingUrl).toString();
+    } catch {
       return [];
     }
 
@@ -96,7 +105,7 @@ const discoverSitemap = async (
   listingUrl: string,
   deps: DiscoveryDeps,
 ): Promise<DiscoveredItem[]> => {
-  const { gotClient, rateLimiter } = deps;
+  const { gotClient, rateLimiter, timeoutMs } = deps;
 
   await rateLimiter.acquire();
 
@@ -104,6 +113,7 @@ const discoverSitemap = async (
   try {
     const response = await gotClient.get(listingUrl, {
       headers: { Accept: "application/xml, text/xml" },
+      ...(timeoutMs ? { timeout: { request: timeoutMs } } : {}),
     });
     rateLimiter.recordResponse(response.statusCode);
     body = response.body;
@@ -133,7 +143,7 @@ const discoverSitemap = async (
     );
   }
 
-  return parseSitemapUrls(doc);
+  return parseSitemapUrls(doc, listingUrl);
 };
 
 /** Sitemap listing discovery strategy. */

--- a/packages/shared/agent-ingestion/src/discovery/types.ts
+++ b/packages/shared/agent-ingestion/src/discovery/types.ts
@@ -1,4 +1,5 @@
 import type got from "got";
+import type { HostErrorTracker } from "../host-error-tracker";
 import type { RateLimiter } from "../resilience";
 
 /** One article item yielded by a listing discovery strategy. */
@@ -20,6 +21,12 @@ export type DiscoveryDeps = {
   gotClient: typeof got;
   rateLimiter: RateLimiter;
   logger: DiscoveryLogger;
+  /** When provided, hosts over the error threshold are skipped in discovery. */
+  hostErrorTracker?: HostErrorTracker;
+  /** Per-strategy HTTP timeout in milliseconds. Passed to the underlying got request. */
+  timeoutMs?: number;
+  /** Maximum concurrent discovery sources processed by runDiscovery. Defaults to 4. */
+  concurrency?: number;
 };
 
 /** Contract implemented by every listing discovery strategy. */


### PR DESCRIPTION
## Summary

Before this change, the page-collection discovery stage ran sources sequentially with no concurrency cap, no per-call timeout, and no overall deadline. A single slow or unresponsive feed could stall the entire Hermes job. This PR bounds the run at every scale point — concurrent discovery, per-strategy timeouts, item and fetch caps, batched persistence, and a run-level deadline that degrades gracefully to `partial_success`.

## Related issues

Closes #689

## Important changes

- **Bounded discovery concurrency** — `runDiscovery` now uses `pMap` with a configurable `discovery.concurrency` cap (default 4). Sources run concurrently; one stalled source no longer blocks the rest.
- **Per-strategy HTTP timeout** — `discovery.timeoutMs` (default 30 s) is passed to the underlying got request so a hung socket is aborted and the strategy chain falls through, not stalled.
- **Shared `HostErrorTracker`** — the same instance used by fetch is now passed into discovery deps so a host over the error-rate threshold is skipped in both stages.
- **Relative URL resolution** — RSS/Atom and sitemap strategies now resolve relative `<link>` / `<loc>` values to absolute against the listing URL before returning items.
- **Per-run item and fetch caps** — `collection.maxDiscoveredItemsPerRun` (default 500) caps candidates before fetch; `collection.perRunFetchBudget` (default 50) caps URLs sent to the fetch stage. Both log the dropped count.
- **Batched persistence** — `dataCollection.create` is called once with all gate-surviving sources instead of one call per source.
- **Run deadline** — `run.maxDurationMs` (default 5 min) stops the pipeline from starting new fetches once exceeded. The run finalizes with `partial_success` and `summary.deadlineHit: true`.

## Other changes

- `DiscoveryDeps` gains optional `hostErrorTracker`, `timeoutMs`, and `concurrency` fields — backward-compatible; existing callers without these fields behave identically to before.
- Three new tests: deadline stops fetch, `maxDiscoveredItemsPerRun` truncates and logs, and tracking params are stripped before dedup.

## Key files to review

- [packages/shared/agent-ingestion/src/discovery/run-discovery.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.ts) — `pMap`, host-breaker check, and cache cache-miss path.
- [apps/mediapulse/agents/page-collection/src/run.ts](apps/mediapulse/agents/page-collection/src/run.ts) — caps, deadline check, and batched persist.
- [apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts](apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts) — new `discovery`, `collection`, and `run` config sections.

## How to test

1. Run `pnpm code-quality` — all checks pass.
2. Configure a run with `run.maxDurationMs: 1` and confirm the result is `partial_success` with `deadlineHit: true` and no fetch calls.
3. Configure `collection.maxDiscoveredItemsPerRun: 2` with a feed that returns more items; confirm the warn log shows the correct `droppedByRunItemCap` count.
4. Point a source at a slow host; confirm the run completes within `discovery.timeoutMs` with a classified timeout failure.
