### PR TITLE
Replace per-source strategies[] and defaultDiscoveryChain with single strategy enum

### DIFF
--- a/apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts
+++ b/apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts
@@ -1,0 +1,129 @@
+/**
+ * Data migration: page-collection AgentConfig rows — strategies[] → strategy (plan 106).
+ *
+ * For each curatedSource:
+ *   - Sets `strategy` = first valid value in the old `strategies` array, else "rss".
+ *   - Deletes the `strategies` key from the source object.
+ * Deletes the top-level `defaultDiscoveryChain` key.
+ *
+ * Required because the JSON Schema is additionalProperties:false — stale keys
+ * would fail the dashboard save path.
+ *
+ * Usage:
+ *   pnpm tsx apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts
+ */
+import { config } from "dotenv";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const envPath = path.resolve(__dirname, "../.env.local");
+if (!fs.existsSync(envPath)) {
+  console.error(`Missing ${envPath}. Run ./dev-bootstrap.sh first.`);
+  process.exit(1);
+}
+config({ path: envPath });
+
+const VALID_STRATEGIES = new Set(["rss", "sitemap", "generic-links"]);
+
+type RawCuratedSource = {
+  listingUrl?: string;
+  strategies?: unknown[];
+  strategy?: string;
+  enabled?: boolean;
+  maxItems?: number;
+  [key: string]: unknown;
+};
+
+type RawConfig = {
+  curatedSources?: RawCuratedSource[];
+  defaultDiscoveryChain?: unknown;
+  [key: string]: unknown;
+};
+
+function migrateConfig(config: RawConfig): {
+  migrated: RawConfig;
+  changed: boolean;
+} {
+  let changed = false;
+  const migrated = { ...config };
+
+  if ("defaultDiscoveryChain" in migrated) {
+    delete migrated.defaultDiscoveryChain;
+    changed = true;
+  }
+
+  if (Array.isArray(migrated.curatedSources)) {
+    migrated.curatedSources = migrated.curatedSources.map((source) => {
+      const updated = { ...source };
+
+      if ("strategies" in updated) {
+        const strategies = updated.strategies;
+        const firstValid = Array.isArray(strategies)
+          ? (strategies.find(
+              (value): value is string =>
+                typeof value === "string" && VALID_STRATEGIES.has(value),
+            ) ?? "rss")
+          : "rss";
+
+        if (!updated.strategy) {
+          updated.strategy = firstValid;
+        }
+
+        delete updated.strategies;
+        changed = true;
+      }
+
+      return updated;
+    });
+  }
+
+  return { migrated, changed };
+}
+
+async function main() {
+  const { createPrismaClient } =
+    await import("@hermes/orchestration-database/client");
+  const prisma = createPrismaClient();
+
+  try {
+    const configs = await prisma.agentConfig.findMany({
+      where: { agentId: "page-collection" },
+    });
+
+    console.log(`Found ${configs.length} page-collection AgentConfig rows.`);
+
+    let updatedCount = 0;
+
+    for (const row of configs) {
+      const rawConfig = row.config as RawConfig;
+      const { migrated, changed } = migrateConfig(rawConfig);
+
+      if (!changed) {
+        continue;
+      }
+
+      await prisma.agentConfig.update({
+        where: { id: row.id },
+        data: { config: migrated },
+      });
+
+      updatedCount += 1;
+      console.log(`  Updated config "${row.name}" (${row.id})`);
+    }
+
+    console.log(
+      `Migration complete. ${updatedCount}/${configs.length} rows updated.`,
+    );
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error("Migration failed:", error);
+  process.exit(1);
+});

