### PR TITLE
Add page-collection InsightsProvider with extended run counters

### DIFF
--- a/.github/scripts/detect-changed-services.sh
+++ b/.github/scripts/detect-changed-services.sh
@@ -22,7 +22,7 @@ if [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
       echo 'matrix=[{"service":"agent-auth-api","dockerfile":"apps/hermes/agent-auth-api/Dockerfile","image":"app-agent-auth-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_AUTH_API"},{"service":"agent-data-api","dockerfile":"apps/mediapulse/agent-data-api/Dockerfile","image":"app-agent-data-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_DATA_API"},{"service":"domain-api","dockerfile":"apps/mediapulse/domain-api/Dockerfile","image":"app-domain-api","webhook_secret":"COOLIFY_WEBHOOK_APP_DOMAIN_API"},{"service":"agent-registry-api","dockerfile":"apps/hermes/agent-registry-api/Dockerfile","image":"app-agent-registry-api","webhook_secret":"COOLIFY_WEBHOOK_APP_AGENT_REGISTRY_API"},{"service":"user-registration","dockerfile":"apps/mediapulse/user-registration/Dockerfile","image":"app-user-registration","webhook_secret":"COOLIFY_WEBHOOK_APP_USER_REGISTRATION"},{"service":"hermes","dockerfile":"apps/hermes/dashboard/Dockerfile","image":"app-hermes","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES"},{"service":"hermes-worker","dockerfile":"apps/hermes/worker/Dockerfile","image":"app-hermes-worker","webhook_secret":"COOLIFY_WEBHOOK_APP_HERMES_WORKER"}]' >>"$GITHUB_OUTPUT"
       ;;
     agent)
-      echo 'matrix=[{"service":"data-collection","dockerfile":"apps/mediapulse/agents/data-collection/Dockerfile","image":"agent-data-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION"},{"service":"content-generation","dockerfile":"apps/mediapulse/agents/content-generation/Dockerfile","image":"agent-content-generation","webhook_secret":"COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION"},{"service":"article-analysis","dockerfile":"apps/mediapulse/agents/article-analysis/Dockerfile","image":"agent-article-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS"},{"service":"query-analysis","dockerfile":"apps/mediapulse/agents/query-analysis/Dockerfile","image":"agent-query-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS"},{"service":"delivery","dockerfile":"apps/mediapulse/agents/delivery/Dockerfile","image":"agent-delivery","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DELIVERY"},{"service":"ticker-echo","dockerfile":"apps/mediapulse/agents/ticker-echo/Dockerfile","image":"agent-ticker-echo","webhook_secret":"COOLIFY_WEBHOOK_AGENT_TICKER_ECHO"},{"service":"agent-user-registration","dockerfile":"apps/mediapulse/agents/user-registration/Dockerfile","image":"agent-user-registration","webhook_secret":"COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION"}]' >>"$GITHUB_OUTPUT"
+      echo 'matrix=[{"service":"data-collection","dockerfile":"apps/mediapulse/agents/data-collection/Dockerfile","image":"agent-data-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DATA_COLLECTION"},{"service":"content-generation","dockerfile":"apps/mediapulse/agents/content-generation/Dockerfile","image":"agent-content-generation","webhook_secret":"COOLIFY_WEBHOOK_AGENT_CONTENT_GENERATION"},{"service":"article-analysis","dockerfile":"apps/mediapulse/agents/article-analysis/Dockerfile","image":"agent-article-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_ARTICLE_ANALYSIS"},{"service":"query-analysis","dockerfile":"apps/mediapulse/agents/query-analysis/Dockerfile","image":"agent-query-analysis","webhook_secret":"COOLIFY_WEBHOOK_AGENT_QUERY_ANALYSIS"},{"service":"delivery","dockerfile":"apps/mediapulse/agents/delivery/Dockerfile","image":"agent-delivery","webhook_secret":"COOLIFY_WEBHOOK_AGENT_DELIVERY"},{"service":"ticker-echo","dockerfile":"apps/mediapulse/agents/ticker-echo/Dockerfile","image":"agent-ticker-echo","webhook_secret":"COOLIFY_WEBHOOK_AGENT_TICKER_ECHO"},{"service":"agent-user-registration","dockerfile":"apps/mediapulse/agents/user-registration/Dockerfile","image":"agent-user-registration","webhook_secret":"COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION"},{"service":"page-collection","dockerfile":"apps/mediapulse/agents/page-collection/Dockerfile","image":"agent-page-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_PAGE_COLLECTION"}]' >>"$GITHUB_OUTPUT"
       ;;
     *)
       echo "Unsupported WORKFLOW: $workflow" >&2
@@ -66,7 +66,7 @@ if [ "$shared_changed" = "true" ]; then
       services_list=$'agent-auth-api\nagent-data-api\ndomain-api\nagent-registry-api\nuser-registration\nhermes\nhermes-worker\n'
       ;;
     agent)
-      services_list=$'data-collection\ncontent-generation\narticle-analysis\nquery-analysis\ndelivery\nticker-echo\nagent-user-registration\n'
+      services_list=$'data-collection\ncontent-generation\narticle-analysis\nquery-analysis\ndelivery\nticker-echo\nagent-user-registration\npage-collection\n'
       ;;
   esac
 else
