### PR TITLE
Add delivery insights provider

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -72,6 +72,7 @@ import { createPageCollectionInsightsProvider } from "./services/insights/page-c
 import { createContentGenerationInsightsProvider } from "./services/insights/content-generation-insights-provider.js";
 import { createUserRegistrationInsightsProvider } from "./services/insights/user-registration-insights-provider.js";
 import { createDataCollectionInsightsProvider } from "./services/insights/data-collection-insights-provider.js";
+import { createDeliveryInsightsProvider } from "./services/insights/delivery-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -247,6 +248,11 @@ registerInsightsProvider(
     dataCollectionRun: prisma.dataCollectionRun,
     dataCollectionFailure: prisma.dataCollectionFailure,
     dataSource: prisma.dataSource,
+  }),
+);
+registerInsightsProvider(
+  createDeliveryInsightsProvider({
+    deliveryRun: prisma.deliveryRun,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
@@ -1,0 +1,326 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+
+import { createDeliveryInsightsProvider } from "./delivery-insights-provider.js";
+
+function makeRecipient(overrides?: {
+  status?: string;
+  attempts?: number;
+  errorCategory?: string | null;
+}) {
+  return {
+    status: overrides?.status ?? "success",
+    attempts: overrides?.attempts ?? 1,
+    errorCategory:
+      overrides?.errorCategory !== undefined ? overrides.errorCategory : null,
+  };
+}
+
+function makeRun(overrides?: {
+  tickerId?: string;
+  outcome?: string;
+  stage?: string | null;
+  successCount?: number;
+  failureCount?: number;
+  skippedCount?: number;
+  durationMs?: number;
+  runSkipReason?: string | null;
+  createdAt?: Date;
+  recipients?: ReturnType<typeof makeRecipient>[];
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    outcome: overrides?.outcome ?? "success",
+    stage: overrides?.stage !== undefined ? overrides.stage : null,
+    successCount: overrides?.successCount ?? 3,
+    failureCount: overrides?.failureCount ?? 0,
+    skippedCount: overrides?.skippedCount ?? 0,
+    durationMs: overrides?.durationMs ?? 5000,
+    runSkipReason:
+      overrides?.runSkipReason !== undefined ? overrides.runSkipReason : null,
+    createdAt: overrides?.createdAt ?? new Date("2026-06-07T08:00:00.000Z"),
+    recipients: overrides?.recipients ?? [
+      makeRecipient(),
+      makeRecipient(),
+      makeRecipient(),
+    ],
+  };
+}
+
+function makeDeps(overrides?: { runs?: ReturnType<typeof makeRun>[] }) {
+  const runs = overrides?.runs ?? [makeRun()];
+
+  return {
+    deliveryRun: {
+      findMany: async () => runs,
+    },
+  };
+}
+
+describe("createDeliveryInsightsProvider", () => {
+  it("returns a payload that parses through insightsPayloadSchema", async () => {
+    const provider = createDeliveryInsightsProvider(makeDeps());
+    const payload = await provider.compute({ window: "7d" });
+
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.agentId).toBe("delivery");
+    expect(parsed.window).toBe("7d");
+    expect(typeof parsed.generatedAt).toBe("string");
+    expect(Array.isArray(parsed.kpis)).toBe(true);
+    expect(Array.isArray(parsed.alerts)).toBe(true);
+    expect(Array.isArray(parsed.sections)).toBe(true);
+  });
+
+  it("outcome breakdown counts each DeliveryRunOutcome correctly", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "partial_success", failureCount: 1 }),
+          makeRun({ outcome: "failed", stage: "send" }),
+          makeRun({ outcome: "skipped", runSkipReason: "no_newsletter" }),
+          makeRun({ outcome: "skipped_all_already_delivered" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const outcomeSection = payload.sections.find(
+      (s) => s.id === "what-outcome",
+    );
+
+    expect(outcomeSection).toBeDefined();
+    expect(outcomeSection!.widget.kind).toBe("breakdown");
+    if (outcomeSection!.widget.kind === "breakdown") {
+      const successSlice = outcomeSection!.widget.slices.find(
+        (s) => s.label === "Success",
+      );
+      const partialSlice = outcomeSection!.widget.slices.find(
+        (s) => s.label === "Partial success",
+      );
+      const failedSlice = outcomeSection!.widget.slices.find(
+        (s) => s.label === "Failed",
+      );
+      expect(successSlice?.value).toBe(2);
+      expect(partialSlice?.value).toBe(1);
+      expect(failedSlice?.value).toBe(1);
+      const fractionSum = outcomeSection!.widget.slices.reduce(
+        (sum, s) => sum + s.fraction,
+        0,
+      );
+      expect(fractionSum).toBeCloseTo(1);
+    }
+  });
+
+  it("recipient funnel: attempted >= succeeded and succeeds == sum of successCount from active runs", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success", successCount: 5, failureCount: 0 }),
+          makeRun({
+            outcome: "partial_success",
+            successCount: 3,
+            failureCount: 2,
+          }),
+          makeRun({
+            outcome: "skipped",
+            successCount: 0,
+            failureCount: 0,
+            runSkipReason: "no_newsletter",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const funnelSection = payload.sections.find(
+      (s) => s.id === "who-recipient-funnel",
+    );
+
+    expect(funnelSection).toBeDefined();
+    expect(funnelSection!.widget.kind).toBe("funnel");
+    if (funnelSection!.widget.kind === "funnel") {
+      const attempted = funnelSection!.widget.stages.find(
+        (s) => s.label === "Attempted",
+      );
+      const delivered = funnelSection!.widget.stages.find(
+        (s) => s.label === "Delivered",
+      );
+      expect(attempted?.value).toBe(10);
+      expect(delivered?.value).toBe(8);
+      expect(attempted!.value).toBeGreaterThanOrEqual(delivered!.value);
+    }
+  });
+
+  it("error category breakdown aggregates only failed recipients", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "partial_success",
+            successCount: 2,
+            failureCount: 2,
+            recipients: [
+              makeRecipient({ status: "success" }),
+              makeRecipient({ status: "success" }),
+              makeRecipient({
+                status: "failed",
+                errorCategory: "resend_rate_limited",
+              }),
+              makeRecipient({
+                status: "failed",
+                errorCategory: "resend_transient",
+              }),
+            ],
+          }),
+          makeRun({
+            outcome: "success",
+            successCount: 1,
+            recipients: [makeRecipient({ status: "success" })],
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const errorSection = payload.sections.find(
+      (s) => s.id === "why-error-category",
+    );
+
+    expect(errorSection).toBeDefined();
+    expect(errorSection!.widget.kind).toBe("breakdown");
+    if (errorSection!.widget.kind === "breakdown") {
+      const totalInBreakdown = errorSection!.widget.slices.reduce(
+        (sum, s) => sum + s.value,
+        0,
+      );
+      expect(totalInBreakdown).toBe(2);
+      const rateLimitSlice = errorSection!.widget.slices.find(
+        (s) => s.label === "resend_rate_limited",
+      );
+      expect(rateLimitSlice?.value).toBe(1);
+    }
+  });
+
+  it("attempts histogram buckets recipients by attempt count, skipping skipped recipients", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "partial_success",
+            recipients: [
+              makeRecipient({ status: "success", attempts: 1 }),
+              makeRecipient({ status: "success", attempts: 3 }),
+              makeRecipient({ status: "failed", attempts: 4 }),
+              makeRecipient({ status: "skipped", attempts: 0 }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const histogramSection = payload.sections.find(
+      (s) => s.id === "how-attempts-histogram",
+    );
+
+    expect(histogramSection).toBeDefined();
+    expect(histogramSection!.widget.kind).toBe("histogram");
+    if (histogramSection!.widget.kind === "histogram") {
+      const totalBucketCount = histogramSection!.widget.buckets.reduce(
+        (sum, b) => sum + b.count,
+        0,
+      );
+      expect(totalBucketCount).toBe(3);
+      const oneBucket = histogramSection!.widget.buckets.find(
+        (b) => b.label === "1 attempt",
+      );
+      expect(oneBucket?.count).toBe(1);
+      const fourPlusBucket = histogramSection!.widget.buckets.find(
+        (b) => b.label === "4+ attempts",
+      );
+      expect(fourPlusBucket?.count).toBe(1);
+    }
+  });
+
+  it("KPI includes a numeric delta for runs and recipients_reached", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            createdAt: new Date("2026-06-07T08:00:00.000Z"),
+            successCount: 4,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const runsKpi = payload.kpis.find((k) => k.id === "runs");
+    const recipientsKpi = payload.kpis.find(
+      (k) => k.id === "recipients_reached",
+    );
+
+    expect(runsKpi).toBeDefined();
+    expect(runsKpi!.value).toBe(1);
+    expect(typeof runsKpi!.delta).toBe("number");
+    expect(recipientsKpi).toBeDefined();
+    expect(recipientsKpi!.value).toBe(4);
+    expect(typeof recipientsKpi!.delta).toBe("number");
+  });
+
+  it("caps per-ticker delivery bars at TOP_N + Other bucket", async () => {
+    const manyRuns = Array.from({ length: 15 }, (_, index) =>
+      makeRun({ tickerId: `ticker-${index}` }),
+    );
+
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({ runs: manyRuns }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    expect(tickerBar).toBeDefined();
+    if (tickerBar!.widget.kind === "categoryBar") {
+      expect(tickerBar!.widget.bars.length).toBeLessThanOrEqual(11);
+      const other = tickerBar!.widget.bars.find((b) => b.label === "Other");
+      expect(other).toBeDefined();
+    }
+  });
+
+  it("emits a stage-failure alert when runs fail at send or fetch stage", async () => {
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "failed", stage: "send", recipients: [] }),
+          makeRun({ outcome: "success" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const stageAlert = payload.alerts.find((a) =>
+      a.id.startsWith("stage-failure-"),
+    );
+
+    expect(stageAlert).toBeDefined();
+    expect(stageAlert!.severity).toBe("warning");
+  });
+
+  it("returns a valid payload when all inputs are empty", async () => {
+    const provider = createDeliveryInsightsProvider(makeDeps({ runs: [] }));
+
+    const payload = await provider.compute({ window: "7d" });
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(parsed.kpis.length).toBeGreaterThanOrEqual(3);
+    expect(parsed.alerts).toHaveLength(0);
+    expect(parsed.sections.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
@@ -344,13 +344,16 @@ export function createDeliveryInsightsProvider(
 
       // What — delivery outcome breakdown
       if (totalRuns > 0) {
-        const outcomeEntries: Array<[string, number]> = [
+        const allOutcomeEntries: Array<[string, number]> = [
           ["Success", successRuns.length],
           ["Partial success", partialSuccessRuns.length],
           ["Failed", failedRuns.length],
           ["Skipped", skippedRuns.length],
           ["Skipped (already delivered)", skippedAllDeliveredRuns.length],
-        ].filter(([, count]) => count > 0) as Array<[string, number]>;
+        ];
+        const outcomeEntries = allOutcomeEntries.filter(
+          (entry): entry is [string, number] => entry[1] > 0,
+        );
 
         sections.push({
           id: "what-outcome",

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
@@ -1,0 +1,567 @@
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+const FAILURE_RATE_THRESHOLD = 0.2;
+const RATE_LIMIT_THRESHOLD = 0.1;
+const PARTIAL_SUCCESS_SPIKE_THRESHOLD = 0.5;
+const STALE_THRESHOLD_24H_MS = 6 * 60 * 60 * 1000;
+const STALE_THRESHOLD_DEFAULT_MS = 48 * 60 * 60 * 1000;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type RecipientRow = {
+  status: string;
+  attempts: number;
+  errorCategory: string | null;
+};
+
+type DeliveryRunRow = {
+  tickerId: string;
+  outcome: string;
+  stage: string | null;
+  successCount: number;
+  failureCount: number;
+  skippedCount: number;
+  durationMs: number;
+  runSkipReason: string | null;
+  createdAt: Date;
+  recipients: RecipientRow[];
+};
+
+type DeliveryInsightsDeps = {
+  deliveryRun: {
+    findMany: (args: {
+      where: {
+        agentId: string;
+        createdAt: { gte: Date };
+        tickerId?: string;
+      };
+      orderBy: { createdAt: "asc" };
+      select: {
+        tickerId: boolean;
+        outcome: boolean;
+        stage: boolean;
+        successCount: boolean;
+        failureCount: boolean;
+        skippedCount: boolean;
+        durationMs: boolean;
+        runSkipReason: boolean;
+        createdAt: boolean;
+        recipients: {
+          select: {
+            status: boolean;
+            attempts: boolean;
+            errorCategory: boolean;
+          };
+        };
+      };
+    }) => Promise<DeliveryRunRow[]>;
+  };
+};
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+function medianOf(values: number[]): number | null {
+  if (values.length === 0) {
+    return null;
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return Math.round((sorted[mid - 1]! + sorted[mid]!) / 2);
+  }
+
+  return sorted[mid]!;
+}
+
+function isSkippedOutcome(outcome: string): boolean {
+  return outcome === "skipped" || outcome === "skipped_all_already_delivered";
+}
+
+export function createDeliveryInsightsProvider(
+  deps: DeliveryInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "delivery",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const runSelect = {
+        tickerId: true,
+        outcome: true,
+        stage: true,
+        successCount: true,
+        failureCount: true,
+        skippedCount: true,
+        durationMs: true,
+        runSkipReason: true,
+        createdAt: true,
+        recipients: {
+          select: {
+            status: true,
+            attempts: true,
+            errorCategory: true,
+          },
+        },
+      } as const;
+
+      const [runs, priorRuns] = await Promise.all([
+        deps.deliveryRun.findMany({
+          where: {
+            agentId: "delivery",
+            createdAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { createdAt: "asc" },
+          select: runSelect,
+        }),
+        deps.deliveryRun.findMany({
+          where: {
+            agentId: "delivery",
+            createdAt: { gte: priorStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { createdAt: "asc" },
+          select: runSelect,
+        }),
+      ]);
+
+      const priorWindowRuns = priorRuns.filter(
+        (r) => r.createdAt >= priorStart && r.createdAt < windowStart,
+      );
+
+      // ─── Run outcome counts ──────────────────────────────────────────────
+
+      const totalRuns = runs.length;
+      const activeRuns = runs.filter((r) => !isSkippedOutcome(r.outcome));
+      const successRuns = runs.filter((r) => r.outcome === "success");
+      const partialSuccessRuns = runs.filter(
+        (r) => r.outcome === "partial_success",
+      );
+      const failedRuns = runs.filter((r) => r.outcome === "failed");
+      const skippedRuns = runs.filter((r) => r.outcome === "skipped");
+      const skippedAllDeliveredRuns = runs.filter(
+        (r) => r.outcome === "skipped_all_already_delivered",
+      );
+
+      const priorTotalRuns = priorWindowRuns.length;
+      const priorSuccessCount = priorWindowRuns.reduce(
+        (sum, r) => sum + r.successCount,
+        0,
+      );
+
+      // ─── Recipient aggregates ────────────────────────────────────────────
+
+      const totalRecipientsReached = runs.reduce(
+        (sum, r) => sum + r.successCount,
+        0,
+      );
+
+      const activeAttempted = activeRuns.reduce(
+        (sum, r) => sum + r.successCount + r.failureCount,
+        0,
+      );
+      const activeDelivered = activeRuns.reduce(
+        (sum, r) => sum + r.successCount,
+        0,
+      );
+
+      const allRecipients = runs.flatMap((r) => r.recipients);
+      const failedRecipients = allRecipients.filter(
+        (r) => r.status === "failed",
+      );
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const activeRunCount = successRuns.length + partialSuccessRuns.length;
+      const successRate =
+        totalRuns > 0 ? Math.round((activeRunCount / totalRuns) * 100) : 0;
+
+      const activeDurations = activeRuns.map((r) => r.durationMs);
+      const medianDuration = medianOf(activeDurations);
+
+      const kpis: KpiCard[] = [
+        {
+          id: "runs",
+          label: "Runs",
+          value: totalRuns,
+          delta: totalRuns - priorTotalRuns,
+        },
+        {
+          id: "success_rate",
+          label: "Success rate",
+          value: successRate,
+          unit: "%",
+        },
+        {
+          id: "recipients_reached",
+          label: "Recipients reached",
+          value: totalRecipientsReached,
+          delta: totalRecipientsReached - priorSuccessCount,
+        },
+        ...(medianDuration !== null
+          ? [
+              {
+                id: "median_duration_ms",
+                label: "Median duration",
+                value: medianDuration,
+                unit: "ms",
+              } satisfies KpiCard,
+            ]
+          : []),
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      // Recent send/fetch stage failure
+      const stageFails = failedRuns.filter(
+        (r) => r.stage === "send" || r.stage === "fetch",
+      );
+      if (stageFails.length > 0) {
+        const lastFail = stageFails[stageFails.length - 1]!;
+        alerts.push({
+          id: `stage-failure-${lastFail.stage}`,
+          severity: "warning",
+          message: `${stageFails.length} run(s) failed at the "${lastFail.stage}" stage`,
+          sectionRef: "why-error-category",
+        });
+      }
+
+      // Rate-limited recipients
+      const rateLimitedRecipients = failedRecipients.filter(
+        (r) => r.errorCategory === "resend_rate_limited",
+      );
+      if (
+        allRecipients.length > 0 &&
+        rateLimitedRecipients.length / allRecipients.length >
+          RATE_LIMIT_THRESHOLD
+      ) {
+        alerts.push({
+          id: "rate-limited-recipients",
+          severity: "warning",
+          message: `${rateLimitedRecipients.length} recipient(s) were rate-limited by Resend`,
+          sectionRef: "why-error-category",
+        });
+      }
+
+      // Partial success spike
+      if (
+        activeRuns.length > 0 &&
+        partialSuccessRuns.length / activeRuns.length >
+          PARTIAL_SUCCESS_SPIKE_THRESHOLD
+      ) {
+        alerts.push({
+          id: "partial-success-spike",
+          severity: "warning",
+          message: `${Math.round((partialSuccessRuns.length / activeRuns.length) * 100)}% of delivery runs are partial_success — some recipients may be missing newsletters`,
+          sectionRef: "what-outcome",
+        });
+      }
+
+      // High failure rate
+      if (
+        totalRuns > 0 &&
+        failedRuns.length / totalRuns > FAILURE_RATE_THRESHOLD
+      ) {
+        alerts.push({
+          id: "high-failure-rate",
+          severity: "warning",
+          message: `Failure rate is ${Math.round((failedRuns.length / totalRuns) * 100)}% — above the ${FAILURE_RATE_THRESHOLD * 100}% threshold`,
+          sectionRef: "why-error-category",
+        });
+      }
+
+      // Stale last run
+      if (totalRuns > 0) {
+        const staleThresholdMs =
+          ctx.window === "24h"
+            ? STALE_THRESHOLD_24H_MS
+            : STALE_THRESHOLD_DEFAULT_MS;
+        const lastRun = runs[runs.length - 1];
+        if (
+          lastRun &&
+          now.getTime() - lastRun.createdAt.getTime() > staleThresholdMs
+        ) {
+          alerts.push({
+            id: "stale-last-run",
+            severity: "info",
+            message: `No run in the last ${ctx.window === "24h" ? "6 hours" : "48 hours"}`,
+          });
+        }
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — delivery outcome breakdown
+      if (totalRuns > 0) {
+        const outcomeEntries: Array<[string, number]> = [
+          ["Success", successRuns.length],
+          ["Partial success", partialSuccessRuns.length],
+          ["Failed", failedRuns.length],
+          ["Skipped", skippedRuns.length],
+          ["Skipped (already delivered)", skippedAllDeliveredRuns.length],
+        ].filter(([, count]) => count > 0) as Array<[string, number]>;
+
+        sections.push({
+          id: "what-outcome",
+          category: "what",
+          title: "Delivery outcome breakdown",
+          insight:
+            "Distribution of delivery run outcomes over the selected window.",
+          widget: {
+            kind: "breakdown",
+            slices: outcomeEntries.map(([label, value]) => ({
+              label,
+              value,
+              fraction: value / totalRuns,
+            })),
+          },
+        });
+      }
+
+      // When — recipients delivered per day (Σ successCount by day)
+      const recipientsDailyBuckets = buildWindowDates(windowStart, now);
+      for (const run of runs) {
+        const dayKey = run.createdAt.toISOString().slice(0, 10);
+        if (recipientsDailyBuckets.has(dayKey)) {
+          recipientsDailyBuckets.set(
+            dayKey,
+            (recipientsDailyBuckets.get(dayKey) ?? 0) + run.successCount,
+          );
+        }
+      }
+      sections.push({
+        id: "when-recipients",
+        category: "when",
+        title: "Recipients delivered over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(recipientsDailyBuckets.entries()).map(
+            ([ts, value]) => ({
+              ts: `${ts}T00:00:00.000Z`,
+              value,
+            }),
+          ),
+          unit: "recipients",
+        },
+      });
+
+      // Where — per-ticker delivery counts (categoryBar, top-N)
+      const tickerDeliveryCounts = new Map<string, number>();
+      for (const run of runs) {
+        tickerDeliveryCounts.set(
+          run.tickerId,
+          (tickerDeliveryCounts.get(run.tickerId) ?? 0) + 1,
+        );
+      }
+      if (tickerDeliveryCounts.size > 0) {
+        sections.push({
+          id: "where-per-ticker",
+          category: "where",
+          title: "Deliveries by ticker",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(tickerDeliveryCounts.entries()).map(
+                ([label, value]) => ({ label, value }),
+              ),
+              TOP_N,
+            ),
+            unit: "runs",
+          },
+        });
+      }
+
+      // Who — recipient funnel (attempted → delivered, from active runs only)
+      // Skipped runs are excluded so the funnel reflects actual delivery attempts.
+      sections.push({
+        id: "who-recipient-funnel",
+        category: "who",
+        title: "Recipient funnel",
+        insight:
+          "Skipped runs are excluded — the funnel counts only recipients from runs that attempted delivery.",
+        widget: {
+          kind: "funnel",
+          stages: [
+            { label: "Attempted", value: activeAttempted },
+            { label: "Delivered", value: activeDelivered },
+          ],
+        },
+      });
+
+      // Why — recipient error category breakdown (only failed recipients)
+      if (failedRecipients.length > 0) {
+        const errorCategories = new Map<string, number>();
+        for (const recipient of failedRecipients) {
+          const category = recipient.errorCategory ?? "unknown";
+          errorCategories.set(
+            category,
+            (errorCategories.get(category) ?? 0) + 1,
+          );
+        }
+        const errorTotal = failedRecipients.length;
+        sections.push({
+          id: "why-error-category",
+          category: "why",
+          title: "Recipient failure categories",
+          widget: {
+            kind: "breakdown",
+            slices: bucketTopN(
+              Array.from(errorCategories.entries()).map(([label, value]) => ({
+                label,
+                value,
+                fraction: errorTotal > 0 ? value / errorTotal : 0,
+              })),
+              TOP_N,
+            ),
+          },
+        });
+      }
+
+      // Why — run skip reason breakdown (skipped runs only)
+      const skippedAllRuns = [...skippedRuns, ...skippedAllDeliveredRuns];
+      if (skippedAllRuns.length > 0) {
+        const skipReasons = new Map<string, number>();
+        for (const run of skippedAllRuns) {
+          const reason = run.runSkipReason ?? run.outcome;
+          skipReasons.set(reason, (skipReasons.get(reason) ?? 0) + 1);
+        }
+        const skipTotal = skippedAllRuns.length;
+        sections.push({
+          id: "why-skip-reason",
+          category: "why",
+          title: "Run skip reasons",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(skipReasons.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: skipTotal > 0 ? value / skipTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // How — recipient attempts histogram (from recipient rows, excluding skipped recipients)
+      const attemptedRecipients = allRecipients.filter(
+        (r) => r.status !== "skipped",
+      );
+      if (attemptedRecipients.length > 0) {
+        const attemptBuckets = new Map([
+          ["1 attempt", 0],
+          ["2 attempts", 0],
+          ["3 attempts", 0],
+          ["4+ attempts", 0],
+        ]);
+        for (const recipient of attemptedRecipients) {
+          if (recipient.attempts <= 1) {
+            attemptBuckets.set(
+              "1 attempt",
+              (attemptBuckets.get("1 attempt") ?? 0) + 1,
+            );
+          } else if (recipient.attempts === 2) {
+            attemptBuckets.set(
+              "2 attempts",
+              (attemptBuckets.get("2 attempts") ?? 0) + 1,
+            );
+          } else if (recipient.attempts === 3) {
+            attemptBuckets.set(
+              "3 attempts",
+              (attemptBuckets.get("3 attempts") ?? 0) + 1,
+            );
+          } else {
+            attemptBuckets.set(
+              "4+ attempts",
+              (attemptBuckets.get("4+ attempts") ?? 0) + 1,
+            );
+          }
+        }
+        sections.push({
+          id: "how-attempts-histogram",
+          category: "how",
+          title: "Recipient retry attempts",
+          widget: {
+            kind: "histogram",
+            buckets: Array.from(attemptBuckets.entries()).map(
+              ([label, count]) => ({ label, count }),
+            ),
+          },
+        });
+      }
+
+      // How — median duration stat (active runs only — skipped runs have near-zero duration)
+      if (medianDuration !== null) {
+        sections.push({
+          id: "how-median-duration",
+          category: "how",
+          title: "Median delivery duration",
+          insight: "Duration is measured for active (non-skipped) runs only.",
+          widget: {
+            kind: "stat",
+            value: medianDuration,
+            unit: "ms",
+          },
+        });
+      }
+
+      return {
+        agentId: "delivery",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds the delivery insights provider — the third `AgentInsightsProvider` after page-collection and content-generation. It queries `DeliveryRun` rows (filtered to `agentId = "delivery"`) with nested `DeliveryRecipientOutcome` rows and assembles a contract-valid `InsightsPayload`. The generic dashboard tab from Plan 103 now renders delivery data with no UI changes.

## Related issues

Closes #721

## Important changes

- New `createDeliveryInsightsProvider` factory in `agent-data-api/src/services/insights/` — assembles outcome breakdown, recipients-over-time, per-ticker counts, recipient funnel (skipped runs excluded), errorCategory + runSkipReason breakdowns, attempts histogram, and median duration stat
- Registered at startup alongside page-collection in `index.ts`

## Other changes

- `delivery-insights-provider.test.ts` — 9 fixture tests covering schema validation, outcome fractions, recipient funnel invariants, error-category isolation, attempts histogram, KPI deltas, top-N bucketing, stage-failure alert, and an all-empty case

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts` — factory with injected Prisma delegates
- `apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts` — fixture tests
- `apps/mediapulse/agent-data-api/src/index.ts` — provider registration

## How to test

1. Run `pnpm --filter @mediapulse/agent-data-api test` — all 9 new tests and the full suite should pass
2. With `HERMES_AGENT_INSIGHTS_ENABLED` on, open a delivery agent → Insights tab
3. Confirm: outcome breakdown, recipients timeline, per-ticker bars, recipient funnel, error categories, and retry histogram all render
4. Use the window switcher (24h / 7d / 30d) to confirm re-fetch works