--- a/apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts
+++ b/apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts
@@ -85,42 +85,36 @@ function migrateConfig(config: RawConfig): {
 }
 
 async function main() {
-  const { createPrismaClient } =
-    await import("@hermes/orchestration-database/client");
-  const prisma = createPrismaClient();
+  const { prisma } = await import("@hermes/orchestration-database");
 
-  try {
-    const configs = await prisma.agentConfig.findMany({
-      where: { agentId: "page-collection" },
-    });
+  const configs = await prisma.agentConfig.findMany({
+    where: { agentId: "page-collection" },
+  });
 
-    console.log(`Found ${configs.length} page-collection AgentConfig rows.`);
+  console.log(`Found ${configs.length} page-collection AgentConfig rows.`);
 
-    let updatedCount = 0;
+  let updatedCount = 0;
 
-    for (const row of configs) {
-      const rawConfig = row.config as RawConfig;
-      const { migrated, changed } = migrateConfig(rawConfig);
+  for (const row of configs) {
+    const rawConfig = row.config as RawConfig;
+    const { migrated, changed } = migrateConfig(rawConfig);
 
-      if (!changed) {
-        continue;
-      }
-
-      await prisma.agentConfig.update({
-        where: { id: row.id },
-        data: { config: migrated },
-      });
-
-      updatedCount += 1;
-      console.log(`  Updated config "${row.name}" (${row.id})`);
+    if (!changed) {
+      continue;
     }
 
-    console.log(
-      `Migration complete. ${updatedCount}/${configs.length} rows updated.`,
-    );
-  } finally {
-    await prisma.$disconnect();
+    await prisma.agentConfig.update({
+      where: { id: row.id },
+      data: { config: migrated as object },
+    });
+
+    updatedCount += 1;
+    console.log(`  Updated config "${row.name}" (${row.id})`);
   }
+
+  console.log(
+    `Migration complete. ${updatedCount}/${configs.length} rows updated.`,
+  );
 }
 
 main().catch((error) => {

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -30,7 +30,7 @@ const baseConfig = ConfigSchema.parse({
   curatedSources: [
     {
       listingUrl: "https://example.com/feed",
-      strategies: ["rss"],
+      strategy: "rss",
     },
   ],
   providers: {

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -137,7 +137,7 @@ export async function runPageCollection(
   const discoverySources: DiscoverySource[] = config.curatedSources.map(
     (source) => ({
       url: source.listingUrl,
-      strategies: source.strategies ?? config.defaultDiscoveryChain,
+      strategy: source.strategy,
       enabled: source.enabled,
       maxItems: source.maxItems,
     }),

--- a/apps/mediapulse/agents/page-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/config-schema.test.ts
@@ -9,11 +9,6 @@ describe("ConfigSchema", () => {
     const result = await ConfigSchema.parseAsync({});
 
     expect(result.curatedSources).toEqual([]);
-    expect(result.defaultDiscoveryChain).toEqual([
-      "rss",
-      "sitemap",
-      "generic-links",
-    ]);
     expect(result.gates.relevance.enabled).toBe(true);
     expect(result.gates.freshness.enabled).toBe(true);
     expect(result.resilience.deadUrlCache.enabled).toBe(true);
@@ -21,29 +16,39 @@ describe("ConfigSchema", () => {
     expect(result.runPolicy.minSuccessfulSources).toBe(1);
   });
 
-  it("accepts a curatedSource with listingUrl only (inherits default chain)", async () => {
+  it("accepts a curatedSource with listingUrl only (defaults strategy to rss)", async () => {
     const result = await ConfigSchema.parseAsync({
       curatedSources: [{ listingUrl: "https://example.com/feed" }],
     });
 
     expect(result.curatedSources[0]).toMatchObject({
       listingUrl: "https://example.com/feed",
+      strategy: "rss",
       enabled: true,
     });
-    expect(result.curatedSources[0]?.strategies).toBeUndefined();
   });
 
-  it("accepts a curatedSource with a strategies override", async () => {
+  it("accepts a curatedSource with an explicit strategy override", async () => {
     const result = await ConfigSchema.parseAsync({
       curatedSources: [
         {
           listingUrl: "https://example.com/news",
-          strategies: ["generic-links"],
+          strategy: "generic-links",
         },
       ],
     });
 
-    expect(result.curatedSources[0]?.strategies).toEqual(["generic-links"]);
+    expect(result.curatedSources[0]?.strategy).toBe("generic-links");
+  });
+
+  it("accepts all valid strategy enum values", async () => {
+    for (const strategy of ["rss", "sitemap", "generic-links"] as const) {
+      const result = await ConfigSchema.parseAsync({
+        curatedSources: [{ listingUrl: "https://example.com/feed", strategy }],
+      });
+
+      expect(result.curatedSources[0]?.strategy).toBe(strategy);
+    }
   });
 
   it("rejects an unknown strategy value in curatedSources", async () => {
@@ -52,18 +57,8 @@ describe("ConfigSchema", () => {
         curatedSources: [
           {
             listingUrl: "https://example.com/feed",
-            strategies: ["unknown-strategy"],
+            strategy: "unknown-strategy",
           },
-        ],
-      }),
-    ).rejects.toBeInstanceOf(Error);
-  });
-
-  it("rejects an empty strategies array in curatedSources", async () => {
-    await expect(
-      ConfigSchema.parseAsync({
-        curatedSources: [
-          { listingUrl: "https://example.com/feed", strategies: [] },
         ],
       }),
     ).rejects.toBeInstanceOf(Error);
@@ -84,22 +79,6 @@ describe("ConfigSchema", () => {
 
     expect(result.curatedSources[0]?.enabled).toBe(true);
   });
-
-  it("defaultDiscoveryChain defaults to [rss, sitemap, generic-links]", async () => {
-    const result = await ConfigSchema.parseAsync({});
-
-    expect(result.defaultDiscoveryChain).toEqual([
-      "rss",
-      "sitemap",
-      "generic-links",
-    ]);
-  });
-
-  it("rejects an empty defaultDiscoveryChain", async () => {
-    await expect(
-      ConfigSchema.parseAsync({ defaultDiscoveryChain: [] }),
-    ).rejects.toBeInstanceOf(Error);
-  });
 });
 
 describe("getConfigSchema", () => {
@@ -113,7 +92,7 @@ describe("getConfigSchema", () => {
       result.schema as { properties?: Record<string, unknown> }
     ).properties;
     expect(properties).toHaveProperty("curatedSources");
-    expect(properties).toHaveProperty("defaultDiscoveryChain");
+    expect(properties).not.toHaveProperty("defaultDiscoveryChain");
     expect(properties).toHaveProperty("gates");
     expect(properties).toHaveProperty("resilience");
   });

--- a/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts
@@ -174,16 +174,18 @@ const providersSchema = z
   .default({})
   .describe("External fetch providers used by the pipeline.");
 
-const discoveryStrategyEnum = z.enum(["rss", "sitemap", "generic-links"]);
+export const discoveryStrategyEnum = z.enum([
+  "rss",
+  "sitemap",
+  "generic-links",
+]);
 
 const curatedSourceSchema = z.object({
   listingUrl: z.string().url().describe("URL of the listing page or feed."),
-  strategies: z
-    .array(discoveryStrategyEnum)
-    .nonempty()
-    .optional()
+  strategy: discoveryStrategyEnum
+    .default("rss")
     .describe(
-      "Ordered strategy chain override for this source. Omit to inherit defaultDiscoveryChain.",
+      "What kind of URL this source is: rss feed, sitemap, or a generic listing page scraped for same-host links.",
     ),
   enabled: z
     .boolean()
@@ -397,13 +399,6 @@ export const ConfigSchema = z.object({
     .default([])
     .describe(
       "Operator-managed listing sources. Each entry is a feed or listing page the agent discovers articles from.",
-    ),
-  defaultDiscoveryChain: z
-    .array(discoveryStrategyEnum)
-    .nonempty()
-    .default(["rss", "sitemap", "generic-links"])
-    .describe(
-      "Ordered discovery strategy chain applied to sources that do not override their own chain.",
     ),
   providers: providersSchema,
   gates: gatesSchema,

--- a/packages/shared/agent-ingestion/src/discovery/registry.ts
+++ b/packages/shared/agent-ingestion/src/discovery/registry.ts
@@ -3,11 +3,6 @@ import { rssStrategy } from "./rss";
 import { sitemapStrategy } from "./sitemap";
 import type { ListingDiscoveryStrategy } from "./types";
 
-/** Ordered default discovery chain tried for every source unless overridden. */
-export const DEFAULT_DISCOVERY_CHAIN: ReadonlyArray<
-  "rss" | "sitemap" | "generic-links"
-> = ["rss", "sitemap", "generic-links"];
-
 /**
  * Returns the listing discovery strategy for the given type.
  *

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts
@@ -38,76 +38,103 @@ describe("discoverOneSource", () => {
     vi.resetAllMocks();
   });
 
-  it("returns items from the first strategy that succeeds with non-empty results", async () => {
+  it("returns items when the chosen strategy succeeds with non-empty results", async () => {
     const rssItems = [{ url: "https://example.com/a" }];
     vi.mocked(rssStrategy.discover).mockResolvedValue(rssItems);
 
     const result = await discoverOneSource(
-      {
-        url: "https://example.com/feed",
-        strategies: ["rss", "sitemap", "generic-links"],
-      },
+      { url: "https://example.com/feed", strategy: "rss" },
       buildDeps(),
     );
 
     expect(result.items).toEqual(rssItems);
     expect(result.failures).toHaveLength(0);
+    expect(result.winningStrategy).toBe("rss");
     expect(vi.mocked(sitemapStrategy.discover)).not.toHaveBeenCalled();
+    expect(vi.mocked(genericLinksStrategy.discover)).not.toHaveBeenCalled();
   });
 
-  it("falls through rss error → sitemap empty → generic-links succeeds", async () => {
-    const genericItems = [{ url: "https://example.com/article/one" }];
-    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
-    vi.mocked(sitemapStrategy.discover).mockResolvedValue([]);
-    vi.mocked(genericLinksStrategy.discover).mockResolvedValue(genericItems);
+  it("returns empty items and a failure when the strategy returns no items", async () => {
+    vi.mocked(rssStrategy.discover).mockResolvedValue([]);
 
     const result = await discoverOneSource(
-      {
-        url: "https://example.com/news",
-        strategies: ["rss", "sitemap", "generic-links"],
-      },
-      buildDeps(),
-    );
-
-    expect(result.items).toEqual(genericItems);
-    expect(result.failures).toHaveLength(2);
-    expect(result.failures[0]?.strategyType).toBe("rss");
-    expect(result.failures[1]?.strategyType).toBe("sitemap");
-  });
-
-  it("returns empty items and all failures when the whole chain is exhausted", async () => {
-    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
-    vi.mocked(sitemapStrategy.discover).mockRejectedValue(
-      new Error("sitemap gone"),
-    );
-    vi.mocked(genericLinksStrategy.discover).mockRejectedValue(
-      new Error("403"),
-    );
-
-    const result = await discoverOneSource(
-      {
-        url: "https://example.com/news",
-        strategies: ["rss", "sitemap", "generic-links"],
-      },
+      { url: "https://example.com/feed", strategy: "rss" },
       buildDeps(),
     );
 
     expect(result.items).toHaveLength(0);
-    expect(result.failures).toHaveLength(3);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.strategyType).toBe("rss");
+    expect(result.failures[0]?.errorCategory).toBe("provider_data_invalid");
+    expect(result.winningStrategy).toBeNull();
   });
 
-  it("respects maxItems when the winning strategy returns too many", async () => {
+  it("returns empty items and a failure when the strategy throws", async () => {
+    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
+
+    const result = await discoverOneSource(
+      { url: "https://example.com/feed", strategy: "rss" },
+      buildDeps(),
+    );
+
+    expect(result.items).toHaveLength(0);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.strategyType).toBe("rss");
+    expect(result.winningStrategy).toBeNull();
+  });
+
+  it("runs the sitemap strategy when strategy is sitemap", async () => {
+    const sitemapItems = [{ url: "https://example.com/sitemap-article" }];
+    vi.mocked(sitemapStrategy.discover).mockResolvedValue(sitemapItems);
+
+    const result = await discoverOneSource(
+      { url: "https://example.com/sitemap.xml", strategy: "sitemap" },
+      buildDeps(),
+    );
+
+    expect(result.items).toEqual(sitemapItems);
+    expect(result.winningStrategy).toBe("sitemap");
+    expect(vi.mocked(rssStrategy.discover)).not.toHaveBeenCalled();
+  });
+
+  it("runs the generic-links strategy when strategy is generic-links", async () => {
+    const genericItems = [{ url: "https://example.com/article/one" }];
+    vi.mocked(genericLinksStrategy.discover).mockResolvedValue(genericItems);
+
+    const result = await discoverOneSource(
+      { url: "https://example.com/news", strategy: "generic-links" },
+      buildDeps(),
+    );
+
+    expect(result.items).toEqual(genericItems);
+    expect(result.winningStrategy).toBe("generic-links");
+    expect(vi.mocked(rssStrategy.discover)).not.toHaveBeenCalled();
+  });
+
+  it("respects maxItems when the strategy returns too many", async () => {
     const manyItems = Array.from({ length: 20 }, (_, index) => ({
       url: `https://example.com/articles/${index}`,
     }));
     vi.mocked(rssStrategy.discover).mockResolvedValue(manyItems);
 
     const result = await discoverOneSource(
-      { url: "https://example.com/feed", strategies: ["rss"], maxItems: 5 },
+      { url: "https://example.com/feed", strategy: "rss", maxItems: 5 },
       buildDeps(),
     );
 
     expect(result.items).toHaveLength(5);
+  });
+
+  it("does not fall through to other strategies when the chosen one fails", async () => {
+    vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
+
+    await discoverOneSource(
+      { url: "https://example.com/feed", strategy: "rss" },
+      buildDeps(),
+    );
+
+    expect(vi.mocked(sitemapStrategy.discover)).not.toHaveBeenCalled();
+    expect(vi.mocked(genericLinksStrategy.discover)).not.toHaveBeenCalled();
   });
 });
 
@@ -123,8 +150,8 @@ describe("runDiscovery", () => {
 
     const result = await runDiscovery(
       [
-        { url: "https://a.com/feed", strategies: ["rss"] },
-        { url: "https://b.com/feed", strategies: ["rss"], enabled: false },
+        { url: "https://a.com/feed", strategy: "rss" },
+        { url: "https://b.com/feed", strategy: "rss", enabled: false },
       ],
       buildDeps(),
     );
@@ -140,8 +167,8 @@ describe("runDiscovery", () => {
 
     const result = await runDiscovery(
       [
-        { url: "https://example.com/feed.rss", strategies: ["rss"] },
-        { url: "https://example.com/sitemap.xml", strategies: ["sitemap"] },
+        { url: "https://example.com/feed.rss", strategy: "rss" },
+        { url: "https://example.com/sitemap.xml", strategy: "sitemap" },
       ],
       buildDeps(),
     );
@@ -154,7 +181,7 @@ describe("runDiscovery", () => {
     vi.mocked(rssStrategy.discover).mockRejectedValue(RSS_ERROR);
 
     const result = await runDiscovery(
-      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      [{ url: "https://example.com/feed", strategy: "rss" }],
       buildDeps(),
     );
 
@@ -188,7 +215,7 @@ describe("runDiscovery with cache", () => {
     });
 
     const result = await runDiscovery(
-      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      [{ url: "https://example.com/feed", strategy: "rss" }],
       buildDeps(),
       cache,
     );
@@ -204,7 +231,7 @@ describe("runDiscovery with cache", () => {
     const cache = buildCache();
 
     const result = await runDiscovery(
-      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      [{ url: "https://example.com/feed", strategy: "rss" }],
       buildDeps(),
       cache,
     );
@@ -224,17 +251,10 @@ describe("runDiscovery with cache", () => {
 
   it("does not record an empty discovery result", async () => {
     vi.mocked(rssStrategy.discover).mockResolvedValue([]);
-    vi.mocked(sitemapStrategy.discover).mockResolvedValue([]);
-    vi.mocked(genericLinksStrategy.discover).mockResolvedValue([]);
     const cache = buildCache();
 
     await runDiscovery(
-      [
-        {
-          url: "https://example.com/feed",
-          strategies: ["rss", "sitemap", "generic-links"],
-        },
-      ],
+      [{ url: "https://example.com/feed", strategy: "rss" }],
       buildDeps(),
       cache,
     );
@@ -267,7 +287,7 @@ describe("runDiscovery with cache", () => {
     };
 
     const source = [
-      { url: "https://example.com/feed", strategies: ["rss"] as const },
+      { url: "https://example.com/feed", strategy: "rss" as const },
     ];
     const deps = buildDeps();
 
@@ -277,12 +297,12 @@ describe("runDiscovery with cache", () => {
     expect(scrapeCount).toBe(1);
   });
 
-  it("falls back to live scrape when no cache is provided (Plan 95 behavior unchanged)", async () => {
+  it("falls back to live scrape when no cache is provided", async () => {
     const liveItems = [{ url: "https://example.com/live-article" }];
     vi.mocked(rssStrategy.discover).mockResolvedValue(liveItems);
 
     const result = await runDiscovery(
-      [{ url: "https://example.com/feed", strategies: ["rss"] }],
+      [{ url: "https://example.com/feed", strategy: "rss" }],
       buildDeps(),
     );
 

--- a/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
+++ b/packages/shared/agent-ingestion/src/discovery/run-discovery.ts
@@ -1,10 +1,7 @@
 import { classifyError, isRetryableError } from "../error-classification";
 import { hostFromUrl } from "../host-error-tracker";
 import { pMap } from "../p-map";
-import {
-  createListingDiscoveryStrategy,
-  DEFAULT_DISCOVERY_CHAIN,
-} from "./registry";
+import { createListingDiscoveryStrategy } from "./registry";
 import type { DiscoveredItem, DiscoveryDeps } from "./types";
 
 const DEFAULT_DISCOVERY_CONCURRENCY = 4;
@@ -14,8 +11,8 @@ export type DiscoverySource = {
   url: string;
   /** Whether to include this source. Defaults to true when omitted. */
   enabled?: boolean;
-  /** Ordered strategy chain override; falls back to DEFAULT_DISCOVERY_CHAIN. */
-  strategies?: ReadonlyArray<"rss" | "sitemap" | "generic-links">;
+  /** The single strategy the operator chose for this source. */
+  strategy: "rss" | "sitemap" | "generic-links";
   /** Maximum items to return from this source. */
   maxItems?: number;
 };
@@ -70,12 +67,10 @@ export type DiscoveryCache = {
 };
 
 /**
- * Runs a source through its ordered strategy chain with fallback.
+ * Runs a source through the single operator-chosen strategy.
  *
- * The first strategy that returns a non-empty list wins. An error or empty
- * result falls through to the next strategy. Every per-strategy failure is
- * collected; the source yields `{ items: [], failures }` only when the whole
- * chain is exhausted — mirroring fetchOneResult's loop over the provider chain.
+ * An error or empty result yields `{ items: [], failures }`. Failure shape is
+ * unchanged so observability and SourceDiscoveryReport are untouched.
  *
  * @param source - Listing source configuration.
  * @param deps - Shared discovery dependencies.
@@ -84,43 +79,48 @@ export const discoverOneSource = async (
   source: DiscoverySource,
   deps: DiscoveryDeps,
 ): Promise<SourceDiscoveryOutcome> => {
-  const chain = source.strategies ?? DEFAULT_DISCOVERY_CHAIN;
-  const failures: DiscoveryFailure[] = [];
+  const strategyType = source.strategy;
+  const strategy = createListingDiscoveryStrategy(strategyType);
 
-  for (const strategyType of chain) {
-    const strategy = createListingDiscoveryStrategy(strategyType);
+  try {
+    const items = await strategy.discover(source.url, deps);
 
-    try {
-      const items = await strategy.discover(source.url, deps);
+    if (items.length === 0) {
+      return {
+        items: [],
+        failures: [
+          {
+            sourceUrl: source.url,
+            strategyType,
+            errorCategory: "provider_data_invalid",
+            message: "Strategy returned no items",
+            retryable: false,
+          },
+        ],
+        winningStrategy: null,
+      };
+    }
 
-      if (items.length === 0) {
-        failures.push({
+    const limited =
+      source.maxItems !== undefined ? items.slice(0, source.maxItems) : items;
+
+    return { items: limited, failures: [], winningStrategy: strategyType };
+  } catch (error) {
+    const classified = classifyError(error);
+    return {
+      items: [],
+      failures: [
+        {
           sourceUrl: source.url,
           strategyType,
-          errorCategory: "provider_data_invalid",
-          message: "Strategy returned no items",
-          retryable: false,
-        });
-        continue;
-      }
-
-      const limited =
-        source.maxItems !== undefined ? items.slice(0, source.maxItems) : items;
-
-      return { items: limited, failures, winningStrategy: strategyType };
-    } catch (error) {
-      const classified = classifyError(error);
-      failures.push({
-        sourceUrl: source.url,
-        strategyType,
-        errorCategory: classified.category,
-        message: classified.message,
-        retryable: isRetryableError(error),
-      });
-    }
+          errorCategory: classified.category,
+          message: classified.message,
+          retryable: isRetryableError(error),
+        },
+      ],
+      winningStrategy: null,
+    };
   }
-
-  return { items: [], failures, winningStrategy: null };
 };
 
 /**

--- a/packages/shared/agent-ingestion/src/index.ts
+++ b/packages/shared/agent-ingestion/src/index.ts
@@ -96,10 +96,7 @@ export {
   type RunCounters,
 } from "./run-status";
 
-export {
-  DEFAULT_DISCOVERY_CHAIN,
-  createListingDiscoveryStrategy,
-} from "./discovery/registry";
+export { createListingDiscoveryStrategy } from "./discovery/registry";
 
 export {
   discoverOneSource,


### PR DESCRIPTION
## Summary

Replaces the per-source `strategies[]` array and the global `defaultDiscoveryChain` with a single `strategy` enum field on each curated source. The operator picks one type — `rss`, `sitemap`, or `generic-links` — that matches the URL, and discovery runs exactly that one strategy. This also eliminates the validation error caused by the dashboard seeding an empty string as `strategies[0]`.

## Related issues

Closes #703

## Important changes

- `curatedSourceSchema` now has `strategy: discoveryStrategyEnum.default("rss")` instead of `strategies: z.array(...).nonempty().optional()`. `defaultDiscoveryChain` is removed from `ConfigSchema`.
- `DiscoverySource.strategy` is a single `"rss" | "sitemap" | "generic-links"` string. `discoverOneSource` runs exactly that one strategy — no chain loop, no `DEFAULT_DISCOVERY_CHAIN` fallback.
- `DEFAULT_DISCOVERY_CHAIN` is removed from `registry.ts` and the `agent-ingestion` package index.
- Migration script (`migrate-page-collection-single-strategy.ts`) backfills existing AgentConfig rows: sets `strategy` from the first valid value in `strategies[]` (falls back to `"rss"`), then deletes `strategies` and `defaultDiscoveryChain` from every stored config.

## Other changes

- Config schema tests updated: `strategy` default/enum cases replace old `strategies` array cases; `defaultDiscoveryChain` assertions removed.
- `run-discovery` tests rewritten from chain-fallback scenarios to single-strategy outcome tests.
- `run.test.ts` fixture updated from `strategies: ["rss"]` to `strategy: "rss"`.
- PRD updated to describe the single operator-chosen strategy model instead of the ordered chain.
- `discoveryStrategyEnum` is now exported from `config-schema.ts` for reuse by the plan 107 form.

## Key files to review

- [config-schema.ts](apps/mediapulse/agents/page-collection/src/utilities/config-schema.ts) — schema change: `strategy` field, no `defaultDiscoveryChain`.
- [run-discovery.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.ts) — `DiscoverySource` type and `discoverOneSource` logic.
- [migrate-page-collection-single-strategy.ts](apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts) — data migration script to run at deploy time.
- [run-discovery.test.ts](packages/shared/agent-ingestion/src/discovery/run-discovery.test.ts) — single-strategy outcome tests.

## How to test

1. Run `pnpm --filter "@mediapulse/page-collection" test` — all 36 tests should pass.
2. Run `pnpm --filter "@workspace/agent-ingestion" test` — all 116 tests should pass.
3. Run `pnpm --filter "@mediapulse/page-collection" type:check` — no errors.
4. Confirm `getConfigSchema()` output has no `defaultDiscoveryChain` property and `curatedSources` items have a `strategy` string field.
5. After deploy, run the migration script: `pnpm tsx apps/hermes/dashboard/scripts/migrate-page-collection-single-strategy.ts` — confirm logged row count matches page-collection AgentConfig rows and each config no longer has `strategies` or `defaultDiscoveryChain`.