@@ -114,6 +114,9 @@ else
         ;;
       apps/mediapulse/agents/user-registration/*)
         [ "$workflow" = "agent" ] && append_service "agent-user-registration"
+        ;;
+      apps/mediapulse/agents/page-collection/*)
+        [ "$workflow" = "agent" ] && append_service "page-collection"
         ;;
     esac
   done <<<"$changed_files"
@@ -171,6 +174,9 @@ lookup_service_config() {
       ;;
     agent-user-registration)
       echo '{"service":"agent-user-registration","dockerfile":"apps/mediapulse/agents/user-registration/Dockerfile","image":"agent-user-registration","webhook_secret":"COOLIFY_WEBHOOK_AGENT_USER_REGISTRATION"}'
+      ;;
+    page-collection)
+      echo '{"service":"page-collection","dockerfile":"apps/mediapulse/agents/page-collection/Dockerfile","image":"agent-page-collection","webhook_secret":"COOLIFY_WEBHOOK_AGENT_PAGE_COLLECTION"}'
       ;;
     *)
       return 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -eu
 
-          ALL_SERVICES='["user-registration","domain-api","agent-data-api","agent-auth-api","agent-registry-api","hermes","hermes-worker","data-collection","content-generation","delivery","ticker-echo","article-analysis","query-analysis","agent-user-registration"]'
+          ALL_SERVICES='["user-registration","domain-api","agent-data-api","agent-auth-api","agent-registry-api","hermes","hermes-worker","data-collection","content-generation","delivery","ticker-echo","article-analysis","query-analysis","agent-user-registration","page-collection"]'
 
           changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
 
@@ -72,6 +72,7 @@ jobs:
               apps/mediapulse/agents/article-analysis/*)  services_list+=$'article-analysis\n' ;;
               apps/mediapulse/agents/query-analysis/*)    services_list+=$'query-analysis\n' ;;
               apps/mediapulse/agents/user-registration/*)  services_list+=$'agent-user-registration\n' ;;
+              apps/mediapulse/agents/page-collection/*)   services_list+=$'page-collection\n' ;;
             esac
           done <<< "$changed_files"
 
@@ -117,6 +118,7 @@ jobs:
             article-analysis)   echo "dockerfile=apps/mediapulse/agents/article-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
             query-analysis)          echo "dockerfile=apps/mediapulse/agents/query-analysis/Dockerfile" >> "$GITHUB_OUTPUT" ;;
             agent-user-registration) echo "dockerfile=apps/mediapulse/agents/user-registration/Dockerfile" >> "$GITHUB_OUTPUT" ;;
+            page-collection)        echo "dockerfile=apps/mediapulse/agents/page-collection/Dockerfile" >> "$GITHUB_OUTPUT" ;;
           esac
 
       - uses: docker/setup-buildx-action@v3

--- a/apps/hermes/dashboard/app/dashboard/schedules/schedule-form-fields.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/schedule-form-fields.test.tsx
@@ -312,12 +312,13 @@ describe("ScheduleFormFields", () => {
     );
 
     // Assert
-    expect(screen.getByLabelText("Pipeline")).toBeInTheDocument();
+    const pipelineSelect = screen.getByLabelText("Pipeline");
+    expect(pipelineSelect).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "Pipeline A" }),
+      within(pipelineSelect).getByRole("option", { name: "Pipeline A" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "Pipeline B" }),
+      within(pipelineSelect).getByRole("option", { name: "Pipeline B" }),
     ).toBeInTheDocument();
   });
 

--- a/apps/hermes/dashboard/app/dashboard/schedules/schedule-form-fields.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/schedule-form-fields.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import {
   ScheduleFormFields,
@@ -253,10 +253,13 @@ describe("ScheduleFormFields", () => {
     );
 
     // Assert
-    expect(screen.getByLabelText("Repeat")).toBeInTheDocument();
-    expect(screen.getByRole("option", { name: "Once" })).toBeInTheDocument();
+    const repeatSelect = screen.getByLabelText("Repeat");
+    expect(repeatSelect).toBeInTheDocument();
     expect(
-      screen.getByRole("option", { name: "Repeating" }),
+      within(repeatSelect).getByRole("option", { name: "Once" }),
+    ).toBeInTheDocument();
+    expect(
+      within(repeatSelect).getByRole("option", { name: "Repeating" }),
     ).toBeInTheDocument();
   });
 

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -6,6 +6,7 @@ import {
   agentDataApiManifestForVersion,
   camelCaseResourceKeyToPathSegment,
 } from "@workspace/agent-data-api-contract";
+import { prisma } from "@mediapulse/database";
 import { env } from "@mediapulse/env";
 import { logger, slimPinoLogger } from "@workspace/logger";
 import { Hono } from "hono";
@@ -67,6 +68,8 @@ import {
 } from "./routes/content-generation-run.js";
 import { getSectionCoverageRollupHandler } from "./routes/section-coverage-rollup.js";
 import { getAgentInsights } from "./routes/agent-insights.js";
+import { createPageCollectionInsightsProvider } from "./services/insights/page-collection-insights-provider.js";
+import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
   type AgentDataApiHandlers,
@@ -216,6 +219,14 @@ for (const version of AGENT_DATA_API_LIVE_VERSIONS) {
   );
   app.route(`${AGENT_DATA_API_PREFIX}/${version}`, versionApi);
 }
+
+registerInsightsProvider(
+  createPageCollectionInsightsProvider({
+    dataCollectionRun: prisma.dataCollectionRun,
+    discoverySourceHealth: prisma.discoverySourceHealth,
+    dataSource: prisma.dataSource,
+  }),
+);
 
 export { app };
 export default {

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection-run.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection-run.ts
@@ -38,6 +38,18 @@ export async function postDataCollectionRun(
     const body = await context.req.json();
     const data = await postDataCollectionRunBodySchema.parseAsync(body);
 
+    const {
+      queriesTotal,
+      urlsTotal,
+      searchSuccess,
+      searchFailed,
+      fetchSuccess,
+      fetchFailed,
+      retryCount,
+      ...extendedCounterFields
+    } = data.counters;
+    const hasExtended = Object.keys(extendedCounterFields).length > 0;
+
     await prisma.dataCollectionRun.create({
       data: {
         id: data.id,
@@ -45,13 +57,14 @@ export async function postDataCollectionRun(
         startedAt: new Date(data.startedAt),
         completedAt: data.completedAt ? new Date(data.completedAt) : null,
         status: data.status,
-        queriesTotal: data.counters.queriesTotal,
-        urlsTotal: data.counters.urlsTotal,
-        searchSuccess: data.counters.searchSuccess,
-        searchFailed: data.counters.searchFailed,
-        fetchSuccess: data.counters.fetchSuccess,
-        fetchFailed: data.counters.fetchFailed,
-        retryCount: data.counters.retryCount,
+        queriesTotal,
+        urlsTotal,
+        searchSuccess,
+        searchFailed,
+        fetchSuccess,
+        fetchFailed,
+        retryCount,
+        ...(hasExtended ? { extendedCounters: extendedCounterFields } : {}),
       },
     });
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts
@@ -1,0 +1,289 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+
+import { createPageCollectionInsightsProvider } from "./page-collection-insights-provider.js";
+
+const NOW = new Date("2026-06-08T12:00:00.000Z");
+
+function makeRun(overrides?: {
+  tickerId?: string;
+  startedAt?: Date;
+  status?: string;
+  fetchSuccess?: number;
+  extendedCounters?: object | null;
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    startedAt: overrides?.startedAt ?? new Date("2026-06-07T08:00:00.000Z"),
+    status: overrides?.status ?? "success",
+    fetchSuccess: overrides?.fetchSuccess ?? 5,
+    extendedCounters: overrides?.extendedCounters ?? null,
+  };
+}
+
+function makeSourceHealth(overrides?: {
+  listingUrl?: string;
+  runDate?: Date;
+  discovered?: boolean;
+  itemCount?: number;
+  winningStrategy?: string | null;
+  failureCount?: number;
+}) {
+  return {
+    listingUrl: overrides?.listingUrl ?? "https://example.com/feed",
+    runDate: overrides?.runDate ?? new Date("2026-06-07T00:00:00.000Z"),
+    discovered: overrides?.discovered ?? true,
+    itemCount: overrides?.itemCount ?? 10,
+    winningStrategy: overrides?.winningStrategy ?? "rss",
+    failureCount: overrides?.failureCount ?? 0,
+  };
+}
+
+function makeDataSource(overrides?: {
+  tickerId?: string;
+  url?: string;
+  metadata?: object | null;
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    url: overrides?.url ?? "https://publisher.com/article-1",
+    metadata: overrides?.metadata ?? { provider: "jina" },
+  };
+}
+
+function makeDeps(overrides?: {
+  runs?: ReturnType<typeof makeRun>[];
+  sourceHealth?: ReturnType<typeof makeSourceHealth>[];
+  dataSources?: ReturnType<typeof makeDataSource>[];
+}) {
+  const runs = overrides?.runs ?? [makeRun()];
+  const sourceHealth = overrides?.sourceHealth ?? [makeSourceHealth()];
+  const dataSources = overrides?.dataSources ?? [makeDataSource()];
+
+  return {
+    dataCollectionRun: {
+      findMany: async () => runs,
+    },
+    discoverySourceHealth: {
+      findMany: async () => sourceHealth,
+    },
+    dataSource: {
+      findMany: async () => dataSources,
+    },
+  };
+}
+
+describe("createPageCollectionInsightsProvider", () => {
+  it("returns a payload that parses through insightsPayloadSchema", async () => {
+    const provider = createPageCollectionInsightsProvider(makeDeps());
+    const payload = await provider.compute({ window: "7d" });
+
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.agentId).toBe("page-collection");
+    expect(parsed.window).toBe("7d");
+    expect(typeof parsed.generatedAt).toBe("string");
+    expect(Array.isArray(parsed.kpis)).toBe(true);
+    expect(Array.isArray(parsed.alerts)).toBe(true);
+    expect(Array.isArray(parsed.sections)).toBe(true);
+  });
+
+  it("includes a funnel section with correct stage ordering", async () => {
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            extendedCounters: {
+              discovered: 100,
+              afterPrefilter: 80,
+              persisted: 20,
+            },
+            fetchSuccess: 30,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const funnel = payload.sections.find((s) => s.id === "what-funnel");
+
+    expect(funnel).toBeDefined();
+    expect(funnel!.widget.kind).toBe("funnel");
+    if (funnel!.widget.kind === "funnel") {
+      expect(funnel!.widget.stages[0]!.label).toBe("Discovered");
+      expect(funnel!.widget.stages[0]!.value).toBe(100);
+      expect(funnel!.widget.stages[3]!.label).toBe("Persisted");
+      expect(funnel!.widget.stages[3]!.value).toBe(20);
+    }
+  });
+
+  it("aggregates extended counter drop reasons into the why-drops breakdown", async () => {
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            extendedCounters: {
+              droppedByRelevance: 10,
+              droppedByFreshness: 5,
+              droppedByContentQuality: { too_short: 3 },
+            },
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const drops = payload.sections.find((s) => s.id === "why-drops");
+
+    expect(drops).toBeDefined();
+    expect(drops!.widget.kind).toBe("breakdown");
+    if (drops!.widget.kind === "breakdown") {
+      const relevance = drops!.widget.slices.find(
+        (s) => s.label === "Relevance",
+      );
+      expect(relevance?.value).toBe(10);
+      const freshness = drops!.widget.slices.find(
+        (s) => s.label === "Freshness",
+      );
+      expect(freshness?.value).toBe(5);
+      const fractions = drops!.widget.slices.map((s) => s.fraction);
+      const fractionSum = fractions.reduce((sum, f) => sum + f, 0);
+      expect(fractionSum).toBeCloseTo(1);
+    }
+  });
+
+  it("caps per-ticker bars at TOP_N + Other bucket", async () => {
+    const manyTickers = Array.from({ length: 15 }, (_, i) =>
+      makeDataSource({ tickerId: `ticker-${i}`, url: `https://pub${i}.com/a` }),
+    );
+
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({ dataSources: manyTickers }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "who-per-ticker");
+
+    expect(tickerBar).toBeDefined();
+    if (tickerBar!.widget.kind === "categoryBar") {
+      expect(tickerBar!.widget.bars.length).toBeLessThanOrEqual(11);
+      const other = tickerBar!.widget.bars.find((b) => b.label === "Other");
+      expect(other).toBeDefined();
+    }
+  });
+
+  it("emits a strategy mix breakdown from DiscoverySourceHealth", async () => {
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({
+        sourceHealth: [
+          makeSourceHealth({ winningStrategy: "rss" }),
+          makeSourceHealth({ winningStrategy: "rss" }),
+          makeSourceHealth({ winningStrategy: "sitemap" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const strategySection = payload.sections.find(
+      (s) => s.id === "how-strategy-mix",
+    );
+
+    expect(strategySection).toBeDefined();
+    if (strategySection!.widget.kind === "breakdown") {
+      const rss = strategySection!.widget.slices.find((s) => s.label === "rss");
+      expect(rss?.value).toBe(2);
+      expect(rss?.fraction).toBeCloseTo(2 / 3);
+    }
+  });
+
+  it("emits a provider mix breakdown from DataSource metadata", async () => {
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({
+        dataSources: [
+          makeDataSource({ metadata: { provider: "jina" } }),
+          makeDataSource({ metadata: { provider: "jina" } }),
+          makeDataSource({ metadata: { provider: "firecrawl" } }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const providerSection = payload.sections.find(
+      (s) => s.id === "how-provider-mix",
+    );
+
+    expect(providerSection).toBeDefined();
+    if (providerSection!.widget.kind === "breakdown") {
+      const jina = providerSection!.widget.slices.find(
+        (s) => s.label === "jina",
+      );
+      expect(jina?.value).toBe(2);
+    }
+  });
+
+  it("computes KPI deltas from the prior period", async () => {
+    const recentRun = makeRun({
+      startedAt: new Date("2026-06-07T08:00:00.000Z"),
+      fetchSuccess: 10,
+    });
+
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({ runs: [recentRun] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const articleKpi = payload.kpis.find((k) => k.id === "articles_collected");
+
+    expect(articleKpi).toBeDefined();
+    expect(articleKpi!.value).toBe(10);
+    expect(typeof articleKpi!.delta).toBe("number");
+  });
+
+  it("emits a consecutive-failure alert when a source fails 3+ days", async () => {
+    const failedSource = "https://bad-feed.example.com/rss";
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({
+        sourceHealth: [
+          makeSourceHealth({
+            listingUrl: failedSource,
+            discovered: false,
+            failureCount: 1,
+          }),
+          makeSourceHealth({
+            listingUrl: failedSource,
+            discovered: false,
+            failureCount: 1,
+          }),
+          makeSourceHealth({
+            listingUrl: failedSource,
+            discovered: false,
+            failureCount: 1,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const failAlert = payload.alerts.find((a) =>
+      a.id.startsWith("consecutive-fail-"),
+    );
+
+    expect(failAlert).toBeDefined();
+    expect(failAlert!.severity).toBe("warning");
+  });
+
+  it("returns a valid payload when all inputs are empty", async () => {
+    const provider = createPageCollectionInsightsProvider(
+      makeDeps({ runs: [], sourceHealth: [], dataSources: [] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.kpis).toHaveLength(4);
+    expect(parsed.alerts).toHaveLength(0);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
@@ -1,0 +1,727 @@
+import type { Prisma } from "@mediapulse/database";
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type RunRow = {
+  tickerId: string;
+  startedAt: Date;
+  status: string;
+  fetchSuccess: number;
+  extendedCounters: Prisma.JsonValue | null;
+};
+
+type SourceHealthRow = {
+  listingUrl: string;
+  runDate: Date;
+  discovered: boolean;
+  itemCount: number;
+  winningStrategy: string | null;
+  failureCount: number;
+};
+
+type DataSourceRow = {
+  tickerId: string;
+  url: string;
+  metadata: Prisma.JsonValue | null;
+};
+
+type PageCollectionInsightsDeps = {
+  dataCollectionRun: {
+    findMany: (args: {
+      where: {
+        startedAt: { gte: Date };
+        tickerId?: string;
+      };
+      orderBy: { startedAt: "asc" };
+      select: {
+        tickerId: boolean;
+        startedAt: boolean;
+        status: boolean;
+        fetchSuccess: boolean;
+        extendedCounters: boolean;
+      };
+    }) => Promise<RunRow[]>;
+  };
+  discoverySourceHealth: {
+    findMany: (args: {
+      where: { runDate: { gte: Date } };
+      select: {
+        listingUrl: boolean;
+        runDate: boolean;
+        discovered: boolean;
+        itemCount: boolean;
+        winningStrategy: boolean;
+        failureCount: boolean;
+      };
+    }) => Promise<SourceHealthRow[]>;
+  };
+  dataSource: {
+    findMany: (args: {
+      where: { createdAt: { gte: Date }; tickerId?: string };
+      select: { tickerId: boolean; url: boolean; metadata: boolean };
+      take: number;
+    }) => Promise<DataSourceRow[]>;
+  };
+};
+
+type ExtendedCounters = {
+  discovered?: number;
+  afterPrefilter?: number;
+  cacheHits?: number;
+  cacheMisses?: number;
+  droppedByRelevance?: number;
+  droppedByContentQuality?: Record<string, number>;
+  droppedByFreshness?: number;
+  droppedByDeadUrl?: number;
+  droppedByHostErrorRate?: number;
+  droppedByFetchBudget?: number;
+  droppedByRunItemCap?: number;
+  droppedByUrlNoise?: number;
+  persisted?: number;
+  durationMs?: number;
+};
+
+function parseExtendedCounters(raw: Prisma.JsonValue | null): ExtendedCounters {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as ExtendedCounters;
+}
+
+function domainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+export function createPageCollectionInsightsProvider(
+  deps: PageCollectionInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "page-collection",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const [runs, priorRuns, sourceHealth, dataSources] = await Promise.all([
+        deps.dataCollectionRun.findMany({
+          where: {
+            startedAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { startedAt: "asc" },
+          select: {
+            tickerId: true,
+            startedAt: true,
+            status: true,
+            fetchSuccess: true,
+            extendedCounters: true,
+          },
+        }),
+        deps.dataCollectionRun.findMany({
+          where: {
+            startedAt: { gte: priorStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { startedAt: "asc" },
+          select: {
+            tickerId: true,
+            startedAt: true,
+            status: true,
+            fetchSuccess: true,
+            extendedCounters: true,
+          },
+        }),
+        deps.discoverySourceHealth.findMany({
+          where: { runDate: { gte: windowStart } },
+          select: {
+            listingUrl: true,
+            runDate: true,
+            discovered: true,
+            itemCount: true,
+            winningStrategy: true,
+            failureCount: true,
+          },
+        }),
+        deps.dataSource.findMany({
+          where: {
+            createdAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          select: { tickerId: true, url: true, metadata: true },
+          take: 2000,
+        }),
+      ]);
+
+      const priorWindowRuns = priorRuns.filter(
+        (r) => r.startedAt >= priorStart && r.startedAt < windowStart,
+      );
+
+      // ─── Aggregated run counters ─────────────────────────────────────────
+
+      const totalRuns = runs.length;
+      const successfulRuns = runs.filter(
+        (r) => r.status === "success" || r.status === "partial_success",
+      ).length;
+      const totalArticles = runs.reduce((sum, r) => sum + r.fetchSuccess, 0);
+      const priorArticles = priorWindowRuns.reduce(
+        (sum, r) => sum + r.fetchSuccess,
+        0,
+      );
+
+      let totalDiscovered = 0;
+      let totalAfterPrefilter = 0;
+      let totalCacheHits = 0;
+      let totalCacheMisses = 0;
+      let totalDroppedByRelevance = 0;
+      let totalDroppedByFreshness = 0;
+      let totalDroppedByDeadUrl = 0;
+      let totalDroppedByHostErrorRate = 0;
+      let totalDroppedByFetchBudget = 0;
+      let totalDroppedByRunItemCap = 0;
+      let totalDroppedByUrlNoise = 0;
+      let totalPersisted = 0;
+      const totalDroppedByContentQuality: Record<string, number> = {};
+
+      for (const run of runs) {
+        const ext = parseExtendedCounters(run.extendedCounters);
+        totalDiscovered += ext.discovered ?? run.fetchSuccess;
+        totalAfterPrefilter += ext.afterPrefilter ?? run.fetchSuccess;
+        totalCacheHits += ext.cacheHits ?? 0;
+        totalCacheMisses += ext.cacheMisses ?? 0;
+        totalDroppedByRelevance += ext.droppedByRelevance ?? 0;
+        totalDroppedByFreshness += ext.droppedByFreshness ?? 0;
+        totalDroppedByDeadUrl += ext.droppedByDeadUrl ?? 0;
+        totalDroppedByHostErrorRate += ext.droppedByHostErrorRate ?? 0;
+        totalDroppedByFetchBudget += ext.droppedByFetchBudget ?? 0;
+        totalDroppedByRunItemCap += ext.droppedByRunItemCap ?? 0;
+        totalDroppedByUrlNoise += ext.droppedByUrlNoise ?? 0;
+        totalPersisted += ext.persisted ?? run.fetchSuccess;
+
+        for (const [reason, count] of Object.entries(
+          ext.droppedByContentQuality ?? {},
+        )) {
+          totalDroppedByContentQuality[reason] =
+            (totalDroppedByContentQuality[reason] ?? 0) + count;
+        }
+      }
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const successRate =
+        totalRuns > 0 ? Math.round((successfulRuns / totalRuns) * 100) : 0;
+
+      const cacheTotal = totalCacheHits + totalCacheMisses;
+      const cacheHitRate =
+        cacheTotal > 0 ? Math.round((totalCacheHits / cacheTotal) * 100) : 0;
+
+      const priorRunCount = priorWindowRuns.length;
+      const articleDelta = totalArticles - priorArticles;
+
+      const uniqueSources = new Set(sourceHealth.map((r) => r.listingUrl)).size;
+      const failedSources = new Set(
+        sourceHealth
+          .filter((r) => !r.discovered && r.failureCount > 0)
+          .map((r) => r.listingUrl),
+      ).size;
+      const healthySources = uniqueSources - failedSources;
+
+      const kpis: KpiCard[] = [
+        {
+          id: "runs",
+          label: "Runs",
+          value: totalRuns,
+          delta: totalRuns - priorRunCount,
+        },
+        {
+          id: "success_rate",
+          label: "Success rate",
+          value: successRate,
+          unit: "%",
+        },
+        {
+          id: "articles_collected",
+          label: "Articles collected",
+          value: totalArticles,
+          delta: articleDelta,
+        },
+        {
+          id: "healthy_sources",
+          label: "Healthy sources",
+          value: `${healthySources}/${uniqueSources}`,
+        },
+        ...(cacheTotal > 0
+          ? [
+              {
+                id: "cache_hit_rate",
+                label: "Cache hit rate",
+                value: cacheHitRate,
+                unit: "%",
+              } satisfies KpiCard,
+            ]
+          : []),
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      const sourceFailureCounts = new Map<string, number>();
+      for (const record of sourceHealth) {
+        if (!record.discovered) {
+          sourceFailureCounts.set(
+            record.listingUrl,
+            (sourceFailureCounts.get(record.listingUrl) ?? 0) + 1,
+          );
+        }
+      }
+      for (const [url, count] of sourceFailureCounts) {
+        if (count >= 3) {
+          alerts.push({
+            id: `consecutive-fail-${domainFromUrl(url)}`,
+            severity: "warning",
+            message: `${domainFromUrl(url)} failed discovery for ${count} consecutive days`,
+            sectionRef: "where-source-health",
+          });
+        }
+      }
+
+      if (totalRuns > 0) {
+        const staleThresholdMs =
+          ctx.window === "24h" ? 6 * 60 * 60 * 1000 : 48 * 60 * 60 * 1000;
+        const lastRun = runs[runs.length - 1];
+        if (
+          lastRun &&
+          now.getTime() - lastRun.startedAt.getTime() > staleThresholdMs
+        ) {
+          alerts.push({
+            id: "stale-last-run",
+            severity: "info",
+            message: `No run in the last ${ctx.window === "24h" ? "6 hours" : "48 hours"}`,
+          });
+        }
+      }
+
+      const dominantDropCount = Math.max(
+        totalDroppedByRelevance,
+        totalDroppedByFreshness,
+        ...Object.values(totalDroppedByContentQuality),
+      );
+      const totalFetched = totalAfterPrefilter;
+      if (totalFetched > 10 && dominantDropCount / totalFetched > 0.5) {
+        alerts.push({
+          id: "high-drop-rate",
+          severity: "warning",
+          message: `More than 50% of fetched articles are being dropped by quality/relevance gates`,
+          sectionRef: "why-drops",
+        });
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — funnel
+      sections.push({
+        id: "what-funnel",
+        category: "what",
+        title: "Collection funnel",
+        insight:
+          "Articles discovered through the pipeline to final persistence.",
+        widget: {
+          kind: "funnel",
+          stages: [
+            { label: "Discovered", value: totalDiscovered },
+            { label: "After prefilter", value: totalAfterPrefilter },
+            { label: "Fetched", value: totalArticles },
+            { label: "Persisted", value: totalPersisted },
+          ],
+        },
+      });
+
+      // When — time series (articles persisted per day)
+      const dailyBuckets = buildWindowDates(windowStart, now);
+      for (const run of runs) {
+        const dayKey = run.startedAt.toISOString().slice(0, 10);
+        if (dailyBuckets.has(dayKey)) {
+          dailyBuckets.set(
+            dayKey,
+            (dailyBuckets.get(dayKey) ?? 0) + run.fetchSuccess,
+          );
+        }
+      }
+      sections.push({
+        id: "when-timeseries",
+        category: "when",
+        title: "Articles over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(dailyBuckets.entries()).map(([ts, value]) => ({
+            ts: `${ts}T00:00:00.000Z`,
+            value,
+          })),
+          unit: "articles",
+        },
+      });
+
+      // When — freshness histogram (days since discovery vs count of articles)
+      const freshnessHistogram = new Map([
+        ["same day", 0],
+        ["1-2 days", 0],
+        ["3-7 days", 0],
+        ["8-30 days", 0],
+        [">30 days", 0],
+      ]);
+      for (const source of dataSources) {
+        const ageDays = (now.getTime() - now.getTime()) / (24 * 60 * 60 * 1000);
+        if (ageDays < 1)
+          freshnessHistogram.set(
+            "same day",
+            (freshnessHistogram.get("same day") ?? 0) + 1,
+          );
+        else if (ageDays <= 2)
+          freshnessHistogram.set(
+            "1-2 days",
+            (freshnessHistogram.get("1-2 days") ?? 0) + 1,
+          );
+        else if (ageDays <= 7)
+          freshnessHistogram.set(
+            "3-7 days",
+            (freshnessHistogram.get("3-7 days") ?? 0) + 1,
+          );
+        else if (ageDays <= 30)
+          freshnessHistogram.set(
+            "8-30 days",
+            (freshnessHistogram.get("8-30 days") ?? 0) + 1,
+          );
+        else
+          freshnessHistogram.set(
+            ">30 days",
+            (freshnessHistogram.get(">30 days") ?? 0) + 1,
+          );
+      }
+      if (dataSources.length > 0) {
+        sections.push({
+          id: "when-freshness",
+          category: "when",
+          title: "Article freshness",
+          widget: {
+            kind: "histogram",
+            buckets: Array.from(freshnessHistogram.entries()).map(
+              ([label, count]) => ({ label, count }),
+            ),
+          },
+        });
+      }
+
+      // Where — source bar (top sources by item count)
+      const sourceItemCounts = new Map<string, number>();
+      for (const record of sourceHealth) {
+        const domain = domainFromUrl(record.listingUrl);
+        sourceItemCounts.set(
+          domain,
+          (sourceItemCounts.get(domain) ?? 0) + record.itemCount,
+        );
+      }
+      if (sourceItemCounts.size > 0) {
+        sections.push({
+          id: "where-source-bar",
+          category: "where",
+          title: "Items by source",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(sourceItemCounts.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "items",
+          },
+        });
+      }
+
+      // Where — source health table
+      const sourceHealthByUrl = new Map<
+        string,
+        { discovered: number; failed: number; total: number }
+      >();
+      for (const record of sourceHealth) {
+        const existing = sourceHealthByUrl.get(record.listingUrl) ?? {
+          discovered: 0,
+          failed: 0,
+          total: 0,
+        };
+        sourceHealthByUrl.set(record.listingUrl, {
+          discovered: existing.discovered + (record.discovered ? 1 : 0),
+          failed: existing.failed + (record.discovered ? 0 : 1),
+          total: existing.total + 1,
+        });
+      }
+      if (sourceHealthByUrl.size > 0) {
+        const healthRows = bucketTopN(
+          Array.from(sourceHealthByUrl.entries()).map(([url, stats]) => ({
+            label: domainFromUrl(url),
+            value: stats.discovered,
+          })),
+          TOP_N,
+        );
+        sections.push({
+          id: "where-source-health",
+          category: "where",
+          title: "Source health",
+          widget: {
+            kind: "table",
+            columns: ["Source", "Discovered days", "Failed days"],
+            rows: healthRows.map((row) => {
+              const stats = Array.from(sourceHealthByUrl.entries()).find(
+                ([url]) => domainFromUrl(url) === row.label,
+              )?.[1];
+              return [row.label, stats?.discovered ?? 0, stats?.failed ?? 0];
+            }),
+          },
+        });
+      }
+
+      // Who — per-ticker bar
+      const tickerArticleCounts = new Map<string, number>();
+      for (const source of dataSources) {
+        tickerArticleCounts.set(
+          source.tickerId,
+          (tickerArticleCounts.get(source.tickerId) ?? 0) + 1,
+        );
+      }
+      if (tickerArticleCounts.size > 0) {
+        sections.push({
+          id: "who-per-ticker",
+          category: "who",
+          title: "Articles by ticker",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(tickerArticleCounts.entries()).map(
+                ([label, value]) => ({
+                  label,
+                  value,
+                }),
+              ),
+              TOP_N,
+            ),
+            unit: "articles",
+          },
+        });
+      }
+
+      // Who — per-publisher bar (domain of data source URL)
+      const publisherCounts = new Map<string, number>();
+      for (const source of dataSources) {
+        const publisher = domainFromUrl(source.url);
+        publisherCounts.set(
+          publisher,
+          (publisherCounts.get(publisher) ?? 0) + 1,
+        );
+      }
+      if (publisherCounts.size > 0) {
+        sections.push({
+          id: "who-per-publisher",
+          category: "who",
+          title: "Articles by publisher",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(publisherCounts.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "articles",
+          },
+        });
+      }
+
+      // Why — drop reason breakdown
+      const dropReasons: Array<{
+        label: string;
+        value: number;
+        fraction: number;
+      }> = [];
+      const dropEntries: Array<[string, number]> = [
+        ["Relevance", totalDroppedByRelevance],
+        ["Freshness", totalDroppedByFreshness],
+        ["Dead URL", totalDroppedByDeadUrl],
+        ["Host error rate", totalDroppedByHostErrorRate],
+        ["Fetch budget", totalDroppedByFetchBudget],
+        ["Run item cap", totalDroppedByRunItemCap],
+        ["URL noise", totalDroppedByUrlNoise],
+        ...Object.entries(totalDroppedByContentQuality).map(
+          ([reason, count]) =>
+            [`Content: ${reason}`, count] as [string, number],
+        ),
+      ];
+      const totalDropped = dropEntries.reduce((sum, [, v]) => sum + v, 0);
+      for (const [label, value] of dropEntries) {
+        if (value > 0) {
+          dropReasons.push({
+            label,
+            value,
+            fraction: totalDropped > 0 ? value / totalDropped : 0,
+          });
+        }
+      }
+      if (dropReasons.length > 0) {
+        sections.push({
+          id: "why-drops",
+          category: "why",
+          title: "Drop reasons",
+          widget: {
+            kind: "breakdown",
+            slices: dropReasons,
+          },
+        });
+      }
+
+      // How — discovery strategy mix
+      const strategyMix = new Map<string, number>();
+      for (const record of sourceHealth) {
+        if (record.winningStrategy) {
+          strategyMix.set(
+            record.winningStrategy,
+            (strategyMix.get(record.winningStrategy) ?? 0) + 1,
+          );
+        }
+      }
+      if (strategyMix.size > 0) {
+        const strategyTotal = Array.from(strategyMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "how-strategy-mix",
+          category: "how",
+          title: "Discovery strategy mix",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(strategyMix.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: strategyTotal > 0 ? value / strategyTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // How — fetch provider mix
+      const providerMix = new Map<string, number>();
+      for (const source of dataSources) {
+        const meta =
+          source.metadata &&
+          typeof source.metadata === "object" &&
+          !Array.isArray(source.metadata)
+            ? (source.metadata as { provider?: string })
+            : null;
+        if (meta?.provider) {
+          providerMix.set(
+            meta.provider,
+            (providerMix.get(meta.provider) ?? 0) + 1,
+          );
+        }
+      }
+      if (providerMix.size > 0) {
+        const providerTotal = Array.from(providerMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "how-provider-mix",
+          category: "how",
+          title: "Fetch provider mix",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(providerMix.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: providerTotal > 0 ? value / providerTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // How — cache hit rate stat
+      if (cacheTotal > 0) {
+        sections.push({
+          id: "how-cache-hit",
+          category: "how",
+          title: "Cache hit rate",
+          widget: {
+            kind: "stat",
+            value: cacheHitRate,
+            unit: "%",
+          },
+        });
+      }
+
+      return {
+        agentId: "page-collection",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -573,4 +573,28 @@ describe("runPageCollection", () => {
 
     expect(discoverySourceHealthRecordMock).not.toHaveBeenCalled();
   });
+
+  it("includes metadata.provider on each persisted source", async () => {
+    await runPageCollection(createContext());
+
+    expect(dataCollectionCreateMock).toHaveBeenCalledOnce();
+
+    const persistedSource = dataCollectionCreateMock.mock.calls[0]![0][0];
+
+    expect(persistedSource.metadata).toBeDefined();
+    expect(persistedSource.metadata.provider).toBe("jina");
+  });
+
+  it("includes widened extended counters in the DataCollectionRun payload", async () => {
+    await runPageCollection(createContext());
+
+    expect(runCreateMock).toHaveBeenCalledOnce();
+
+    const runPayload = runCreateMock.mock.calls[0]![0];
+
+    expect(typeof runPayload.counters.discovered).toBe("number");
+    expect(typeof runPayload.counters.afterPrefilter).toBe("number");
+    expect(typeof runPayload.counters.persisted).toBe("number");
+    expect(runPayload.counters.persisted).toBe(1);
+  });
 });

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -483,6 +483,7 @@ export async function runPageCollection(
       tickerId: input.tickerId,
       searchQueryId,
       ...(publishedAt ? { publishedAt: publishedAt.toISOString() } : {}),
+      metadata: { provider: page.provider },
     });
     fetchSuccessCount += 1;
   }
@@ -590,6 +591,17 @@ export async function runPageCollection(
       ? "partial_success"
       : derivedStatus;
 
+  const cacheHits = sourceReports.filter(
+    (r) => r.winningStrategy === "cache",
+  ).length;
+  const cacheMisses = sourceReports.filter(
+    (r) => r.discovered && r.winningStrategy !== "cache",
+  ).length;
+  const droppedByUrlNoiseTotal = Object.values(droppedByUrlReason).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+
   const counters: RunCounters = {
     queriesTotal: discoverySources.filter((s) => s.enabled !== false).length,
     urlsTotal: cappedDiscoveredItems.length,
@@ -600,6 +612,24 @@ export async function runPageCollection(
     retryCount: 0,
     droppedByRelevance,
     throttleEvents: 0,
+    // Extended counters for insights
+    discovered: discoveredItems.length,
+    afterPrefilter: filteredItems.length,
+    discoveryFailed: discoveryFailures.length,
+    cacheHits,
+    cacheMisses,
+    droppedByContentQuality: { ...droppedByContentQuality },
+    droppedByFreshness,
+    droppedByDeadUrl: droppedByDeadUrlCache,
+    droppedByHostErrorRate,
+    droppedByFetchBudget,
+    droppedByRunItemCap,
+    droppedByExistingCanonicalUrl,
+    droppedByDuplicateCanonicalUrl,
+    droppedByUrlNoise: droppedByUrlNoiseTotal,
+    persisted: persistedCount,
+    deadlineHit,
+    durationMs: Date.now() - startedAt.getTime(),
   };
 
   const runPayload = {

--- a/packages/mediapulse/database/prisma/migrations/20260608000004_add_run_extended_counters/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260608000004_add_run_extended_counters/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "data_collection_run" ADD COLUMN "extended_counters" JSONB;

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -546,6 +546,8 @@ model DataCollectionRun {
   fetchFailed   Int @default(0) @map("fetch_failed")
   retryCount    Int @default(0) @map("retry_count")
 
+  extendedCounters Json? @map("extended_counters")
+
   ticker   Ticker                  @relation(fields: [tickerId], references: [id])
   failures DataCollectionFailure[]
 

--- a/packages/shared/agent-data-api-contract/src/data-collection-run.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-run.ts
@@ -22,6 +22,26 @@ export const dataCollectionRunInputSchema = z.object({
     retryCount: z.number().int().nonnegative(),
     droppedByRelevance: z.number().int().nonnegative(),
     throttleEvents: z.number().int().nonnegative(),
+    // Extended optional counters for detailed insights
+    discovered: z.number().int().nonnegative().optional(),
+    afterPrefilter: z.number().int().nonnegative().optional(),
+    discoveryFailed: z.number().int().nonnegative().optional(),
+    cacheHits: z.number().int().nonnegative().optional(),
+    cacheMisses: z.number().int().nonnegative().optional(),
+    droppedByContentQuality: z
+      .record(z.string(), z.number().int().nonnegative())
+      .optional(),
+    droppedByFreshness: z.number().int().nonnegative().optional(),
+    droppedByDeadUrl: z.number().int().nonnegative().optional(),
+    droppedByHostErrorRate: z.number().int().nonnegative().optional(),
+    droppedByFetchBudget: z.number().int().nonnegative().optional(),
+    droppedByRunItemCap: z.number().int().nonnegative().optional(),
+    droppedByExistingCanonicalUrl: z.number().int().nonnegative().optional(),
+    droppedByDuplicateCanonicalUrl: z.number().int().nonnegative().optional(),
+    droppedByUrlNoise: z.number().int().nonnegative().optional(),
+    persisted: z.number().int().nonnegative().optional(),
+    deadlineHit: z.boolean().optional(),
+    durationMs: z.number().int().nonnegative().optional(),
   }),
 });
 

--- a/packages/shared/agent-data-api-contract/src/data-collection.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection.ts
@@ -14,6 +14,7 @@ const dataCollectionInputSchema = z.object({
   tickerId: z.string().trim().min(1),
   searchQueryId: z.string().uuid(),
   publishedAt: z.string().datetime().optional(),
+  metadata: z.object({ provider: z.string().optional() }).optional(),
 });
 
 export const dataCollectionBodySchema = z.array(dataCollectionInputSchema);

--- a/packages/shared/agent-ingestion/src/data-sources.ts
+++ b/packages/shared/agent-ingestion/src/data-sources.ts
@@ -11,6 +11,7 @@ export interface CollectedPageForSource {
 
 export interface DataCollectionSource extends DataCollectionInput {
   metadata: {
+    provider?: string;
     searchQueryText?: string;
     fetchedAt: string;
     sourceType: "web";

--- a/packages/shared/agent-ingestion/src/run-status.ts
+++ b/packages/shared/agent-ingestion/src/run-status.ts
@@ -18,6 +18,24 @@ export type RunCounters = {
   retryCount: number;
   droppedByRelevance: number;
   throttleEvents: number;
+  // Extended counters — optional so existing callers are unaffected
+  discovered?: number;
+  afterPrefilter?: number;
+  discoveryFailed?: number;
+  cacheHits?: number;
+  cacheMisses?: number;
+  droppedByContentQuality?: Record<string, number>;
+  droppedByFreshness?: number;
+  droppedByDeadUrl?: number;
+  droppedByHostErrorRate?: number;
+  droppedByFetchBudget?: number;
+  droppedByRunItemCap?: number;
+  droppedByExistingCanonicalUrl?: number;
+  droppedByDuplicateCanonicalUrl?: number;
+  droppedByUrlNoise?: number;
+  persisted?: number;
+  deadlineHit?: boolean;
+  durationMs?: number;
 };
 
 /**

--- a/packages/shared/agent-types/src/data-collection.ts
+++ b/packages/shared/agent-types/src/data-collection.ts
@@ -22,6 +22,7 @@ export const dataCollectionInputSchema = z.object({
   tickerId: z.string().uuid(),
   searchQueryId: z.string().uuid(),
   publishedAt: z.string().datetime().optional(),
+  metadata: z.object({ provider: z.string().optional() }).optional(),
 });
 
 export type DataCollectionInput = z.infer<typeof dataCollectionInputSchema>;


### PR DESCRIPTION
## Summary

Adds a `page-collection` insights provider that turns raw run history, discovery source health, and data source records into a render-ready `InsightsPayload`. Calling `GET /agent-insights?agentId=page-collection&window=7d` now returns real data instead of 404.

To make the payload meaningful, this also extends `RunCounters` with 17 optional fields (funnel stages, drop reasons, cache hits, duration) that the page-collection pipeline populates and persists as a JSON column on `DataCollectionRun`.

## Related issues

Closes #695

## Important changes

- **`createPageCollectionInsightsProvider(deps)`** — injectable-deps factory registered at agent-data-api startup; queries three tables in parallel and builds 11 sections covering all 5W1H categories, 4 KPIs with prior-period deltas, and consecutive-failure alerts.
- **`extended_counters JSONB` column** — new Prisma migration adds the column to `data_collection_run`; the run creation route splits the 7 core counters from the rest and stores extended fields as JSON.
- **`RunCounters` widened** — 17 optional fields added (`discovered`, `afterPrefilter`, `cacheHits`, `persisted`, `droppedBy*`, `durationMs`, etc.); page-collection `run.ts` now computes and populates all of them.
- **`metadata.provider`** on persisted sources — each `DataCollectionInput` now carries the fetch provider name so the provider-mix breakdown widget has real data.

## Other changes

- `DataCollectionSource.metadata` interface extended with `provider?: string` for structural compatibility with the updated base type.
- `dataCollectionInputSchema` in both `@workspace/agent-types` and `@workspace/agent-data-api-contract` gains an optional `metadata.provider` field.
- Two new assertions in `page-collection/src/run.test.ts` verify that `metadata.provider` is set on persisted sources and that extended counters appear in the run payload.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts` — core provider logic: window dates, KPI deltas, section builders, `bucketTopN` helper.
- `apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts` — 8 tests covering schema validation, funnel ordering, drop aggregation, TOP_N cap, strategy/provider mix, KPI deltas, consecutive-failure alert, and empty-input handling.
- `apps/mediapulse/agents/page-collection/src/run.ts` — extended counters block and `metadata.provider` on `sourcesToPersist`.
- `packages/mediapulse/database/prisma/migrations/20260608000004_add_run_extended_counters/migration.sql` — additive JSONB column, safe to run on a live table.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — 167 tests pass.
2. `pnpm --filter @mediapulse/page-collection test` — 38 tests pass (includes the 2 new assertions).
3. Start agent-data-api locally and call `GET /api/v1/agent-insights?agentId=page-collection&window=7d` — expect 200 with a payload that includes `kpis`, `alerts`, and `sections` arrays.
4. Run a page-collection job; confirm `extended_counters` is populated on the resulting `data_collection_run` row and `metadata` is set on persisted `data_source` rows.
