### PR TITLE
Add reconciliation sweep for cascade-cancelled pending pipeline executions

### DIFF
--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -12,6 +12,7 @@ import {
 import { logger } from "@workspace/logger";
 import { executeHttpTrigger } from "./execute-http-trigger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
+import { reconcileOrphanedPendingExecutions } from "./reconcile-orphaned-pending";
 import {
   DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
   jobHandlers,
@@ -105,6 +106,12 @@ const mockPoolQuery = vi.fn();
 
 vi.mock("./cleanup-orphaned-executions", () => ({
   cleanupOrphanedExecutions: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("./reconcile-orphaned-pending", () => ({
+  reconcileOrphanedPendingExecutions: vi
+    .fn()
+    .mockResolvedValue({ reEnqueued: 0, settled: 0 }),
 }));
 
 vi.mock("./execute-http-trigger", () => ({
@@ -1050,9 +1057,13 @@ describe("jobHandlers", () => {
   });
 
   describe("cleanup_orphaned_executions", () => {
-    it("calls cleanupOrphanedExecutions with orchestration prisma and logs resolved count", async () => {
+    it("calls cleanupOrphanedExecutions and reconcileOrphanedPendingExecutions and logs combined counts", async () => {
       // Setup
       vi.mocked(cleanupOrphanedExecutions).mockResolvedValue(3);
+      vi.mocked(reconcileOrphanedPendingExecutions).mockResolvedValue({
+        reEnqueued: 2,
+        settled: 1,
+      });
 
       // Act
       await jobHandlers.cleanup_orphaned_executions(
@@ -1066,8 +1077,15 @@ describe("jobHandlers", () => {
       expect(cleanupOrphanedExecutions).toHaveBeenCalledWith(
         expect.objectContaining({ db: expect.any(Object) }),
       );
+      expect(reconcileOrphanedPendingExecutions).toHaveBeenCalledTimes(1);
+      expect(reconcileOrphanedPendingExecutions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          db: expect.any(Object),
+          dataQueuePool: expect.any(Object),
+        }),
+      );
       expect(logger.info).toHaveBeenCalledWith(
-        { resolved: 3 },
+        { resolved: 3, reEnqueued: 2, reconciledSettled: 1 },
         "cleanup_orphaned_executions: sweep complete",
       );
     });

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -29,6 +29,7 @@ import {
 import { getJobQueue } from "./queue";
 import { executeHttpTrigger } from "./execute-http-trigger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
+import { reconcileOrphanedPendingExecutions } from "./reconcile-orphaned-pending";
 
 /** Default cap for DataQueue `invoke_agent` job timeout (abort + supervisor reclaim). */
 export const DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS = 1_800_000;
@@ -754,10 +755,25 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
   },
 
   cleanup_orphaned_executions: async () => {
-    const resolved = await cleanupOrphanedExecutions({
-      db: orchestrationPrisma,
-      logger,
-    });
-    logger.info({ resolved }, "cleanup_orphaned_executions: sweep complete");
+    const jobQueue = getJobQueue();
+    const pool = jobQueue.getPool?.();
+    const [resolved, reconciled] = await Promise.all([
+      cleanupOrphanedExecutions({ db: orchestrationPrisma, logger }),
+      pool
+        ? reconcileOrphanedPendingExecutions({
+            db: orchestrationPrisma,
+            dataQueuePool: pool,
+            logger,
+          })
+        : Promise.resolve({ reEnqueued: 0, settled: 0 }),
+    ]);
+    logger.info(
+      {
+        resolved,
+        reEnqueued: reconciled.reEnqueued,
+        reconciledSettled: reconciled.settled,
+      },
+      "cleanup_orphaned_executions: sweep complete",
+    );
   },
 };

--- a/apps/hermes/worker/src/reconcile-orphaned-pending.test.ts
+++ b/apps/hermes/worker/src/reconcile-orphaned-pending.test.ts
@@ -1,0 +1,526 @@
+/** @vitest-environment node */
+import {
+  AgentJobExecutionStatus,
+  ScheduleStepRollupStatus,
+} from "@hermes/orchestration-database";
+import { applyInvocationCompletion } from "@hermes/scheduler";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  DEFAULT_PENDING_ORPHAN_THRESHOLD_MINUTES,
+  reconcileOrphanedPendingExecutions,
+} from "./reconcile-orphaned-pending";
+
+vi.mock("@hermes/orchestration-database", () => ({
+  AgentJobExecutionStatus: {
+    pending: "pending",
+    running: "running",
+    completed: "completed",
+    failed: "failed",
+    cancelled: "cancelled",
+  },
+  ScheduleStepRollupStatus: {
+    pending: "pending",
+    running: "running",
+    success: "success",
+    partial: "partial",
+    failed: "failed",
+    skipped: "skipped",
+    cancelled: "cancelled",
+  },
+}));
+
+vi.mock("@hermes/scheduler", () => ({
+  applyInvocationCompletion: vi.fn().mockResolvedValue(undefined),
+  parseEffectiveExecutionConfig: vi.fn().mockReturnValue({
+    schemaVersion: 1,
+    stepRollupPolicy: "strict",
+    stepOrder: "sequential",
+    continueSequentialAfterPartial: false,
+  }),
+}));
+
+const mockFindMany = vi.fn();
+const mockUpdate = vi.fn();
+const mockFindUnique = vi.fn();
+const mockFindFirst = vi.fn();
+
+const makeDb = () =>
+  ({
+    agentJobExecution: { findMany: mockFindMany, update: mockUpdate },
+    pipelineStep: { findUnique: mockFindUnique, findFirst: mockFindFirst },
+    scheduleStepExecution: { findUnique: mockFindUnique },
+    httpTriggerStepExecution: { findUnique: mockFindUnique },
+    manualPipelineStepExecution: { findUnique: mockFindUnique },
+    scheduleExecution: { findUnique: mockFindUnique },
+    httpTriggerExecution: { findUnique: mockFindUnique },
+    manualPipelineExecution: { findUnique: mockFindUnique },
+  }) as unknown as Parameters<
+    typeof reconcileOrphanedPendingExecutions
+  >[0]["db"];
+
+const makePool = (rows: object[] = [], rowCount = 0) => ({
+  query: vi.fn().mockResolvedValue({ rows, rowCount }),
+});
+
+const makeLogger = () => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+});
+
+const makePendingRow = (
+  overrides: Partial<{
+    jobId: string;
+    scheduleExecutionId: string | null;
+    httpTriggerExecutionId: string | null;
+    manualExecutionId: string | null;
+    pipelineStepId: string | null;
+    pipelineId: string | null;
+    enqueuedAt: Date;
+  }> = {},
+) => ({
+  jobId: "job-1",
+  scheduleExecutionId: "se-1",
+  httpTriggerExecutionId: null,
+  manualExecutionId: null,
+  pipelineStepId: "step-2",
+  pipelineId: "pipeline-1",
+  enqueuedAt: new Date(Date.now() - 60 * 60 * 1_000),
+  ...overrides,
+});
+
+describe("reconcileOrphanedPendingExecutions", () => {
+  beforeEach(() => {
+    mockFindMany.mockReset();
+    mockUpdate.mockReset();
+    mockFindUnique.mockReset();
+    mockFindFirst.mockReset();
+    vi.mocked(applyInvocationCompletion).mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 0,0 when no pending rows exist", async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: makePool(),
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 0 });
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+  });
+
+  it("uses DEFAULT_PENDING_ORPHAN_THRESHOLD_MINUTES (35) when threshold is omitted", async () => {
+    const before = Date.now();
+    mockFindMany.mockResolvedValue([]);
+
+    await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: makePool(),
+      logger: makeLogger(),
+    });
+
+    const where = mockFindMany.mock.calls[0]![0].where as {
+      enqueuedAt: { lt: Date };
+    };
+    const cutoff = where.enqueuedAt.lt.getTime();
+    expect(cutoff).toBeLessThanOrEqual(
+      before - DEFAULT_PENDING_ORPHAN_THRESHOLD_MINUTES * 60 * 1_000 + 100,
+    );
+  });
+
+  it("settles as failed when DataQueue job is absent", async () => {
+    const row = makePendingRow();
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([]); // empty rows = job not found
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    expect(applyInvocationCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        scheduleExecutionId: "se-1",
+        terminal: expect.objectContaining({
+          status: AgentJobExecutionStatus.failed,
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("skips rows whose DataQueue job is still pending", async () => {
+    const row = makePendingRow();
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([
+      {
+        id: 99,
+        status: "pending",
+        pending_reason: null,
+        next_attempt_at: null,
+      },
+    ]);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 0 });
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+  });
+
+  it("skips rows whose DataQueue job is failed-with-retries pending", async () => {
+    const row = makePendingRow();
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([
+      {
+        id: 99,
+        status: "failed",
+        pending_reason: null,
+        next_attempt_at: new Date(Date.now() + 60_000),
+      },
+    ]);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 0 });
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+  });
+
+  it("settles as failed when DataQueue job is terminal-failed (no retries)", async () => {
+    const row = makePendingRow();
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([
+      { id: 99, status: "failed", pending_reason: null, next_attempt_at: null },
+    ]);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    expect(applyInvocationCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        terminal: expect.objectContaining({
+          status: AgentJobExecutionStatus.failed,
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it("settles as cancelled when DataQueue job is user-cancelled (no cascade)", async () => {
+    const row = makePendingRow();
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([
+      {
+        id: 99,
+        status: "cancelled",
+        pending_reason: null,
+        next_attempt_at: null,
+      },
+    ]);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    expect(applyInvocationCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: "job-1",
+        terminal: expect.objectContaining({
+          status: AgentJobExecutionStatus.cancelled,
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  describe("cascade-cancelled jobs", () => {
+    const cascadePendingReason = JSON.stringify({
+      rootJobId: 42,
+      dependencyCascade: true,
+    });
+
+    it("re-enqueues cascade-cancelled job when predecessor step succeeded", async () => {
+      const row = makePendingRow();
+      mockFindMany.mockResolvedValue([row]);
+
+      const poolQuery = vi
+        .fn()
+        // First call: look up job
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              id: 99,
+              status: "cancelled",
+              pending_reason: cascadePendingReason,
+              next_attempt_at: null,
+            },
+          ],
+        })
+        // Second call: UPDATE to reset to pending
+        .mockResolvedValueOnce({ rows: [{ id: 99 }] });
+
+      const pool = { query: poolQuery };
+
+      // pipelineStep.findUnique for current step order
+      mockFindUnique
+        .mockResolvedValueOnce({ order: 2 }) // thisStep
+        // predecessorStep found via findFirst
+        // scheduleStepExecution for predecessor
+        .mockResolvedValueOnce({
+          rollupStatus: ScheduleStepRollupStatus.success,
+        });
+
+      // pipelineStep.findFirst for predecessor
+      mockFindFirst.mockResolvedValueOnce({ id: "step-1" });
+
+      const result = await reconcileOrphanedPendingExecutions({
+        db: makeDb(),
+        dataQueuePool: pool,
+        logger: makeLogger(),
+      });
+
+      expect(result).toEqual({ reEnqueued: 1, settled: 0 });
+      expect(applyInvocationCompletion).not.toHaveBeenCalled();
+
+      // Verify the UPDATE SQL cleared dependency links
+      const updateCall = poolQuery.mock.calls[1];
+      expect(updateCall![0]).toContain("depends_on_job_ids = '{}'");
+      expect(updateCall![1]).toEqual([99]);
+    });
+
+    it("settles as cancelled when predecessor step failed", async () => {
+      const row = makePendingRow();
+      mockFindMany.mockResolvedValue([row]);
+
+      const poolQuery = vi.fn().mockResolvedValueOnce({
+        rows: [
+          {
+            id: 99,
+            status: "cancelled",
+            pending_reason: cascadePendingReason,
+            next_attempt_at: null,
+          },
+        ],
+      });
+      const pool = { query: poolQuery };
+
+      mockFindUnique
+        .mockResolvedValueOnce({ order: 2 }) // thisStep
+        .mockResolvedValueOnce({
+          rollupStatus: ScheduleStepRollupStatus.failed,
+        }); // predecessor step execution
+
+      mockFindFirst.mockResolvedValueOnce({ id: "step-1" });
+
+      const result = await reconcileOrphanedPendingExecutions({
+        db: makeDb(),
+        dataQueuePool: pool,
+        logger: makeLogger(),
+      });
+
+      expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+      expect(applyInvocationCompletion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobId: "job-1",
+          terminal: expect.objectContaining({
+            status: AgentJobExecutionStatus.cancelled,
+          }),
+        }),
+        expect.any(Object),
+      );
+    });
+
+    it("settles as cancelled when predecessor step rollup is still pending (upstream not settled)", async () => {
+      const row = makePendingRow();
+      mockFindMany.mockResolvedValue([row]);
+
+      const poolQuery = vi.fn().mockResolvedValueOnce({
+        rows: [
+          {
+            id: 99,
+            status: "cancelled",
+            pending_reason: cascadePendingReason,
+            next_attempt_at: null,
+          },
+        ],
+      });
+      const pool = { query: poolQuery };
+
+      mockFindUnique
+        .mockResolvedValueOnce({ order: 2 }) // thisStep
+        .mockResolvedValueOnce({
+          rollupStatus: ScheduleStepRollupStatus.pending,
+        }); // predecessor still pending
+
+      mockFindFirst.mockResolvedValueOnce({ id: "step-1" });
+
+      const result = await reconcileOrphanedPendingExecutions({
+        db: makeDb(),
+        dataQueuePool: pool,
+        logger: makeLogger(),
+      });
+
+      expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    });
+
+    it("settles as cancelled when this is the first wave (no predecessor step)", async () => {
+      const row = makePendingRow();
+      mockFindMany.mockResolvedValue([row]);
+
+      const poolQuery = vi.fn().mockResolvedValueOnce({
+        rows: [
+          {
+            id: 99,
+            status: "cancelled",
+            pending_reason: cascadePendingReason,
+            next_attempt_at: null,
+          },
+        ],
+      });
+      const pool = { query: poolQuery };
+
+      mockFindUnique.mockResolvedValueOnce({ order: 1 }); // thisStep = wave 1
+      mockFindFirst.mockResolvedValueOnce(null); // no predecessor
+
+      const result = await reconcileOrphanedPendingExecutions({
+        db: makeDb(),
+        dataQueuePool: pool,
+        logger: makeLogger(),
+      });
+
+      expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    });
+  });
+
+  it("continues processing subsequent rows when one row throws", async () => {
+    const rowFail = makePendingRow({ jobId: "job-bad" });
+    const rowOk = makePendingRow({
+      jobId: "job-ok",
+      scheduleExecutionId: null,
+      pipelineStepId: null,
+    });
+    mockFindMany.mockResolvedValue([rowFail, rowOk]);
+
+    const poolQuery = vi
+      .fn()
+      // job-bad lookup throws
+      .mockRejectedValueOnce(new Error("DB error"))
+      // job-ok: absent
+      .mockResolvedValueOnce({ rows: [] });
+
+    const pool = { query: poolQuery };
+    mockUpdate.mockResolvedValue(undefined);
+
+    const logger = makeLogger();
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger,
+    });
+
+    expect(result.settled).toBe(1);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.objectContaining({ jobId: "job-bad" }),
+      expect.stringContaining(
+        "reconcile_orphaned_pending: failed to process row",
+      ),
+    );
+  });
+
+  it("marks directly as failed (no applyInvocationCompletion) when no parent execution id", async () => {
+    const row = makePendingRow({
+      scheduleExecutionId: null,
+      httpTriggerExecutionId: null,
+      manualExecutionId: null,
+      pipelineStepId: null,
+    });
+    mockFindMany.mockResolvedValue([row]);
+    const pool = makePool([]); // absent job
+    mockUpdate.mockResolvedValue(undefined);
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: pool,
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 0, settled: 1 });
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { jobId: "job-1" },
+      data: expect.objectContaining({
+        status: AgentJobExecutionStatus.failed,
+        completedAt: expect.any(Date),
+      }),
+    });
+  });
+
+  it("regression: mirrors execution 3af5f40e — cascade-cancelled delivery after succeeded content-gen re-enqueues", async () => {
+    // Delivery step jobs (wave 3) were cascade-cancelled after a transient
+    // content-gen failure. Content-gen ultimately succeeded (rollup = success).
+    // The reconcile sweep must re-enqueue the delivery jobs.
+    const deliveryRow = makePendingRow({
+      jobId: "delivery-job-1",
+      scheduleExecutionId: "exec-3af5f40e",
+      pipelineStepId: "delivery-step",
+      pipelineId: "pipeline-mediapulse",
+    });
+    mockFindMany.mockResolvedValue([deliveryRow]);
+
+    const cascadeReason = JSON.stringify({
+      rootJobId: 777,
+      dependencyCascade: true,
+    });
+    const poolQuery = vi
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: 555,
+            status: "cancelled",
+            pending_reason: cascadeReason,
+            next_attempt_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 555 }] }); // UPDATE succeeded
+
+    mockFindUnique.mockResolvedValueOnce({ order: 3 }); // delivery is step 3
+    mockFindFirst.mockResolvedValueOnce({ id: "content-gen-step" }); // predecessor = content-gen
+    mockFindUnique.mockResolvedValueOnce({
+      rollupStatus: ScheduleStepRollupStatus.success,
+    }); // content-gen succeeded
+
+    const result = await reconcileOrphanedPendingExecutions({
+      db: makeDb(),
+      dataQueuePool: { query: poolQuery },
+      logger: makeLogger(),
+    });
+
+    expect(result).toEqual({ reEnqueued: 1, settled: 0 });
+    expect(applyInvocationCompletion).not.toHaveBeenCalled();
+  });
+});

