### PR TITLE
Add content-generation insights provider

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -69,6 +69,7 @@ import {
 import { getSectionCoverageRollupHandler } from "./routes/section-coverage-rollup.js";
 import { getAgentInsights } from "./routes/agent-insights.js";
 import { createPageCollectionInsightsProvider } from "./services/insights/page-collection-insights-provider.js";
+import { createContentGenerationInsightsProvider } from "./services/insights/content-generation-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -225,6 +226,12 @@ registerInsightsProvider(
     dataCollectionRun: prisma.dataCollectionRun,
     discoverySourceHealth: prisma.discoverySourceHealth,
     dataSource: prisma.dataSource,
+  }),
+);
+registerInsightsProvider(
+  createContentGenerationInsightsProvider({
+    contentGenerationRun: prisma.contentGenerationRun,
+    newsletter: prisma.newsletter,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
@@ -1,0 +1,418 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+
+import { createContentGenerationInsightsProvider } from "./content-generation-insights-provider.js";
+
+function makeRun(overrides?: {
+  tickerId?: string;
+  outcome?: string;
+  stage?: string | null;
+  errorCode?: string | null;
+  errorCategory?: string | null;
+  durationMs?: number | null;
+  createdAt?: Date;
+  details?: object | null;
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    outcome: overrides?.outcome ?? "success",
+    stage: overrides?.stage !== undefined ? overrides.stage : null,
+    errorCode: overrides?.errorCode !== undefined ? overrides.errorCode : null,
+    errorCategory:
+      overrides?.errorCategory !== undefined ? overrides.errorCategory : null,
+    durationMs:
+      overrides?.durationMs !== undefined ? overrides.durationMs : 10000,
+    createdAt: overrides?.createdAt ?? new Date("2026-06-07T08:00:00.000Z"),
+    details: overrides?.details !== undefined ? overrides.details : null,
+  };
+}
+
+function makeNewsletter(overrides?: {
+  tickerId?: string;
+  createdAt?: Date;
+  model?: string | null;
+  totalTokens?: number | null;
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    createdAt: overrides?.createdAt ?? new Date("2026-06-07T08:00:00.000Z"),
+    model: overrides?.model !== undefined ? overrides.model : "gpt-4o",
+    totalTokens:
+      overrides?.totalTokens !== undefined ? overrides.totalTokens : 1500,
+  };
+}
+
+function makeDeps(overrides?: {
+  runs?: ReturnType<typeof makeRun>[];
+  newsletters?: ReturnType<typeof makeNewsletter>[];
+}) {
+  const runs = overrides?.runs ?? [makeRun()];
+  const newsletters = overrides?.newsletters ?? [makeNewsletter()];
+
+  return {
+    contentGenerationRun: {
+      findMany: async () => runs,
+    },
+    newsletter: {
+      findMany: async () => newsletters,
+    },
+  };
+}
+
+describe("createContentGenerationInsightsProvider", () => {
+  it("returns a payload that parses through insightsPayloadSchema", async () => {
+    const provider = createContentGenerationInsightsProvider(makeDeps());
+    const payload = await provider.compute({ window: "7d" });
+
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.agentId).toBe("content-generation");
+    expect(parsed.window).toBe("7d");
+    expect(typeof parsed.generatedAt).toBe("string");
+    expect(Array.isArray(parsed.kpis)).toBe(true);
+    expect(Array.isArray(parsed.alerts)).toBe(true);
+    expect(Array.isArray(parsed.sections)).toBe(true);
+  });
+
+  it("outcome breakdown fractions sum to 1", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "no_sources",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const outcomeSection = payload.sections.find(
+      (s) => s.id === "what-outcome",
+    );
+
+    expect(outcomeSection).toBeDefined();
+    expect(outcomeSection!.widget.kind).toBe("breakdown");
+    if (outcomeSection!.widget.kind === "breakdown") {
+      const fractionSum = outcomeSection!.widget.slices.reduce(
+        (sum, s) => sum + s.fraction,
+        0,
+      );
+      expect(fractionSum).toBeCloseTo(1);
+    }
+  });
+
+  it("failure-by-stage breakdown counts only failed runs", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "no_sources",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const failureSection = payload.sections.find(
+      (s) => s.id === "why-failure-by-stage",
+    );
+
+    expect(failureSection).toBeDefined();
+    expect(failureSection!.widget.kind).toBe("breakdown");
+    if (failureSection!.widget.kind === "breakdown") {
+      const totalInBreakdown = failureSection!.widget.slices.reduce(
+        (sum, s) => sum + s.value,
+        0,
+      );
+      expect(totalInBreakdown).toBe(2);
+      const llmSlice = failureSection!.widget.slices.find(
+        (s) => s.label === "llm",
+      );
+      expect(llmSlice?.value).toBe(2);
+    }
+  });
+
+  it("skip-reason breakdown counts only skipped runs", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "no_sources",
+          }),
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "skipped_fresh_newsletter_exists",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const skipSection = payload.sections.find(
+      (s) => s.id === "why-skip-reason",
+    );
+
+    expect(skipSection).toBeDefined();
+    expect(skipSection!.widget.kind).toBe("breakdown");
+    if (skipSection!.widget.kind === "breakdown") {
+      const totalInBreakdown = skipSection!.widget.slices.reduce(
+        (sum, s) => sum + s.value,
+        0,
+      );
+      expect(totalInBreakdown).toBe(2);
+      const noSourcesSlice = skipSection!.widget.slices.find(
+        (s) => s.label === "no_sources",
+      );
+      expect(noSourcesSlice?.value).toBe(1);
+    }
+  });
+
+  it("section-fill sums citedBullets per section from run details", async () => {
+    const makeDetails = (bullets: Record<string, number>) => ({
+      sectionFill: {
+        bySection: Object.fromEntries(
+          Object.entries(bullets).map(([k, v]) => [k, { citedBullets: v }]),
+        ),
+      },
+    });
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "success",
+            details: makeDetails({ intro: 3, body: 5 }),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetails({ intro: 2, body: 4, conclusion: 1 }),
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            details: makeDetails({ intro: 99 }),
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const fillSection = payload.sections.find(
+      (s) => s.id === "how-section-fill",
+    );
+
+    expect(fillSection).toBeDefined();
+    expect(fillSection!.widget.kind).toBe("categoryBar");
+    if (fillSection!.widget.kind === "categoryBar") {
+      const introBar = fillSection!.widget.bars.find(
+        (b) => b.label === "intro",
+      );
+      const bodyBar = fillSection!.widget.bars.find((b) => b.label === "body");
+      const conclusionBar = fillSection!.widget.bars.find(
+        (b) => b.label === "conclusion",
+      );
+      expect(introBar?.value).toBe(5);
+      expect(bodyBar?.value).toBe(9);
+      expect(conclusionBar?.value).toBe(1);
+    }
+  });
+
+  it("stage funnel has monotonically non-increasing counts", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "no_sources",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const funnelSection = payload.sections.find(
+      (s) => s.id === "what-stage-funnel",
+    );
+
+    expect(funnelSection).toBeDefined();
+    expect(funnelSection!.widget.kind).toBe("funnel");
+    if (funnelSection!.widget.kind === "funnel") {
+      const values = funnelSection!.widget.stages.map((s) => s.value);
+      for (let i = 1; i < values.length; i++) {
+        expect(values[i]).toBeLessThanOrEqual(values[i - 1]!);
+      }
+    }
+  });
+
+  it("KPI includes a numeric delta for runs", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [makeRun({ createdAt: new Date("2026-06-07T08:00:00.000Z") })],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const runsKpi = payload.kpis.find((k) => k.id === "runs");
+
+    expect(runsKpi).toBeDefined();
+    expect(runsKpi!.value).toBe(1);
+    expect(typeof runsKpi!.delta).toBe("number");
+  });
+
+  it("caps per-ticker bars at TOP_N + Other bucket", async () => {
+    const manyNewsletters = Array.from({ length: 15 }, (_, index) =>
+      makeNewsletter({ tickerId: `ticker-${index}` }),
+    );
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({ newsletters: manyNewsletters }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    expect(tickerBar).toBeDefined();
+    if (tickerBar!.widget.kind === "categoryBar") {
+      expect(tickerBar!.widget.bars.length).toBeLessThanOrEqual(11);
+      const other = tickerBar!.widget.bars.find((b) => b.label === "Other");
+      expect(other).toBeDefined();
+    }
+  });
+
+  it("model mix fractions sum to 1", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({ model: "gpt-4o" }),
+          makeNewsletter({ model: "gpt-4o" }),
+          makeNewsletter({ model: "gpt-4o-mini" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const modelSection = payload.sections.find((s) => s.id === "who-model-mix");
+
+    expect(modelSection).toBeDefined();
+    if (modelSection!.widget.kind === "breakdown") {
+      const fractionSum = modelSection!.widget.slices.reduce(
+        (sum, s) => sum + s.fraction,
+        0,
+      );
+      expect(fractionSum).toBeCloseTo(1);
+      const gpt4oSlice = modelSection!.widget.slices.find(
+        (s) => s.label === "gpt-4o",
+      );
+      expect(gpt4oSlice?.value).toBe(2);
+    }
+  });
+
+  it("median duration excludes null durationMs values", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "skipped",
+            stage: "precheck",
+            errorCode: "no_sources",
+            durationMs: null,
+          }),
+          makeRun({ outcome: "success", durationMs: 10000 }),
+          makeRun({ outcome: "success", durationMs: 20000 }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const medianKpi = payload.kpis.find((k) => k.id === "median_duration_ms");
+
+    expect(medianKpi).toBeDefined();
+    expect(medianKpi!.value).toBe(15000);
+  });
+
+  it("emits a high-failure-rate alert when failure rate exceeds 20%", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({ outcome: "success" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const failAlert = payload.alerts.find((a) => a.id === "high-failure-rate");
+
+    expect(failAlert).toBeDefined();
+    expect(failAlert!.severity).toBe("warning");
+  });
+
+  it("returns a valid payload when all inputs are empty", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({ runs: [], newsletters: [] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.kpis.length).toBeGreaterThanOrEqual(3);
+    expect(parsed.alerts).toHaveLength(0);
+    expect(parsed.sections.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
@@ -1,0 +1,721 @@
+import type { Prisma } from "@mediapulse/database";
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+const FAILURE_RATE_THRESHOLD = 0.2;
+const STALE_THRESHOLD_24H_MS = 6 * 60 * 60 * 1000;
+const STALE_THRESHOLD_DEFAULT_MS = 48 * 60 * 60 * 1000;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type CgRunRow = {
+  tickerId: string;
+  outcome: string;
+  stage: string | null;
+  errorCode: string | null;
+  errorCategory: string | null;
+  durationMs: number | null;
+  createdAt: Date;
+  details: Prisma.JsonValue | null;
+};
+
+type NewsletterRow = {
+  tickerId: string;
+  createdAt: Date;
+  model: string | null;
+  totalTokens: number | null;
+};
+
+type ContentGenerationInsightsDeps = {
+  contentGenerationRun: {
+    findMany: (args: {
+      where: {
+        agentId: string;
+        createdAt: { gte: Date };
+        tickerId?: string;
+      };
+      orderBy: { createdAt: "asc" };
+      select: {
+        tickerId: boolean;
+        outcome: boolean;
+        stage: boolean;
+        errorCode: boolean;
+        errorCategory: boolean;
+        durationMs: boolean;
+        createdAt: boolean;
+        details: boolean;
+      };
+    }) => Promise<CgRunRow[]>;
+  };
+  newsletter: {
+    findMany: (args: {
+      where: {
+        createdAt: { gte: Date };
+        tickerId?: string;
+      };
+      orderBy: { createdAt: "asc" };
+      select: {
+        tickerId: boolean;
+        createdAt: boolean;
+        model: boolean;
+        totalTokens: boolean;
+      };
+    }) => Promise<NewsletterRow[]>;
+  };
+};
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+function medianOf(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  }
+
+  return sorted[mid]!;
+}
+
+function extractCgFillBySection(
+  details: Prisma.JsonValue | null,
+): Record<string, { citedBullets: number }> | null {
+  if (
+    details === null ||
+    typeof details !== "object" ||
+    Array.isArray(details)
+  ) {
+    return null;
+  }
+  const sectionFill = (details as Record<string, unknown>).sectionFill;
+  if (
+    sectionFill === null ||
+    typeof sectionFill !== "object" ||
+    Array.isArray(sectionFill)
+  ) {
+    return null;
+  }
+  const bySection = (sectionFill as Record<string, unknown>).bySection;
+  if (
+    bySection === null ||
+    typeof bySection !== "object" ||
+    Array.isArray(bySection)
+  ) {
+    return null;
+  }
+
+  return bySection as Record<string, { citedBullets: number }>;
+}
+
+export function createContentGenerationInsightsProvider(
+  deps: ContentGenerationInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "content-generation",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const runSelect = {
+        tickerId: true,
+        outcome: true,
+        stage: true,
+        errorCode: true,
+        errorCategory: true,
+        durationMs: true,
+        createdAt: true,
+        details: true,
+      } as const;
+
+      const [runs, priorRuns, newsletters] = await Promise.all([
+        deps.contentGenerationRun.findMany({
+          where: {
+            agentId: "content-generation",
+            createdAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { createdAt: "asc" },
+          select: runSelect,
+        }),
+        deps.contentGenerationRun.findMany({
+          where: {
+            agentId: "content-generation",
+            createdAt: { gte: priorStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { createdAt: "asc" },
+          select: runSelect,
+        }),
+        deps.newsletter.findMany({
+          where: {
+            createdAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { createdAt: "asc" },
+          select: {
+            tickerId: true,
+            createdAt: true,
+            model: true,
+            totalTokens: true,
+          },
+        }),
+      ]);
+
+      const priorWindowRuns = priorRuns.filter(
+        (r) => r.createdAt >= priorStart && r.createdAt < windowStart,
+      );
+
+      // ─── Outcome counts ──────────────────────────────────────────────────
+
+      const totalRuns = runs.length;
+      const successRuns = runs.filter((r) => r.outcome === "success");
+      const failedRuns = runs.filter((r) => r.outcome === "failed");
+      const skippedRuns = runs.filter((r) => r.outcome === "skipped");
+
+      const priorSuccessCount = priorWindowRuns.filter(
+        (r) => r.outcome === "success",
+      ).length;
+
+      // Each successful run creates exactly one newsletter, so prior success count
+      // approximates prior newsletter count without an additional query.
+      const priorNewsletterCount = priorSuccessCount;
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const successRate =
+        totalRuns > 0 ? Math.round((successRuns.length / totalRuns) * 100) : 0;
+
+      const durations = runs
+        .filter((r) => r.durationMs !== null)
+        .map((r) => r.durationMs!);
+      const medianDuration = medianOf(durations);
+
+      const totalTokens = newsletters.reduce(
+        (sum, n) => sum + (n.totalTokens ?? 0),
+        0,
+      );
+
+      const kpis: KpiCard[] = [
+        {
+          id: "runs",
+          label: "Runs",
+          value: totalRuns,
+          delta: totalRuns - priorWindowRuns.length,
+        },
+        {
+          id: "success_rate",
+          label: "Success rate",
+          value: successRate,
+          unit: "%",
+        },
+        {
+          id: "newsletters",
+          label: "Newsletters generated",
+          value: newsletters.length,
+          delta: newsletters.length - priorNewsletterCount,
+        },
+        ...(medianDuration !== null
+          ? [
+              {
+                id: "median_duration_ms",
+                label: "Median duration",
+                value: medianDuration,
+                unit: "ms",
+              } satisfies KpiCard,
+            ]
+          : []),
+        {
+          id: "total_tokens",
+          label: "Total tokens",
+          value: totalTokens,
+        },
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      if (
+        totalRuns > 0 &&
+        failedRuns.length / totalRuns > FAILURE_RATE_THRESHOLD
+      ) {
+        alerts.push({
+          id: "high-failure-rate",
+          severity: "warning",
+          message: `Failure rate is ${Math.round((failedRuns.length / totalRuns) * 100)}% — above the ${FAILURE_RATE_THRESHOLD * 100}% threshold`,
+          sectionRef: "why-failure-by-stage",
+        });
+      }
+
+      const failuresByStage = new Map<string, number>();
+      for (const run of failedRuns) {
+        if (run.stage) {
+          failuresByStage.set(
+            run.stage,
+            (failuresByStage.get(run.stage) ?? 0) + 1,
+          );
+        }
+      }
+      if (failuresByStage.size > 0) {
+        let dominantStage = "";
+        let dominantCount = 0;
+        for (const [stage, count] of failuresByStage) {
+          if (count > dominantCount) {
+            dominantStage = stage;
+            dominantCount = count;
+          }
+        }
+        if (dominantCount >= 3) {
+          alerts.push({
+            id: `dominant-failure-stage-${dominantStage}`,
+            severity: "warning",
+            message: `Most failures occur at the "${dominantStage}" stage (${dominantCount} runs)`,
+            sectionRef: "why-failure-by-stage",
+          });
+        }
+      }
+
+      const noSourcesCount = skippedRuns.filter(
+        (r) => r.errorCode === "no_sources",
+      ).length;
+      if (noSourcesCount >= 3) {
+        alerts.push({
+          id: "recurring-no-sources",
+          severity: "warning",
+          message: `"no_sources" skip occurred ${noSourcesCount} times — check data pipeline for missing article ingestion`,
+          sectionRef: "why-skip-reason",
+        });
+      }
+
+      if (totalRuns > 0) {
+        const staleThresholdMs =
+          ctx.window === "24h"
+            ? STALE_THRESHOLD_24H_MS
+            : STALE_THRESHOLD_DEFAULT_MS;
+        const lastRun = runs[runs.length - 1];
+        if (
+          lastRun &&
+          now.getTime() - lastRun.createdAt.getTime() > staleThresholdMs
+        ) {
+          alerts.push({
+            id: "stale-last-run",
+            severity: "info",
+            message: `No run in the last ${ctx.window === "24h" ? "6 hours" : "48 hours"}`,
+          });
+        }
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — outcome breakdown
+      if (totalRuns > 0) {
+        const outcomeSlices = [
+          {
+            label: "Success",
+            value: successRuns.length,
+            fraction: successRuns.length / totalRuns,
+          },
+          {
+            label: "Skipped",
+            value: skippedRuns.length,
+            fraction: skippedRuns.length / totalRuns,
+          },
+          {
+            label: "Failed",
+            value: failedRuns.length,
+            fraction: failedRuns.length / totalRuns,
+          },
+        ].filter((s) => s.value > 0);
+
+        sections.push({
+          id: "what-outcome",
+          category: "what",
+          title: "Outcome breakdown",
+          insight: "Distribution of run outcomes over the selected window.",
+          widget: {
+            kind: "breakdown",
+            slices: outcomeSlices,
+          },
+        });
+      }
+
+      // What — stage funnel (runs reaching each stage)
+      const stageDropCounts = new Map<string, number>();
+      for (const run of runs) {
+        if (run.stage) {
+          stageDropCounts.set(
+            run.stage,
+            (stageDropCounts.get(run.stage) ?? 0) + 1,
+          );
+        }
+      }
+      const reachedPrecheck = totalRuns;
+      const reachedLlm =
+        reachedPrecheck - (stageDropCounts.get("precheck") ?? 0);
+      const reachedValidate = reachedLlm - (stageDropCounts.get("llm") ?? 0);
+      const reachedPersist =
+        reachedValidate - (stageDropCounts.get("validate") ?? 0);
+      const reachedNewsletter =
+        reachedPersist - (stageDropCounts.get("persist") ?? 0);
+
+      sections.push({
+        id: "what-stage-funnel",
+        category: "what",
+        title: "Stage funnel",
+        insight:
+          "Runs passing through each stage of the content-generation pipeline.",
+        widget: {
+          kind: "funnel",
+          stages: [
+            { label: "Precheck", value: reachedPrecheck },
+            { label: "LLM", value: reachedLlm },
+            { label: "Validate", value: reachedValidate },
+            { label: "Persist", value: reachedPersist },
+            { label: "Newsletter", value: reachedNewsletter },
+          ],
+        },
+      });
+
+      // When — runs per day
+      const runsDailyBuckets = buildWindowDates(windowStart, now);
+      for (const run of runs) {
+        const dayKey = run.createdAt.toISOString().slice(0, 10);
+        if (runsDailyBuckets.has(dayKey)) {
+          runsDailyBuckets.set(dayKey, (runsDailyBuckets.get(dayKey) ?? 0) + 1);
+        }
+      }
+      sections.push({
+        id: "when-runs",
+        category: "when",
+        title: "Runs over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(runsDailyBuckets.entries()).map(([ts, value]) => ({
+            ts: `${ts}T00:00:00.000Z`,
+            value,
+          })),
+          unit: "runs",
+        },
+      });
+
+      // When — tokens per day (from newsletters only — failed/skipped runs produce no tokens)
+      if (newsletters.length > 0) {
+        const tokensDailyBuckets = buildWindowDates(windowStart, now);
+        for (const newsletter of newsletters) {
+          const dayKey = newsletter.createdAt.toISOString().slice(0, 10);
+          if (tokensDailyBuckets.has(dayKey)) {
+            tokensDailyBuckets.set(
+              dayKey,
+              (tokensDailyBuckets.get(dayKey) ?? 0) +
+                (newsletter.totalTokens ?? 0),
+            );
+          }
+        }
+        sections.push({
+          id: "when-tokens",
+          category: "when",
+          title: "Tokens over time",
+          insight:
+            "Daily token usage reflects successfully generated newsletters only — failed and skipped runs do not consume tokens.",
+          widget: {
+            kind: "timeSeries",
+            points: Array.from(tokensDailyBuckets.entries()).map(
+              ([ts, value]) => ({
+                ts: `${ts}T00:00:00.000Z`,
+                value,
+              }),
+            ),
+            unit: "tokens",
+          },
+        });
+      }
+
+      // Where — newsletters by ticker (top-N)
+      const tickerNewsletterCounts = new Map<string, number>();
+      for (const newsletter of newsletters) {
+        tickerNewsletterCounts.set(
+          newsletter.tickerId,
+          (tickerNewsletterCounts.get(newsletter.tickerId) ?? 0) + 1,
+        );
+      }
+      if (tickerNewsletterCounts.size > 0) {
+        sections.push({
+          id: "where-per-ticker",
+          category: "where",
+          title: "Newsletters by ticker",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(tickerNewsletterCounts.entries()).map(
+                ([label, value]) => ({ label, value }),
+              ),
+              TOP_N,
+            ),
+            unit: "newsletters",
+          },
+        });
+      }
+
+      // Who — model mix from Newsletter.model
+      const modelMix = new Map<string, number>();
+      for (const newsletter of newsletters) {
+        const model = newsletter.model ?? "unknown";
+        modelMix.set(model, (modelMix.get(model) ?? 0) + 1);
+      }
+      if (modelMix.size > 0) {
+        const modelTotal = Array.from(modelMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "who-model-mix",
+          category: "who",
+          title: "Model mix",
+          insight:
+            "Model distribution reflects successfully generated newsletters only.",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(modelMix.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: modelTotal > 0 ? value / modelTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // Why — failures by stage (only failed runs)
+      if (failedRuns.length > 0) {
+        const failureStages = new Map<string, number>();
+        for (const run of failedRuns) {
+          const stage = run.stage ?? "unknown";
+          failureStages.set(stage, (failureStages.get(stage) ?? 0) + 1);
+        }
+        const failTotal = failedRuns.length;
+        sections.push({
+          id: "why-failure-by-stage",
+          category: "why",
+          title: "Failures by stage",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(failureStages.entries()).map(
+              ([label, value]) => ({
+                label,
+                value,
+                fraction: failTotal > 0 ? value / failTotal : 0,
+              }),
+            ),
+          },
+        });
+      }
+
+      // Why — error category breakdown (only failed runs)
+      if (failedRuns.length > 0) {
+        const errorCategories = new Map<string, number>();
+        for (const run of failedRuns) {
+          const category = run.errorCategory ?? "unknown";
+          errorCategories.set(
+            category,
+            (errorCategories.get(category) ?? 0) + 1,
+          );
+        }
+        const categoryTotal = failedRuns.length;
+        sections.push({
+          id: "why-error-category",
+          category: "why",
+          title: "Error categories",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(errorCategories.entries()).map(
+              ([label, value]) => ({
+                label,
+                value,
+                fraction: categoryTotal > 0 ? value / categoryTotal : 0,
+              }),
+            ),
+          },
+        });
+      }
+
+      // Why — skip reason breakdown (only skipped runs)
+      if (skippedRuns.length > 0) {
+        const skipReasons = new Map<string, number>();
+        for (const run of skippedRuns) {
+          const reason = run.errorCode ?? "unknown";
+          skipReasons.set(reason, (skipReasons.get(reason) ?? 0) + 1);
+        }
+        const skipTotal = skippedRuns.length;
+        sections.push({
+          id: "why-skip-reason",
+          category: "why",
+          title: "Skip reasons",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(skipReasons.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: skipTotal > 0 ? value / skipTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // How — duration histogram (only non-null durationMs)
+      if (durations.length > 0) {
+        const durationBuckets = new Map([
+          ["< 5s", 0],
+          ["5-15s", 0],
+          ["15-30s", 0],
+          ["30-60s", 0],
+          ["> 60s", 0],
+        ]);
+        for (const ms of durations) {
+          const seconds = ms / 1000;
+          if (seconds < 5) {
+            durationBuckets.set("< 5s", (durationBuckets.get("< 5s") ?? 0) + 1);
+          } else if (seconds < 15) {
+            durationBuckets.set(
+              "5-15s",
+              (durationBuckets.get("5-15s") ?? 0) + 1,
+            );
+          } else if (seconds < 30) {
+            durationBuckets.set(
+              "15-30s",
+              (durationBuckets.get("15-30s") ?? 0) + 1,
+            );
+          } else if (seconds < 60) {
+            durationBuckets.set(
+              "30-60s",
+              (durationBuckets.get("30-60s") ?? 0) + 1,
+            );
+          } else {
+            durationBuckets.set(
+              "> 60s",
+              (durationBuckets.get("> 60s") ?? 0) + 1,
+            );
+          }
+        }
+        sections.push({
+          id: "how-duration-histogram",
+          category: "how",
+          title: "Run duration distribution",
+          widget: {
+            kind: "histogram",
+            buckets: Array.from(durationBuckets.entries()).map(
+              ([label, count]) => ({ label, count }),
+            ),
+          },
+        });
+      }
+
+      // How — median duration stat
+      if (medianDuration !== null) {
+        sections.push({
+          id: "how-median-duration",
+          category: "how",
+          title: "Median run duration",
+          widget: {
+            kind: "stat",
+            value: medianDuration,
+            unit: "ms",
+          },
+        });
+      }
+
+      // How — section-fill coverage (cited bullets per section, summed across successful runs)
+      const sectionFillTotals = new Map<string, number>();
+      for (const run of successRuns) {
+        const bySection = extractCgFillBySection(run.details);
+        if (bySection === null) {
+          continue;
+        }
+        for (const [sectionId, data] of Object.entries(bySection)) {
+          if (typeof data.citedBullets === "number") {
+            sectionFillTotals.set(
+              sectionId,
+              (sectionFillTotals.get(sectionId) ?? 0) + data.citedBullets,
+            );
+          }
+        }
+      }
+      if (sectionFillTotals.size > 0) {
+        sections.push({
+          id: "how-section-fill",
+          category: "how",
+          title: "Section fill coverage",
+          insight:
+            "Total cited bullets per newsletter section across successful runs.",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(sectionFillTotals.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "cited bullets",
+          },
+        });
+      }
+
+      return {
+        agentId: "content-generation",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the content-generation insights provider — the second `AgentInsightsProvider` after page-collection. It reads the already-persisted `ContentGenerationRun` diagnostics (filtered to `agentId = "content-generation"`) and `Newsletter` rows over a rolling window, then assembles a contract-valid `InsightsPayload` of 5W1H widgets. The generic dashboard tab introduced by Plan 103 now renders real data for content-generation with no UI changes.

## Related issues

Closes #719

## Important changes

- New `createContentGenerationInsightsProvider` factory in `agent-data-api/src/services/insights/` — 5W1H widget assembly with outcome breakdown + stage funnel, runs/tokens over time, per-ticker counts, model mix, failure/skip breakdowns, duration histogram, and section-fill coverage
- Registered at `agent-data-api` startup alongside the page-collection provider in `index.ts`

## Other changes

- `content-generation-insights-provider.test.ts` — 12 fixture tests covering schema validation, fraction sums, section isolation (failed/skipped only in their respective breakdowns), section-fill aggregation, top-N bucketing, stale/failure alerts, and an all-empty case

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts` — factory implementation with injected Prisma delegates
- `apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts` — fixture tests
- `apps/mediapulse/agent-data-api/src/index.ts` — provider registration

## How to test

1. Run `pnpm --filter @mediapulse/agent-data-api test` — all 12 new tests and the full suite should pass
2. With `HERMES_AGENT_INSIGHTS_ENABLED` on, open a content-generation agent → Insights tab
3. Confirm: outcome breakdown, runs/tokens timelines, model mix, failure/skip breakdowns, and section-fill coverage all render
4. Use the window switcher (24h / 7d / 30d) and confirm re-fetch works
