### PR TITLE
Fix data bugs in page-collection insights provider and upgrade chart UI

### DIFF
--- a/apps/hermes/dashboard/components/insights/widget-renderer.test.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.test.tsx
@@ -4,26 +4,28 @@ import { describe, expect, it, vi } from "vitest";
 import { WidgetRenderer } from "./widget-renderer";
 
 vi.mock("recharts", () => ({
-  ResponsiveContainer: ({ children }: React.PropsWithChildren) => (
-    <div data-testid="responsive-container">{children}</div>
+  AreaChart: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="area-chart">{children}</div>
   ),
-  LineChart: ({ children }: React.PropsWithChildren) => (
-    <div data-testid="line-chart">{children}</div>
-  ),
+  Area: () => <div data-testid="area" />,
   BarChart: ({ children }: React.PropsWithChildren) => (
     <div data-testid="bar-chart">{children}</div>
   ),
-  Line: () => <div data-testid="line" />,
-  Bar: () => <div data-testid="bar" />,
+  Bar: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="bar">{children}</div>
+  ),
   XAxis: () => <div data-testid="x-axis" />,
   YAxis: () => <div data-testid="y-axis" />,
-  Tooltip: () => <div data-testid="tooltip" />,
-  FunnelChart: ({ children }: React.PropsWithChildren) => (
-    <div data-testid="funnel-chart">{children}</div>
-  ),
-  Funnel: () => <div data-testid="funnel" />,
-  LabelList: () => <div data-testid="label-list" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
   Cell: () => <div data-testid="cell" />,
+}));
+
+vi.mock("@workspace/ui/components/chart", () => ({
+  ChartContainer: ({ children }: React.PropsWithChildren) => (
+    <div data-testid="chart-container">{children}</div>
+  ),
+  ChartTooltip: () => null,
+  ChartTooltipContent: () => null,
 }));
 
 describe("WidgetRenderer", () => {
@@ -36,13 +38,13 @@ describe("WidgetRenderer", () => {
 
     expect(screen.getByText("42")).toBeInTheDocument();
     expect(screen.getByText("ms")).toBeInTheDocument();
-    expect(screen.getByText("+5")).toBeInTheDocument();
+    expect(screen.getByText("+5 vs prior period")).toBeInTheDocument();
   });
 
   it("renders stat widget with negative delta", () => {
     render(<WidgetRenderer widget={{ kind: "stat", value: 10, delta: -3 }} />);
 
-    expect(screen.getByText("-3")).toBeInTheDocument();
+    expect(screen.getByText("-3 vs prior period")).toBeInTheDocument();
   });
 
   it("renders stat widget without delta", () => {
@@ -51,7 +53,7 @@ describe("WidgetRenderer", () => {
     expect(screen.getByText("7")).toBeInTheDocument();
   });
 
-  it("renders timeSeries widget with a line chart", () => {
+  it("renders timeSeries widget with an area chart", () => {
     render(
       <WidgetRenderer
         widget={{
@@ -64,7 +66,7 @@ describe("WidgetRenderer", () => {
       />,
     );
 
-    expect(screen.getByTestId("line-chart")).toBeInTheDocument();
+    expect(screen.getByTestId("area-chart")).toBeInTheDocument();
   });
 
   it("renders categoryBar widget with a bar chart", () => {
@@ -114,14 +116,11 @@ describe("WidgetRenderer", () => {
     );
 
     expect(screen.getByText("Top")).toBeInTheDocument();
-    expect(screen.getByText("100")).toBeInTheDocument();
-    expect(screen.getByText("(100%)")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
     expect(screen.getByText("Middle")).toBeInTheDocument();
-    expect(screen.getByText("50")).toBeInTheDocument();
-    expect(screen.getByText("(50%)")).toBeInTheDocument();
+    expect(screen.getByText("50%")).toBeInTheDocument();
     expect(screen.getByText("Bottom")).toBeInTheDocument();
-    expect(screen.getByText("25")).toBeInTheDocument();
-    expect(screen.getByText("(25%)")).toBeInTheDocument();
+    expect(screen.getByText("25%")).toBeInTheDocument();
   });
 
   it("renders breakdown widget with labels and percentages", () => {
@@ -139,10 +138,10 @@ describe("WidgetRenderer", () => {
 
     expect(screen.getByText("Alpha")).toBeInTheDocument();
     expect(screen.getByText("60")).toBeInTheDocument();
-    expect(screen.getByText("(60%)")).toBeInTheDocument();
+    expect(screen.getByText("60%")).toBeInTheDocument();
     expect(screen.getByText("Beta")).toBeInTheDocument();
     expect(screen.getByText("40")).toBeInTheDocument();
-    expect(screen.getByText("(40%)")).toBeInTheDocument();
+    expect(screen.getByText("40%")).toBeInTheDocument();
   });
 
   it("renders table widget with columns and rows", () => {

--- a/apps/hermes/dashboard/components/insights/widget-renderer.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.tsx
@@ -2,19 +2,40 @@
 
 import type { Widget } from "@workspace/agent-data-api-contract";
 import {
+  AreaChart,
+  Area,
   BarChart,
   Bar,
   XAxis,
   YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  LineChart,
-  Line,
+  CartesianGrid,
+  Cell,
 } from "recharts";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@workspace/ui/components/chart";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
 
 type WidgetRendererProps = {
   widget: Widget;
 };
+
+const CHART_COLORS = [
+  "var(--chart-1)",
+  "var(--chart-2)",
+  "var(--chart-3)",
+  "var(--chart-4)",
+  "var(--chart-5)",
+];
+
+function formatTs(ts: string): string {
+  const date = new Date(ts);
+  if (isNaN(date.getTime())) return ts;
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
 
 /**
  * Renders a single insight widget by kind.
@@ -23,29 +44,40 @@ type WidgetRendererProps = {
  */
 export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   if (widget.kind === "stat") {
-    const deltaSign =
-      widget.delta !== undefined && widget.delta >= 0 ? "+" : "";
-    const deltaColor =
-      widget.delta === undefined
-        ? ""
-        : widget.delta >= 0
-          ? "text-green-600"
-          : "text-red-600";
+    const isPositive = widget.delta !== undefined && widget.delta > 0;
+    const isNegative = widget.delta !== undefined && widget.delta < 0;
+    const deltaColor = isPositive
+      ? "text-emerald-600"
+      : isNegative
+        ? "text-red-500"
+        : "text-muted-foreground";
+    const DeltaIcon = isPositive
+      ? TrendingUp
+      : isNegative
+        ? TrendingDown
+        : Minus;
 
     return (
-      <div className="py-4">
-        <span className="text-4xl font-bold text-foreground">
-          {widget.value}
-        </span>
-        {widget.unit && (
-          <span className="ml-1 text-lg text-muted-foreground">
-            {widget.unit}
+      <div className="py-2">
+        <div className="flex items-end gap-2">
+          <span className="text-4xl font-bold tracking-tight text-foreground">
+            {widget.value}
           </span>
-        )}
+          {widget.unit && (
+            <span className="mb-1 text-base text-muted-foreground">
+              {widget.unit}
+            </span>
+          )}
+        </div>
         {widget.delta !== undefined && (
-          <div className={`mt-1 text-sm font-medium ${deltaColor}`}>
-            {deltaSign}
-            {widget.delta}
+          <div
+            className={`mt-1.5 flex items-center gap-1 text-sm font-medium ${deltaColor}`}
+          >
+            <DeltaIcon className="h-3.5 w-3.5" />
+            <span>
+              {widget.delta > 0 ? "+" : ""}
+              {widget.delta} vs prior period
+            </span>
           </div>
         )}
       </div>
@@ -53,51 +85,131 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   }
 
   if (widget.kind === "timeSeries") {
-    const data = widget.points.map((point) => ({
-      ts: point.ts,
-      value: point.value,
-    }));
+    const config: ChartConfig = {
+      value: { label: widget.unit ?? "Value", color: "var(--chart-1)" },
+    };
 
     return (
-      <ResponsiveContainer width="100%" height={200}>
-        <LineChart data={data}>
-          <XAxis dataKey="ts" tick={{ fontSize: 11 }} />
-          <YAxis tick={{ fontSize: 11 }} unit={widget.unit} />
-          <Tooltip />
-          <Line type="monotone" dataKey="value" stroke="#6366f1" dot={false} />
-        </LineChart>
-      </ResponsiveContainer>
+      <ChartContainer config={config} className="h-48 w-full">
+        <AreaChart
+          data={widget.points}
+          margin={{ top: 4, right: 4, left: -16, bottom: 0 }}
+        >
+          <defs>
+            <linearGradient id="gradValue" x1="0" y1="0" x2="0" y2="1">
+              <stop
+                offset="5%"
+                stopColor="var(--color-value)"
+                stopOpacity={0.3}
+              />
+              <stop
+                offset="95%"
+                stopColor="var(--color-value)"
+                stopOpacity={0}
+              />
+            </linearGradient>
+          </defs>
+          <CartesianGrid vertical={false} className="stroke-border/40" />
+          <XAxis
+            dataKey="ts"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tick={{ fontSize: 11 }}
+            tickFormatter={formatTs}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 11 }}
+            tickMargin={4}
+          />
+          <ChartTooltip
+            content={<ChartTooltipContent labelFormatter={formatTs} />}
+          />
+          <Area
+            type="natural"
+            dataKey="value"
+            stroke="var(--color-value)"
+            strokeWidth={2}
+            fill="url(#gradValue)"
+            dot={false}
+            activeDot={{ r: 4, strokeWidth: 0 }}
+          />
+        </AreaChart>
+      </ChartContainer>
     );
   }
 
   if (widget.kind === "categoryBar") {
+    const config: ChartConfig = {
+      value: { label: widget.unit ?? "Value", color: "var(--chart-1)" },
+    };
+
     return (
-      <ResponsiveContainer width="100%" height={200}>
-        <BarChart data={widget.bars}>
-          <XAxis dataKey="label" tick={{ fontSize: 11 }} />
-          <YAxis tick={{ fontSize: 11 }} unit={widget.unit} />
-          <Tooltip />
-          <Bar dataKey="value" fill="#6366f1" />
+      <ChartContainer config={config} className="h-48 w-full">
+        <BarChart
+          data={widget.bars}
+          margin={{ top: 4, right: 4, left: -16, bottom: 0 }}
+        >
+          <CartesianGrid vertical={false} className="stroke-border/40" />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tick={{ fontSize: 11 }}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 11 }}
+            tickMargin={4}
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Bar
+            dataKey="value"
+            fill="var(--color-value)"
+            radius={[4, 4, 0, 0]}
+          />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartContainer>
     );
   }
 
   if (widget.kind === "histogram") {
-    const data = widget.buckets.map((bucket) => ({
-      label: bucket.label,
-      count: bucket.count,
-    }));
+    const config: ChartConfig = {
+      count: { label: "Count", color: "var(--chart-1)" },
+    };
 
     return (
-      <ResponsiveContainer width="100%" height={200}>
-        <BarChart data={data}>
-          <XAxis dataKey="label" tick={{ fontSize: 11 }} />
-          <YAxis tick={{ fontSize: 11 }} />
-          <Tooltip />
-          <Bar dataKey="count" fill="#6366f1" />
+      <ChartContainer config={config} className="h-48 w-full">
+        <BarChart
+          data={widget.buckets}
+          margin={{ top: 4, right: 4, left: -16, bottom: 0 }}
+        >
+          <CartesianGrid vertical={false} className="stroke-border/40" />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={8}
+            tick={{ fontSize: 11 }}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 11 }}
+            tickMargin={4}
+          />
+          <ChartTooltip content={<ChartTooltipContent />} />
+          <Bar
+            dataKey="count"
+            fill="var(--color-count)"
+            radius={[4, 4, 0, 0]}
+          />
         </BarChart>
-      </ResponsiveContainer>
+      </ChartContainer>
     );
   }
 
@@ -105,18 +217,29 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
     const firstValue = widget.stages[0]?.value ?? 0;
 
     return (
-      <ul className="space-y-2 py-2">
-        {widget.stages.map((stage) => {
+      <ul className="space-y-2.5 py-2">
+        {widget.stages.map((stage, index) => {
           const percentage =
             firstValue > 0 ? Math.round((stage.value / firstValue) * 100) : 100;
+          const color = CHART_COLORS[index % CHART_COLORS.length];
 
           return (
-            <li key={stage.label} className="flex items-center gap-3 text-sm">
-              <span className="w-32 shrink-0 text-muted-foreground">
-                {stage.label}
-              </span>
-              <span className="font-medium text-foreground">{stage.value}</span>
-              <span className="text-muted-foreground">({percentage}%)</span>
+            <li key={stage.label} className="space-y-1">
+              <div className="flex items-center justify-between text-xs">
+                <span className="text-muted-foreground">{stage.label}</span>
+                <span className="tabular-nums font-medium text-foreground">
+                  {stage.value.toLocaleString()}
+                  <span className="ml-1.5 text-muted-foreground">
+                    {percentage}%
+                  </span>
+                </span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div
+                  className="h-full rounded-full transition-all"
+                  style={{ width: `${percentage}%`, backgroundColor: color }}
+                />
+              </div>
             </li>
           );
         })}
@@ -125,22 +248,77 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   }
 
   if (widget.kind === "breakdown") {
-    return (
-      <ul className="space-y-2 py-2">
-        {widget.slices.map((slice) => {
-          const percentage = Math.round(slice.fraction * 100);
+    const config: ChartConfig = Object.fromEntries(
+      widget.slices.map((slice, index) => [
+        slice.label,
+        {
+          label: slice.label,
+          color: CHART_COLORS[index % CHART_COLORS.length],
+        },
+      ]),
+    );
+    const data = widget.slices.map((slice) => ({
+      label: slice.label,
+      value: slice.value,
+    }));
 
-          return (
-            <li key={slice.label} className="flex items-center gap-3 text-sm">
-              <span className="w-32 shrink-0 text-muted-foreground">
-                {slice.label}
-              </span>
-              <span className="font-medium text-foreground">{slice.value}</span>
-              <span className="text-muted-foreground">({percentage}%)</span>
-            </li>
-          );
-        })}
-      </ul>
+    return (
+      <div className="space-y-4">
+        <ChartContainer config={config} className="h-40 w-full">
+          <BarChart
+            data={data}
+            margin={{ top: 4, right: 4, left: -16, bottom: 0 }}
+          >
+            <CartesianGrid vertical={false} className="stroke-border/40" />
+            <XAxis
+              dataKey="label"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tick={{ fontSize: 11 }}
+            />
+            <YAxis
+              tickLine={false}
+              axisLine={false}
+              tick={{ fontSize: 11 }}
+              tickMargin={4}
+            />
+            <ChartTooltip content={<ChartTooltipContent nameKey="label" />} />
+            <Bar dataKey="value" radius={[4, 4, 0, 0]}>
+              {data.map((_, index) => (
+                <Cell
+                  key={index}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ChartContainer>
+        <ul className="space-y-1.5">
+          {widget.slices.map((slice, index) => {
+            const percentage = Math.round(slice.fraction * 100);
+            const color = CHART_COLORS[index % CHART_COLORS.length];
+
+            return (
+              <li key={slice.label} className="flex items-center gap-2 text-xs">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-sm"
+                  style={{ backgroundColor: color }}
+                />
+                <span className="flex-1 text-muted-foreground">
+                  {slice.label}
+                </span>
+                <span className="tabular-nums font-medium text-foreground">
+                  {slice.value.toLocaleString()}
+                </span>
+                <span className="w-9 text-right tabular-nums text-muted-foreground">
+                  {percentage}%
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
     );
   }
 
@@ -162,9 +340,15 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
           </thead>
           <tbody>
             {widget.rows.map((row, rowIndex) => (
-              <tr key={rowIndex} className="border-b border-border/30">
+              <tr
+                key={rowIndex}
+                className="border-b border-border/30 transition-colors hover:bg-muted/30"
+              >
                 {row.map((cell, cellIndex) => (
-                  <td key={cellIndex} className="py-2 pr-4 text-foreground">
+                  <td
+                    key={cellIndex}
+                    className="py-2 pr-4 tabular-nums text-foreground"
+                  >
                     {cell ?? "—"}
                   </td>
                 ))}

--- a/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts
@@ -45,12 +45,16 @@ function makeSourceHealth(overrides?: {
 function makeDataSource(overrides?: {
   tickerId?: string;
   url?: string;
+  createdAt?: Date;
   metadata?: object | null;
+  ticker?: { symbol: string };
 }) {
   return {
     tickerId: overrides?.tickerId ?? "ticker-1",
     url: overrides?.url ?? "https://publisher.com/article-1",
+    createdAt: overrides?.createdAt ?? new Date(),
     metadata: overrides?.metadata ?? { provider: "jina" },
+    ticker: overrides?.ticker ?? { symbol: "AAPL" },
   };
 }
 
@@ -157,7 +161,11 @@ describe("createPageCollectionInsightsProvider", () => {
 
   it("caps per-ticker bars at TOP_N + Other bucket", async () => {
     const manyTickers = Array.from({ length: 15 }, (_, i) =>
-      makeDataSource({ tickerId: `ticker-${i}`, url: `https://pub${i}.com/a` }),
+      makeDataSource({
+        tickerId: `ticker-${i}`,
+        url: `https://pub${i}.com/a`,
+        ticker: { symbol: `TICK${i}` },
+      }),
     );
 
     const provider = createPageCollectionInsightsProvider(

--- a/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
@@ -39,7 +39,9 @@ type SourceHealthRow = {
 type DataSourceRow = {
   tickerId: string;
   url: string;
+  createdAt: Date;
   metadata: Prisma.JsonValue | null;
+  ticker: { symbol: string };
 };
 
 type PageCollectionInsightsDeps = {
@@ -75,7 +77,13 @@ type PageCollectionInsightsDeps = {
   dataSource: {
     findMany: (args: {
       where: { createdAt: { gte: Date }; tickerId?: string };
-      select: { tickerId: boolean; url: boolean; metadata: boolean };
+      select: {
+        tickerId: boolean;
+        url: boolean;
+        createdAt: boolean;
+        metadata: boolean;
+        ticker: { select: { symbol: boolean } };
+      };
       take: number;
     }) => Promise<DataSourceRow[]>;
   };
@@ -200,7 +208,13 @@ export function createPageCollectionInsightsProvider(
             createdAt: { gte: windowStart },
             ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
           },
-          select: { tickerId: true, url: true, metadata: true },
+          select: {
+            tickerId: true,
+            url: true,
+            createdAt: true,
+            metadata: true,
+            ticker: { select: { symbol: true } },
+          },
           take: 2000,
         }),
       ]);
@@ -425,7 +439,8 @@ export function createPageCollectionInsightsProvider(
         [">30 days", 0],
       ]);
       for (const source of dataSources) {
-        const ageDays = (now.getTime() - now.getTime()) / (24 * 60 * 60 * 1000);
+        const ageDays =
+          (now.getTime() - source.createdAt.getTime()) / (24 * 60 * 60 * 1000);
         if (ageDays < 1)
           freshnessHistogram.set(
             "same day",
@@ -494,27 +509,26 @@ export function createPageCollectionInsightsProvider(
         });
       }
 
-      // Where — source health table
-      const sourceHealthByUrl = new Map<
+      // Where — source health table (aggregated by domain)
+      const sourceHealthByDomain = new Map<
         string,
-        { discovered: number; failed: number; total: number }
+        { discovered: number; failed: number }
       >();
       for (const record of sourceHealth) {
-        const existing = sourceHealthByUrl.get(record.listingUrl) ?? {
+        const domain = domainFromUrl(record.listingUrl);
+        const existing = sourceHealthByDomain.get(domain) ?? {
           discovered: 0,
           failed: 0,
-          total: 0,
         };
-        sourceHealthByUrl.set(record.listingUrl, {
+        sourceHealthByDomain.set(domain, {
           discovered: existing.discovered + (record.discovered ? 1 : 0),
           failed: existing.failed + (record.discovered ? 0 : 1),
-          total: existing.total + 1,
         });
       }
-      if (sourceHealthByUrl.size > 0) {
+      if (sourceHealthByDomain.size > 0) {
         const healthRows = bucketTopN(
-          Array.from(sourceHealthByUrl.entries()).map(([url, stats]) => ({
-            label: domainFromUrl(url),
+          Array.from(sourceHealthByDomain.entries()).map(([domain, stats]) => ({
+            label: domain,
             value: stats.discovered,
           })),
           TOP_N,
@@ -527,9 +541,7 @@ export function createPageCollectionInsightsProvider(
             kind: "table",
             columns: ["Source", "Discovered days", "Failed days"],
             rows: healthRows.map((row) => {
-              const stats = Array.from(sourceHealthByUrl.entries()).find(
-                ([url]) => domainFromUrl(url) === row.label,
-              )?.[1];
+              const stats = sourceHealthByDomain.get(row.label);
               return [row.label, stats?.discovered ?? 0, stats?.failed ?? 0];
             }),
           },
@@ -539,9 +551,10 @@ export function createPageCollectionInsightsProvider(
       // Who — per-ticker bar
       const tickerArticleCounts = new Map<string, number>();
       for (const source of dataSources) {
+        const symbol = source.ticker.symbol;
         tickerArticleCounts.set(
-          source.tickerId,
-          (tickerArticleCounts.get(source.tickerId) ?? 0) + 1,
+          symbol,
+          (tickerArticleCounts.get(symbol) ?? 0) + 1,
         );
       }
       if (tickerArticleCounts.size > 0) {


### PR DESCRIPTION
## Summary

Three bugs in the page-collection insights provider were silently corrupting the data shown in the agent insights dashboard. This PR fixes all three and also upgrades the chart renderer to use shadcn chart components with gradients and better tooltips.

## Related issues

Closes #711

## Important changes

- **Freshness histogram was broken**: `ageDays` was computed as `now - now` (always 0), so every article landed in the "same day" bucket regardless of actual age. Now uses `source.createdAt`. Added `createdAt` to `DataSourceRow`, the Prisma select, and the deps interface.
- **Source health table had wrong counts**: Records were aggregated by full URL, then reverse-mapped to domain with a linear `.find()`. When two listing URLs share a domain, the `.find()` picked the first match and showed its counts, not the aggregate. Now aggregates by domain directly — the reverse-lookup and its O(n²) behavior are gone.
- **Ticker chart showed internal IDs**: The "Articles by ticker" bar used `source.tickerId` as labels. Now joins `ticker { symbol }` and uses the human-readable symbol instead (e.g. `AAPL`).

## Other changes

- Widget renderer upgraded to shadcn `ChartContainer` / `ChartTooltip` / `ChartTooltipContent` with gradient area fills, rounded bar corners, trend icons (`TrendingUp` / `TrendingDown` / `Minus`) on stat widgets, and per-stage colors on funnel progress bars.
- Test factory `makeDataSource` updated with `createdAt` and `ticker` fields; the per-ticker bucketing test now varies symbols so the "Other" bucket assertion is meaningful.

## Key files to review

- [`page-collection-insights-provider.ts`](apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts) — three bug fixes in `DataSourceRow`, the `dataSource` select, freshness loop, and source health aggregation
- [`widget-renderer.tsx`](apps/hermes/dashboard/components/insights/widget-renderer.tsx) — shadcn chart upgrade
- [`page-collection-insights-provider.test.ts`](apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.test.ts) — updated fixtures

## How to test

1. Run `pnpm --filter @mediapulse/agent-data-api test` — all 167 tests should pass.
2. Open the agent insights tab for the page-collection agent.
3. Verify the freshness histogram shows actual age buckets (not everything in "same day").
4. Verify the source health table shows correct discovered/failed day counts per domain.
5. Verify the "Articles by ticker" chart shows symbols like `AAPL` instead of internal IDs.
6. Verify chart widgets render with gradient fills, rounded bar tops, and styled tooltips.
