### PR TITLE
Add per-source discovery health tracking to listing pipeline

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -32,6 +32,10 @@ import {
   postListingDiscoveryCacheRecord,
 } from "./routes/listing-discovery-cache.js";
 import {
+  postDiscoverySourceHealthRecord,
+  postDiscoverySourceHealthGet,
+} from "./routes/discovery-source-health.js";
+import {
   getDataCollection,
   postDataCollection,
 } from "./routes/data-collection.js";
@@ -176,6 +180,12 @@ const routeHandlers = {
   },
   listingDiscoveryCacheRecord: {
     post: postListingDiscoveryCacheRecord,
+  },
+  discoverySourceHealthRecord: {
+    post: postDiscoverySourceHealthRecord,
+  },
+  discoverySourceHealthGet: {
+    post: postDiscoverySourceHealthGet,
   },
 } satisfies AgentDataApiHandlers;
 

--- a/apps/mediapulse/agent-data-api/src/routes/discovery-source-health.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/discovery-source-health.ts
@@ -1,0 +1,59 @@
+import { Context } from "hono";
+
+import {
+  postDiscoverySourceHealthRecordBodySchema,
+  postDiscoverySourceHealthGetBodySchema,
+} from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+import { prisma } from "@mediapulse/database";
+
+import {
+  recordDiscoverySourceHealth,
+  getDiscoverySourceHealth,
+} from "../services/discovery-source-health.js";
+
+/**
+ * Upserts per-source daily discovery health rows.
+ *
+ * @param context - Hono context; JSON body array of health record inputs.
+ * @returns JSON `{ recorded }`.
+ */
+export async function postDiscoverySourceHealthRecord(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed =
+      await postDiscoverySourceHealthRecordBodySchema.parseAsync(body);
+    const recorded = await recordDiscoverySourceHealth(parsed, {
+      discoverySourceHealth: prisma.discoverySourceHealth,
+    });
+
+    return context.json({ recorded }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}
+
+/**
+ * Returns per-source discovery health entries with derived failure signals.
+ *
+ * @param context - Hono context; JSON body `{ listingUrls, windowDays }`.
+ * @returns JSON array of health entries.
+ */
+export async function postDiscoverySourceHealthGet(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const parsed =
+      await postDiscoverySourceHealthGetBodySchema.parseAsync(body);
+    const entries = await getDiscoverySourceHealth(parsed, {
+      discoverySourceHealth: prisma.discoverySourceHealth,
+    });
+
+    return context.json(entries, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/discovery-source-health.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/discovery-source-health.test.ts
@@ -1,0 +1,271 @@
+/** @vitest-environment node */
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getDiscoverySourceHealth,
+  recordDiscoverySourceHealth,
+} from "./discovery-source-health";
+
+const makeRow = (
+  overrides: Partial<{
+    listingUrl: string;
+    runDate: Date;
+    discovered: boolean;
+    itemCount: number;
+    winningStrategy: string | null;
+    failureCount: number;
+    lastError: string | null;
+    computedAt: Date;
+  }> = {},
+) => ({
+  id: "row-id",
+  listingUrl: "https://example.com/feed",
+  runDate: new Date("2026-06-08T00:00:00.000Z"),
+  discovered: true,
+  itemCount: 3,
+  winningStrategy: "rss" as string | null,
+  failureCount: 0,
+  lastError: null as string | null,
+  computedAt: new Date("2026-06-08T10:00:00.000Z"),
+  ...overrides,
+});
+
+describe("recordDiscoverySourceHealth", () => {
+  it("upserts each record with normalized runDate", async () => {
+    const now = new Date("2026-06-08T12:00:00.000Z");
+    const upsert = vi.fn().mockResolvedValue({});
+
+    const recorded = await recordDiscoverySourceHealth(
+      [
+        {
+          listingUrl: "https://example.com/feed",
+          runDate: "2026-06-08T09:45:00.000Z",
+          discovered: true,
+          itemCount: 5,
+          winningStrategy: "rss",
+          failureCount: 0,
+          lastError: null,
+        },
+      ],
+      {
+        discoverySourceHealth: { upsert, findMany: vi.fn() },
+        now,
+      },
+    );
+
+    expect(recorded).toBe(1);
+    expect(upsert).toHaveBeenCalledOnce();
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          listingUrl_runDate: {
+            listingUrl: "https://example.com/feed",
+            runDate: new Date("2026-06-08T00:00:00.000Z"),
+          },
+        },
+        create: expect.objectContaining({
+          listingUrl: "https://example.com/feed",
+          runDate: new Date("2026-06-08T00:00:00.000Z"),
+          discovered: true,
+          itemCount: 5,
+          winningStrategy: "rss",
+          failureCount: 0,
+          lastError: null,
+        }),
+        update: expect.objectContaining({
+          discovered: true,
+          itemCount: 5,
+          winningStrategy: "rss",
+          failureCount: 0,
+          lastError: null,
+          computedAt: now,
+        }),
+      }),
+    );
+  });
+
+  it("upserts multiple records and returns the count", async () => {
+    const upsert = vi.fn().mockResolvedValue({});
+
+    const recorded = await recordDiscoverySourceHealth(
+      [
+        {
+          listingUrl: "https://a.com/feed",
+          runDate: "2026-06-08T00:00:00.000Z",
+          discovered: true,
+          itemCount: 2,
+          failureCount: 0,
+        },
+        {
+          listingUrl: "https://b.com/feed",
+          runDate: "2026-06-08T00:00:00.000Z",
+          discovered: false,
+          itemCount: 0,
+          failureCount: 3,
+          lastError: "Connection refused",
+        },
+      ],
+      {
+        discoverySourceHealth: { upsert, findMany: vi.fn() },
+      },
+    );
+
+    expect(recorded).toBe(2);
+    expect(upsert).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns 0 and does not call upsert when records array is empty", async () => {
+    const upsert = vi.fn();
+
+    const recorded = await recordDiscoverySourceHealth([], {
+      discoverySourceHealth: { upsert, findMany: vi.fn() },
+    });
+
+    expect(recorded).toBe(0);
+    expect(upsert).not.toHaveBeenCalled();
+  });
+});
+
+describe("getDiscoverySourceHealth", () => {
+  it("returns empty array when listingUrls is empty", async () => {
+    const findMany = vi.fn();
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: [], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result).toEqual([]);
+    expect(findMany).not.toHaveBeenCalled();
+  });
+
+  it("returns entry with empty rows and zero signals when no data exists", async () => {
+    const findMany = vi.fn().mockResolvedValue([]);
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      listingUrl: "https://example.com/feed",
+      rows: [],
+      consecutiveFailedRuns: 0,
+      lastSuccessfulAt: null,
+      failureRate: 0,
+    });
+  });
+
+  it("computes consecutiveFailedRuns from trailing failed rows (newest first)", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      makeRow({
+        runDate: new Date("2026-06-08T00:00:00.000Z"),
+        discovered: false,
+        computedAt: new Date("2026-06-08T10:00:00.000Z"),
+      }),
+      makeRow({
+        runDate: new Date("2026-06-07T00:00:00.000Z"),
+        discovered: false,
+        computedAt: new Date("2026-06-07T10:00:00.000Z"),
+      }),
+      makeRow({
+        runDate: new Date("2026-06-06T00:00:00.000Z"),
+        discovered: true,
+        computedAt: new Date("2026-06-06T10:00:00.000Z"),
+      }),
+    ]);
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result[0]!.consecutiveFailedRuns).toBe(2);
+  });
+
+  it("returns consecutiveFailedRuns of 0 when the latest row is discovered", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      makeRow({
+        runDate: new Date("2026-06-08T00:00:00.000Z"),
+        discovered: true,
+      }),
+      makeRow({
+        runDate: new Date("2026-06-07T00:00:00.000Z"),
+        discovered: false,
+      }),
+    ]);
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result[0]!.consecutiveFailedRuns).toBe(0);
+  });
+
+  it("computes lastSuccessfulAt from the most recent discovered row", async () => {
+    const successComputedAt = new Date("2026-06-07T10:00:00.000Z");
+    const findMany = vi.fn().mockResolvedValue([
+      makeRow({
+        runDate: new Date("2026-06-08T00:00:00.000Z"),
+        discovered: false,
+        computedAt: new Date("2026-06-08T10:00:00.000Z"),
+      }),
+      makeRow({
+        runDate: new Date("2026-06-07T00:00:00.000Z"),
+        discovered: true,
+        computedAt: successComputedAt,
+      }),
+    ]);
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result[0]!.lastSuccessfulAt).toBe(successComputedAt.toISOString());
+  });
+
+  it("computes failureRate as the ratio of not-discovered rows to total", async () => {
+    const findMany = vi
+      .fn()
+      .mockResolvedValue([
+        makeRow({ discovered: true }),
+        makeRow({ discovered: false }),
+        makeRow({ discovered: false }),
+        makeRow({ discovered: true }),
+      ]);
+
+    const result = await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 30 },
+      { discoverySourceHealth: { upsert: vi.fn(), findMany } },
+    );
+
+    expect(result[0]!.failureRate).toBe(0.5);
+  });
+
+  it("passes the correct window start date to the query", async () => {
+    const now = new Date("2026-06-08T12:00:00.000Z");
+    const findMany = vi.fn().mockResolvedValue([]);
+
+    await getDiscoverySourceHealth(
+      { listingUrls: ["https://example.com/feed"], windowDays: 7 },
+      {
+        discoverySourceHealth: { upsert: vi.fn(), findMany },
+        now,
+      },
+    );
+
+    expect(findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          runDate: {
+            gte: new Date("2026-06-01T00:00:00.000Z"),
+          },
+        }),
+      }),
+    );
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/discovery-source-health.ts
+++ b/apps/mediapulse/agent-data-api/src/services/discovery-source-health.ts
@@ -1,0 +1,160 @@
+import type { Prisma } from "@mediapulse/database";
+import type {
+  DiscoverySourceHealthRecordInput,
+  PostDiscoverySourceHealthGetBody,
+  PostDiscoverySourceHealthGetResponse,
+} from "@workspace/agent-data-api-contract";
+
+const toUtcRunDate = (date: Date): Date =>
+  new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+
+const utcDayStart = (date: Date): Date =>
+  new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+
+type DiscoverySourceHealthDb = Pick<
+  typeof import("@mediapulse/database").prisma.discoverySourceHealth,
+  "upsert" | "findMany"
+>;
+
+export type RecordDiscoverySourceHealthDeps = {
+  discoverySourceHealth: DiscoverySourceHealthDb;
+  now?: Date;
+};
+
+export type GetDiscoverySourceHealthDeps = {
+  discoverySourceHealth: DiscoverySourceHealthDb;
+  now?: Date;
+};
+
+/**
+ * Upserts per-source daily health rows keyed by `(listingUrl, runDate)`.
+ *
+ * @param records - Health rows to upsert.
+ * @param deps - Database delegate and optional clock.
+ * @returns Number of rows upserted.
+ */
+export async function recordDiscoverySourceHealth(
+  records: readonly DiscoverySourceHealthRecordInput[],
+  deps: RecordDiscoverySourceHealthDeps,
+): Promise<number> {
+  const { discoverySourceHealth } = deps;
+  const now = deps.now ?? new Date();
+  let recorded = 0;
+
+  for (const record of records) {
+    const normalizedRunDate = toUtcRunDate(new Date(record.runDate));
+
+    const upsertArgs = {
+      where: {
+        listingUrl_runDate: {
+          listingUrl: record.listingUrl,
+          runDate: normalizedRunDate,
+        },
+      },
+      create: {
+        listingUrl: record.listingUrl,
+        runDate: normalizedRunDate,
+        discovered: record.discovered,
+        itemCount: record.itemCount,
+        winningStrategy: record.winningStrategy ?? null,
+        failureCount: record.failureCount,
+        lastError: record.lastError ?? null,
+      },
+      update: {
+        discovered: record.discovered,
+        itemCount: record.itemCount,
+        winningStrategy: record.winningStrategy ?? null,
+        failureCount: record.failureCount,
+        lastError: record.lastError ?? null,
+        computedAt: now,
+      },
+    } satisfies Prisma.DiscoverySourceHealthUpsertArgs;
+
+    await discoverySourceHealth.upsert(upsertArgs);
+    recorded += 1;
+  }
+
+  return recorded;
+}
+
+/**
+ * Returns per-source health entries with derived failure signals for the given window.
+ *
+ * @param body - Listing URLs and lookback window in days.
+ * @param deps - Database delegate and optional clock.
+ * @returns Array of health entries with computed `consecutiveFailedRuns`, `lastSuccessfulAt`, `failureRate`.
+ */
+export async function getDiscoverySourceHealth(
+  body: PostDiscoverySourceHealthGetBody,
+  deps: GetDiscoverySourceHealthDeps,
+): Promise<PostDiscoverySourceHealthGetResponse> {
+  const { listingUrls, windowDays } = body;
+  const now = deps.now ?? new Date();
+  const windowStartMs = now.getTime() - windowDays * 24 * 60 * 60 * 1000;
+  const windowStart = toUtcRunDate(new Date(windowStartMs));
+
+  if (listingUrls.length === 0) {
+    return [];
+  }
+
+  const rows = await deps.discoverySourceHealth.findMany({
+    where: {
+      listingUrl: { in: listingUrls },
+      runDate: { gte: windowStart },
+    },
+    orderBy: [{ listingUrl: "asc" }, { runDate: "desc" }],
+  });
+
+  const grouped = new Map<string, typeof rows>();
+  for (const row of rows) {
+    const group = grouped.get(row.listingUrl);
+    if (group) {
+      group.push(row);
+    } else {
+      grouped.set(row.listingUrl, [row]);
+    }
+  }
+
+  return listingUrls.map((listingUrl) => {
+    const listingRows = grouped.get(listingUrl) ?? [];
+
+    let consecutiveFailedRuns = 0;
+    for (const row of listingRows) {
+      if (!row.discovered) {
+        consecutiveFailedRuns += 1;
+      } else {
+        break;
+      }
+    }
+
+    const lastSuccessfulRow = listingRows.find((row) => row.discovered);
+    const lastSuccessfulAt = lastSuccessfulRow
+      ? lastSuccessfulRow.computedAt.toISOString()
+      : null;
+
+    const failedCount = listingRows.filter((row) => !row.discovered).length;
+    const failureRate =
+      listingRows.length > 0 ? failedCount / listingRows.length : 0;
+
+    return {
+      listingUrl,
+      rows: listingRows.map((row) => ({
+        listingUrl: row.listingUrl,
+        runDate: utcDayStart(row.runDate).toISOString(),
+        discovered: row.discovered,
+        itemCount: row.itemCount,
+        winningStrategy: row.winningStrategy,
+        failureCount: row.failureCount,
+        lastError: row.lastError,
+        computedAt: row.computedAt.toISOString(),
+      })),
+      consecutiveFailedRuns,
+      lastSuccessfulAt,
+      failureRate,
+    };
+  });
+}

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -96,6 +96,7 @@ const tickerGetMock = vi.fn();
 const curatedListingQueryCreateMock = vi.fn();
 const listingDiscoveryCacheLookupMock = vi.fn();
 const listingDiscoveryCacheRecordMock = vi.fn();
