### PR TITLE
Cancel in-flight processing jobs via cooperative poller in invoke_agent

### DIFF
--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -69,6 +69,7 @@ vi.mock("@hermes/env/hermes-worker", () => ({
     HERMES_INVOKE_AGENT_RETRY_BACKOFF: undefined as string | undefined,
     HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: undefined as string | undefined,
     HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS: undefined as string | undefined,
+    HERMES_INVOKE_AGENT_CANCEL_POLL_MS: undefined as string | undefined,
   },
 }));
 
@@ -847,6 +848,119 @@ describe("jobHandlers", () => {
         }),
         expect.any(Object),
       );
+    });
+
+    it("aborts in-flight invoke and records cancelled when cancelledAt is set mid-flight, clearing the timer", async () => {
+      vi.useFakeTimers();
+      try {
+        // invokeAgentPost resolves with an AbortError when the signal fires
+        vi.mocked(invokeAgentPost).mockImplementationOnce(
+          (_endpoint, _body, options) => {
+            return new Promise((resolve) => {
+              options.signal!.addEventListener(
+                "abort",
+                () => {
+                  const err = Object.assign(new Error("AbortError"), {
+                    name: "AbortError",
+                  });
+                  resolve({ kind: "transport_error", error: err });
+                },
+                { once: true },
+              );
+            });
+          },
+        );
+
+        // First call (pre-invoke check): not cancelled yet
+        // Second call (poller): cancelled
+        mockPrisma.scheduleExecution.findUnique
+          .mockResolvedValueOnce({ cancelledAt: null })
+          .mockResolvedValueOnce({ cancelledAt: new Date() });
+
+        const handlerPromise = jobHandlers.invoke_agent(
+          payload,
+          signal,
+          jobCtx,
+        );
+
+        // Advance past the 3000 ms default poll interval; this fires the poller,
+        // which aborts the local controller, which resolves invokeAgentPost.
+        await vi.advanceTimersByTimeAsync(3001);
+
+        await handlerPromise;
+
+        expect(vi.getTimerCount()).toBe(0);
+
+        expect(applyInvocationCompletion).toHaveBeenCalledWith(
+          expect.objectContaining({
+            jobId: payload.jobId,
+            scheduleExecutionId: payload.scheduleExecutionId,
+            terminal: expect.objectContaining({
+              status: AgentJobExecutionStatus.cancelled,
+            }),
+          }),
+          expect.any(Object),
+        );
+
+        expect(invokeAgentPost).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("swallows DB errors inside the cancel poller and does not crash the handler", async () => {
+      vi.useFakeTimers();
+      try {
+        // invokeAgentPost resolves normally after the poller fires (but DB error is swallowed)
+        let resolveInvoke!: (
+          value: Awaited<ReturnType<typeof invokeAgentPost>>,
+        ) => void;
+        const invokePromise = new Promise<
+          Awaited<ReturnType<typeof invokeAgentPost>>
+        >((resolve) => {
+          resolveInvoke = resolve;
+        });
+        vi.mocked(invokeAgentPost).mockReturnValueOnce(invokePromise);
+
+        // Poller DB call throws
+        mockPrisma.scheduleExecution.findUnique
+          .mockResolvedValueOnce({ cancelledAt: null })
+          .mockRejectedValueOnce(new Error("DB connection lost"));
+
+        const handlerPromise = jobHandlers.invoke_agent(
+          payload,
+          signal,
+          jobCtx,
+        );
+
+        // Fire the poller — DB error should be swallowed, handler keeps running
+        await vi.advanceTimersByTimeAsync(3001);
+
+        expect(logger.warn).toHaveBeenCalledWith(
+          expect.objectContaining({ jobId: payload.jobId }),
+          "invoke_agent: cancel poller DB error swallowed",
+        );
+
+        // Now let the invoke complete normally
+        vi.mocked(parseAgentResponseEnvelope).mockReturnValue({
+          ok: true,
+          envelope: { schemaVersion: 1, status: "success", truncated: {} },
+        });
+        resolveInvoke({
+          kind: "http",
+          response: {
+            statusCode: 200,
+            rawBody: '{"schemaVersion":1,"status":"success"}',
+            isEmptyBody: false,
+          },
+        });
+
+        await handlerPromise;
+
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -499,107 +499,235 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
       return;
     }
 
-    const httpClient = createHttpClient(signal);
-    const authToken = await getJwtForDomainIntegration(
-      payload.domainIntegrationId,
-    );
-    const endpoint = { url: payload.endpointUrl, method: "POST" as const };
-    const postResult = await invokeAgentPost(
-      endpoint,
-      payload.body as Record<string, unknown>,
-      {
-        jobId: payload.jobId,
-        executionId: payload.executionId,
-        scheduleId: payload.scheduleId ?? payload.httpTriggerId,
-        scheduleExecutionId:
-          payload.scheduleExecutionId ?? payload.httpTriggerExecutionId,
-        manualExecutionId: payload.manualExecutionId,
-        pipelineStepId: payload.pipelineStepId,
-        authToken,
-        timeoutMs: payload.timeoutMs,
-        signal,
-      },
-      httpClient,
-    );
-
-    if (postResult.kind === "transport_error") {
-      const aborted =
-        signal.aborted ||
-        postResult.error.name === "AbortError" ||
-        /abort/i.test(postResult.error.message);
-      if (aborted) {
-        await applyInvocationCompletion(
-          {
-            jobId: payload.jobId,
-            scheduleExecutionId: payload.scheduleExecutionId,
-            httpTriggerExecutionId: payload.httpTriggerExecutionId,
-            manualExecutionId: payload.manualExecutionId,
-            pipelineStepId: payload.pipelineStepId,
-            terminal: {
-              status: AgentJobExecutionStatus.cancelled,
-              error: {
-                cancelled: true,
-                message: "Agent invoke aborted (cancelled or signal)",
-                retryable: false,
-              },
-            },
-          },
-          completionDeps,
-        );
-        return;
-      }
-      logger.error(
-        {
-          err: postResult.error,
-          jobId: payload.jobId,
-          agentId: payload.agentId,
-          scheduleId: payload.scheduleId,
-        },
-        "invoke_agent transport failure",
-      );
-      await handleTransientInvokeFailure({
-        payload,
-        message: postResult.error.message,
-        errorToThrow: postResult.error,
-      });
+    const cancelPollMs =
+      parsePositiveIntEnv(env.HERMES_INVOKE_AGENT_CANCEL_POLL_MS) ?? 3_000;
+    const localController = new AbortController();
+    const localSignal = localController.signal;
+    if (signal.aborted) {
+      localController.abort(signal.reason);
     } else {
-      if (signal.aborted) {
-        await applyInvocationCompletion(
-          {
-            jobId: payload.jobId,
-            scheduleExecutionId: payload.scheduleExecutionId,
-            httpTriggerExecutionId: payload.httpTriggerExecutionId,
-            manualExecutionId: payload.manualExecutionId,
-            pipelineStepId: payload.pipelineStepId,
-            terminal: {
-              status: AgentJobExecutionStatus.cancelled,
-              error: {
-                cancelled: true,
-                message: "Agent invoke aborted after response (cancelled)",
-                retryable: false,
+      signal.addEventListener(
+        "abort",
+        () => localController.abort(signal.reason),
+        { once: true },
+      );
+    }
+    const cancelPoller = setInterval(() => {
+      void (async () => {
+        try {
+          const executionCheck = payload.scheduleExecutionId
+            ? await orchestrationPrisma.scheduleExecution.findUnique({
+                where: { id: payload.scheduleExecutionId },
+                select: { cancelledAt: true },
+              })
+            : payload.httpTriggerExecutionId
+              ? await orchestrationPrisma.httpTriggerExecution.findUnique({
+                  where: { id: payload.httpTriggerExecutionId },
+                  select: { cancelledAt: true },
+                })
+              : await orchestrationPrisma.manualPipelineExecution.findUnique({
+                  where: { id: payload.manualExecutionId! },
+                  select: { cancelledAt: true },
+                });
+          if (executionCheck?.cancelledAt && !localController.signal.aborted) {
+            localController.abort();
+          }
+        } catch (err) {
+          logger.warn(
+            { err, jobId: payload.jobId },
+            "invoke_agent: cancel poller DB error swallowed",
+          );
+        }
+      })();
+    }, cancelPollMs);
+    try {
+      const httpClient = createHttpClient(localSignal);
+      const authToken = await getJwtForDomainIntegration(
+        payload.domainIntegrationId,
+      );
+      const endpoint = { url: payload.endpointUrl, method: "POST" as const };
+      const postResult = await invokeAgentPost(
+        endpoint,
+        payload.body as Record<string, unknown>,
+        {
+          jobId: payload.jobId,
+          executionId: payload.executionId,
+          scheduleId: payload.scheduleId ?? payload.httpTriggerId,
+          scheduleExecutionId:
+            payload.scheduleExecutionId ?? payload.httpTriggerExecutionId,
+          manualExecutionId: payload.manualExecutionId,
+          pipelineStepId: payload.pipelineStepId,
+          authToken,
+          timeoutMs: payload.timeoutMs,
+          signal: localSignal,
+        },
+        httpClient,
+      );
+
+      if (postResult.kind === "transport_error") {
+        const aborted =
+          localSignal.aborted ||
+          postResult.error.name === "AbortError" ||
+          /abort/i.test(postResult.error.message);
+        if (aborted) {
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.cancelled,
+                error: {
+                  cancelled: true,
+                  message: "Agent invoke aborted (cancelled or signal)",
+                  retryable: false,
+                },
               },
             },
+            completionDeps,
+          );
+          return;
+        }
+        logger.error(
+          {
+            err: postResult.error,
+            jobId: payload.jobId,
+            agentId: payload.agentId,
+            scheduleId: payload.scheduleId,
           },
-          completionDeps,
+          "invoke_agent transport failure",
         );
-        return;
-      }
-
-      const { statusCode, rawBody, isEmptyBody } = postResult.response;
-
-      if (statusCode >= 500) {
-        const bodyMessage = parseHttpErrorBodyMessage(rawBody);
-        const message = bodyMessage ?? `Agent HTTP ${statusCode}`;
-        const err = new Error(`Agent returned HTTP ${statusCode}`);
         await handleTransientInvokeFailure({
           payload,
-          message,
-          errorToThrow: err,
+          message: postResult.error.message,
+          errorToThrow: postResult.error,
         });
-      }
+      } else {
+        if (localSignal.aborted) {
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.cancelled,
+                error: {
+                  cancelled: true,
+                  message: "Agent invoke aborted after response (cancelled)",
+                  retryable: false,
+                },
+              },
+            },
+            completionDeps,
+          );
+          return;
+        }
 
-      if (statusCode >= 400) {
-        const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+        const { statusCode, rawBody, isEmptyBody } = postResult.response;
+
+        if (statusCode >= 500) {
+          const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+          const message = bodyMessage ?? `Agent HTTP ${statusCode}`;
+          const err = new Error(`Agent returned HTTP ${statusCode}`);
+          await handleTransientInvokeFailure({
+            payload,
+            message,
+            errorToThrow: err,
+          });
+        }
+
+        if (statusCode >= 400) {
+          const bodyMessage = parseHttpErrorBodyMessage(rawBody);
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.failed,
+                error: {
+                  message: bodyMessage ?? `HTTP ${statusCode}`,
+                  retryable: false,
+                },
+              },
+            },
+            completionDeps,
+          );
+          return;
+        }
+
+        if (statusCode >= 200 && statusCode < 300) {
+          const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
+          if (!parsed.ok) {
+            await applyInvocationCompletion(
+              {
+                jobId: payload.jobId,
+                scheduleExecutionId: payload.scheduleExecutionId,
+                httpTriggerExecutionId: payload.httpTriggerExecutionId,
+                manualExecutionId: payload.manualExecutionId,
+                pipelineStepId: payload.pipelineStepId,
+                terminal: {
+                  status: AgentJobExecutionStatus.failed,
+                  error: {
+                    message: parsed.error.message,
+                    code: parsed.error.code,
+                    retryable: false,
+                  },
+                },
+              },
+              completionDeps,
+            );
+            return;
+          }
+          if (parsed.envelope.status === "failure") {
+            await applyInvocationCompletion(
+              {
+                jobId: payload.jobId,
+                scheduleExecutionId: payload.scheduleExecutionId,
+                httpTriggerExecutionId: payload.httpTriggerExecutionId,
+                manualExecutionId: payload.manualExecutionId,
+                pipelineStepId: payload.pipelineStepId,
+                terminal: {
+                  status: AgentJobExecutionStatus.failed,
+                  error: {
+                    message:
+                      parsed.envelope.message ??
+                      "Agent reported semantic failure",
+                    retryable: false,
+                    semantic: true,
+                  },
+                  agentResponse:
+                    parsed.envelope as unknown as Prisma.InputJsonValue,
+                  semanticStatus: "failure",
+                },
+              },
+              completionDeps,
+            );
+            return;
+          }
+          await applyInvocationCompletion(
+            {
+              jobId: payload.jobId,
+              scheduleExecutionId: payload.scheduleExecutionId,
+              httpTriggerExecutionId: payload.httpTriggerExecutionId,
+              manualExecutionId: payload.manualExecutionId,
+              pipelineStepId: payload.pipelineStepId,
+              terminal: {
+                status: AgentJobExecutionStatus.completed,
+                envelope: parsed.envelope,
+              },
+            },
+            completionDeps,
+          );
+          return;
+        }
+
         await applyInvocationCompletion(
           {
             jobId: payload.jobId,
@@ -610,99 +738,16 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             terminal: {
               status: AgentJobExecutionStatus.failed,
               error: {
-                message: bodyMessage ?? `HTTP ${statusCode}`,
+                message: `Unexpected HTTP status ${statusCode}`,
                 retryable: false,
               },
             },
           },
           completionDeps,
         );
-        return;
       }
-
-      if (statusCode >= 200 && statusCode < 300) {
-        const parsed = parseAgentResponseEnvelope(rawBody, isEmptyBody);
-        if (!parsed.ok) {
-          await applyInvocationCompletion(
-            {
-              jobId: payload.jobId,
-              scheduleExecutionId: payload.scheduleExecutionId,
-              httpTriggerExecutionId: payload.httpTriggerExecutionId,
-              manualExecutionId: payload.manualExecutionId,
-              pipelineStepId: payload.pipelineStepId,
-              terminal: {
-                status: AgentJobExecutionStatus.failed,
-                error: {
-                  message: parsed.error.message,
-                  code: parsed.error.code,
-                  retryable: false,
-                },
-              },
-            },
-            completionDeps,
-          );
-          return;
-        }
-        if (parsed.envelope.status === "failure") {
-          await applyInvocationCompletion(
-            {
-              jobId: payload.jobId,
-              scheduleExecutionId: payload.scheduleExecutionId,
-              httpTriggerExecutionId: payload.httpTriggerExecutionId,
-              manualExecutionId: payload.manualExecutionId,
-              pipelineStepId: payload.pipelineStepId,
-              terminal: {
-                status: AgentJobExecutionStatus.failed,
-                error: {
-                  message:
-                    parsed.envelope.message ??
-                    "Agent reported semantic failure",
-                  retryable: false,
-                  semantic: true,
-                },
-                agentResponse:
-                  parsed.envelope as unknown as Prisma.InputJsonValue,
-                semanticStatus: "failure",
-              },
-            },
-            completionDeps,
-          );
-          return;
-        }
-        await applyInvocationCompletion(
-          {
-            jobId: payload.jobId,
-            scheduleExecutionId: payload.scheduleExecutionId,
-            httpTriggerExecutionId: payload.httpTriggerExecutionId,
-            manualExecutionId: payload.manualExecutionId,
-            pipelineStepId: payload.pipelineStepId,
-            terminal: {
-              status: AgentJobExecutionStatus.completed,
-              envelope: parsed.envelope,
-            },
-          },
-          completionDeps,
-        );
-        return;
-      }
-
-      await applyInvocationCompletion(
-        {
-          jobId: payload.jobId,
-          scheduleExecutionId: payload.scheduleExecutionId,
-          httpTriggerExecutionId: payload.httpTriggerExecutionId,
-          manualExecutionId: payload.manualExecutionId,
-          pipelineStepId: payload.pipelineStepId,
-          terminal: {
-            status: AgentJobExecutionStatus.failed,
-            error: {
-              message: `Unexpected HTTP status ${statusCode}`,
-              retryable: false,
-            },
-          },
-        },
-        completionDeps,
-      );
+    } finally {
+      clearInterval(cancelPoller);
     }
   },
 

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -48,6 +48,8 @@ HERMES_INVOKE_AGENT_RETRY_BACKOFF= # optional
 HERMES_INVOKE_AGENT_RETRY_DELAY_MAX= # optional #number
 # Optional: cap DataQueue invoke_agent job timeout in ms (AbortController + supervisor reclaim). Default 1800000 (30 min). Agent HTTP deadline stays on pipeline timeout.
 HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS= # optional #number #default
+# Optional: interval in ms between cancelledAt polls while invoke_agent is in-flight (default 3000).
+HERMES_INVOKE_AGENT_CANCEL_POLL_MS= # optional #number
 
 # Optional: grace window in ms for startup schedule reconciliation. Schedules overdue beyond this are rolled forward; those within it still run once via the normal tick. Default 900000 (15 min).
 HERMES_SCHEDULE_RECOVERY_GRACE_MS=900000 #number #default

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -22,6 +22,7 @@ export const env = createEnv({
     HERMES_INVOKE_AGENT_RETRY_BACKOFF: z.string().optional(),
     HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: z.string().optional(),
     HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS: z.string().optional(),
+    HERMES_INVOKE_AGENT_CANCEL_POLL_MS: z.string().optional(),
     HERMES_SCHEDULE_RECOVERY_GRACE_MS: z.number({ coerce: true }).optional(),
   },
   client: {


### PR DESCRIPTION
## Summary

Jobs in DataQueue `processing` state kept running for up to 30 minutes after a user cancelled a schedule or execution because the worker only checked `cancelledAt` once before the HTTP call and DataQueue's signal fires only on timeout. This adds a lightweight cooperative poller inside `invoke_agent` that re-reads `cancelledAt` every few seconds, aborts the in-flight request immediately on cancellation, and settles the pipeline through the existing completion path.

## Related issues

Closes #713

## Important changes

- `invoke_agent` now creates a local `AbortController` chained to DataQueue's signal. The local signal — not the raw DataQueue signal — is passed to `createHttpClient` and `invokeAgentPost`, so a poller-driven abort correctly cancels the got request.
- A `setInterval` poller re-reads the parent execution's `cancelledAt` every `HERMES_INVOKE_AGENT_CANCEL_POLL_MS` ms (default 3 s). When cancellation is detected it calls `localController.abort()`, which unblocks the awaited invoke and routes through the existing `applyInvocationCompletion` cancelled path.
- Abort-detection branches now key off `localSignal.aborted` instead of `signal.aborted`, so a poller-driven abort is classified as `cancelled` rather than a retryable transient failure.
- The poll timer is always cleared in a `finally` block covering every exit path (success, error, abort, throw from `handleTransientInvokeFailure`).

## Other changes

- `HERMES_INVOKE_AGENT_CANCEL_POLL_MS` added to the hermes-worker env schema (`z.string().optional()`, same pattern as other numeric env vars) and documented in `.env`.
- Transient DB errors inside the poller are swallowed with a `warn` log so a momentary DB hiccup does not crash the handler.

## Key files to review

- [apps/hermes/worker/src/job-handlers.ts](apps/hermes/worker/src/job-handlers.ts) — local controller setup, signal chaining, poller, try/finally, and `localSignal` in all three abort-detection spots.
- [apps/hermes/worker/src/job-handlers.test.ts](apps/hermes/worker/src/job-handlers.test.ts) — two new tests: mid-flight cancel with fake timers (asserts cancelled status and zero pending timers after handler resolves) and swallowed DB error in the poller.
- [packages/hermes/env/src/hermes-worker.ts](packages/hermes/env/src/hermes-worker.ts) — new env var.

## How to test

1. Run `pnpm --filter @hermes/worker test` — all 43 tests should pass, including the two new ones.
2. In a staging environment: start a long-running pipeline execution, then cancel it from the dashboard while a job is actively invoking an agent. Confirm the job settles to `cancelled` within a few seconds rather than waiting for the DataQueue job timeout.
3. Confirm that non-cancelled jobs (normal success, 4xx, 5xx, transport errors) behave exactly as before.
