### PR TITLE
Exchange HERMES_INTERNAL_API_KEY for JWT before calling agent-data-api insights endpoint

### DIFF
--- a/apps/hermes/dashboard/lib/agent-data-api-client.ts
+++ b/apps/hermes/dashboard/lib/agent-data-api-client.ts
@@ -25,11 +25,7 @@ export const createDashboardAgentDataApiClient = (options?: {
 }) =>
   createAgentDataApiClient({
     baseUrl: options?.baseUrl ?? env.AGENT_DATA_API_URL ?? "",
-    token:
-      options?.token ??
-      (env.HERMES_INTERNAL_API_KEY
-        ? `Bearer ${env.HERMES_INTERNAL_API_KEY}`
-        : undefined),
+    token: options?.token ?? env.HERMES_INTERNAL_API_KEY,
     getFn: options?.getFn,
     postFn: options?.postFn,
   });

--- a/apps/hermes/dashboard/lib/agent-insights-api.ts
+++ b/apps/hermes/dashboard/lib/agent-insights-api.ts
@@ -2,9 +2,7 @@ import type { InsightsPayload } from "@workspace/agent-data-api-contract";
 import { createAgentTokenClient } from "@workspace/agent-auth-client";
 import { env } from "@hermes/env";
 
-import {
-  createDashboardAgentDataApiClient,
-} from "@/lib/agent-data-api-client";
+import { createDashboardAgentDataApiClient } from "@/lib/agent-data-api-client";
 
 type AgentInsightsClient = Pick<
   ReturnType<typeof createDashboardAgentDataApiClient>,
@@ -23,7 +21,11 @@ type GetAgentInsightsResult =
 let hermesTokenClient: ReturnType<typeof createAgentTokenClient> | null = null;
 
 function getHermesTokenClient() {
-  if (!hermesTokenClient && env.AGENT_AUTH_API_URL && env.HERMES_INTERNAL_API_KEY) {
+  if (
+    !hermesTokenClient &&
+    env.AGENT_AUTH_API_URL &&
+    env.HERMES_INTERNAL_API_KEY
+  ) {
     hermesTokenClient = createAgentTokenClient({
       authApiUrl: env.AGENT_AUTH_API_URL,
       credential: env.HERMES_INTERNAL_API_KEY,
@@ -53,7 +55,7 @@ export const getAgentInsights = async (
   client?: AgentInsightsClient,
 ): Promise<GetAgentInsightsResult> => {
   try {
-    const resolvedClient = client ?? await buildInsightsClient();
+    const resolvedClient = client ?? (await buildInsightsClient());
     const payload = await resolvedClient.agentInsights.get({
       agentId: params.agentId,
       window: params.window,

--- a/apps/hermes/dashboard/lib/agent-insights-api.ts
+++ b/apps/hermes/dashboard/lib/agent-insights-api.ts
@@ -1,8 +1,9 @@
 import type { InsightsPayload } from "@workspace/agent-data-api-contract";
+import { createAgentTokenClient } from "@workspace/agent-auth-client";
+import { env } from "@hermes/env";
 
 import {
   createDashboardAgentDataApiClient,
-  getDashboardAgentDataApiClient,
 } from "@/lib/agent-data-api-client";
 
 type AgentInsightsClient = Pick<
@@ -19,6 +20,27 @@ type GetAgentInsightsResult =
   | { payload: InsightsPayload; hasInsights: true }
   | { payload: null; hasInsights: false };
 
+let hermesTokenClient: ReturnType<typeof createAgentTokenClient> | null = null;
+
+function getHermesTokenClient() {
+  if (!hermesTokenClient && env.AGENT_AUTH_API_URL && env.HERMES_INTERNAL_API_KEY) {
+    hermesTokenClient = createAgentTokenClient({
+      authApiUrl: env.AGENT_AUTH_API_URL,
+      credential: env.HERMES_INTERNAL_API_KEY,
+    });
+  }
+  return hermesTokenClient;
+}
+
+async function buildInsightsClient(): Promise<AgentInsightsClient> {
+  const tokenClient = getHermesTokenClient();
+  if (tokenClient) {
+    const jwt = await tokenClient.getToken();
+    return createDashboardAgentDataApiClient({ token: `Bearer ${jwt}` });
+  }
+  return createDashboardAgentDataApiClient();
+}
+
 /**
  * Fetches agent insights for a given agent and time window.
  *
@@ -28,10 +50,11 @@ type GetAgentInsightsResult =
  */
 export const getAgentInsights = async (
   params: GetAgentInsightsParams,
-  client: AgentInsightsClient = getDashboardAgentDataApiClient(),
+  client?: AgentInsightsClient,
 ): Promise<GetAgentInsightsResult> => {
   try {
-    const payload = await client.agentInsights.get({
+    const resolvedClient = client ?? await buildInsightsClient();
+    const payload = await resolvedClient.agentInsights.get({
       agentId: params.agentId,
       window: params.window,
     });


### PR DESCRIPTION
## Summary

After #708 got the `Bearer` prefix right, the Insights tab still wouldn't appear — just moved from 400 to 401. The real problem: `HERMES_INTERNAL_API_KEY` is a raw secret, not a JWT. `agent-auth-api`'s `POST /api/verify` only accepts JWTs, so verification always fails.

`getAgentInsights` now calls `createAgentTokenClient` to exchange the internal key for a short-lived JWT before each request. The token client caches internally, so repeated page loads within the TTL don't re-hit `POST /api/token`. The `Bearer`-prefix patch on `getDashboardAgentDataApiClient` is also reverted — the singleton still uses a raw key, so leaving it prefixed there was misleading.

## Related issues

Closes #709

## Important changes

- `getAgentInsights` now gets a JWT via `createAgentTokenClient` before calling agent-data-api, using `HERMES_INTERNAL_API_KEY` as the credential and `AGENT_AUTH_API_URL` as the token endpoint.
- `client` parameter on `getAgentInsights` is now optional (no default value) so tests can still inject a mock without touching the token exchange path.
- Reverts the `Bearer`-prefix change on `getDashboardAgentDataApiClient` from #708 — it was half-right but misleading for future callers.

## Other changes

- Removes the now-unused `getDashboardAgentDataApiClient` import from `agent-insights-api.ts`.

## Key files to review

- `apps/hermes/dashboard/lib/agent-insights-api.ts` — token client setup and `buildInsightsClient`; confirm the fallback path when `AGENT_AUTH_API_URL` or `HERMES_INTERNAL_API_KEY` is unset.
- `apps/hermes/dashboard/lib/agent-data-api-client.ts` — verify the revert looks clean.

## How to test

1. Set `AGENT_DATA_API_URL=http://localhost:8081` in `apps/hermes/dashboard/.env.local`.
2. Start agent-auth-api and agent-data-api locally.
3. Open the page-collection agent detail page in the dashboard.
4. Confirm the Insights tab appears and loads data.
5. Check agent-data-api logs — `GET /api/v1/agent-insights` should return 200.
6. Check agent-auth-api logs — `POST /api/token` fires on the first load, subsequent loads within the JWT TTL should not re-hit it.
