### PR TITLE
Batch AgentJobExecution inserts to fix expired-transaction timeout on large fan-outs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,5 @@ GRAPH_REPORT.md
 # Cursor
 .cursor/plans
 prds/
+
+.claude/

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -47,20 +47,16 @@ const createExecutionPersistenceStubs = () => {
       update: vi.fn().mockResolvedValue(undefined),
     },
     manualPipelineStepExecution: {
-      create: vi.fn().mockResolvedValue(undefined),
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
       update: vi.fn().mockResolvedValue(undefined),
     },
     agentJobExecution: {
-      create: vi.fn().mockResolvedValue(undefined),
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
       update: vi.fn().mockResolvedValue(undefined),
       updateMany: vi.fn().mockResolvedValue({ count: 1 }),
       count: vi.fn().mockResolvedValue(0),
     },
-    $transaction: vi.fn(),
   };
-  stubs.$transaction.mockImplementation(
-    async (fn: (tx: typeof stubs) => Promise<unknown>) => fn(stubs),
-  );
   return stubs;
 };
 
@@ -404,5 +400,67 @@ describe("createRunPipelineHandler", () => {
     });
     expect(stubs.agentJobExecution.update).toHaveBeenCalled();
     expect(stubs.manualPipelineExecution.update).toHaveBeenCalled();