+const discoverySourceHealthRecordMock = vi.fn();
 
 vi.mock("@workspace/agent-data-api-client", () => ({
   createAgentDataApiClient: vi.fn(() => ({
@@ -128,6 +129,9 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     },
     listingDiscoveryCacheRecord: {
       create: listingDiscoveryCacheRecordMock,
+    },
+    discoverySourceHealthRecord: {
+      create: discoverySourceHealthRecordMock,
     },
   })),
 }));
@@ -182,6 +186,16 @@ describe("runPageCollection", () => {
         },
       ],
       failures: [],
+      sourceReports: [
+        {
+          listingUrl: "https://example.com/feed",
+          discovered: true,
+          itemCount: 1,
+          winningStrategy: "rss",
+          failureCount: 0,
+          lastError: null,
+        },
+      ],
     });
 
     vi.mocked(performWebFetch).mockResolvedValue([
@@ -210,6 +224,7 @@ describe("runPageCollection", () => {
     failureCreateMock.mockResolvedValue({});
     listingDiscoveryCacheLookupMock.mockResolvedValue({ entries: [] });
     listingDiscoveryCacheRecordMock.mockResolvedValue({});
+    discoverySourceHealthRecordMock.mockResolvedValue({ recorded: 1 });
   });
 
   afterEach(() => {
@@ -269,6 +284,7 @@ describe("runPageCollection", () => {
           retryable: true,
         },
       ],
+      sourceReports: [],
     });
 
     const result = await runPageCollection(createContext());
@@ -287,6 +303,7 @@ describe("runPageCollection", () => {
         { url: "https://example.com/off-topic", title: "Sports news today" },
       ],
       failures: [],
+      sourceReports: [],
     });
 
     const result = await runPageCollection(createContext());
@@ -301,6 +318,7 @@ describe("runPageCollection", () => {
     vi.mocked(runDiscovery).mockResolvedValue({
       items: [{ url: "https://example.com/no-title" }],
       failures: [],
+      sourceReports: [],
     });
 
     vi.mocked(performWebFetch).mockResolvedValue([
@@ -361,6 +379,7 @@ describe("runPageCollection", () => {
     vi.mocked(runDiscovery).mockResolvedValue({
       items: [],
       failures: [],
+      sourceReports: [],
     });
 
     const result = await runPageCollection(createContext());
@@ -380,6 +399,7 @@ describe("runPageCollection", () => {
     vi.mocked(runDiscovery).mockResolvedValue({
       items: manyItems,
       failures: [],
+      sourceReports: [],
     });
     vi.mocked(performWebFetch).mockResolvedValue([
       mockFetchSuccess({
@@ -430,6 +450,7 @@ describe("runPageCollection", () => {
           },
         ],
         failures: [],
+        sourceReports: [],
       };
     });
 
@@ -472,6 +493,7 @@ describe("runPageCollection", () => {
         },
       ],
       failures: [],
+      sourceReports: [],
     });
 
     vi.mocked(performWebFetch).mockResolvedValue([
@@ -499,5 +521,56 @@ describe("runPageCollection", () => {
 
     expect(fetchInputs).toHaveLength(1);
     expect(fetchInputs[0]!.url).toBe("https://example.com/article-1");
+  });
+
+  it("posts per-source discovery health records to the health endpoint after the run", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [
+        {
+          url: "https://example.com/article-1",
+          title: validArticleTitle,
+          publishedAt: "2026-06-08T00:00:00.000Z",
+        },
+      ],
+      failures: [],
+      sourceReports: [
+        {
+          listingUrl: "https://example.com/feed",
+          discovered: true,
+          itemCount: 1,
+          winningStrategy: "rss",
+          failureCount: 0,
+          lastError: null,
+        },
+      ],
+    });
+
+    await runPageCollection(createContext());
+
+    expect(discoverySourceHealthRecordMock).toHaveBeenCalledOnce();
+    const healthRecords = discoverySourceHealthRecordMock.mock.calls[0]![0];
+
+    expect(healthRecords).toHaveLength(1);
+    expect(healthRecords[0]).toMatchObject({
+      listingUrl: "https://example.com/feed",
+      discovered: true,
+      itemCount: 1,
+      winningStrategy: "rss",
+      failureCount: 0,
+      lastError: null,
+    });
+    expect(typeof healthRecords[0].runDate).toBe("string");
+  });
+
+  it("does not post health records when sourceReports is empty", async () => {
+    vi.mocked(runDiscovery).mockResolvedValue({
+      items: [],
+      failures: [],
+      sourceReports: [],
+    });
+
+    await runPageCollection(createContext());
+
+    expect(discoverySourceHealthRecordMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -179,13 +179,23 @@ export async function runPageCollection(
         }
       : undefined;
 
-  const { items: discoveredItems, failures: discoveryFailures } =
-    await runDiscovery(discoverySources, discoveryDeps, discoveryCache);
+  const {
+    items: discoveredItems,
+    failures: discoveryFailures,
+    sourceReports,
+  } = await runDiscovery(discoverySources, discoveryDeps, discoveryCache);
 
   log.info(
     {
       discoveredCount: discoveredItems.length,
       discoveryFailureCount: discoveryFailures.length,
+      perSource: sourceReports.map((report) => ({
+        listingUrl: report.listingUrl.slice(0, 80),
+        discovered: report.discovered,
+        itemCount: report.itemCount,
+        winningStrategy: report.winningStrategy,
+        failureCount: report.failureCount,
+      })),
     },
     "discovery stage finished",
   );
@@ -527,6 +537,30 @@ export async function runPageCollection(
           "failed to record dead URLs; continuing without negative cache write",
         );
       }
+    }
+  }
+
+  if (sourceReports.length > 0) {
+    const healthRecords = sourceReports.map((report) => ({
+      listingUrl: report.listingUrl,
+      runDate: startedAt.toISOString(),
+      discovered: report.discovered,
+      itemCount: report.itemCount,
+      winningStrategy: report.winningStrategy,
+      failureCount: report.failureCount,
+      lastError: report.lastError,
+    }));
+    try {
+      await dataApiClient.discoverySourceHealthRecord.create(healthRecords);
+      log.info(
+        { healthRecordCount: healthRecords.length },
+        "posted per-source discovery health records",
+      );
+    } catch (healthError) {
+      log.warn(
+        { healthRecordCount: healthRecords.length, err: healthError },
+        "failed to post discovery source health records; continuing",
+      );
     }
   }
 

--- a/packages/mediapulse/database/prisma/migrations/20260608000003_add_discovery_source_health/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260608000003_add_discovery_source_health/migration.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "discovery_source_health" (
+    "id" TEXT NOT NULL,
+    "listing_url" TEXT NOT NULL,
+    "run_date" DATE NOT NULL,
+    "discovered" BOOLEAN NOT NULL,
+    "item_count" INTEGER NOT NULL,
+    "winning_strategy" TEXT,
+    "failure_count" INTEGER NOT NULL,
+    "last_error" TEXT,
+    "computed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "discovery_source_health_pkey" PRIMARY KEY ("id")
+);
+CREATE UNIQUE INDEX "discovery_source_health_listing_url_run_date_key" ON "discovery_source_health"("listing_url", "run_date");
+CREATE INDEX "discovery_source_health_listing_url_run_date_idx" ON "discovery_source_health"("listing_url", "run_date" DESC);

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -90,6 +90,22 @@ model ListingDiscoveryCache {
   @@map("listing_discovery_cache")
 }
 
+model DiscoverySourceHealth {
+  id              String   @id @default(uuid())
+  listingUrl      String   @map("listing_url")
+  runDate         DateTime @map("run_date") @db.Date
+  discovered      Boolean
+  itemCount       Int      @map("item_count")
+  winningStrategy String?  @map("winning_strategy")
+  failureCount    Int      @map("failure_count")
+  lastError       String?  @map("last_error")
+  computedAt      DateTime @default(now()) @map("computed_at")
+
+  @@unique([listingUrl, runDate])
+  @@index([listingUrl, runDate(sort: Desc)])
+  @@map("discovery_source_health")
+}
+
 model Newsletter {
   id          String   @id @default(uuid())
   subject     String

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -44,6 +44,12 @@ import {
   postListingDiscoveryCacheRecordResponseSchema,
 } from "./listing-discovery-cache.js";
 import {
+  postDiscoverySourceHealthRecordBodySchema,
+  postDiscoverySourceHealthRecordResponseSchema,
+  postDiscoverySourceHealthGetBodySchema,
+  postDiscoverySourceHealthGetResponseSchema,
+} from "./discovery-source-health.js";
+import {
   getDataCollectionRecentSourceFingerprintsQuerySchema,
   getDataCollectionRecentSourceFingerprintsResponseSchema,
 } from "./data-collection.js";
@@ -599,6 +605,38 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postListingDiscoveryCacheRecordBodySchema,
         response: postListingDiscoveryCacheRecordResponseSchema,
+      },
+    },
+  },
+  discoverySourceHealthRecord: {
+    v1: {
+      pathSegment: "/discovery-source-health/record",
+      post: {
+        body: postDiscoverySourceHealthRecordBodySchema,
+        response: postDiscoverySourceHealthRecordResponseSchema,
+      },
+    },
+    v2: {
+      pathSegment: "/discovery-source-health/record",
+      post: {
+        body: postDiscoverySourceHealthRecordBodySchema,
+        response: postDiscoverySourceHealthRecordResponseSchema,
+      },
+    },
+  },
+  discoverySourceHealthGet: {
+    v1: {
+      pathSegment: "/discovery-source-health/get",
+      post: {
+        body: postDiscoverySourceHealthGetBodySchema,
+        response: postDiscoverySourceHealthGetResponseSchema,
+      },
+    },
+    v2: {
+      pathSegment: "/discovery-source-health/get",
+      post: {
+        body: postDiscoverySourceHealthGetBodySchema,
+        response: postDiscoverySourceHealthGetResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/discovery-source-health.ts
+++ b/packages/shared/agent-data-api-contract/src/discovery-source-health.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+
+const discoverySourceHealthRecordInputSchema = z.object({
+  listingUrl: z.string().url(),
+  runDate: z.string().datetime(),
+  discovered: z.boolean(),
+  itemCount: z.number().int().nonnegative(),
+  winningStrategy: z.string().nullable().optional(),
+  failureCount: z.number().int().nonnegative(),
+  lastError: z.string().nullable().optional(),
+});
+
+/**
+ * Body for POST `/discovery-source-health/record`: per-source daily health rows to upsert.
+ */
+export const postDiscoverySourceHealthRecordBodySchema = z.array(
+  discoverySourceHealthRecordInputSchema,
+);
+
+/**
+ * Response: number of rows upserted.
+ */
+export const postDiscoverySourceHealthRecordResponseSchema = z.object({
+  recorded: z.number().int().nonnegative(),
+});
+
+/**
+ * Body for POST `/discovery-source-health/get`: listing URLs and lookback window.
+ */
+export const postDiscoverySourceHealthGetBodySchema = z.object({
+  listingUrls: z.array(z.string().url()),
+  windowDays: z.number().int().positive().default(30),
+});
+
+const discoverySourceHealthRowSchema = z.object({
+  listingUrl: z.string().url(),
+  runDate: z.string().datetime(),
+  discovered: z.boolean(),
+  itemCount: z.number().int().nonnegative(),
+  winningStrategy: z.string().nullable(),
+  failureCount: z.number().int().nonnegative(),
+  lastError: z.string().nullable(),
+  computedAt: z.string().datetime(),
+});
+
+const discoverySourceHealthEntrySchema = z.object({
+  listingUrl: z.string().url(),
+  rows: z.array(discoverySourceHealthRowSchema),
+  consecutiveFailedRuns: z.number().int().nonnegative(),
+  lastSuccessfulAt: z.string().datetime().nullable(),
+  failureRate: z.number().min(0).max(1),
+});
+
+/**
+ * Response: per-source health entries with derived failure signals.
+ */
+export const postDiscoverySourceHealthGetResponseSchema = z.array(
+  discoverySourceHealthEntrySchema,
+);
+
+export type PostDiscoverySourceHealthRecordBody = z.infer<
+  typeof postDiscoverySourceHealthRecordBodySchema
+>;
+export type PostDiscoverySourceHealthRecordResponse = z.infer<
+  typeof postDiscoverySourceHealthRecordResponseSchema
+>;
+export type PostDiscoverySourceHealthGetBody = z.infer<
+  typeof postDiscoverySourceHealthGetBodySchema
+>;
+export type PostDiscoverySourceHealthGetResponse = z.infer<
+  typeof postDiscoverySourceHealthGetResponseSchema
+>;
+export type DiscoverySourceHealthRecordInput = z.infer<
+  typeof discoverySourceHealthRecordInputSchema
+>;
+export type DiscoverySourceHealthEntry = z.infer<
+  typeof discoverySourceHealthEntrySchema
+>;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -114,6 +114,18 @@ export {
   type PostListingDiscoveryCacheRecordResponse,
 } from "./listing-discovery-cache.js";
 export {
+  postDiscoverySourceHealthRecordBodySchema,
+  postDiscoverySourceHealthRecordResponseSchema,
+  postDiscoverySourceHealthGetBodySchema,
+  postDiscoverySourceHealthGetResponseSchema,
+  type PostDiscoverySourceHealthRecordBody,
+  type PostDiscoverySourceHealthRecordResponse,
+  type PostDiscoverySourceHealthGetBody,
+  type PostDiscoverySourceHealthGetResponse,
+  type DiscoverySourceHealthRecordInput,
+  type DiscoverySourceHealthEntry,
+} from "./discovery-source-health.js";
+export {
   deliveryNewsletterSchema,
   deliverySubscriberSchema,
   getDeliveryQuerySchema,

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
@@ -33,12 +33,24 @@ export type DiscoveryFailure = {
 export type SourceDiscoveryOutcome = {
   items: DiscoveredItem[];
   failures: DiscoveryFailure[];
+  winningStrategy: string | null;
+};
+
+/** Per-source health snapshot produced by runDiscovery for observability. */
+export type SourceDiscoveryReport = {
+  listingUrl: string;
+  discovered: boolean;
+  itemCount: number;
+  winningStrategy: string | null;
+  failureCount: number;
+  lastError: string | null;
 };
 
 /** Aggregate result of running discovery over all sources. */
 export type RunDiscoveryResult = {
   items: DiscoveredItem[];
   failures: DiscoveryFailure[];
+  sourceReports: SourceDiscoveryReport[];
 };
 
 /** Optional cache port for cross-ticker listing discovery deduplication. */
@@ -95,7 +107,7 @@ export const discoverOneSource = async (
       const limited =
         source.maxItems !== undefined ? items.slice(0, source.maxItems) : items;
 
-      return { items: limited, failures };
+      return { items: limited, failures, winningStrategy: strategyType };
     } catch (error) {
       const classified = classifyError(error);
       failures.push({
@@ -108,7 +120,7 @@ export const discoverOneSource = async (
     }
   }
 
-  return { items: [], failures };
+  return { items: [], failures, winningStrategy: null };
 };
 
 /**
@@ -133,6 +145,7 @@ export const runDiscovery = async (
 
   const allItems: DiscoveredItem[] = [];
   const allFailures: DiscoveryFailure[] = [];
+  const allSourceReports: SourceDiscoveryReport[] = [];
   const seen = new Set<string>();
 
   const tryDiscover = async (
@@ -151,6 +164,7 @@ export const runDiscovery = async (
             retryable: false,
           },
         ],
+        winningStrategy: null,
       };
     }
     const outcome = await discoverOneSource(source, deps);
@@ -168,6 +182,22 @@ export const runDiscovery = async (
     }
   };
 
+  const buildReport = (
+    listingUrl: string,
+    outcome: SourceDiscoveryOutcome,
+  ): SourceDiscoveryReport => {
+    const lastFailure = outcome.failures[outcome.failures.length - 1];
+
+    return {
+      listingUrl,
+      discovered: outcome.items.length > 0,
+      itemCount: outcome.items.length,
+      winningStrategy: outcome.winningStrategy,
+      failureCount: outcome.failures.length,
+      lastError: lastFailure?.message ?? null,
+    };
+  };
+
   if (cache && enabledSources.length > 0) {
     const sourceUrls = enabledSources.map((source) => source.url);
     const cacheHits = await cache.lookup(sourceUrls);
@@ -179,8 +209,16 @@ export const runDiscovery = async (
       (source) => !hitMap.has(source.url),
     );
 
-    for (const [, cachedItems] of hitMap) {
+    for (const [listingUrl, cachedItems] of hitMap) {
       addItems(cachedItems);
+      allSourceReports.push({
+        listingUrl,
+        discovered: cachedItems.length > 0,
+        itemCount: cachedItems.length,
+        winningStrategy: "cache",
+        failureCount: 0,
+        lastError: null,
+      });
     }
 
     if (missedSources.length > 0) {
@@ -200,12 +238,12 @@ export const runDiscovery = async (
         const outcome = missOutcomes[index]!;
         allFailures.push(...outcome.failures);
         addItems(outcome.items);
+        allSourceReports.push(buildReport(source.url, outcome));
+
         if (outcome.items.length > 0) {
-          const winningStrategy =
-            source.strategies?.[0] ?? DEFAULT_DISCOVERY_CHAIN[0] ?? "rss";
           freshEntries.push({
             listingUrl: source.url,
-            strategy: winningStrategy,
+            strategy: outcome.winningStrategy ?? "rss",
             items: outcome.items,
             ttlSeconds: cache.ttlSeconds,
           });
@@ -217,14 +255,25 @@ export const runDiscovery = async (
       }
     }
 
-    return { items: allItems, failures: allFailures };
+    return {
+      items: allItems,
+      failures: allFailures,
+      sourceReports: allSourceReports,
+    };
   }
 
   const outcomes = await pMap(enabledSources, tryDiscover, { concurrency });
-  for (const outcome of outcomes) {
+  for (let index = 0; index < enabledSources.length; index += 1) {
+    const source = enabledSources[index]!;
+    const outcome = outcomes[index]!;
     allFailures.push(...outcome.failures);
     addItems(outcome.items);
+    allSourceReports.push(buildReport(source.url, outcome));
   }
 
-  return { items: allItems, failures: allFailures };
+  return {
+    items: allItems,
+    failures: allFailures,
+    sourceReports: allSourceReports,
+  };
 };

--- a/packages/shared/agent-ingestion/src/index.ts
+++ b/packages/shared/agent-ingestion/src/index.ts
@@ -108,6 +108,7 @@ export {
   type DiscoverySource,
   type DiscoveryFailure,
   type SourceDiscoveryOutcome,
+  type SourceDiscoveryReport,
   type RunDiscoveryResult,
 } from "./discovery/run-discovery";
 


### PR DESCRIPTION
## Summary

Adds a `DiscoverySourceHealth` table so operators can spot broken listing feeds without waiting for article volume to drop. Each page-collection run now records one health row per source, and the agent-data-api exposes endpoints to upsert those rows and query derived failure signals (consecutive failed runs, last successful run, failure rate over a configurable window).

## Related issues

Closes #691

## Important changes

- **New Prisma model and migration** — `DiscoverySourceHealth` keyed on `(listingUrl, runDate)` with a DESC index for efficient windowed queries.
- **`runDiscovery` shape extended** — `SourceDiscoveryOutcome` now includes `winningStrategy: string | null`; `RunDiscoveryResult` now includes `sourceReports: SourceDiscoveryReport[]`. Cache hits produce `winningStrategy = "cache"`.
- **Health post in page-collection** — health rows are submitted at the end of each run. A failure to post is warn-logged but does not fail the run.

## Other changes

- Added `discoverySourceHealthRecord` and `discoverySourceHealthGet` manifest entries and route handlers to agent-data-api.
- Exported `SourceDiscoveryReport` from `@workspace/agent-ingestion`.
- `discovery stage finished` log now includes a `perSource` array for per-source observability.
- Service test covers `consecutiveFailedRuns`, `lastSuccessfulAt`, `failureRate`, and window-start query logic.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` — new model definition and indexes.
- `packages/shared/agent-ingestion/src/discovery/run-discovery.ts` — `winningStrategy` + `sourceReports` additions.
- `apps/mediapulse/agent-data-api/src/services/discovery-source-health.ts` — upsert logic and derived-signal computation.
- `apps/mediapulse/agents/page-collection/src/run.ts` — health post block (try/catch, non-fatal).

## How to test

1. Run `pnpm code-quality` from the repo root — all checks should pass.
2. Run `pnpm --filter @mediapulse/agent-data-api test:coverage` — 24 test files, 155 tests pass.
3. Run `pnpm --filter @workspace/agent-ingestion test:coverage` — 20 test files, 113 tests pass.
4. Run `pnpm --filter @mediapulse/page-collection test:coverage` — 4 test files, 36 tests pass.
5. In a local environment with a database, run a page-collection cycle and confirm `discovery_source_health` rows are created with the correct `listing_url`, `run_date` (UTC midnight), and `winning_strategy` values.
