### PR TITLE
Fix agent insights tab hidden by missing Bearer prefix in dashboard API client

### DIFF
--- a/apps/hermes/dashboard/lib/agent-data-api-client.ts
+++ b/apps/hermes/dashboard/lib/agent-data-api-client.ts
@@ -25,7 +25,11 @@ export const createDashboardAgentDataApiClient = (options?: {
 }) =>
   createAgentDataApiClient({
     baseUrl: options?.baseUrl ?? env.AGENT_DATA_API_URL ?? "",
-    token: options?.token ?? env.HERMES_INTERNAL_API_KEY,
+    token:
+      options?.token ??
+      (env.HERMES_INTERNAL_API_KEY
+        ? `Bearer ${env.HERMES_INTERNAL_API_KEY}`
+        : undefined),
     getFn: options?.getFn,
     postFn: options?.postFn,
   });


### PR DESCRIPTION
## Summary

The Insights tab on the agent detail page was never showing, even with a registered provider and `AGENT_DATA_API_URL` set. Every request to `/api/v1/agent-insights` was returning 400, which `getAgentInsights` silently caught and converted to `null`, hiding the tab entirely.

The root cause: `createDashboardAgentDataApiClient` passed `HERMES_INTERNAL_API_KEY` (a raw secret) directly to the SDK's `token` option. The SDK's `buildAuthHeaders` sets `Authorization: <value>` as-is, but Hono's `bearerAuth` middleware requires `Authorization: Bearer <value>` and rejects anything else with 400.

Agent calls aren't affected because agent tokens come pre-formatted as `"Bearer <jwt>"` from `AgentRunContext`.

## Related issues

Closes #707

## Important changes

- `createDashboardAgentDataApiClient` now prefixes `HERMES_INTERNAL_API_KEY` with `"Bearer "` before passing it to the SDK, so the Authorization header is correctly formatted for Hono's bearer auth middleware.

## Other changes

None.

## Key files to review

- `apps/hermes/dashboard/lib/agent-data-api-client.ts` - the one-line fix; worth confirming the `options?.token` override path is untouched so tests using injected tokens still work.

## How to test

1. Set `AGENT_DATA_API_URL=http://localhost:8081` in `apps/hermes/dashboard/.env.local`.
2. Start the agent-data-api service.
3. Open the dashboard and navigate to the page-collection agent detail page.
4. Confirm the Insights tab appears and loads data without errors.
5. Check server logs to confirm `/api/v1/agent-insights` returns 200, not 400.