+  });
+
+  it("persists a large fan-out in a single createMany call with no per-row creates", async () => {
+    const FAN_OUT = 1000;
+    const stubs = createExecutionPersistenceStubs();
+    const enqueueMock = vi.fn().mockResolvedValue(undefined);
+    const handler = createRunPipelineHandler({
+      expandStepInputs: async (ctx) =>
+        Array.from({ length: FAN_OUT }, (_, index) => ({
+          ...ctx.input,
+          _index: index,
+        })),
+      enqueueManualAgentInvocations: enqueueMock,
+      db: {
+        ...stubs,
+        pipeline: {
+          findUnique: vi.fn().mockResolvedValue(createPipelineWithSteps()),
+        },
+        variable: { findMany: vi.fn().mockResolvedValue([]) },
+        agentRegistry: {
+          findFirst: vi.fn().mockResolvedValue({
+            agentId: "ag1",
+            agentVersion: "1.0.0",
+            endpoint: { url: "https://agent.example/run", method: "POST" },
+            inputSchema: null,
+            configSchema: null,
+            isActive: true,
+          }),
+          findMany: vi.fn().mockResolvedValue([
+            {
+              agentId: "ag1",
+              agentVersion: "1.0.0",
+              endpoint: { url: "https://agent.example/run", method: "POST" },
+              inputSchema: null,
+              configSchema: null,
+              isActive: true,
+            },
+          ]),
+        },
+        agentConfig: { findFirst: vi.fn().mockResolvedValue(null) },
+      } as never,
+    });
+
+    const result = await handler(request({ pipelineId: "p-1" }));
+    expect(result.status).toBe(true);
+    expect(result).toMatchObject({ data: { ok: true, runStatus: "running" } });
+
+    expect(stubs.agentJobExecution.createMany).toHaveBeenCalledTimes(1);
+    const createManyArg = stubs.agentJobExecution.createMany.mock
+      .calls[0]?.[0] as {
+      data: unknown[];
+    };
+    expect(createManyArg.data).toHaveLength(FAN_OUT);
+
+    expect(stubs.manualPipelineStepExecution.createMany).toHaveBeenCalledTimes(
+      1,
+    );
+    expect(enqueueMock).toHaveBeenCalledTimes(1);
+    const batch = enqueueMock.mock.calls[0]?.[0] as Array<{
+      payload: { manualExecutionId: string };
+    }>;
+    expect(batch).toHaveLength(FAN_OUT);
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -408,10 +408,10 @@ export const createRunPipelineHandler = ({
         );
       }
 
-      for (const step of pipeline.steps) {
-        const expectedInvocationCount = stepExpected.get(step.id) ?? 0;
-        await db.manualPipelineStepExecution.create({
-          data: {
+      await db.manualPipelineStepExecution.createMany({
+        data: pipeline.steps.map((step) => {
+          const expectedInvocationCount = stepExpected.get(step.id) ?? 0;
+          return {
             manualExecutionId: execution.id,
             pipelineStepId: step.id,
             expectedInvocationCount,
@@ -419,9 +419,9 @@ export const createRunPipelineHandler = ({
               expectedInvocationCount > 0
                 ? ScheduleStepRollupStatus.running
                 : ScheduleStepRollupStatus.pending,
-          },
-        });
-      }
+          };
+        }),
+      });
 
       if (jobsCreated === 0) {
         return successResponse({
@@ -520,23 +520,18 @@ export const createRunPipelineHandler = ({
         });
       }
 
-      await db.$transaction(async (tx) => {
-        for (const item of enqueueItems) {
-          await tx.agentJobExecution.create({
-            data: {
-              jobId: item.payload.jobId,
-              agentId: item.payload.agentId,
-              manualExecutionId: execution.id,
-              pipelineId: pipeline.id,
-              pipelineStepId: item.payload.pipelineStepId,
-              status: AgentJobExecutionStatus.pending,
-              enqueuedAt: executionTime,
-              params: item.payload.body.input as Prisma.InputJsonValue,
-              invocationConfig: item.payload.body
-                .config as Prisma.InputJsonValue,
-            },
-          });
-        }
+      await db.agentJobExecution.createMany({
+        data: enqueueItems.map((item) => ({
+          jobId: item.payload.jobId,
+          agentId: item.payload.agentId,
+          manualExecutionId: execution.id,
+          pipelineId: pipeline.id,
+          pipelineStepId: item.payload.pipelineStepId,
+          status: AgentJobExecutionStatus.pending,
+          enqueuedAt: executionTime,
+          params: item.payload.body.input as Prisma.InputJsonValue,
+          invocationConfig: item.payload.body.config as Prisma.InputJsonValue,
+        })),
       });
 
       let jobsEnqueued = 0;

--- a/apps/hermes/worker/src/execute-http-trigger.test.ts
+++ b/apps/hermes/worker/src/execute-http-trigger.test.ts
@@ -81,10 +81,10 @@ describe("executeHttpTrigger", () => {
           update: vi.fn().mockResolvedValue(undefined),
         },
         httpTriggerStepExecution: {
-          create: vi.fn().mockResolvedValue(undefined),
+          createMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
         agentJobExecution: {
-          create: vi.fn().mockResolvedValue(undefined),
+          createMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
       };
       await fn(tx);
@@ -160,10 +160,10 @@ describe("executeHttpTrigger", () => {
           update: vi.fn().mockResolvedValue(undefined),
         },
         httpTriggerStepExecution: {
-          create: vi.fn().mockResolvedValue(undefined),
+          createMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
         agentJobExecution: {
-          create: vi.fn().mockResolvedValue(undefined),
+          createMany: vi.fn().mockResolvedValue({ count: 0 }),
         },
       };
       await fn(tx);

--- a/apps/hermes/worker/src/execute-http-trigger.ts
+++ b/apps/hermes/worker/src/execute-http-trigger.ts
@@ -193,35 +193,31 @@ export const executeHttpTrigger = async (
         jobsCreated,
       },
     });
-    for (const [
-      pipelineStepId,
-      expectedInvocationCount,
-    ] of stepExpected.entries()) {
-      await tx.httpTriggerStepExecution.create({
-        data: {
+    await tx.httpTriggerStepExecution.createMany({
+      data: Array.from(
+        stepExpected.entries(),
+        ([pipelineStepId, expectedInvocationCount]) => ({
           httpTriggerExecutionId,
           pipelineStepId,
           expectedInvocationCount,
           rollupStatus: ScheduleStepRollupStatus.pending,
-        },
-      });
-    }
-    for (const item of enqueueItems) {
-      await tx.agentJobExecution.create({
-        data: {
-          jobId: item.payload.jobId,
-          agentId: item.payload.agentId,
-          httpTriggerId: trigger.id,
-          httpTriggerExecutionId,
-          pipelineId: pipeline.id,
-          pipelineStepId: item.payload.pipelineStepId,
-          status: AgentJobExecutionStatus.pending,
-          enqueuedAt: new Date(),
-          params: item.payload.body.input as Prisma.InputJsonValue,
-          invocationConfig: item.payload.body.config as Prisma.InputJsonValue,
-        },
-      });
-    }
+        }),
+      ),
+    });
+    await tx.agentJobExecution.createMany({
+      data: enqueueItems.map((item) => ({
+        jobId: item.payload.jobId,
+        agentId: item.payload.agentId,
+        httpTriggerId: trigger.id,
+        httpTriggerExecutionId,
+        pipelineId: pipeline.id,
+        pipelineStepId: item.payload.pipelineStepId,
+        status: AgentJobExecutionStatus.pending,
+        enqueuedAt: new Date(),
+        params: item.payload.body.input as Prisma.InputJsonValue,
+        invocationConfig: item.payload.body.config as Prisma.InputJsonValue,
+      })),
+    });
   });
 
   let jobsEnqueued = 0;

--- a/packages/hermes/scheduler/src/execute-schedule.test.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.test.ts
@@ -96,8 +96,12 @@ const createMockDb = (opts?: {
   const $transaction = vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
     const tx = {
       scheduleExecution: { create: scheduleExecutionCreate },
-      scheduleStepExecution: { create: vi.fn().mockResolvedValue(undefined) },
-      agentJobExecution: { create: vi.fn().mockResolvedValue(undefined) },
+      scheduleStepExecution: {
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
+      agentJobExecution: {
+        createMany: vi.fn().mockResolvedValue({ count: 0 }),
+      },
     };
     return fn(tx);
   });
@@ -118,7 +122,7 @@ const createMockDb = (opts?: {
       ]),
     },
     agentJobExecution: {
-      create: vi.fn().mockResolvedValue(undefined),
+      createMany: vi.fn().mockResolvedValue({ count: 0 }),
       update: vi.fn().mockResolvedValue(undefined),
     },
     schedule: { update: vi.fn().mockResolvedValue(undefined) },
@@ -550,5 +554,89 @@ describe("executeSchedule", () => {
     expect(payload).toBeDefined();
     expect(payload!.body.input).toEqual({ apiKey: "resolved-secret" });
     expect(payload!.body.config).toEqual({ token: "resolved-secret" });
+  });
+
+  it("persists a large fan-out in a single createMany call with no per-row creates", async () => {
+    const FAN_OUT = 1000;
+    const schedule = createMockSchedule();
+
+    let capturedTx: {
+      agentJobExecution: {
+        createMany: ReturnType<typeof vi.fn>;
+        create?: ReturnType<typeof vi.fn>;
+      };
+      scheduleStepExecution: {
+        createMany: ReturnType<typeof vi.fn>;
+        create?: ReturnType<typeof vi.fn>;
+      };
+    } | null = null;
+
+    const agentJobExecutionCreateMany = vi
+      .fn()
+      .mockResolvedValue({ count: FAN_OUT });
+    const scheduleStepExecutionCreateMany = vi
+      .fn()
+      .mockResolvedValue({ count: 1 });
+
+    const db = {
+      ...createMockDb(),
+      $transaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        const tx = {
+          scheduleExecution: {
+            create: vi.fn().mockResolvedValue({ id: "se-regression" }),
+          },
+          scheduleStepExecution: {
+            createMany: scheduleStepExecutionCreateMany,
+          },
+          agentJobExecution: { createMany: agentJobExecutionCreateMany },
+        };
+        capturedTx = tx;
+
+        return fn(tx);
+      }),
+      agentRegistry: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            agentId: "agent-a",
+            agentVersion: "1.0.0",
+            endpoint: { url: "https://agent.example/run", method: "POST" },
+            isActive: true,
+          },
+        ]),
+      },
+    };
+
+    const enqueueAgentInvocations = vi.fn().mockResolvedValue(undefined);
+    const deps: ExecuteScheduleDeps = {
+      db: db as unknown as ExecuteScheduleDeps["db"],
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      enqueueAgentInvocations,
+      expandStepInputs: async () =>
+        Array.from({ length: FAN_OUT }, (_, index) => ({
+          id: `item-${index}`,
+        })),
+    };
+
+    await executeSchedule(schedule, deps);
+
+    expect(capturedTx).not.toBeNull();
+    expect(capturedTx!.agentJobExecution.createMany).toHaveBeenCalledTimes(1);
+    const createManyArg = capturedTx!.agentJobExecution.createMany.mock
+      .calls[0]?.[0] as {
+      data: unknown[];
+    };
+    expect(createManyArg.data).toHaveLength(FAN_OUT);
+    expect(capturedTx!.agentJobExecution.create).toBeUndefined();
+
+    expect(enqueueAgentInvocations).toHaveBeenCalledTimes(1);
+    const [items] = enqueueAgentInvocations.mock.calls[0] as [
+      EnqueueInvokeAgentItem[],
+    ];
+    expect(items).toHaveLength(FAN_OUT);
+    expect(
+      items.every(
+        (item) => item.payload.scheduleExecutionId === "se-regression",
+      ),
+    ).toBe(true);
   });
 });

