### PR TITLE
feat(agent-data-api): add user-registration insights provider

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -70,6 +70,7 @@ import { getSectionCoverageRollupHandler } from "./routes/section-coverage-rollu
 import { getAgentInsights } from "./routes/agent-insights.js";
 import { createPageCollectionInsightsProvider } from "./services/insights/page-collection-insights-provider.js";
 import { createContentGenerationInsightsProvider } from "./services/insights/content-generation-insights-provider.js";
+import { createUserRegistrationInsightsProvider } from "./services/insights/user-registration-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -232,6 +233,12 @@ registerInsightsProvider(
   createContentGenerationInsightsProvider({
     contentGenerationRun: prisma.contentGenerationRun,
     newsletter: prisma.newsletter,
+  }),
+);
+registerInsightsProvider(
+  createUserRegistrationInsightsProvider({
+    mediapulseUser: prisma.mediapulseUser,
+    userTicker: prisma.userTicker,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect } from "vitest";
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+import { createUserRegistrationInsightsProvider } from "./user-registration-insights-provider.js";
+
+const WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const now = new Date();
+const windowStart = new Date(now.getTime() - WINDOW_MS);
+const priorStart = new Date(windowStart.getTime() - WINDOW_MS);
+
+function makeDate(base: Date, offsetMs: number): Date {
+  return new Date(base.getTime() + offsetMs);
+}
+
+function makeUser(offsetMs: number) {
+  return { createdAt: new Date(now.getTime() - offsetMs) };
+}
+
+function makeTicker(
+  id: string,
+  overrides: Partial<{
+    tickerId: string;
+    userId: string;
+    enabled: boolean;
+    createdAt: Date;
+    registrationConfirmedAt: Date | null;
+    unsubscribedAt: Date | null;
+    unsubscribeMethod: string | null;
+    symbol: string;
+  }> = {},
+) {
+  return {
+    id,
+    tickerId: overrides.tickerId ?? "ticker-aapl",
+    userId: overrides.userId ?? "user-1",
+    enabled: overrides.enabled ?? true,
+    createdAt: overrides.createdAt ?? makeDate(windowStart, 3600 * 1000),
+    registrationConfirmedAt: overrides.registrationConfirmedAt ?? null,
+    unsubscribedAt: overrides.unsubscribedAt ?? null,
+    unsubscribeMethod: overrides.unsubscribeMethod ?? null,
+    ticker: { symbol: overrides.symbol ?? "AAPL" },
+  };
+}
+
+function makeConfirmedActive(id: string, symbol = "AAPL") {
+  return makeTicker(id, {
+    registrationConfirmedAt: makeDate(windowStart, 3600 * 1000 * 2),
+    enabled: true,
+    symbol,
+  });
+}
+
+function makeUnsubscribed(id: string, method: string | null = "link") {
+  return makeTicker(id, {
+    registrationConfirmedAt: makeDate(windowStart, 3600 * 1000 * 2),
+    unsubscribedAt: makeDate(windowStart, 3600 * 1000 * 4),
+    unsubscribeMethod: method,
+    enabled: false,
+  });
+}
+
+function makeDeps(
+  users: { createdAt: Date }[],
+  byCreatedAt: ReturnType<typeof makeTicker>[],
+  byConfirmedAt: ReturnType<typeof makeTicker>[],
+  byUnsubscribedAt: ReturnType<typeof makeTicker>[],
+  active: ReturnType<typeof makeTicker>[],
+) {
+  const callCounts = { confirmed: 0, unsubscribed: 0, active: 0, created: 0 };
+  return {
+    deps: {
+      mediapulseUser: { findMany: async () => users },
+      userTicker: {
+        findMany: async (args: {
+          where: {
+            createdAt?: { gte: Date };
+            registrationConfirmedAt?: { gte: Date };
+            unsubscribedAt?: { gte: Date } | null;
+            enabled?: boolean;
+          };
+        }) => {
+          if (
+            args.where.enabled === true &&
+            args.where.unsubscribedAt === null
+          ) {
+            callCounts.active += 1;
+            return active;
+          }
+          if (args.where.registrationConfirmedAt) {
+            callCounts.confirmed += 1;
+            return byConfirmedAt;
+          }
+          if (
+            args.where.unsubscribedAt &&
+            typeof args.where.unsubscribedAt === "object" &&
+            "gte" in args.where.unsubscribedAt
+          ) {
+            callCounts.unsubscribed += 1;
+            return byUnsubscribedAt;
+          }
+          callCounts.created += 1;
+          return byCreatedAt;
+        },
+      },
+    },
+    callCounts,
+  };
+}
+
+describe("createUserRegistrationInsightsProvider", () => {
+  it("produces a payload that validates against insightsPayloadSchema", async () => {
+    const confirmed = makeConfirmedActive("ut-1");
+    const { deps } = makeDeps(
+      [makeUser(3600 * 1000)],
+      [confirmed],
+      [confirmed],
+      [],
+      [confirmed],
+    );
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.agentId).toBe("user-registration");
+  });
+
+  it("funnel stages are monotonically non-increasing in a healthy scenario", async () => {
+    const rows = [
+      makeConfirmedActive("ut-1"),
+      makeConfirmedActive("ut-2"),
+      makeTicker("ut-3"),
+    ];
+    const { deps } = makeDeps(
+      [makeUser(1000)],
+      rows,
+      rows.slice(0, 2),
+      [],
+      rows.slice(0, 2),
+    );
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const funnel = payload.sections.find(
+      (s) => s.id === "what-lifecycle-funnel",
+    );
+    expect(funnel?.widget.kind).toBe("funnel");
+    if (funnel?.widget.kind === "funnel") {
+      const values = funnel.widget.stages.map((s) => s.value);
+      for (let i = 1; i < values.length; i++) {
+        expect(values[i]).toBeLessThanOrEqual(values[i - 1]!);
+      }
+    }
+  });
+
+  it("status breakdown fractions sum to 1", async () => {
+    const rows = [
+      makeConfirmedActive("ut-1"),
+      makeTicker("ut-2"),
+      makeUnsubscribed("ut-3"),
+    ];
+    const { deps } = makeDeps(
+      [],
+      rows,
+      [],
+      rows.filter((r) => r.unsubscribedAt !== null),
+      [],
+    );
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const whoSection = payload.sections.find(
+      (s) => s.id === "who-status-breakdown",
+    );
+    expect(whoSection?.widget.kind).toBe("breakdown");
+    if (whoSection?.widget.kind === "breakdown") {
+      const total = whoSection.widget.slices.reduce(
+        (sum, s) => sum + s.fraction,
+        0,
+      );
+      expect(total).toBeCloseTo(1, 5);
+    }
+  });
+
+  it("unsubscribe-method breakdown excludes null-method rows", async () => {
+    const withMethod = makeUnsubscribed("ut-1", "link");
+    const withOneClick = makeUnsubscribed("ut-2", "one_click");
+    const adminDisable = makeUnsubscribed("ut-3", null);
+    const { deps } = makeDeps(
+      [],
+      [],
+      [],
+      [withMethod, withOneClick, adminDisable],
+      [],
+    );
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const whySection = payload.sections.find(
+      (s) => s.id === "why-unsubscribe-method",
+    );
+    expect(whySection?.widget.kind).toBe("breakdown");
+    if (whySection?.widget.kind === "breakdown") {
+      const total = whySection.widget.slices.reduce(
+        (sum, s) => sum + s.value,
+        0,
+      );
+      expect(total).toBe(2);
+      expect(whySection.widget.slices.every((s) => s.label !== null)).toBe(
+        true,
+      );
+    }
+  });
+
+  it("confirmation rate = confirmed / new subscriptions in window", async () => {
+    const newSubs = [
+      makeConfirmedActive("ut-1"),
+      makeConfirmedActive("ut-2"),
+      makeTicker("ut-3"),
+    ];
+    const { deps } = makeDeps(
+      [],
+      newSubs,
+      newSubs.filter((r) => r.registrationConfirmedAt !== null),
+      [],
+      [],
+    );
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const rateKpi = payload.kpis.find((k) => k.id === "confirmation_rate");
+    expect(rateKpi?.value).toBe(67);
+  });
+
+  it("KPI delta reflects prior-window comparison", async () => {
+    const currentSub = makeTicker("ut-current", {
+      createdAt: makeDate(windowStart, 3600 * 1000),
+    });
+    const priorSub = makeTicker("ut-prior", {
+      createdAt: makeDate(priorStart, 3600 * 1000),
+    });
+
+    const { deps } = makeDeps([], [currentSub, priorSub], [], [], []);
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const subsKpi = payload.kpis.find((k) => k.id === "new_subscriptions");
+    expect(subsKpi?.value).toBe(1);
+    expect(subsKpi?.delta).toBe(0);
+  });
+
+  it("top-N capping for per-ticker active subscribers", async () => {
+    const manyTickers = Array.from({ length: 15 }, (_, i) =>
+      makeTicker(`ut-${i}`, {
+        tickerId: `ticker-${i}`,
+        symbol: `TKR${i}`,
+        enabled: true,
+        registrationConfirmedAt: makeDate(windowStart, 1000),
+      }),
+    );
+    const { deps } = makeDeps([], [], [], [], manyTickers);
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const whereSection = payload.sections.find(
+      (s) => s.id === "where-per-ticker",
+    );
+    expect(whereSection?.widget.kind).toBe("categoryBar");
+    if (whereSection?.widget.kind === "categoryBar") {
+      expect(whereSection.widget.bars.length).toBeLessThanOrEqual(11);
+      const otherBar = whereSection.widget.bars.find(
+        (b) => b.label === "Other",
+      );
+      expect(otherBar).toBeDefined();
+    }
+  });
+
+  it("confirmation-rate-drop alert fires when rate drops >20pp vs prior window", async () => {
+    const currentSubs = [
+      makeTicker("ut-c1"),
+      makeTicker("ut-c2"),
+      makeTicker("ut-c3"),
+    ];
+    const priorSubs = [
+      makeConfirmedActive("ut-p1"),
+      makeConfirmedActive("ut-p2"),
+    ].map((r) => ({
+      ...r,
+      createdAt: makeDate(priorStart, 3600 * 1000),
+    }));
+
+    const { deps } = makeDeps([], [...currentSubs, ...priorSubs], [], [], []);
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    const alert = payload.alerts.find((a) => a.id === "confirmation-rate-drop");
+    expect(alert).toBeDefined();
+    expect(alert?.severity).toBe("warning");
+  });
+
+  it("produces a valid empty payload when no data exists", async () => {
+    const { deps } = makeDeps([], [], [], [], []);
+    const provider = createUserRegistrationInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.kpis.find((k) => k.id === "new_subscriptions")?.value).toBe(
+      0,
+    );
+    expect(
+      payload.sections.find((s) => s.id === "where-per-ticker"),
+    ).toBeUndefined();
+    expect(
+      payload.sections.find((s) => s.id === "why-unsubscribe-method"),
+    ).toBeUndefined();
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.ts
@@ -1,0 +1,524 @@
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type UserRow = {
+  createdAt: Date;
+};
+
+type UserTickerRow = {
+  id: string;
+  tickerId: string;
+  userId: string;
+  enabled: boolean;
+  createdAt: Date;
+  registrationConfirmedAt: Date | null;
+  unsubscribedAt: Date | null;
+  unsubscribeMethod: string | null;
+  ticker: { symbol: string };
+};
+
+type UserRegistrationInsightsDeps = {
+  mediapulseUser: {
+    findMany: (args: {
+      where: { createdAt: { gte: Date } };
+      select: { createdAt: boolean };
+    }) => Promise<UserRow[]>;
+  };
+  userTicker: {
+    findMany: (args: {
+      where: {
+        createdAt?: { gte: Date };
+        registrationConfirmedAt?: { gte: Date };
+        unsubscribedAt?: { gte: Date } | null;
+        enabled?: boolean;
+        tickerId?: string;
+      };
+      select: {
+        id: boolean;
+        tickerId: boolean;
+        userId: boolean;
+        enabled: boolean;
+        createdAt: boolean;
+        registrationConfirmedAt: boolean;
+        unsubscribedAt: boolean;
+        unsubscribeMethod: boolean;
+        ticker: { select: { symbol: boolean } };
+      };
+      take?: number;
+    }) => Promise<UserTickerRow[]>;
+  };
+};
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+function mergeByIdDedup(rows: UserTickerRow[][]): UserTickerRow[] {
+  const seen = new Map<string, UserTickerRow>();
+  for (const batch of rows) {
+    for (const row of batch) {
+      if (!seen.has(row.id)) {
+        seen.set(row.id, row);
+      }
+    }
+  }
+  return Array.from(seen.values());
+}
+
+export function createUserRegistrationInsightsProvider(
+  deps: UserRegistrationInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "user-registration",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const tickerFilter = ctx.tickerId ? { tickerId: ctx.tickerId } : {};
+      const fullSelect = {
+        id: true,
+        tickerId: true,
+        userId: true,
+        enabled: true,
+        createdAt: true,
+        registrationConfirmedAt: true,
+        unsubscribedAt: true,
+        unsubscribeMethod: true,
+        ticker: { select: { symbol: true } },
+      };
+
+      const [
+        allUsers,
+        newSubRows,
+        confirmedRows,
+        unsubscribedRows,
+        activeRows,
+      ] = await Promise.all([
+        deps.mediapulseUser.findMany({
+          where: { createdAt: { gte: priorStart } },
+          select: { createdAt: true },
+        }),
+        deps.userTicker.findMany({
+          where: { createdAt: { gte: priorStart }, ...tickerFilter },
+          select: fullSelect,
+        }),
+        deps.userTicker.findMany({
+          where: {
+            registrationConfirmedAt: { gte: windowStart },
+            ...tickerFilter,
+          },
+          select: fullSelect,
+        }),
+        deps.userTicker.findMany({
+          where: {
+            unsubscribedAt: { gte: windowStart },
+            ...tickerFilter,
+          },
+          select: fullSelect,
+        }),
+        deps.userTicker.findMany({
+          where: { enabled: true, unsubscribedAt: null, ...tickerFilter },
+          select: fullSelect,
+          take: 5000,
+        }),
+      ]);
+
+      // Merge and deduplicate rows touched in the window
+      const windowTouched = mergeByIdDedup([
+        newSubRows.filter((r) => r.createdAt >= windowStart),
+        confirmedRows,
+        unsubscribedRows,
+      ]);
+
+      const currentSubs = newSubRows.filter((r) => r.createdAt >= windowStart);
+      const priorSubs = newSubRows.filter(
+        (r) => r.createdAt >= priorStart && r.createdAt < windowStart,
+      );
+
+      const currentUsers = allUsers.filter((u) => u.createdAt >= windowStart);
+      const priorUsers = allUsers.filter(
+        (u) => u.createdAt >= priorStart && u.createdAt < windowStart,
+      );
+
+      // All confirmed in window (including older subs that confirmed this window)
+      const confirmedInWindow = mergeByIdDedup([
+        newSubRows.filter(
+          (r) =>
+            r.registrationConfirmedAt !== null &&
+            r.registrationConfirmedAt >= windowStart,
+        ),
+        confirmedRows,
+      ]);
+
+      // All unsubscribed in window (including older subs)
+      const unsubscribedInWindow = mergeByIdDedup([
+        newSubRows.filter(
+          (r) => r.unsubscribedAt !== null && r.unsubscribedAt >= windowStart,
+        ),
+        unsubscribedRows,
+      ]);
+
+      const priorConfirmed = newSubRows.filter(
+        (r) =>
+          r.createdAt >= priorStart &&
+          r.createdAt < windowStart &&
+          r.registrationConfirmedAt !== null,
+      );
+      const priorUnsubscribed = newSubRows.filter(
+        (r) =>
+          r.createdAt >= priorStart &&
+          r.createdAt < windowStart &&
+          r.unsubscribedAt !== null,
+      );
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const totalNewUsers = currentUsers.length;
+      const totalNewSubs = currentSubs.length;
+      const totalConfirmedInWindow = confirmedInWindow.length;
+      const totalUnsubscribedInWindow = unsubscribedInWindow.length;
+      const totalActive = activeRows.length;
+
+      const confirmationRate =
+        totalNewSubs > 0
+          ? Math.round((totalConfirmedInWindow / totalNewSubs) * 100)
+          : 0;
+
+      const priorConfirmationRate =
+        priorSubs.length > 0
+          ? Math.round((priorConfirmed.length / priorSubs.length) * 100)
+          : null;
+
+      const kpis: KpiCard[] = [
+        {
+          id: "new_users",
+          label: "New users",
+          value: totalNewUsers,
+          delta: totalNewUsers - priorUsers.length,
+        },
+        {
+          id: "new_subscriptions",
+          label: "New subscriptions",
+          value: totalNewSubs,
+          delta: totalNewSubs - priorSubs.length,
+        },
+        {
+          id: "confirmation_rate",
+          label: "Confirmation rate",
+          value: confirmationRate,
+          unit: "%",
+        },
+        {
+          id: "active_subscribers",
+          label: "Active subscribers",
+          value: totalActive,
+        },
+        {
+          id: "unsubscribes",
+          label: "Unsubscribes",
+          value: totalUnsubscribedInWindow,
+          delta: totalUnsubscribedInWindow - priorUnsubscribed.length,
+        },
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      if (
+        priorConfirmationRate !== null &&
+        priorConfirmationRate > 0 &&
+        confirmationRate < priorConfirmationRate - 20
+      ) {
+        alerts.push({
+          id: "confirmation-rate-drop",
+          severity: "warning",
+          message: `Confirmation rate dropped from ${priorConfirmationRate}% to ${confirmationRate}%`,
+          sectionRef: "how-confirmation-rate",
+        });
+      }
+
+      const priorUnsubRate =
+        priorSubs.length > 0
+          ? Math.round((priorUnsubscribed.length / priorSubs.length) * 100)
+          : 0;
+      const currentUnsubRate =
+        totalNewSubs > 0
+          ? Math.round((totalUnsubscribedInWindow / totalNewSubs) * 100)
+          : 0;
+      if (
+        priorUnsubRate > 0 &&
+        currentUnsubRate > priorUnsubRate * 2 &&
+        totalUnsubscribedInWindow > 3
+      ) {
+        alerts.push({
+          id: "unsubscribe-spike",
+          severity: "warning",
+          message: `Unsubscribe rate spiked: ${currentUnsubRate}% vs ${priorUnsubRate}% in the prior window`,
+          sectionRef: "why-unsubscribe-method",
+        });
+      }
+
+      if (totalNewSubs === 0 && ctx.window !== "24h") {
+        alerts.push({
+          id: "no-new-registrations",
+          severity: "info",
+          message: "No new subscriptions in the window",
+        });
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — subscription lifecycle funnel
+      // Active = confirmed-in-window rows that are still enabled and not unsubscribed.
+      // This ensures each stage is a subset of the previous.
+      const activeConfirmedRows = confirmedInWindow.filter(
+        (r) => r.enabled && r.unsubscribedAt === null,
+      ).length;
+      sections.push({
+        id: "what-lifecycle-funnel",
+        category: "what",
+        title: "Subscription lifecycle",
+        insight:
+          "New = created this window; Confirmed = confirmed this window; Active = confirmed this window and still enabled; Unsubscribed = unsubscribed this window.",
+        widget: {
+          kind: "funnel",
+          stages: [
+            { label: "New subscriptions", value: totalNewSubs },
+            { label: "Confirmed", value: totalConfirmedInWindow },
+            { label: "Active", value: activeConfirmedRows },
+            { label: "Unsubscribed", value: totalUnsubscribedInWindow },
+          ],
+        },
+      });
+
+      // When — registrations and confirmations per day
+      const regDailyBuckets = buildWindowDates(windowStart, now);
+      const confDailyBuckets = buildWindowDates(windowStart, now);
+
+      for (const sub of currentSubs) {
+        const dayKey = sub.createdAt.toISOString().slice(0, 10);
+        if (regDailyBuckets.has(dayKey)) {
+          regDailyBuckets.set(dayKey, (regDailyBuckets.get(dayKey) ?? 0) + 1);
+        }
+      }
+      for (const sub of confirmedInWindow) {
+        if (sub.registrationConfirmedAt === null) continue;
+        const dayKey = sub.registrationConfirmedAt.toISOString().slice(0, 10);
+        if (confDailyBuckets.has(dayKey)) {
+          confDailyBuckets.set(dayKey, (confDailyBuckets.get(dayKey) ?? 0) + 1);
+        }
+      }
+
+      sections.push({
+        id: "when-registrations",
+        category: "when",
+        title: "Registrations over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(regDailyBuckets.entries()).map(([ts, value]) => ({
+            ts: `${ts}T00:00:00.000Z`,
+            value,
+          })),
+          unit: "subscriptions",
+        },
+      });
+
+      const hasConfirmations = Array.from(confDailyBuckets.values()).some(
+        (v) => v > 0,
+      );
+      if (hasConfirmations) {
+        sections.push({
+          id: "when-confirmations",
+          category: "when",
+          title: "Confirmations over time",
+          widget: {
+            kind: "timeSeries",
+            points: Array.from(confDailyBuckets.entries()).map(
+              ([ts, value]) => ({
+                ts: `${ts}T00:00:00.000Z`,
+                value,
+              }),
+            ),
+            unit: "confirmations",
+          },
+        });
+      }
+
+      // Where — active subscriptions per ticker (top-N)
+      const perTickerActive = new Map<string, number>();
+      for (const row of activeRows) {
+        perTickerActive.set(
+          row.ticker.symbol,
+          (perTickerActive.get(row.ticker.symbol) ?? 0) + 1,
+        );
+      }
+      if (perTickerActive.size > 0) {
+        sections.push({
+          id: "where-per-ticker",
+          category: "where",
+          title: "Active subscribers by ticker",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(perTickerActive.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "subscribers",
+          },
+        });
+      }
+
+      // Who — subscription status breakdown (for subscriptions touched in window)
+      const statusCounts = { pending: 0, confirmedActive: 0, unsubscribed: 0 };
+      for (const row of windowTouched) {
+        if (row.unsubscribedAt !== null) {
+          statusCounts.unsubscribed += 1;
+        } else if (row.registrationConfirmedAt !== null && row.enabled) {
+          statusCounts.confirmedActive += 1;
+        } else {
+          statusCounts.pending += 1;
+        }
+      }
+      const statusTotal =
+        statusCounts.pending +
+        statusCounts.confirmedActive +
+        statusCounts.unsubscribed;
+      if (statusTotal > 0) {
+        sections.push({
+          id: "who-status-breakdown",
+          category: "who",
+          title: "Subscription status",
+          widget: {
+            kind: "breakdown",
+            slices: [
+              {
+                label: "Pending",
+                value: statusCounts.pending,
+                fraction:
+                  statusTotal > 0 ? statusCounts.pending / statusTotal : 0,
+              },
+              {
+                label: "Confirmed active",
+                value: statusCounts.confirmedActive,
+                fraction:
+                  statusTotal > 0
+                    ? statusCounts.confirmedActive / statusTotal
+                    : 0,
+              },
+              {
+                label: "Unsubscribed",
+                value: statusCounts.unsubscribed,
+                fraction:
+                  statusTotal > 0 ? statusCounts.unsubscribed / statusTotal : 0,
+              },
+            ].filter((s) => s.value > 0),
+          },
+        });
+      }
+
+      // Why — unsubscribe-method breakdown (only rows with unsubscribeMethod set)
+      const methodCounts = new Map<string, number>();
+      for (const row of unsubscribedInWindow) {
+        if (row.unsubscribeMethod === null) continue;
+        methodCounts.set(
+          row.unsubscribeMethod,
+          (methodCounts.get(row.unsubscribeMethod) ?? 0) + 1,
+        );
+      }
+      if (methodCounts.size > 0) {
+        const methodTotal = Array.from(methodCounts.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "why-unsubscribe-method",
+          category: "why",
+          title: "Unsubscribe method",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(methodCounts.entries()).map(
+              ([label, value]) => ({
+                label,
+                value,
+                fraction: methodTotal > 0 ? value / methodTotal : 0,
+              }),
+            ),
+          },
+        });
+      }
+
+      // How — confirmation-rate stat
+      sections.push({
+        id: "how-confirmation-rate",
+        category: "how",
+        title: "Confirmation rate",
+        widget: {
+          kind: "stat",
+          value: confirmationRate,
+          unit: "%",
+        },
+      });
+
+      return {
+        agentId: "user-registration",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds a user-registration insights provider that aggregates `MediapulseUser` and `UserTicker` lifecycle timestamps — no new tables needed. The lifecycle timestamps (`createdAt`, `registrationConfirmedAt`, `unsubscribedAt`, `unsubscribeMethod`) already carry enough signal for a complete subscriber funnel.

## Related issues

Closes #725

## Important changes

- New `createUserRegistrationInsightsProvider(deps)` factory in `agent-data-api/src/services/insights/` implementing `AgentInsightsProvider` with `agentId: "user-registration"`
- Five parallel queries: users by `createdAt`, userTickers by `createdAt` (new subscriptions + delta), by `registrationConfirmedAt` (confirmed this window, including older subs), by `unsubscribedAt` (unsubscribed this window), and by `enabled: true` (active by ticker); rows are deduplicated by id before aggregation
- KPIs: new users (with delta), new subscriptions (with delta), confirmation rate, active subscribers, unsubscribes in window
- Alerts: confirmation-rate drop >20pp vs prior window, unsubscribe spike (2x prior rate with >3 cases), no new registrations (non-24h windows)
- 5W1H sections: subscription lifecycle funnel (new → confirmed → active → unsubscribed, each stage a strict subset), registrations/confirmations per day timeSeries, active subscribers per ticker categoryBar (top-N), subscription status breakdown, unsubscribe-method breakdown (excludes null-method admin disables), confirmation-rate stat
- Provider registered at agent-data-api startup in `index.ts`

## Other changes

- 8-test fixture suite in `user-registration-insights-provider.test.ts` covering schema validation, funnel monotonicity, status fraction sum, null-method exclusion, confirmation rate calculation, KPI deltas, top-N capping, and empty-data handling

## Key files to review

- [apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.ts)
- [apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.test.ts](apps/mediapulse/agent-data-api/src/services/insights/user-registration-insights-provider.test.ts)
- [apps/mediapulse/agent-data-api/src/index.ts](apps/mediapulse/agent-data-api/src/index.ts)

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — all 188 tests green
2. With `HERMES_AGENT_INSIGHTS_ENABLED` on, open a user-registration agent in the UI → Insights tab; confirm the lifecycle funnel, registrations/confirmations timeline, per-ticker active subscribers bar, status breakdown, and unsubscribe-method mix render correctly
