### PR TITLE
Add agent insights protocol: contract, provider registry, and dispatching endpoint

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -66,6 +66,7 @@ import {
   postContentGenerationRun,
 } from "./routes/content-generation-run.js";
 import { getSectionCoverageRollupHandler } from "./routes/section-coverage-rollup.js";
+import { getAgentInsights } from "./routes/agent-insights.js";
 import {
   registerAgentDataApiRoutes,
   type AgentDataApiHandlers,
@@ -186,6 +187,9 @@ const routeHandlers = {
   },
   discoverySourceHealthGet: {
     post: postDiscoverySourceHealthGet,
+  },
+  agentInsights: {
+    get: getAgentInsights,
   },
 } satisfies AgentDataApiHandlers;
 

--- a/apps/mediapulse/agent-data-api/src/routes/agent-insights.test.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/agent-insights.test.ts
@@ -1,0 +1,73 @@
+/** @vitest-environment node */
+
+import { Hono } from "hono";
+import { describe, expect, it, vi } from "vitest";
+
+import { getAgentInsights } from "./agent-insights.js";
+
+vi.mock("../services/agent-insights-registry.js", () => ({
+  resolveInsightsProvider: vi.fn(),
+}));
+
+import { resolveInsightsProvider } from "../services/agent-insights-registry.js";
+
+const VALID_PAYLOAD = {
+  agentId: "page-collection",
+  window: "7d",
+  generatedAt: "2026-06-08T00:00:00.000Z",
+  kpis: [{ id: "k1", label: "Articles", value: 42 }],
+  alerts: [],
+  sections: [
+    {
+      id: "s1",
+      category: "what",
+      title: "Article stat",
+      widget: { kind: "stat", value: 42 },
+    },
+  ],
+};
+
+describe("getAgentInsights", () => {
+  it("dispatches to the registered provider and returns the payload", async () => {
+    vi.mocked(resolveInsightsProvider).mockReturnValue({
+      agentId: "page-collection",
+      compute: vi.fn().mockResolvedValue(VALID_PAYLOAD),
+    });
+
+    const app = new Hono();
+    app.get("/", getAgentInsights);
+
+    const response = await app.request("/?agentId=page-collection&window=7d");
+
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as typeof VALID_PAYLOAD;
+    expect(body.agentId).toBe("page-collection");
+    expect(body.window).toBe("7d");
+    expect(resolveInsightsProvider).toHaveBeenCalledWith("page-collection");
+  });
+
+  it("returns 404 when no provider is registered for agentId", async () => {
+    vi.mocked(resolveInsightsProvider).mockReturnValue(undefined);
+
+    const app = new Hono();
+    app.get("/", getAgentInsights);
+
+    const response = await app.request("/?agentId=unknown-agent&window=7d");
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns 400 when the provider returns an invalid payload", async () => {
+    vi.mocked(resolveInsightsProvider).mockReturnValue({
+      agentId: "bad-provider",
+      compute: vi.fn().mockResolvedValue({ invalid: true }),
+    });
+
+    const app = new Hono();
+    app.get("/", getAgentInsights);
+
+    const response = await app.request("/?agentId=bad-provider&window=7d");
+
+    expect(response.status).toBe(400);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/routes/agent-insights.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/agent-insights.ts
@@ -1,0 +1,39 @@
+import {
+  getAgentInsightsQuerySchema,
+  insightsPayloadSchema,
+} from "@workspace/agent-data-api-contract";
+import { internalError, notFound } from "@workspace/api-utils";
+import type { Context } from "hono";
+
+import { resolveInsightsProvider } from "../services/agent-insights-registry.js";
+
+/**
+ * Returns an insights payload for a registered agent.
+ *
+ * @param context - Hono request context; query params `agentId`, `window`, and optional `tickerId`.
+ * @returns Parsed `InsightsPayload` or 404 when no provider is registered for `agentId`.
+ */
+export const getAgentInsights = async (context: Context): Promise<Response> => {
+  try {
+    const query = getAgentInsightsQuerySchema.parse(context.req.query());
+    const provider = resolveInsightsProvider(query.agentId);
+
+    if (!provider) {
+      return notFound(
+        context,
+        `No insights provider registered for agent: ${query.agentId}`,
+      );
+    }
+
+    const payload = await provider.compute({
+      window: query.window,
+      tickerId: query.tickerId,
+    });
+
+    const response = insightsPayloadSchema.parse(payload);
+
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+};

--- a/apps/mediapulse/agent-data-api/src/services/agent-insights-registry.ts
+++ b/apps/mediapulse/agent-data-api/src/services/agent-insights-registry.ts
@@ -1,0 +1,23 @@
+import type { InsightsPayload } from "@workspace/agent-data-api-contract";
+
+export type InsightsContext = {
+  window: "24h" | "7d" | "30d";
+  tickerId?: string;
+};
+
+export interface AgentInsightsProvider {
+  agentId: string;
+  compute(context: InsightsContext): Promise<InsightsPayload>;
+}
+
+const registry = new Map<string, AgentInsightsProvider>();
+
+export const registerInsightsProvider = (
+  provider: AgentInsightsProvider,
+): void => {
+  registry.set(provider.agentId, provider);
+};
+
+export const resolveInsightsProvider = (
+  agentId: string,
+): AgentInsightsProvider | undefined => registry.get(agentId);

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -105,6 +105,10 @@ import {
   getSectionCoverageRollupQuerySchema,
   getSectionCoverageRollupResponseSchema,
 } from "./section-coverage-rollup.js";
+import {
+  getAgentInsightsQuerySchema,
+  getAgentInsightsResponseSchema,
+} from "./agent-insights.js";
 
 type AgentDataApiMethodSchema =
   | {
@@ -637,6 +641,20 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postDiscoverySourceHealthGetBodySchema,
         response: postDiscoverySourceHealthGetResponseSchema,
+      },
+    },
+  },
+  agentInsights: {
+    v1: {
+      get: {
+        query: getAgentInsightsQuerySchema,
+        response: getAgentInsightsResponseSchema,
+      },
+    },
+    v2: {
+      get: {
+        query: getAgentInsightsQuerySchema,
+        response: getAgentInsightsResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/agent-insights.test.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-insights.test.ts
@@ -1,0 +1,140 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { insightsPayloadSchema, widgetSchema } from "./agent-insights.js";
+
+const FUNNEL_WIDGET = {
+  kind: "funnel" as const,
+  stages: [
+    { label: "Discovered", value: 100 },
+    { label: "Collected", value: 60 },
+  ],
+};
+
+const TIME_SERIES_WIDGET = {
+  kind: "timeSeries" as const,
+  points: [{ ts: "2026-06-01T00:00:00.000Z", value: 42 }],
+  unit: "articles",
+};
+
+const CATEGORY_BAR_WIDGET = {
+  kind: "categoryBar" as const,
+  bars: [{ label: "Finance", value: 12 }],
+};
+
+const BREAKDOWN_WIDGET = {
+  kind: "breakdown" as const,
+  slices: [{ label: "RSS", value: 80, fraction: 0.8 }],
+};
+
+const HISTOGRAM_WIDGET = {
+  kind: "histogram" as const,
+  buckets: [{ label: "0–10", count: 5 }],
+};
+
+const TABLE_WIDGET = {
+  kind: "table" as const,
+  columns: ["Source", "Count"],
+  rows: [["example.com", 7]],
+};
+
+const STAT_WIDGET = {
+  kind: "stat" as const,
+  value: 42,
+  unit: "articles",
+};
+
+describe("widgetSchema", () => {
+  it.each([
+    ["funnel", FUNNEL_WIDGET],
+    ["timeSeries", TIME_SERIES_WIDGET],
+    ["categoryBar", CATEGORY_BAR_WIDGET],
+    ["breakdown", BREAKDOWN_WIDGET],
+    ["histogram", HISTOGRAM_WIDGET],
+    ["table", TABLE_WIDGET],
+    ["stat", STAT_WIDGET],
+  ] as const)("parses a %s widget", (_kind, widget) => {
+    const result = widgetSchema.parse(widget);
+
+    expect(result.kind).toBe(widget.kind);
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(() => widgetSchema.parse({ kind: "unknown", value: 1 })).toThrow();
+  });
+});
+
+describe("insightsPayloadSchema", () => {
+  it("parses a representative payload with one of each widget kind", () => {
+    const payload = insightsPayloadSchema.parse({
+      agentId: "page-collection",
+      window: "7d",
+      generatedAt: "2026-06-08T00:00:00.000Z",
+      kpis: [
+        {
+          id: "k1",
+          label: "Articles collected",
+          value: 100,
+          unit: "items",
+          delta: 5,
+          sparkline: [10, 20, 15],
+        },
+      ],
+      alerts: [
+        {
+          id: "a1",
+          severity: "warning",
+          message: "Discovery failure rate above threshold",
+          sectionRef: "s1",
+        },
+      ],
+      sections: [
+        { id: "s1", category: "what", title: "Funnel", widget: FUNNEL_WIDGET },
+        {
+          id: "s2",
+          category: "when",
+          title: "Over time",
+          widget: TIME_SERIES_WIDGET,
+        },
+        {
+          id: "s3",
+          category: "where",
+          title: "By category",
+          widget: CATEGORY_BAR_WIDGET,
+        },
+        {
+          id: "s4",
+          category: "who",
+          title: "Breakdown",
+          widget: BREAKDOWN_WIDGET,
+        },
+        {
+          id: "s5",
+          category: "why",
+          title: "Histogram",
+          widget: HISTOGRAM_WIDGET,
+        },
+        { id: "s6", category: "how", title: "Table", widget: TABLE_WIDGET },
+        { id: "s7", category: "other", title: "Stat", widget: STAT_WIDGET },
+      ],
+    });
+
+    expect(payload.agentId).toBe("page-collection");
+    expect(payload.sections).toHaveLength(7);
+    expect(payload.kpis[0]?.sparkline).toEqual([10, 20, 15]);
+  });
+
+  it("rejects an unknown window value", () => {
+    expect(() =>
+      insightsPayloadSchema.parse({
+        agentId: "x",
+        window: "90d",
+        generatedAt: "2026-06-08T00:00:00.000Z",
+        kpis: [],
+        alerts: [],
+        sections: [],
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/shared/agent-data-api-contract/src/agent-insights.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-insights.ts
@@ -1,0 +1,104 @@
+import { z } from "zod";
+
+const funnelWidgetSchema = z.object({
+  kind: z.literal("funnel"),
+  stages: z.array(z.object({ label: z.string(), value: z.number() })),
+});
+
+const timeSeriesWidgetSchema = z.object({
+  kind: z.literal("timeSeries"),
+  points: z.array(z.object({ ts: z.string(), value: z.number() })),
+  unit: z.string().optional(),
+});
+
+const categoryBarWidgetSchema = z.object({
+  kind: z.literal("categoryBar"),
+  bars: z.array(z.object({ label: z.string(), value: z.number() })),
+  unit: z.string().optional(),
+});
+
+const breakdownWidgetSchema = z.object({
+  kind: z.literal("breakdown"),
+  slices: z.array(
+    z.object({ label: z.string(), value: z.number(), fraction: z.number() }),
+  ),
+});
+
+const histogramWidgetSchema = z.object({
+  kind: z.literal("histogram"),
+  buckets: z.array(z.object({ label: z.string(), count: z.number() })),
+});
+
+const tableWidgetSchema = z.object({
+  kind: z.literal("table"),
+  columns: z.array(z.string()),
+  rows: z.array(z.array(z.union([z.string(), z.number(), z.null()]))),
+});
+
+const statWidgetSchema = z.object({
+  kind: z.literal("stat"),
+  value: z.union([z.string(), z.number()]),
+  unit: z.string().optional(),
+  delta: z.number().optional(),
+});
+
+export const widgetSchema = z.discriminatedUnion("kind", [
+  funnelWidgetSchema,
+  timeSeriesWidgetSchema,
+  categoryBarWidgetSchema,
+  breakdownWidgetSchema,
+  histogramWidgetSchema,
+  tableWidgetSchema,
+  statWidgetSchema,
+]);
+
+export const kpiCardSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  value: z.union([z.string(), z.number()]),
+  unit: z.string().optional(),
+  delta: z.number().optional(),
+  sparkline: z.array(z.number()).optional(),
+});
+
+export const insightAlertSchema = z.object({
+  id: z.string(),
+  severity: z.enum(["info", "warning", "critical"]),
+  message: z.string(),
+  sectionRef: z.string().optional(),
+});
+
+export const insightSectionSchema = z.object({
+  id: z.string(),
+  category: z.enum(["what", "when", "where", "who", "why", "how", "other"]),
+  title: z.string(),
+  insight: z.string().optional(),
+  widget: widgetSchema,
+});
+
+export const insightsPayloadSchema = z.object({
+  agentId: z.string(),
+  window: z.enum(["24h", "7d", "30d"]),
+  generatedAt: z.string().datetime(),
+  kpis: z.array(kpiCardSchema),
+  alerts: z.array(insightAlertSchema),
+  sections: z.array(insightSectionSchema),
+});
+
+export const getAgentInsightsQuerySchema = z.object({
+  agentId: z.string().trim().min(1),
+  window: z.enum(["24h", "7d", "30d"]),
+  tickerId: z.string().optional(),
+});
+
+export const getAgentInsightsResponseSchema = insightsPayloadSchema;
+
+export type Widget = z.infer<typeof widgetSchema>;
+export type KpiCard = z.infer<typeof kpiCardSchema>;
+export type InsightAlert = z.infer<typeof insightAlertSchema>;
+export type InsightSection = z.infer<typeof insightSectionSchema>;
+export type InsightsPayload = z.infer<typeof insightsPayloadSchema>;
+export type GetAgentInsightsQuery = z.infer<typeof getAgentInsightsQuerySchema>;
+export type GetAgentInsightsResponse = z.infer<
+  typeof getAgentInsightsResponseSchema
+>;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -238,6 +238,22 @@ export {
   type SectionCoverageVersionRow,
 } from "./section-coverage-rollup.js";
 export {
+  getAgentInsightsQuerySchema,
+  getAgentInsightsResponseSchema,
+  insightAlertSchema,
+  insightSectionSchema,
+  insightsPayloadSchema,
+  kpiCardSchema,
+  widgetSchema,
+  type GetAgentInsightsQuery,
+  type GetAgentInsightsResponse,
+  type InsightAlert,
+  type InsightSection,
+  type InsightsPayload,
+  type KpiCard,
+  type Widget,
+} from "./agent-insights.js";
+export {
   classifyQueryToSection,
   MEDIAPULSE_NEWSLETTER_SECTIONS,
   NEWSLETTER_SECTION_IDS,


### PR DESCRIPTION
## Summary

Makes agent insights a protocol instead of a feature. The contract package now exports a closed widget union and payload schema; `agent-data-api` gets a provider registry keyed by `agentId` and one `GET /agent-insights` endpoint that dispatches to whichever provider is registered. The next plan wires in the first concrete provider (page-collection); this one is intentionally free of agent-specific logic.

## Related issues

Closes #693

## Important changes

- New `widgetSchema` discriminated union on `kind` — `funnel`, `timeSeries`, `categoryBar`, `breakdown`, `histogram`, `table`, `stat` — exported from `@workspace/agent-data-api-contract`. Unknown kinds are rejected at parse time so the renderer stays bounded.
- `registerInsightsProvider` / `resolveInsightsProvider` are the only public registry API in `agent-data-api`. Providers register at startup and are never hard-coded in the router.
- `GET /agent-insights?agentId=&window=` returns the validated payload or a 404 when no provider is registered. An invalid provider payload returns 400 (ZodError path through `internalError`).

## Other changes

- Added contract tests covering all seven widget kinds and an unknown-kind rejection.
- Added route tests: stub dispatch returning a valid payload, no-provider 404, and invalid-payload 400.

## Key files to review

- `packages/shared/agent-data-api-contract/src/agent-insights.ts` — all contract schemas and types.
- `apps/mediapulse/agent-data-api/src/services/agent-insights-registry.ts` — the registry; straightforward Map wrapper.
- `apps/mediapulse/agent-data-api/src/routes/agent-insights.ts` — the dispatching handler.

## How to test

1. `pnpm --filter @workspace/agent-data-api-contract test` — all widget kinds parse; unknown kind throws.
2. `pnpm --filter @mediapulse/agent-data-api test` — stub dispatch, 404, and 400 tests pass.
3. `pnpm code-quality` — full suite green.