--- a/packages/hermes/scheduler/src/execute-schedule.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.ts
@@ -268,38 +268,36 @@ export const executeSchedule = async (
       },
     });
 
-    for (const [pipelineStepId, count] of stepExpected) {
-      await tx.scheduleStepExecution.create({
-        data: {
-          scheduleExecutionId: se.id,
-          pipelineStepId,
-          expectedInvocationCount: count,
-          succeededCount: 0,
-          failedCount: 0,
-          rollupStatus: ScheduleStepRollupStatus.pending,
-        },
-      });
-    }
+    await tx.scheduleStepExecution.createMany({
+      data: Array.from(stepExpected, ([pipelineStepId, count]) => ({
+        scheduleExecutionId: se.id,
+        pipelineStepId,
+        expectedInvocationCount: count,
+        succeededCount: 0,
+        failedCount: 0,
+        rollupStatus: ScheduleStepRollupStatus.pending,
+      })),
+    });
 
     for (const item of enqueueItems) {
-      const p = item.payload;
-      await tx.agentJobExecution.create({
-        data: {
-          jobId: p.jobId,
-          agentId: p.agentId,
-          scheduleId: schedule.id,
-          scheduleExecutionId: se.id,
-          pipelineId: schedule.pipelineId,
-          pipelineStepId: p.pipelineStepId,
-          status: AgentJobExecutionStatus.pending,
-          priority: schedule.priority,
-          enqueuedAt: executionTime,
-          params: p.body.input as Prisma.InputJsonValue,
-          invocationConfig: p.body.config as Prisma.InputJsonValue,
-        },
-      });
-      p.scheduleExecutionId = se.id;
+      item.payload.scheduleExecutionId = se.id;
     }
