### PR TITLE
Split worker processors and isolate concurrent pipeline execution

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -190,6 +190,7 @@ const defaultEnqueueManualAgentInvocations = async (
             jobIds: item.dependsOnBatchIndices.map((idx) => batchDepRef(idx)),
           }
         : undefined,
+    group: { id: `pipeline:${item.payload.pipelineId}` },
     tags: [
       `manualPipelineExecution:${item.payload.manualExecutionId}`,
       `pipeline:${item.payload.pipelineId}`,

--- a/apps/hermes/worker/src/index.ts
+++ b/apps/hermes/worker/src/index.ts
@@ -14,14 +14,28 @@ const HEARTBEAT_INTERVAL_MS = 60_000;
 /** Logged every 5 minutes to surface memory growth early. */
 const MEMORY_LOG_INTERVAL_MS = 5 * 60 * 1_000;
 
-const processorBatchSize = Math.max(
-  1,
-  Number.parseInt(env.PROCESSOR_BATCH_SIZE ?? "10", 10) || 10,
-);
-const processorConcurrency = Math.max(
+const dataPlaneConc = Math.max(
   1,
   Number.parseInt(env.PROCESSOR_CONCURRENCY ?? "3", 10) || 3,
 );
+const dataPlaneBatch = Math.max(
+  dataPlaneConc,
+  Number.parseInt(env.PROCESSOR_BATCH_SIZE ?? "10", 10) || 10,
+);
+const controlPlaneConc = Math.max(
+  1,
+  Number.parseInt(env.HERMES_CONTROL_PLANE_CONCURRENCY ?? "2", 10) || 2,
+);
+const controlPlaneBatch = Math.max(
+  controlPlaneConc,
+  Number.parseInt(env.HERMES_CONTROL_PLANE_BATCH_SIZE ?? "5", 10) || 5,
+);
+const groupConcurrency = (() => {
+  const raw = env.HERMES_GROUP_CONCURRENCY?.trim();
+  if (!raw) return undefined;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 1 ? n : undefined;
+})();
 
 // ─── Module-level shutdown hook ───────────────────────────────────────────────
 // Set inside main() once the processor/supervisor are running.
@@ -80,7 +94,11 @@ async function main(): Promise<void> {
   const { logger } = await import("@workspace/logger");
 
   let jobQueue: Awaited<ReturnType<typeof getJobQueue>> | null = null;
-  let processor: {
+  let controlPlaneProcessor: {
+    startInBackground: () => void;
+    stopAndDrain: (ms?: number) => Promise<void>;
+  } | null = null;
+  let dataPlaneProcessor: {
     startInBackground: () => void;
     stopAndDrain: (ms?: number) => Promise<void>;
   } | null = null;
@@ -134,17 +152,36 @@ async function main(): Promise<void> {
     graceMs: env.HERMES_SCHEDULE_RECOVERY_GRACE_MS ?? 900_000,
   });
 
-  processor = jobQueue.createProcessor(jobHandlers, {
+  controlPlaneProcessor = jobQueue.createProcessor(jobHandlers, {
     verbose: env.NODE_ENV === "development",
-    workerId: `hermes-${process.pid}`,
-    batchSize: processorBatchSize,
-    concurrency: processorConcurrency,
+    workerId: `hermes-ctrl-${process.pid}`,
+    jobType: [
+      "check_schedules",
+      "execute_http_trigger",
+      "cleanup_orphaned_executions",
+    ],
+    batchSize: controlPlaneBatch,
+    concurrency: controlPlaneConc,
     pollInterval: 5000,
     onError: (err) => {
-      logger.error({ err }, "DataQueue processor error");
+      logger.error({ err }, "DataQueue control-plane processor error");
     },
   });
-  processor.startInBackground();
+  controlPlaneProcessor.startInBackground();
+
+  dataPlaneProcessor = jobQueue.createProcessor(jobHandlers, {
+    verbose: env.NODE_ENV === "development",
+    workerId: `hermes-data-${process.pid}`,
+    jobType: "invoke_agent",
+    batchSize: dataPlaneBatch,
+    concurrency: dataPlaneConc,
+    ...(groupConcurrency !== undefined ? { groupConcurrency } : {}),
+    pollInterval: 5000,
+    onError: (err) => {
+      logger.error({ err }, "DataQueue data-plane processor error");
+    },
+  });
+  dataPlaneProcessor.startInBackground();
 
   supervisor = jobQueue.createSupervisor({
     verbose: env.NODE_ENV === "development",
@@ -159,12 +196,14 @@ async function main(): Promise<void> {
   supervisor.startInBackground();
 
   const shutdown = async (): Promise<void> => {
-    if (processor || supervisor) {
+    if (controlPlaneProcessor || dataPlaneProcessor || supervisor) {
       await Promise.all([
-        processor?.stopAndDrain(DRAIN_TIMEOUT_MS),
+        controlPlaneProcessor?.stopAndDrain(DRAIN_TIMEOUT_MS),
+        dataPlaneProcessor?.stopAndDrain(DRAIN_TIMEOUT_MS),
         supervisor?.stopAndDrain(DRAIN_TIMEOUT_MS),
       ]);
-      processor = null;
+      controlPlaneProcessor = null;
+      dataPlaneProcessor = null;
       supervisor = null;
     }
     if (jobQueue?.getPool?.()) {
@@ -229,10 +268,17 @@ async function main(): Promise<void> {
   logger.info(
     {
       pid: process.pid,
-      concurrency: processorConcurrency,
-      batchSize: processorBatchSize,
+      dataPlane: {
+        concurrency: dataPlaneConc,
+        batchSize: dataPlaneBatch,
+        groupConcurrency,
+      },
+      controlPlane: {
+        concurrency: controlPlaneConc,
+        batchSize: controlPlaneBatch,
+      },
     },
-    "Hermes worker started (processor + supervisor)",
+    "Hermes worker started (control-plane + data-plane processors + supervisor)",
   );
 }
 

--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -10,6 +10,7 @@ import {
   parseAgentResponseEnvelope,
 } from "@hermes/scheduler";
 import { logger } from "@workspace/logger";
+import { executeHttpTrigger } from "./execute-http-trigger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
 import {
   DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
@@ -104,6 +105,10 @@ const mockPoolQuery = vi.fn();
 
 vi.mock("./cleanup-orphaned-executions", () => ({
   cleanupOrphanedExecutions: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("./execute-http-trigger", () => ({
+  executeHttpTrigger: vi.fn(),
 }));
 
 vi.mock("./queue", () => ({
@@ -230,6 +235,7 @@ describe("jobHandlers", () => {
         priority: 0,
         idempotencyKey: "j1",
         timeoutMs: 60_000,
+        group: { id: "pipeline:p1" },
       });
     });
 
@@ -451,6 +457,49 @@ describe("jobHandlers", () => {
       );
 
       expect(executeSchedule).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("execute_http_trigger", () => {
+    it("includes group: { id: pipeline:<pipelineId> } in addJobs for invoke_agent jobs", async () => {
+      vi.mocked(executeHttpTrigger).mockImplementation(async (_id, deps) => {
+        await deps.enqueueAgentInvocations([
+          {
+            payload: {
+              jobId: "j-ht-1",
+              executionId: "e-ht-1",
+              httpTriggerExecutionId: "ht-1",
+              httpTriggerId: "trigger-1",
+              pipelineId: "p-ht",
+              pipelineStepId: "st-ht",
+              domainIntegrationId: "di-1",
+              agentId: "a1",
+              agentVersion: "1.0.0",
+              endpointUrl: "https://a.example/",
+              body: { input: {}, config: {} },
+              timeoutMs: 60_000,
+              priority: 0,
+            },
+          },
+        ]);
+      });
+
+      await jobHandlers.execute_http_trigger(
+        { httpTriggerExecutionId: "ht-1" },
+        new AbortController().signal,
+        {} as Parameters<typeof jobHandlers.execute_http_trigger>[2],
+      );
+
+      expect(mockAddJobs).toHaveBeenCalledTimes(1);
+      const jobDefs = mockAddJobs.mock.calls[0]![0] as Array<{
+        jobType: string;
+        group: { id: string };
+      }>;
+      expect(jobDefs).toHaveLength(1);
+      expect(jobDefs[0]).toMatchObject({
+        jobType: "invoke_agent",
+        group: { id: "pipeline:p-ht" },
+      });
     });
   });
 

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -318,6 +318,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
                       ),
                     }
                   : undefined,
+              group: { id: `pipeline:${item.payload.pipelineId}` },
               tags: [
                 `scheduleExecution:${item.payload.scheduleExecutionId}`,
                 `schedule:${item.payload.scheduleId}`,
@@ -368,6 +369,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
                   ),
                 }
               : undefined,
+          group: { id: `pipeline:${item.payload.pipelineId}` },
           tags: [
             `httpTriggerExecution:${item.payload.httpTriggerExecutionId}`,
             `httpTrigger:${item.payload.httpTriggerId}`,

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -30,11 +30,20 @@ AGENT_AUTH_API_URL=http://localhost:4011 #required
 # Set to "true" in production to reject agent endpoints that use http (non-localhost).
 REQUIRE_HTTPS_AGENT_ENDPOINTS= # optional
 
-# --- Processor (optional; tune for agent invocation throughput) ---
+# --- Data-plane processor (invoke_agent; tune for agent invocation throughput) ---
 # Max jobs fetched per poll. Default 10.
 PROCESSOR_BATCH_SIZE=10 # optional
-# Max concurrent job executions (e.g. agent HTTP calls). Default 3; increase for more parallelism.
+# Max concurrent invoke_agent executions per worker instance. Default 3; increase for more parallelism.
 PROCESSOR_CONCURRENCY=3 # optional
+
+# --- Control-plane processor (check_schedules / execute_http_trigger / cleanup; optional) ---
+# Max concurrent control-plane jobs per worker instance. Default 2.
+HERMES_CONTROL_PLANE_CONCURRENCY= # optional #number
+# Max jobs fetched per poll for the control-plane processor. Default 5.
+HERMES_CONTROL_PLANE_BATCH_SIZE= # optional #number
+# Optional: max concurrent invoke_agent jobs per pipeline group (global across all worker instances).
+# Set to the max parallel agent invocations you allow per pipeline (e.g. same as PROCESSOR_CONCURRENCY).
+HERMES_GROUP_CONCURRENCY= # optional #number
 
 # Optional: DataQueue max attempts for invoke_agent (transport / 5xx retries). Omit for library default (3).
 HERMES_INVOKE_AGENT_MAX_ATTEMPTS= # optional

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -23,6 +23,9 @@ export const env = createEnv({
     HERMES_INVOKE_AGENT_RETRY_DELAY_MAX: z.string().optional(),
     HERMES_INVOKE_AGENT_JOB_TIMEOUT_MS: z.string().optional(),
     HERMES_INVOKE_AGENT_CANCEL_POLL_MS: z.string().optional(),
+    HERMES_CONTROL_PLANE_CONCURRENCY: z.string().optional(),
+    HERMES_CONTROL_PLANE_BATCH_SIZE: z.string().optional(),
+    HERMES_GROUP_CONCURRENCY: z.string().optional(),
     HERMES_SCHEDULE_RECOVERY_GRACE_MS: z.number({ coerce: true }).optional(),
   },
   client: {

--- a/packages/hermes/scheduler/src/execute-schedule.test.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.test.ts
@@ -110,6 +110,7 @@ const createMockDb = (opts?: {
     scheduleExecution: {
       create: scheduleExecutionCreate,
       update: scheduleExecutionUpdate,
+      findFirst: vi.fn().mockResolvedValue(null),
     },
     agentRegistry: {
       findMany: vi.fn().mockResolvedValue([
@@ -362,7 +363,11 @@ describe("executeSchedule", () => {
           },
         ]),
       },
-      scheduleExecution: { create: scheduleExecutionCreate, update: vi.fn() },
+      scheduleExecution: {
+        create: scheduleExecutionCreate,
+        update: vi.fn(),
+        findFirst: vi.fn().mockResolvedValue(null),
+      },
     };
     const deps: ExecuteScheduleDeps = {
       db: db as unknown as ExecuteScheduleDeps["db"],
@@ -638,5 +643,40 @@ describe("executeSchedule", () => {
         (item) => item.payload.scheduleExecutionId === "se-regression",
       ),
     ).toBe(true);
+  });
+
+  it("skips execution and advances nextRunAt when a non-terminal execution already exists", async () => {
+    const schedule = createMockSchedule();
+    const scheduleUpdate = vi.fn().mockResolvedValue(undefined);
+    const db = createMockDb();
+    db.schedule.update = scheduleUpdate;
+    db.scheduleExecution.findFirst = vi
+      .fn()
+      .mockResolvedValue({ id: "se-running", runStatus: "running" });
+
+    const enqueueAgentInvocations = vi.fn().mockResolvedValue(undefined);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const deps: ExecuteScheduleDeps = {
+      db: db as unknown as ExecuteScheduleDeps["db"],
+      logger,
+      enqueueAgentInvocations,
+    };
+
+    await executeSchedule(schedule, deps);
+
+    expect(db.$transaction).not.toHaveBeenCalled();
+    expect(enqueueAgentInvocations).not.toHaveBeenCalled();
+    expect(scheduleUpdate).toHaveBeenCalledTimes(1);
+    expect(scheduleUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: schedule.id } }),
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scheduleId: schedule.id,
+        existingExecutionId: "se-running",
+        existingRunStatus: "running",
+      }),
+      "executeSchedule: skipping tick — prior execution is still non-terminal",
+    );
   });
 });

--- a/packages/hermes/scheduler/src/execute-schedule.ts
+++ b/packages/hermes/scheduler/src/execute-schedule.ts
@@ -150,6 +150,27 @@ export const executeSchedule = async (
     return;
   }
 
+  const nonTerminalExecution = await db.scheduleExecution.findFirst({
+    where: {
+      scheduleId: schedule.id,
+      runStatus: { in: [ScheduleRunStatus.pending, ScheduleRunStatus.running] },
+    },
+    select: { id: true, runStatus: true },
+  });
+  if (nonTerminalExecution) {
+    logger.info(
+      {
+        scheduleId: schedule.id,
+        existingExecutionId: nonTerminalExecution.id,
+        existingRunStatus: nonTerminalExecution.runStatus,
+      },
+      "executeSchedule: skipping tick — prior execution is still non-terminal",
+    );
+    await updateScheduleAfterExecution(db, schedule, executionTime);
+
+    return;
+  }
+
   const planningResult = await planPipelineInvocations({
     db,
     pipeline: {


### PR DESCRIPTION
## Summary

The worker ran a single DataQueue processor shared by all job types. A pipeline that fans out many slow `invoke_agent` jobs — data-collection can enqueue 18 at up to 30 minutes each — held every slot, which starved `check_schedules` and left other pipelines queued indefinitely. On top of that, a schedule slower than its cadence would stack new executions every tick with no guard.

This PR splits the worker into two processors, tags every agent job with its pipeline group, and adds an overlap guard so a schedule can not pile up while it is still running.

## Related issues

Closes #715

## Important changes

- Two DataQueue processors now start from the same `jobHandlers` map: a **control-plane** processor scoped to `check_schedules`, `execute_http_trigger`, and `cleanup_orphaned_executions`, and a **data-plane** processor scoped to `invoke_agent`. Each has its own `workerId`, concurrency, and batch size; both drain on SIGTERM.
- Every `invoke_agent` job now carries `group: { id: "pipeline:<pipelineId>" }` at all three enqueue sites (worker `check_schedules`, worker `execute_http_trigger`, dashboard run-pipeline), unlocking DataQueue's per-group concurrency cap.
- An overlap guard in `executeSchedule` skips a new tick when the same schedule already has a `pending` or `running` execution, logs the skip with the existing execution ID, and still advances `nextRunAt` via the normal path.
- Three new optional env vars: `HERMES_GROUP_CONCURRENCY` (cap on concurrent `invoke_agent` jobs per pipeline group), `HERMES_CONTROL_PLANE_CONCURRENCY` (default 2), `HERMES_CONTROL_PLANE_BATCH_SIZE` (default 5).

## Other changes

- `PROCESSOR_CONCURRENCY` and `PROCESSOR_BATCH_SIZE` now size the **data-plane** (invoke_agent) processor; their meaning is unchanged for existing deployments.
- `packages/hermes/env/src/hermes-worker.ts` updated (source: `env.hermes-worker.example`) with the three new vars.

## Key files to review

- [apps/hermes/worker/src/index.ts](apps/hermes/worker/src/index.ts) — processor split, new env parsing, updated shutdown and startup log.
- [apps/hermes/worker/src/job-handlers.ts](apps/hermes/worker/src/job-handlers.ts) — `group` added to `check_schedules` and `execute_http_trigger` addJobs.
- [apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts](apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts) — `group` added to dashboard manual run.
- [packages/hermes/scheduler/src/execute-schedule.ts](packages/hermes/scheduler/src/execute-schedule.ts) — overlap guard before `planPipelineInvocations`.
- [apps/hermes/worker/src/job-handlers.test.ts](apps/hermes/worker/src/job-handlers.test.ts) — new `execute_http_trigger` group test, group assertion added to existing `check_schedules` test.
- [packages/hermes/scheduler/src/execute-schedule.test.ts](packages/hermes/scheduler/src/execute-schedule.test.ts) — overlap guard test.

## How to test

1. Set `HERMES_GROUP_CONCURRENCY=3` and start the worker; confirm the startup log shows `controlPlane` and `dataPlane` objects with their respective concurrency values.
2. Trigger a pipeline run and confirm the enqueued job row has `group_id = "pipeline:<id>"` in the `job_queue` table.
3. Start a long-running schedule execution, then wait for the next tick; confirm no new `scheduleExecution` row is created while the prior one is in `pending`/`running`, and the worker log contains "skipping tick — prior execution is still non-terminal".
4. With the data-plane slots fully occupied (e.g. set `PROCESSOR_CONCURRENCY=1` and a slow agent), confirm `check_schedules` still fires every minute and enqueues new due schedules.