--- a/apps/hermes/worker/src/reconcile-orphaned-pending.ts
+++ b/apps/hermes/worker/src/reconcile-orphaned-pending.ts
@@ -1,0 +1,421 @@
+import {
+  AgentJobExecutionStatus,
+  ScheduleStepRollupStatus,
+  type PrismaClient,
+} from "@hermes/orchestration-database";
+import {
+  applyInvocationCompletion,
+  parseEffectiveExecutionConfig,
+  type ApplyInvocationCompletionDeps,
+} from "@hermes/scheduler";
+
+export const DEFAULT_PENDING_ORPHAN_THRESHOLD_MINUTES = 35;
+
+/** Minimal subset of the DataQueue pg Pool used for raw SQL in reconciliation. */
+type DataQueuePool = {
+  query<T extends object = object>(
+    text: string,
+    values?: unknown[],
+  ): Promise<{ rows: T[] }>;
+};
+
+export type ReconcileOrphanedPendingDeps = {
+  db: PrismaClient;
+  dataQueuePool: DataQueuePool;
+  logger: ApplyInvocationCompletionDeps["logger"];
+  thresholdMinutes?: number;
+};
+
+export type ReconcileOrphanedPendingResult = {
+  reEnqueued: number;
+  settled: number;
+};
+
+type PendingOrphanRow = {
+  jobId: string;
+  scheduleExecutionId: string | null;
+  httpTriggerExecutionId: string | null;
+  manualExecutionId: string | null;
+  pipelineStepId: string | null;
+  pipelineId: string | null;
+  enqueuedAt: Date;
+};
+
+type DataQueueJobRow = {
+  id: number;
+  status: string;
+  pending_reason: string | null;
+  next_attempt_at: Date | null;
+};
+
+type ExecutionKind = "schedule" | "httpTrigger" | "manual";
+
+function getExecutionKind(row: PendingOrphanRow): ExecutionKind | null {
+  if (row.scheduleExecutionId) return "schedule";
+  if (row.httpTriggerExecutionId) return "httpTrigger";
+  if (row.manualExecutionId) return "manual";
+  return null;
+}
+
+function isCascadeCancelled(pendingReason: string | null): boolean {
+  if (!pendingReason) return false;
+  try {
+    const parsed = JSON.parse(pendingReason) as Record<string, unknown>;
+    return parsed.dependencyCascade === true;
+  } catch {
+    return false;
+  }
+}
+
+async function lookupDataQueueJob(
+  pool: DataQueuePool,
+  jobId: string,
+): Promise<DataQueueJobRow | null> {
+  const result = await pool.query<DataQueueJobRow>(
+    `SELECT id, status, pending_reason, next_attempt_at
+     FROM job_queue
+     WHERE idempotency_key = $1
+     LIMIT 1`,
+    [jobId],
+  );
+  return result.rows[0] ?? null;
+}
+
+async function resetCascadeCancelledJobToPending(
+  pool: DataQueuePool,
+  dqJobId: number,
+): Promise<boolean> {
+  const result = await pool.query<{ id: number }>(
+    `UPDATE job_queue
+     SET status          = 'pending',
+         run_at          = NOW(),
+         locked_at       = NULL,
+         locked_by       = NULL,
+         last_cancelled_at = NULL,
+         attempts        = 0,
+         pending_reason  = NULL,
+         depends_on_job_ids = '{}',
+         wait_until      = NULL,
+         wait_token_id   = NULL
+     WHERE id = $1 AND status = 'cancelled'
+     RETURNING id`,
+    [dqJobId],
+  );
+  return result.rows.length > 0;
+}
+
+/**
+ * Returns true when the immediate predecessor step's rollup status allows the
+ * current step to proceed. For `partial`, consults `continueSequentialAfterPartial`
+ * from the execution's effective config.
+ */
+async function predecessorStepAllowsContinuation(
+  db: PrismaClient,
+  row: PendingOrphanRow,
+  executionKind: ExecutionKind,
+): Promise<boolean> {
+  if (!row.pipelineStepId || !row.pipelineId) return false;
+
+  const thisStep = await db.pipelineStep.findUnique({
+    where: { id: row.pipelineStepId },
+    select: { order: true },
+  });
+  if (!thisStep) return false;
+
+  const predecessorStep = await db.pipelineStep.findFirst({
+    where: { pipelineId: row.pipelineId, order: { lt: thisStep.order } },
+    orderBy: { order: "desc" },
+    select: { id: true },
+  });
+  if (!predecessorStep) return false; // First wave — cannot be cascade-cancelled from an upstream dep
+
+  let predecessorRollup: ScheduleStepRollupStatus | null = null;
+
+  if (executionKind === "schedule" && row.scheduleExecutionId) {
+    const stepExec = await db.scheduleStepExecution.findUnique({
+      where: {
+        scheduleExecutionId_pipelineStepId: {
+          scheduleExecutionId: row.scheduleExecutionId,
+          pipelineStepId: predecessorStep.id,
+        },
+      },
+      select: { rollupStatus: true },
+    });
+    predecessorRollup = stepExec?.rollupStatus ?? null;
+  } else if (executionKind === "httpTrigger" && row.httpTriggerExecutionId) {
+    const stepExec = await db.httpTriggerStepExecution.findUnique({
+      where: {
+        httpTriggerExecutionId_pipelineStepId: {
+          httpTriggerExecutionId: row.httpTriggerExecutionId,
+          pipelineStepId: predecessorStep.id,
+        },
+      },
+      select: { rollupStatus: true },
+    });
+    predecessorRollup = stepExec?.rollupStatus ?? null;
+  } else if (executionKind === "manual" && row.manualExecutionId) {
+    const stepExec = await db.manualPipelineStepExecution.findUnique({
+      where: {
+        manualExecutionId_pipelineStepId: {
+          manualExecutionId: row.manualExecutionId,
+          pipelineStepId: predecessorStep.id,
+        },
+      },
+      select: { rollupStatus: true },
+    });
+    predecessorRollup = stepExec?.rollupStatus ?? null;
+  }
+
+  if (predecessorRollup === null) return false;
+  if (predecessorRollup === ScheduleStepRollupStatus.success) return true;
+
+  if (predecessorRollup === ScheduleStepRollupStatus.partial) {
+    let configJson: unknown = null;
+    try {
+      if (executionKind === "schedule" && row.scheduleExecutionId) {
+        const execution = await db.scheduleExecution.findUnique({
+          where: { id: row.scheduleExecutionId },
+          select: { effectiveExecutionConfig: true },
+        });
+        configJson = execution?.effectiveExecutionConfig;
+      } else if (
+        executionKind === "httpTrigger" &&
+        row.httpTriggerExecutionId
+      ) {
+        const execution = await db.httpTriggerExecution.findUnique({
+          where: { id: row.httpTriggerExecutionId },
+          select: { effectiveExecutionConfig: true },
+        });
+        configJson = execution?.effectiveExecutionConfig;
+      } else if (executionKind === "manual" && row.manualExecutionId) {
+        const execution = await db.manualPipelineExecution.findUnique({
+          where: { id: row.manualExecutionId },
+          select: { effectiveExecutionConfig: true },
+        });
+        configJson = execution?.effectiveExecutionConfig;
+      }
+      if (
+        configJson != null &&
+        typeof configJson === "object" &&
+        !Array.isArray(configJson)
+      ) {
+        const config = parseEffectiveExecutionConfig(
+          configJson as Record<string, unknown>,
+        );
+        return config.continueSequentialAfterPartial;
+      }
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+async function settleOrphanedPendingRow(
+  row: PendingOrphanRow,
+  status: "failed" | "cancelled",
+  completionDeps: ApplyInvocationCompletionDeps,
+  db: PrismaClient,
+): Promise<void> {
+  const executionKind = getExecutionKind(row);
+  const isCancelled = status === "cancelled";
+
+  if (executionKind && row.pipelineStepId) {
+    await applyInvocationCompletion(
+      {
+        jobId: row.jobId,
+        scheduleExecutionId: row.scheduleExecutionId ?? undefined,
+        httpTriggerExecutionId: row.httpTriggerExecutionId ?? undefined,
+        manualExecutionId: row.manualExecutionId ?? undefined,
+        pipelineStepId: row.pipelineStepId,
+        terminal: isCancelled
+          ? {
+              status: AgentJobExecutionStatus.cancelled,
+              error: {
+                cancelled: true,
+                message:
+                  "Orphaned pending: DataQueue job cancelled — user cancel or dependency cascade with failed upstream",
+                retryable: false,
+                orphanCleanup: true,
+              },
+            }
+          : {
+              status: AgentJobExecutionStatus.failed,
+              error: {
+                message:
+                  "Orphaned pending: DataQueue job absent or terminal-failed — worker crash or DLQ exhaustion",
+                retryable: false,
+                orphanCleanup: true,
+              },
+            },
+      },
+      completionDeps,
+    );
+  } else {
+    await db.agentJobExecution.update({
+      where: { jobId: row.jobId },
+      data: {
+        status: isCancelled
+          ? AgentJobExecutionStatus.cancelled
+          : AgentJobExecutionStatus.failed,
+        completedAt: new Date(),
+        error: {
+          message: isCancelled
+            ? "Orphaned pending: DataQueue job cancelled (no parent execution)"
+            : "Orphaned pending: DataQueue job absent or terminal-failed (no parent execution)",
+          retryable: false,
+          orphanCleanup: true,
+        },
+      },
+    });
+  }
+}
+
+/**
+ * Scans `agent_job_execution` rows that are still `pending` past `thresholdMinutes` and whose
+ * DataQueue job has reached a terminal state without the worker running `applyInvocationCompletion`.
+ *
+ * Two actions are taken per row:
+ * - **Re-enqueue**: when the DataQueue job was cascade-cancelled due to a transient upstream failure
+ *   that ultimately succeeded (predecessor step rollup is `success` / `partial` with
+ *   `continueSequentialAfterPartial`), the cancelled DataQueue job is reset to `pending` (dependency
+ *   links cleared) so the worker picks it up on the next poll. This is the recovery path for the
+ *   bug where DataQueue cascade-cancels downstream `waiting` jobs on every upstream failure —
+ *   even transient ones that DataQueue will later retry to success.
+ * - **Settle**: for all other terminal DataQueue states (user-cancel, terminal-failed, absent),
+ *   drives the orchestration row through `applyInvocationCompletion` so the parent execution
+ *   recomputes its rollup and reaches a terminal state. Covers the `pending` / `startedAt = null`
+ *   blind spot that `cleanupOrphanedExecutions` (which only scans `running` rows) cannot reach.
+ *
+ * @param deps - Injected db, DataQueue pool, logger, and optional threshold.
+ * @returns Counts of re-enqueued and settled rows.
+ */
+export async function reconcileOrphanedPendingExecutions(
+  deps: ReconcileOrphanedPendingDeps,
+): Promise<ReconcileOrphanedPendingResult> {
+  const {
+    db,
+    dataQueuePool,
+    logger,
+    thresholdMinutes = DEFAULT_PENDING_ORPHAN_THRESHOLD_MINUTES,
+  } = deps;
+
+  const cutoff = new Date(Date.now() - thresholdMinutes * 60 * 1_000);
+
+  const rows = await db.agentJobExecution.findMany({
+    where: {
+      status: AgentJobExecutionStatus.pending,
+      completedAt: null,
+      enqueuedAt: { lt: cutoff },
+    },
+    select: {
+      jobId: true,
+      scheduleExecutionId: true,
+      httpTriggerExecutionId: true,
+      manualExecutionId: true,
+      pipelineStepId: true,
+      pipelineId: true,
+      enqueuedAt: true,
+    },
+  });
+
+  if (rows.length === 0) {
+    return { reEnqueued: 0, settled: 0 };
+  }
+
+  logger.warn(
+    { count: rows.length, thresholdMinutes },
+    "reconcile_orphaned_pending: found stuck pending rows",
+  );
+
+  const completionDeps: ApplyInvocationCompletionDeps = { db, logger };
+  let reEnqueued = 0;
+  let settled = 0;
+
+  for (const row of rows as PendingOrphanRow[]) {
+    try {
+      const dqJob = await lookupDataQueueJob(dataQueuePool, row.jobId);
+
+      if (!dqJob) {
+        await settleOrphanedPendingRow(row, "failed", completionDeps, db);
+        settled++;
+        logger.warn(
+          { jobId: row.jobId },
+          "reconcile_orphaned_pending: settled absent-job row as failed",
+        );
+        continue;
+      }
+
+      // Skip jobs whose DataQueue state is not terminal: they are still live or awaiting retry.
+      const isPendingRetry =
+        dqJob.status === "failed" && dqJob.next_attempt_at !== null;
+      if (
+        dqJob.status === "pending" ||
+        dqJob.status === "processing" ||
+        dqJob.status === "waiting" ||
+        isPendingRetry
+      ) {
+        continue;
+      }
+
+      if (
+        dqJob.status === "cancelled" &&
+        isCascadeCancelled(dqJob.pending_reason)
+      ) {
+        const executionKind = getExecutionKind(row);
+
+        if (executionKind && row.pipelineStepId) {
+          const canReEnqueue = await predecessorStepAllowsContinuation(
+            db,
+            row,
+            executionKind,
+          );
+
+          if (canReEnqueue) {
+            const reset = await resetCascadeCancelledJobToPending(
+              dataQueuePool,
+              dqJob.id,
+            );
+            if (reset) {
+              reEnqueued++;
+              logger.warn(
+                { jobId: row.jobId, dqJobId: dqJob.id },
+                "reconcile_orphaned_pending: re-enqueued cascade-cancelled job (upstream step succeeded)",
+              );
+            }
+            // Whether or not the reset succeeded, skip settling — the job is either
+            // now pending (success) or already changed state (another process picked it up).
+            continue;
+          }
+        }
+
+        // Upstream step did not succeed — settle the downstream row as cancelled.
+        await settleOrphanedPendingRow(row, "cancelled", completionDeps, db);
+        settled++;
+        logger.warn(
+          { jobId: row.jobId },
+          "reconcile_orphaned_pending: settled cascade-cancelled row (upstream failed)",
+        );
+        continue;
+      }
+
+      // User-cancelled or terminal-failed — settle accordingly.
+      const terminalStatus =
+        dqJob.status === "cancelled" ? "cancelled" : "failed";
+      await settleOrphanedPendingRow(row, terminalStatus, completionDeps, db);
+      settled++;
+      logger.warn(
+        { jobId: row.jobId, dqStatus: dqJob.status },
+        "reconcile_orphaned_pending: settled orphaned pending row",
+      );
+    } catch (err) {
+      logger.error(
+        { err, jobId: row.jobId },
+        "reconcile_orphaned_pending: failed to process row — will retry next sweep",
+      );
+    }
+  }
+
+  return { reEnqueued, settled };
+}


### PR DESCRIPTION
## Summary

Sequential pipelines can get permanently stuck when a transient upstream failure triggers a DataQueue cascade cancellation. DataQueue cancels downstream waiting jobs the moment any prerequisite goes terminal, including failures that Hermes will retry. The cascade is irreversible, so those downstream `agent_job_execution` rows stay `pending` forever and the parent execution never settles. The existing `cleanupOrphanedExecutions` sweep misses them because it only scans `running` rows with a `startedAt` timestamp.

This adds a `reconcileOrphanedPendingExecutions` sweep that runs alongside the existing cron. For each stuck row it either re-enqueues the DataQueue job (when the predecessor step ultimately succeeded) or settles the row through `applyInvocationCompletion` so the parent execution reaches a terminal state.

## Related issues

Closes #717

## Important changes

- New `reconcileOrphanedPendingExecutions` function scans `pending` rows past a 35-minute threshold and checks their DataQueue job status by idempotency key lookup
- Cascade-cancelled jobs whose predecessor step rolled up to `success` (or `partial` with `continueSequentialAfterPartial`) are reset to `pending` with dependency links cleared, so they get picked up on the next DataQueue poll without being cascade-cancelled again
- All other terminal cases (user-cancelled, terminal-failed, absent) are settled via `applyInvocationCompletion`, driving the parent execution rollup to a terminal state
- `cleanup_orphaned_executions` handler now runs both sweeps in parallel and logs combined counts

## Other changes

- `job-handlers.test.ts` mocks `reconcileOrphanedPendingExecutions` and verifies the combined log output

## Key files to review

- [apps/hermes/worker/src/reconcile-orphaned-pending.ts](apps/hermes/worker/src/reconcile-orphaned-pending.ts) - core sweep logic: lookup, cascade check, predecessor rollup query, re-enqueue or settle
- [apps/hermes/worker/src/reconcile-orphaned-pending.test.ts](apps/hermes/worker/src/reconcile-orphaned-pending.test.ts) - 14 tests covering all branches including regression for execution `3af5f40e`
- [apps/hermes/worker/src/job-handlers.ts](apps/hermes/worker/src/job-handlers.ts) - `cleanup_orphaned_executions` handler wired to call both sweeps

## How to test

1. Run `pnpm --filter @hermes/worker test` — all 58 tests should pass, including the 14 new reconciliation tests
2. In a staging or local environment, trigger a sequential pipeline where the first step has a transient failure (that eventually succeeds) and verify the downstream step jobs are re-enqueued within the next 35-minute cleanup window
3. Check the `cleanup_orphaned_executions` log output for `reEnqueued` and `reconciledSettled` counts alongside the existing `resolved` count