+
+    await tx.agentJobExecution.createMany({
+      data: enqueueItems.map(({ payload: p }) => ({
+        jobId: p.jobId,
+        agentId: p.agentId,
+        scheduleId: schedule.id,
+        scheduleExecutionId: se.id,
+        pipelineId: schedule.pipelineId,
+        pipelineStepId: p.pipelineStepId,
+        status: AgentJobExecutionStatus.pending,
+        priority: schedule.priority,
+        enqueuedAt: executionTime,
+        params: p.body.input as Prisma.InputJsonValue,
+        invocationConfig: p.body.config as Prisma.InputJsonValue,
+      })),
+    });
 
     return se;
   });


### PR DESCRIPTION
## Summary

Running a pipeline with a large step fan-out fails every time with "A query cannot be executed on an expired transaction." The run-pipeline route, `executeSchedule`, and `executeHttpTrigger` all opened a Prisma interactive transaction and inserted one `AgentJobExecution` row per planned invocation in a sequential loop. With Prisma's default 5000 ms transaction timeout, a few hundred rows across the loop's round-trips pushed past the ceiling deterministically. This PR replaces each per-row `create` loop with a single `createMany`, collapsing N sequential inserts into one statement and one round-trip, so the timeout ceiling is no longer reachable regardless of fan-out size.

## Related issues

Closes #701

## Important changes

- **`route.post.config.ts`**: the `$transaction` wrapper around the `agentJobExecution.create` loop is dropped; replaced with a direct `db.agentJobExecution.createMany`. The `manualPipelineStepExecution.create` loop is also batched with `createMany`.
- **`execute-schedule.ts`**: inside the existing `$transaction`, the `scheduleStepExecution.create` and `agentJobExecution.create` loops become `createMany`. The `p.scheduleExecutionId = se.id` payload mutation is preserved — all payloads are mutated after `se` is created and before `enqueueAgentInvocations` is called.
- **`execute-http-trigger.ts`**: inside the existing `$transaction`, the `httpTriggerStepExecution.create` and `agentJobExecution.create` loops become `createMany`.

## Other changes

- Test mocks for all three paths updated to expose `createMany` instead of `create` on the affected models.
- High-fan-out regression test added (1000 invocations) asserting a single `createMany` call with 1000 rows and zero per-row `create` calls — the exact case that timed out under the old loop.

## Key files to review

- [apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts](apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts) — the reported failure site; `$transaction` wrapper dropped, both loops batched.
- [packages/hermes/scheduler/src/execute-schedule.ts](packages/hermes/scheduler/src/execute-schedule.ts) — sibling path; `scheduleExecutionId` mutation preserved.
- [apps/hermes/worker/src/execute-http-trigger.ts](apps/hermes/worker/src/execute-http-trigger.ts) — sibling HTTP-trigger path.
- [packages/hermes/scheduler/src/execute-schedule.test.ts](packages/hermes/scheduler/src/execute-schedule.test.ts) — high-fan-out regression test lives here.

## How to test

1. Run `pnpm --filter @hermes/scheduler test` — all 91 tests including the new high-fan-out regression test pass.
2. Run `pnpm --filter @hermes/worker test` — all 41 tests pass.
3. Run `pnpm --filter @hermes/dashboard test` — all 1265 tests pass.
4. Trigger "Run pipeline" on a pipeline whose step expands to several hundred or more invocations and confirm it returns `runStatus: "running"` with no expired-transaction error.
