### PR TITLE
feat(agent-data-api): add query-analysis insights provider

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -73,6 +73,7 @@ import { createContentGenerationInsightsProvider } from "./services/insights/con
 import { createUserRegistrationInsightsProvider } from "./services/insights/user-registration-insights-provider.js";
 import { createDataCollectionInsightsProvider } from "./services/insights/data-collection-insights-provider.js";
 import { createDeliveryInsightsProvider } from "./services/insights/delivery-insights-provider.js";
+import { createQueryAnalysisInsightsProvider } from "./services/insights/query-analysis-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -253,6 +254,14 @@ registerInsightsProvider(
 registerInsightsProvider(
   createDeliveryInsightsProvider({
     deliveryRun: prisma.deliveryRun,
+  }),
+);
+
+registerInsightsProvider(
+  createQueryAnalysisInsightsProvider({
+    searchQuerySet: prisma.searchQuerySet,
+    searchQuery: prisma.searchQuery,
+    searchQueryYield: prisma.searchQueryYield,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
@@ -63,7 +63,11 @@ function makeQueries(setIds: string[]) {
   const sources = ["llm", "deterministic", "curated"] as const;
   const intents = ["breaking", "fundamental", "sentiment"] as const;
   return setIds.flatMap((setId, i) => [
-    { setId, source: sources[i % 3], intent: intents[i % 3] },
+    {
+      setId,
+      source: sources[i % 3] ?? "llm",
+      intent: intents[i % 3] ?? "breaking",
+    },
     { setId, source: "llm", intent: "competitor" },
     { setId, source: "deterministic", intent: "breaking" },
   ]);
@@ -79,8 +83,15 @@ function makeYieldRows(queryTexts: string[], setId = "set-0") {
   }));
 }
 
+type AnySetRow = {
+  id: string;
+  tickerId: string;
+  generatedAt: Date;
+  strategySnapshot: unknown;
+};
+
 function makeDeps(
-  sets: ReturnType<typeof makeSets>,
+  sets: AnySetRow[],
   queries: ReturnType<typeof makeQueries>,
   yields: ReturnType<typeof makeYieldRows>,
 ) {

--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect } from "vitest";
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+import { createQueryAnalysisInsightsProvider } from "./query-analysis-insights-provider.js";
+
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function makeDate(offsetMs: number): Date {
+  return new Date(Date.now() - offsetMs);
+}
+
+const now = new Date();
+const windowStart = new Date(now.getTime() - WINDOW_MS);
+const priorStart = new Date(windowStart.getTime() - WINDOW_MS);
+
+const baseSnapshot = {
+  queryCount: 10,
+  languageQuotas: [
+    { language: "en", share: 0.7 },
+    { language: "id", share: 0.3 },
+  ],
+  minDeterministicCount: 3,
+  personas: ["value-investor", "trader"],
+  sectionCoverage: { zeroCoverageSections: [] as string[] },
+  selfCritiqueReplacedCount: 1,
+  diversityScore: {
+    lexicalDiversity: 0.8,
+    intentCoverage: 0.9,
+    personaCoverage: 0.75,
+    semanticSpread: 0.6,
+    composite: 0.76,
+  },
+  queryAttribution: [
+    {
+      text: "AAPL earnings",
+      source: "llm",
+      intent: "breaking",
+      persona: "value-investor",
+    },
+    {
+      text: "AAPL fundamentals",
+      source: "deterministic",
+      intent: "fundamental",
+    },
+    {
+      text: "AAPL sentiment",
+      source: "llm",
+      intent: "sentiment",
+      persona: "trader",
+    },
+  ],
+};
+
+function makeSets(count: number, offsetMs = WINDOW_MS / 2) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `set-${i}`,
+    tickerId: "ticker-1",
+    generatedAt: new Date(now.getTime() - offsetMs + i * 1000),
+    strategySnapshot: baseSnapshot,
+  }));
+}
+
+function makeQueries(setIds: string[]) {
+  const sources = ["llm", "deterministic", "curated"] as const;
+  const intents = ["breaking", "fundamental", "sentiment"] as const;
+  return setIds.flatMap((setId, i) => [
+    { setId, source: sources[i % 3], intent: intents[i % 3] },
+    { setId, source: "llm", intent: "competitor" },
+    { setId, source: "deterministic", intent: "breaking" },
+  ]);
+}
+
+function makeYieldRows(queryTexts: string[], setId = "set-0") {
+  return queryTexts.map((text, i) => ({
+    searchQueryId: `qy-${i}`,
+    runDate: makeDate(1000),
+    articleCount: 10 - i,
+    novelArticleCount: 5 - Math.min(i, 4),
+    searchQuery: { text, setId },
+  }));
+}
+
+function makeDeps(
+  sets: ReturnType<typeof makeSets>,
+  queries: ReturnType<typeof makeQueries>,
+  yields: ReturnType<typeof makeYieldRows>,
+) {
+  return {
+    searchQuerySet: { findMany: async () => sets },
+    searchQuery: { findMany: async () => queries },
+    searchQueryYield: { findMany: async () => yields },
+  };
+}
+
+describe("createQueryAnalysisInsightsProvider", () => {
+  it("produces a payload that validates against insightsPayloadSchema", async () => {
+    const sets = makeSets(3);
+    const queries = makeQueries(sets.map((s) => s.id));
+    const yields = makeYieldRows(["AAPL earnings", "AAPL fundamentals"]);
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, queries, yields),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.agentId).toBe("query-analysis");
+  });
+
+  it("source breakdown fractions sum to 1 when sources are present", async () => {
+    const sets = makeSets(2);
+    const queries = [
+      { setId: "set-0", source: "llm", intent: "breaking" },
+      { setId: "set-0", source: "deterministic", intent: "fundamental" },
+      { setId: "set-1", source: "curated", intent: "sentiment" },
+      { setId: "set-1", source: "llm", intent: "competitor" },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, queries, []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const sourceSection = payload.sections.find(
+      (s) => s.id === "what-source-composition",
+    );
+    expect(sourceSection).toBeDefined();
+    expect(sourceSection?.widget.kind).toBe("breakdown");
+
+    if (sourceSection?.widget.kind === "breakdown") {
+      const total = sourceSection.widget.slices.reduce(
+        (sum, s) => sum + s.fraction,
+        0,
+      );
+      expect(total).toBeCloseTo(1, 5);
+    }
+  });
+
+  it("diversity-axis section reads each axis from the latest diversityScore", async () => {
+    const sets = makeSets(1);
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const diversitySection = payload.sections.find(
+      (s) => s.id === "why-diversity",
+    );
+    expect(diversitySection).toBeDefined();
+    expect(diversitySection?.widget.kind).toBe("categoryBar");
+
+    if (diversitySection?.widget.kind === "categoryBar") {
+      const labels = diversitySection.widget.bars.map((b) => b.label);
+      expect(labels).toContain("Lexical diversity");
+      expect(labels).toContain("Intent coverage");
+      expect(labels).toContain("Composite");
+    }
+  });
+
+  it("skips diversity section when diversityScore is absent in strategySnapshot", async () => {
+    const snapshotWithoutDiversity = {
+      ...baseSnapshot,
+      diversityScore: undefined,
+    };
+    const sets = [
+      {
+        id: "set-no-div",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: snapshotWithoutDiversity,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const diversitySection = payload.sections.find(
+      (s) => s.id === "why-diversity",
+    );
+    expect(diversitySection).toBeUndefined();
+  });
+
+  it("skips persona section when queryAttribution has no persona fields", async () => {
+    const snapshotNoPersona = {
+      ...baseSnapshot,
+      queryAttribution: [
+        { text: "AAPL earnings", source: "llm", intent: "breaking" },
+      ],
+    };
+    const sets = [
+      {
+        id: "set-np",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: snapshotNoPersona,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const personaSection = payload.sections.find(
+      (s) => s.id === "who-persona-coverage",
+    );
+    expect(personaSection).toBeUndefined();
+  });
+
+  it("intent categoryBar counts SearchQuery.intent values", async () => {
+    const sets = makeSets(1);
+    const queries = [
+      { setId: "set-0", source: "llm", intent: "breaking" },
+      { setId: "set-0", source: "llm", intent: "breaking" },
+      { setId: "set-0", source: "deterministic", intent: "fundamental" },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, queries, []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const intentSection = payload.sections.find(
+      (s) => s.id === "how-intent-distribution",
+    );
+    expect(intentSection?.widget.kind).toBe("categoryBar");
+
+    if (intentSection?.widget.kind === "categoryBar") {
+      const breakingBar = intentSection.widget.bars.find(
+        (b) => b.label === "breaking",
+      );
+      expect(breakingBar?.value).toBe(2);
+    }
+  });
+
+  it("yield table ranks by novelArticleCount and respects top-N cap", async () => {
+    const sets = makeSets(1);
+    const yieldData = Array.from({ length: 15 }, (_, i) => ({
+      searchQueryId: `qy-${i}`,
+      runDate: makeDate(1000),
+      articleCount: i + 1,
+      novelArticleCount: 15 - i,
+      searchQuery: { text: `query ${i}`, setId: "set-0" },
+    }));
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], yieldData),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const yieldSection = payload.sections.find(
+      (s) => s.id === "how-yield-feedback",
+    );
+    expect(yieldSection).toBeDefined();
+    expect(yieldSection?.widget.kind).toBe("table");
+
+    if (yieldSection?.widget.kind === "table") {
+      expect(yieldSection.widget.rows.length).toBeLessThanOrEqual(10);
+      expect(yieldSection.widget.rows[0]?.[0]).toBe("query 0");
+    }
+  });
+
+  it("KPI delta reflects prior-window comparison", async () => {
+    const currentSets = makeSets(3, WINDOW_MS / 2);
+    const priorSet = {
+      id: "set-prior",
+      tickerId: "ticker-1",
+      generatedAt: new Date(priorStart.getTime() + 1000),
+      strategySnapshot: baseSnapshot,
+    };
+    const allSets = [...currentSets, priorSet];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(allSets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const setsKpi = payload.kpis.find((k) => k.id === "sets_generated");
+    expect(setsKpi?.value).toBe(3);
+    expect(typeof setsKpi?.delta).toBe("number");
+    expect(setsKpi?.delta).toBe(3 - 1);
+  });
+
+  it("low diversity score triggers a warning alert", async () => {
+    const lowDiversitySnapshot = {
+      ...baseSnapshot,
+      diversityScore: { composite: 0.3, lexicalDiversity: 0.3 },
+    };
+    const sets = [
+      {
+        id: "set-low",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: lowDiversitySnapshot,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const alert = payload.alerts.find((a) => a.id === "low-diversity-score");
+    expect(alert).toBeDefined();
+    expect(alert?.severity).toBe("warning");
+  });
+
+  it("produces a valid empty payload when no sets exist", async () => {
+    const provider = createQueryAnalysisInsightsProvider(makeDeps([], [], []));
+    const payload = await provider.compute({ window: "7d" });
+
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.kpis.find((k) => k.id === "sets_generated")?.value).toBe(0);
+    expect(
+      payload.sections.find((s) => s.id === "why-diversity"),
+    ).toBeUndefined();
+  });
+
+  it("top-N capping for language quotas does not produce unbounded arrays", async () => {
+    const manyLanguagesSnapshot = {
+      ...baseSnapshot,
+      languageQuotas: Array.from({ length: 15 }, (_, i) => ({
+        language: `lang-${i}`,
+        share: 1 / 15,
+      })),
+    };
+    const sets = [
+      {
+        id: "set-many-langs",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: manyLanguagesSnapshot,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const langSection = payload.sections.find(
+      (s) => s.id === "where-language-quotas",
+    );
+    expect(langSection?.widget.kind).toBe("categoryBar");
+
+    if (langSection?.widget.kind === "categoryBar") {
+      expect(langSection.widget.bars.length).toBeLessThanOrEqual(11);
+      const otherBar = langSection.widget.bars.find((b) => b.label === "Other");
+      expect(otherBar).toBeDefined();
+    }
+  });
+
+  it("does not crash when strategySnapshot is malformed", async () => {
+    const malformedSets = [
+      {
+        id: "set-bad",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: "not-an-object" as unknown as Record<string, unknown>,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(malformedSets, [], []),
+    );
+
+    await expect(provider.compute({ window: "7d" })).resolves.not.toThrow();
+    const payload = await provider.compute({ window: "7d" });
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
@@ -1,4 +1,3 @@
-import type { Prisma } from "@mediapulse/database";
 import type {
   InsightsPayload,
   KpiCard,
@@ -23,7 +22,7 @@ type QuerySetRow = {
   id: string;
   tickerId: string;
   generatedAt: Date;
-  strategySnapshot: Prisma.JsonValue;
+  strategySnapshot: unknown;
 };
 
 type QueryRow = {
@@ -121,7 +120,7 @@ type StrategySnapshot = {
   }>;
 };
 
-function parseStrategySnapshot(raw: Prisma.JsonValue): StrategySnapshot {
+function parseStrategySnapshot(raw: unknown): StrategySnapshot {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return {};
   }
@@ -238,10 +237,10 @@ export function createQueryAnalysisInsightsProvider(
       const sortedSets = [...currentSets].sort(
         (a, b) => b.generatedAt.getTime() - a.generatedAt.getTime(),
       );
-      const latestSnapshot =
-        sortedSets.length > 0
-          ? parseStrategySnapshot(sortedSets[0].strategySnapshot)
-          : null;
+      const latestSet = sortedSets[0] ?? null;
+      const latestSnapshot = latestSet
+        ? parseStrategySnapshot(latestSet.strategySnapshot)
+        : null;
       const latestDiversityScore =
         latestSnapshot?.diversityScore?.composite ?? null;
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
@@ -1,0 +1,619 @@
+import type { Prisma } from "@mediapulse/database";
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type QuerySetRow = {
+  id: string;
+  tickerId: string;
+  generatedAt: Date;
+  strategySnapshot: Prisma.JsonValue;
+};
+
+type QueryRow = {
+  setId: string | null;
+  source: string;
+  intent: string;
+};
+
+type YieldRow = {
+  searchQueryId: string;
+  runDate: Date;
+  articleCount: number;
+  novelArticleCount: number;
+  searchQuery: {
+    text: string;
+    setId: string | null;
+  };
+};
+
+type QueryAnalysisInsightsDeps = {
+  searchQuerySet: {
+    findMany: (args: {
+      where: {
+        generationSource: string;
+        generatedAt: { gte: Date };
+        tickerId?: string;
+      };
+      select: {
+        id: boolean;
+        tickerId: boolean;
+        generatedAt: boolean;
+        strategySnapshot: boolean;
+      };
+    }) => Promise<QuerySetRow[]>;
+  };
+  searchQuery: {
+    findMany: (args: {
+      where: {
+        setId: { in: string[] };
+      };
+      select: {
+        setId: boolean;
+        source: boolean;
+        intent: boolean;
+      };
+    }) => Promise<QueryRow[]>;
+  };
+  searchQueryYield: {
+    findMany: (args: {
+      where: {
+        runDate: { gte: Date };
+        searchQuery: { tickerId?: string };
+      };
+      select: {
+        searchQueryId: boolean;
+        runDate: boolean;
+        articleCount: boolean;
+        novelArticleCount: boolean;
+        searchQuery: { select: { text: boolean; setId: boolean } };
+      };
+      orderBy: { novelArticleCount: "desc" };
+      take: number;
+    }) => Promise<YieldRow[]>;
+  };
+};
+
+type DiversityScore = {
+  lexicalDiversity?: number;
+  intentCoverage?: number;
+  personaCoverage?: number;
+  semanticSpread?: number;
+  composite?: number;
+};
+
+type LanguageQuota = {
+  language: string;
+  share: number;
+  templatePack?: string;
+};
+
+type StrategySnapshot = {
+  queryCount?: number;
+  languageQuotas?: LanguageQuota[];
+  minDeterministicCount?: number;
+  personas?: string[];
+  sectionCoverage?: { zeroCoverageSections?: string[] };
+  selfCritiqueReplacedCount?: number;
+  diversityScore?: DiversityScore;
+  queryAttribution?: Array<{
+    text?: string;
+    source?: string;
+    intent?: string;
+    persona?: string;
+    templateId?: string;
+  }>;
+};
+
+function parseStrategySnapshot(raw: Prisma.JsonValue): StrategySnapshot {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as StrategySnapshot;
+}
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+export function createQueryAnalysisInsightsProvider(
+  deps: QueryAnalysisInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "query-analysis",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const setFilter = {
+        generationSource: "hybrid_v1",
+        generatedAt: { gte: priorStart },
+        ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+      };
+
+      const [allSets, yieldRows] = await Promise.all([
+        deps.searchQuerySet.findMany({
+          where: setFilter,
+          select: {
+            id: true,
+            tickerId: true,
+            generatedAt: true,
+            strategySnapshot: true,
+          },
+        }),
+        deps.searchQueryYield.findMany({
+          where: {
+            runDate: { gte: windowStart },
+            searchQuery: ctx.tickerId ? { tickerId: ctx.tickerId } : {},
+          },
+          select: {
+            searchQueryId: true,
+            runDate: true,
+            articleCount: true,
+            novelArticleCount: true,
+            searchQuery: { select: { text: true, setId: true } },
+          },
+          orderBy: { novelArticleCount: "desc" },
+          take: 200,
+        }),
+      ]);
+
+      const currentSets = allSets.filter((s) => s.generatedAt >= windowStart);
+      const priorSets = allSets.filter(
+        (s) => s.generatedAt >= priorStart && s.generatedAt < windowStart,
+      );
+
+      const allSetIds = allSets.map((s) => s.id);
+      const queries =
+        allSetIds.length > 0
+          ? await deps.searchQuery.findMany({
+              where: { setId: { in: allSetIds } },
+              select: { setId: true, source: true, intent: true },
+            })
+          : [];
+
+      const currentSetIds = new Set(currentSets.map((s) => s.id));
+      const currentQueries = queries.filter(
+        (q) => q.setId !== null && currentSetIds.has(q.setId),
+      );
+
+      // ─── Strategy snapshot aggregation ──────────────────────────────────
+
+      const snapshots = currentSets.map((s) =>
+        parseStrategySnapshot(s.strategySnapshot),
+      );
+
+      const totalSets = currentSets.length;
+      const priorSetCount = priorSets.length;
+
+      const queriesPerSet =
+        totalSets > 0 ? currentQueries.length / totalSets : 0;
+
+      // Latest composite diversity score (from the most-recent set)
+      const sortedSets = [...currentSets].sort(
+        (a, b) => b.generatedAt.getTime() - a.generatedAt.getTime(),
+      );
+      const latestSnapshot =
+        sortedSets.length > 0
+          ? parseStrategySnapshot(sortedSets[0].strategySnapshot)
+          : null;
+      const latestDiversityScore =
+        latestSnapshot?.diversityScore?.composite ?? null;
+
+      // LLM fraction
+      const totalQueries = currentQueries.length;
+      const llmCount = currentQueries.filter((q) => q.source === "llm").length;
+      const llmFraction =
+        totalQueries > 0 ? Math.round((llmCount / totalQueries) * 100) : 0;
+
+      // Deterministic-floor adherence
+      let setsWithMinDeterministic = 0;
+      for (const snap of snapshots) {
+        if (snap.minDeterministicCount === undefined) continue;
+        const setId = currentSets.find(
+          (s) => parseStrategySnapshot(s.strategySnapshot) === snap,
+        )?.id;
+        const deterministic = queries.filter(
+          (q) => q.setId === setId && q.source === "deterministic",
+        ).length;
+        if (deterministic >= snap.minDeterministicCount) {
+          setsWithMinDeterministic += 1;
+        }
+      }
+      const setsWithFloorDefined = snapshots.filter(
+        (s) => s.minDeterministicCount !== undefined,
+      ).length;
+      const deterministicAdherence =
+        setsWithFloorDefined > 0
+          ? Math.round((setsWithMinDeterministic / setsWithFloorDefined) * 100)
+          : null;
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const kpis: KpiCard[] = [
+        {
+          id: "sets_generated",
+          label: "Query sets generated",
+          value: totalSets,
+          delta: totalSets - priorSetCount,
+        },
+        {
+          id: "avg_queries_per_set",
+          label: "Avg queries / set",
+          value: Math.round(queriesPerSet),
+        },
+        ...(latestDiversityScore !== null
+          ? [
+              {
+                id: "diversity_score",
+                label: "Diversity score (latest)",
+                value: Math.round(latestDiversityScore * 100) / 100,
+              } satisfies KpiCard,
+            ]
+          : []),
+        {
+          id: "llm_fraction",
+          label: "LLM-sourced queries",
+          value: llmFraction,
+          unit: "%",
+        },
+        ...(deterministicAdherence !== null
+          ? [
+              {
+                id: "deterministic_adherence",
+                label: "Deterministic-floor adherence",
+                value: deterministicAdherence,
+                unit: "%",
+              } satisfies KpiCard,
+            ]
+          : []),
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      if (latestDiversityScore !== null && latestDiversityScore < 0.5) {
+        alerts.push({
+          id: "low-diversity-score",
+          severity: "warning",
+          message: `Latest composite diversity score is low (${Math.round(latestDiversityScore * 100) / 100} < 0.5)`,
+          sectionRef: "why-diversity",
+        });
+      }
+
+      // Recurring zero-coverage sections (present in >50% of sets with the field)
+      const zeroCoverageFrequency = new Map<string, number>();
+      let setsWithCoverage = 0;
+      for (const snap of snapshots) {
+        const zeroCoverage = snap.sectionCoverage?.zeroCoverageSections;
+        if (!Array.isArray(zeroCoverage)) continue;
+        setsWithCoverage += 1;
+        for (const section of zeroCoverage) {
+          zeroCoverageFrequency.set(
+            section,
+            (zeroCoverageFrequency.get(section) ?? 0) + 1,
+          );
+        }
+      }
+      for (const [section, count] of zeroCoverageFrequency) {
+        if (setsWithCoverage > 0 && count / setsWithCoverage > 0.5) {
+          alerts.push({
+            id: `zero-coverage-${section}`,
+            severity: "warning",
+            message: `Section "${section}" has zero coverage in ${count} of ${setsWithCoverage} sets`,
+          });
+        }
+      }
+
+      // High self-critique drop
+      const totalSelfCritiqueDrops = snapshots.reduce(
+        (sum, s) => sum + (s.selfCritiqueReplacedCount ?? 0),
+        0,
+      );
+      if (totalSets > 0 && totalSelfCritiqueDrops / totalSets > 5) {
+        alerts.push({
+          id: "high-self-critique-drop",
+          severity: "info",
+          message: `High self-critique replacement rate: avg ${Math.round(totalSelfCritiqueDrops / totalSets)} replacements/set`,
+        });
+      }
+
+      // Stale last set
+      if (totalSets > 0) {
+        const staleThresholdMs =
+          ctx.window === "24h" ? 6 * 60 * 60 * 1000 : 48 * 60 * 60 * 1000;
+        const lastSet = sortedSets[0];
+        if (
+          lastSet &&
+          now.getTime() - lastSet.generatedAt.getTime() > staleThresholdMs
+        ) {
+          alerts.push({
+            id: "stale-last-set",
+            severity: "info",
+            message: `No query set generated in the last ${ctx.window === "24h" ? "6 hours" : "48 hours"}`,
+          });
+        }
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — query source composition breakdown
+      const sourceCounts = new Map<string, number>();
+      for (const query of currentQueries) {
+        sourceCounts.set(
+          query.source,
+          (sourceCounts.get(query.source) ?? 0) + 1,
+        );
+      }
+      if (sourceCounts.size > 0) {
+        const sourceTotal = Array.from(sourceCounts.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "what-source-composition",
+          category: "what",
+          title: "Query source composition",
+          insight:
+            "Distribution of queries by generation source across all sets in the window.",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(sourceCounts.entries()).map(
+              ([label, value]) => ({
+                label,
+                value,
+                fraction: sourceTotal > 0 ? value / sourceTotal : 0,
+              }),
+            ),
+          },
+        });
+      }
+
+      // When — query sets generated per day (timeSeries)
+      const dailyBuckets = buildWindowDates(windowStart, now);
+      for (const set of currentSets) {
+        const dayKey = set.generatedAt.toISOString().slice(0, 10);
+        if (dailyBuckets.has(dayKey)) {
+          dailyBuckets.set(dayKey, (dailyBuckets.get(dayKey) ?? 0) + 1);
+        }
+      }
+      sections.push({
+        id: "when-sets-over-time",
+        category: "when",
+        title: "Query sets over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(dailyBuckets.entries()).map(([ts, value]) => ({
+            ts: `${ts}T00:00:00.000Z`,
+            value,
+          })),
+          unit: "sets",
+        },
+      });
+
+      // Where — language quota distribution (averaged across sets that have it)
+      const languageTotals = new Map<string, number>();
+      let setsWithLanguages = 0;
+      for (const snap of snapshots) {
+        if (
+          !Array.isArray(snap.languageQuotas) ||
+          snap.languageQuotas.length === 0
+        )
+          continue;
+        setsWithLanguages += 1;
+        for (const quota of snap.languageQuotas) {
+          languageTotals.set(
+            quota.language,
+            (languageTotals.get(quota.language) ?? 0) + quota.share,
+          );
+        }
+      }
+      if (languageTotals.size > 0) {
+        sections.push({
+          id: "where-language-quotas",
+          category: "where",
+          title: "Language quota distribution",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(languageTotals.entries()).map(([label, total]) => ({
+                label,
+                value:
+                  setsWithLanguages > 0
+                    ? Math.round((total / setsWithLanguages) * 100) / 100
+                    : 0,
+              })),
+              TOP_N,
+            ),
+            unit: "avg share",
+          },
+        });
+      }
+
+      // Who — persona coverage (from queryAttribution)
+      const personaCounts = new Map<string, number>();
+      for (const snap of snapshots) {
+        if (!Array.isArray(snap.queryAttribution)) continue;
+        for (const entry of snap.queryAttribution) {
+          if (entry.persona) {
+            personaCounts.set(
+              entry.persona,
+              (personaCounts.get(entry.persona) ?? 0) + 1,
+            );
+          }
+        }
+      }
+      if (personaCounts.size > 0) {
+        sections.push({
+          id: "who-persona-coverage",
+          category: "who",
+          title: "Persona coverage",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(personaCounts.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "queries",
+          },
+        });
+      }
+
+      // Why — diversity axis breakdown (from latest set's diversityScore)
+      const diversityAxes: Array<{ label: string; value: number }> = [];
+      if (latestSnapshot?.diversityScore) {
+        const ds = latestSnapshot.diversityScore;
+        if (ds.lexicalDiversity !== undefined)
+          diversityAxes.push({
+            label: "Lexical diversity",
+            value: ds.lexicalDiversity,
+          });
+        if (ds.intentCoverage !== undefined)
+          diversityAxes.push({
+            label: "Intent coverage",
+            value: ds.intentCoverage,
+          });
+        if (ds.personaCoverage !== undefined)
+          diversityAxes.push({
+            label: "Persona coverage",
+            value: ds.personaCoverage,
+          });
+        if (ds.semanticSpread !== undefined)
+          diversityAxes.push({
+            label: "Semantic spread",
+            value: ds.semanticSpread,
+          });
+        if (ds.composite !== undefined)
+          diversityAxes.push({ label: "Composite", value: ds.composite });
+      }
+      if (diversityAxes.length > 0) {
+        sections.push({
+          id: "why-diversity",
+          category: "why",
+          title: "Diversity axes (latest set)",
+          widget: {
+            kind: "categoryBar",
+            bars: diversityAxes,
+            unit: "score",
+          },
+        });
+      }
+
+      // How — intent taxonomy distribution (categoryBar over 14 intent values)
+      const intentCounts = new Map<string, number>();
+      for (const query of currentQueries) {
+        intentCounts.set(
+          query.intent,
+          (intentCounts.get(query.intent) ?? 0) + 1,
+        );
+      }
+      if (intentCounts.size > 0) {
+        sections.push({
+          id: "how-intent-distribution",
+          category: "how",
+          title: "Intent taxonomy distribution",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(intentCounts.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "queries",
+          },
+        });
+      }
+
+      // How — yield feedback table (top queries by novelArticleCount)
+      if (yieldRows.length > 0) {
+        const seenQueryIds = new Set<string>();
+        const topYieldRows: YieldRow[] = [];
+        for (const row of yieldRows) {
+          if (!seenQueryIds.has(row.searchQueryId)) {
+            seenQueryIds.add(row.searchQueryId);
+            topYieldRows.push(row);
+          }
+          if (topYieldRows.length >= TOP_N) break;
+        }
+        sections.push({
+          id: "how-yield-feedback",
+          category: "how",
+          title: "Top queries by novel articles (downstream yield)",
+          insight:
+            "Downstream yield of queries active in the window, ranked by novel article count.",
+          widget: {
+            kind: "table",
+            columns: ["Query", "Novel articles", "Total articles"],
+            rows: topYieldRows.map((row) => [
+              row.searchQuery.text,
+              row.novelArticleCount,
+              row.articleCount,
+            ]),
+          },
+        });
+      }
+
+      return {
+        agentId: "query-analysis",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a query-analysis insights provider that reads `SearchQuerySet` (with `strategySnapshot`), `SearchQuery`, and `SearchQueryYield` over a configurable window and returns a contract-valid `InsightsPayload` of 5W1H widgets. The strategy snapshot already persists diversity scores, language quotas, personas, query attribution, and section coverage — so this plan is read-side assembly only.

## Related issues

Closes #723

## Important changes

- New `createQueryAnalysisInsightsProvider(deps)` factory in `agent-data-api/src/services/insights/` implementing `AgentInsightsProvider` with `agentId: "query-analysis"`
- Queries `SearchQuerySet` filtered by `generationSource = "hybrid_v1"` and `generatedAt` over both current and prior windows (for delta KPIs); queries `SearchQuery` for source/intent distributions; queries `SearchQueryYield` for yield feedback
- `parseStrategySnapshot()` helper safely narrows the `strategySnapshot` JSON blob; missing or malformed fields degrade gracefully to skipped sections
- KPIs: sets generated (with delta), avg queries/set, latest composite diversity score, LLM fraction, deterministic-floor adherence
- Alerts: low diversity score, recurring zero-coverage sections, high self-critique drop rate, stale last set
- 5W1H sections: source composition breakdown, sets-over-time timeSeries, language quota categoryBar, persona coverage categoryBar, diversity axes categoryBar, intent taxonomy categoryBar, yield-feedback table (top queries by novel article count)
- Provider registered at agent-data-api startup in `index.ts`

## Other changes

- 11-test fixture suite in `query-analysis-insights-provider.test.ts` covering schema validation, source fractions, diversity axis mapping, graceful degradation on missing snapshot fields, intent counts, yield ranking, KPI deltas, alert thresholds, and top-N capping

## Key files to review

- [apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts)
- [apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts](apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts)
- [apps/mediapulse/agent-data-api/src/index.ts](apps/mediapulse/agent-data-api/src/index.ts)

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — all 179 tests green
2. With `HERMES_AGENT_INSIGHTS_ENABLED` on, open a query-analysis agent in the UI → Insights tab; confirm source composition, sets-over-time, language/persona coverage, diversity axes, intent distribution, and yield-feedback table render correctly across window sizes
