### PR TITLE
Add data-collection insights provider with agentId-based run scoping

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -71,6 +71,7 @@ import { getAgentInsights } from "./routes/agent-insights.js";
 import { createPageCollectionInsightsProvider } from "./services/insights/page-collection-insights-provider.js";
 import { createContentGenerationInsightsProvider } from "./services/insights/content-generation-insights-provider.js";
 import { createUserRegistrationInsightsProvider } from "./services/insights/user-registration-insights-provider.js";
+import { createDataCollectionInsightsProvider } from "./services/insights/data-collection-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -239,6 +240,13 @@ registerInsightsProvider(
   createUserRegistrationInsightsProvider({
     mediapulseUser: prisma.mediapulseUser,
     userTicker: prisma.userTicker,
+  }),
+);
+registerInsightsProvider(
+  createDataCollectionInsightsProvider({
+    dataCollectionRun: prisma.dataCollectionRun,
+    dataCollectionFailure: prisma.dataCollectionFailure,
+    dataSource: prisma.dataSource,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.test.ts
@@ -1,0 +1,288 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+
+import { createDataCollectionInsightsProvider } from "./data-collection-insights-provider.js";
+
+function makeRun(overrides?: {
+  id?: string;
+  tickerId?: string;
+  startedAt?: Date;
+  status?: string;
+  fetchSuccess?: number;
+  searchSuccess?: number;
+  searchFailed?: number;
+  queriesTotal?: number;
+  extendedCounters?: object | null;
+}) {
+  const defaultExtendedCounters = {
+    agentId: "data-collection",
+    persisted: 10,
+    discovered: 20,
+    afterPrefilter: 18,
+    durationMs: 30000,
+  };
+  return {
+    id: overrides?.id ?? "run-1",
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    startedAt:
+      overrides?.startedAt ?? new Date(Date.now() - 24 * 60 * 60 * 1000),
+    status: overrides?.status ?? "success",
+    fetchSuccess: overrides?.fetchSuccess ?? 10,
+    searchSuccess: overrides?.searchSuccess ?? 20,
+    searchFailed: overrides?.searchFailed ?? 2,
+    queriesTotal: overrides?.queriesTotal ?? 5,
+    extendedCounters:
+      overrides !== undefined &&
+      Object.prototype.hasOwnProperty.call(overrides, "extendedCounters")
+        ? overrides.extendedCounters
+        : defaultExtendedCounters,
+  };
+}
+
+function makeFailure(overrides?: {
+  runId?: string;
+  stage?: string;
+  provider?: string;
+  errorCategory?: string;
+}) {
+  return {
+    runId: overrides?.runId ?? "run-1",
+    stage: overrides?.stage ?? "fetch",
+    provider: overrides?.provider ?? "jina",
+    errorCategory: overrides?.errorCategory ?? "network",
+  };
+}
+
+function makeDataSource(overrides?: {
+  tickerId?: string;
+  url?: string;
+  createdAt?: Date;
+  ticker?: { symbol: string };
+}) {
+  return {
+    tickerId: overrides?.tickerId ?? "ticker-1",
+    url: overrides?.url ?? "https://reuters.com/article-1",
+    createdAt: overrides?.createdAt ?? new Date("2026-06-07T08:00:00.000Z"),
+    ticker: overrides?.ticker ?? { symbol: "AAPL" },
+  };
+}
+
+function makeDeps(
+  runs: ReturnType<typeof makeRun>[],
+  failures: ReturnType<typeof makeFailure>[],
+  dataSources: ReturnType<typeof makeDataSource>[],
+) {
+  return {
+    dataCollectionRun: {
+      findMany: async () => runs,
+    },
+    dataCollectionFailure: {
+      findMany: async () => failures,
+    },
+    dataSource: {
+      findMany: async () => dataSources,
+    },
+  };
+}
+
+describe("createDataCollectionInsightsProvider", () => {
+  it("produces a payload that passes insightsPayloadSchema", async () => {
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([makeRun()], [makeFailure()], [makeDataSource()]),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const result = insightsPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+  });
+
+  it("excludes page-collection runs from all counts", async () => {
+    const dataCollectionRun = makeRun({
+      id: "dc-run",
+      fetchSuccess: 10,
+      extendedCounters: { agentId: "data-collection", persisted: 10 },
+    });
+    const pageCollectionRun = makeRun({
+      id: "pc-run",
+      fetchSuccess: 999,
+      extendedCounters: { agentId: "page-collection", persisted: 999 },
+    });
+    const deps = makeDeps([dataCollectionRun, pageCollectionRun], [], []);
+    const provider = createDataCollectionInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+    const articleKpi = payload.kpis.find((k) => k.id === "articles_collected");
+    expect(articleKpi?.value).toBe(10);
+  });
+
+  it("excludes runs without agentId from data-collection counts", async () => {
+    const runWithoutAgentId = makeRun({
+      id: "old-run",
+      fetchSuccess: 999,
+      extendedCounters: null,
+    });
+    const deps = makeDeps([runWithoutAgentId], [], []);
+    const provider = createDataCollectionInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+    const articleKpi = payload.kpis.find((k) => k.id === "articles_collected");
+    expect(articleKpi?.value).toBe(0);
+  });
+
+  it("computes funnel with fetched >= persisted", async () => {
+    const run = makeRun({
+      queriesTotal: 5,
+      fetchSuccess: 8,
+      extendedCounters: {
+        agentId: "data-collection",
+        discovered: 20,
+        persisted: 6,
+      },
+    });
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([run], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const funnel = payload.sections.find((s) => s.id === "what-funnel");
+    expect(funnel?.widget.kind).toBe("funnel");
+    if (funnel?.widget.kind !== "funnel") return;
+    const fetched = funnel.widget.stages.find((s) => s.label === "Fetched");
+    const persisted = funnel.widget.stages.find((s) => s.label === "Persisted");
+    expect(fetched).toBeDefined();
+    expect(persisted).toBeDefined();
+    expect(fetched!.value).toBeGreaterThanOrEqual(persisted!.value);
+  });
+
+  it("aggregates drop reasons from extendedCounters", async () => {
+    const run = makeRun({
+      extendedCounters: {
+        agentId: "data-collection",
+        droppedByRelevance: 5,
+        droppedByFreshness: 3,
+        droppedByContentQuality: { low_quality: 2 },
+        persisted: 10,
+        discovered: 25,
+      },
+    });
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([run], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const dropSection = payload.sections.find(
+      (s) => s.id === "why-drop-reasons",
+    );
+    expect(dropSection).toBeDefined();
+    if (dropSection?.widget.kind !== "breakdown") return;
+    const labels = dropSection.widget.slices.map((s) => s.label);
+    expect(labels).toContain("Relevance");
+    expect(labels).toContain("Freshness");
+    expect(labels).toContain("Content: low_quality");
+  });
+
+  it("drop reason fractions sum to 1", async () => {
+    const run = makeRun({
+      extendedCounters: {
+        agentId: "data-collection",
+        droppedByRelevance: 4,
+        droppedByFreshness: 6,
+        persisted: 10,
+        discovered: 20,
+      },
+    });
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([run], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const dropSection = payload.sections.find(
+      (s) => s.id === "why-drop-reasons",
+    );
+    if (dropSection?.widget.kind !== "breakdown") return;
+    const total = dropSection.widget.slices.reduce(
+      (sum, s) => sum + s.fraction,
+      0,
+    );
+    expect(total).toBeCloseTo(1, 5);
+  });
+
+  it("computes KPI delta between current and prior window", async () => {
+    const windowMs = 7 * 24 * 60 * 60 * 1000;
+    const now = Date.now();
+    const windowStart = now - windowMs;
+    const priorStart = windowStart - windowMs;
+    const priorRun = makeRun({
+      id: "prior-run",
+      startedAt: new Date(priorStart + 1000),
+      fetchSuccess: 5,
+      extendedCounters: { agentId: "data-collection", persisted: 5 },
+    });
+    const currentRun = makeRun({
+      id: "current-run",
+      startedAt: new Date(windowStart + 1000),
+      fetchSuccess: 15,
+      extendedCounters: { agentId: "data-collection", persisted: 15 },
+    });
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([priorRun, currentRun], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const articleKpi = payload.kpis.find((k) => k.id === "articles_collected");
+    expect(articleKpi?.value).toBe(15);
+    expect(articleKpi?.delta).toBe(10);
+  });
+
+  it("emits low-search-success alert when rate is below 50%", async () => {
+    const run = makeRun({
+      searchSuccess: 2,
+      searchFailed: 8,
+      extendedCounters: { agentId: "data-collection", persisted: 2 },
+    });
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([run], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const alert = payload.alerts.find((a) => a.id === "low-search-success");
+    expect(alert).toBeDefined();
+  });
+
+  it("emits stage-failure alert when a stage has more than 5 failures", async () => {
+    const run = makeRun({ id: "run-x" });
+    const failures = Array.from({ length: 6 }, (_, i) =>
+      makeFailure({ runId: "run-x", stage: "fetch", provider: `p-${i}` }),
+    );
+    const deps = makeDeps([run], failures, []);
+    const provider = createDataCollectionInsightsProvider(deps);
+    const payload = await provider.compute({ window: "7d" });
+    const alert = payload.alerts.find((a) => a.id === "stage-failure-fetch");
+    expect(alert).toBeDefined();
+  });
+
+  it("caps top publishers to TOP_N + Other", async () => {
+    const sources = Array.from({ length: 15 }, (_, i) =>
+      makeDataSource({ url: `https://publisher-${i}.com/article` }),
+    );
+    const provider = createDataCollectionInsightsProvider(
+      makeDeps([makeRun()], [], sources),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "where-publishers");
+    if (section?.widget.kind !== "categoryBar") return;
+    expect(section.widget.bars.length).toBeLessThanOrEqual(11);
+    const hasOther = section.widget.bars.some((b) => b.label === "Other");
+    expect(hasOther).toBe(true);
+  });
+
+  it("returns empty payload with schema-valid shape when no runs exist", async () => {
+    const provider = createDataCollectionInsightsProvider(makeDeps([], [], []));
+    const payload = await provider.compute({ window: "7d" });
+    const result = insightsPayloadSchema.safeParse(payload);
+    expect(result.success).toBe(true);
+    expect(payload.kpis.length).toBeGreaterThan(0);
+    expect(payload.sections.length).toBeGreaterThan(0);
+  });
+
+  it("agentId field is set to data-collection", async () => {
+    const provider = createDataCollectionInsightsProvider(makeDeps([], [], []));
+    const payload = await provider.compute({ window: "7d" });
+    expect(payload.agentId).toBe("data-collection");
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -1,0 +1,668 @@
+import type { Prisma } from "@mediapulse/database";
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const TOP_N = 10;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type RunRow = {
+  id: string;
+  tickerId: string;
+  startedAt: Date;
+  status: string;
+  fetchSuccess: number;
+  searchSuccess: number;
+  searchFailed: number;
+  queriesTotal: number;
+  extendedCounters: Prisma.JsonValue | null | undefined;
+};
+
+type FailureRow = {
+  runId: string;
+  stage: string;
+  provider: string;
+  errorCategory: string;
+};
+
+type DataSourceRow = {
+  tickerId: string;
+  url: string;
+  createdAt: Date;
+  ticker: { symbol: string };
+};
+
+type DataCollectionInsightsDeps = {
+  dataCollectionRun: {
+    findMany: (args: {
+      where: {
+        startedAt: { gte: Date };
+        tickerId?: string;
+      };
+      orderBy: { startedAt: "asc" };
+      select: {
+        id: boolean;
+        tickerId: boolean;
+        startedAt: boolean;
+        status: boolean;
+        fetchSuccess: boolean;
+        searchSuccess: boolean;
+        searchFailed: boolean;
+        queriesTotal: boolean;
+        extendedCounters: boolean;
+      };
+    }) => Promise<RunRow[]>;
+  };
+  dataCollectionFailure: {
+    findMany: (args: {
+      where: { runId: { in: string[] } };
+      select: {
+        runId: boolean;
+        stage: boolean;
+        provider: boolean;
+        errorCategory: boolean;
+      };
+    }) => Promise<FailureRow[]>;
+  };
+  dataSource: {
+    findMany: (args: {
+      where: { createdAt: { gte: Date }; tickerId?: string };
+      select: {
+        tickerId: boolean;
+        url: boolean;
+        createdAt: boolean;
+        ticker: { select: { symbol: boolean } };
+      };
+      take: number;
+    }) => Promise<DataSourceRow[]>;
+  };
+};
+
+type ExtendedCounters = {
+  agentId?: string;
+  discovered?: number;
+  afterPrefilter?: number;
+  persisted?: number;
+  droppedByRelevance?: number;
+  droppedByContentQuality?: Record<string, number>;
+  droppedByFreshness?: number;
+  droppedByDeadUrl?: number;
+  droppedByHostErrorRate?: number;
+  droppedByPerQueryBudget?: number;
+  droppedByPerRunBudget?: number;
+  droppedByExistingCanonicalUrl?: number;
+  droppedByDuplicateCanonicalUrl?: number;
+  droppedByUrlNoise?: number;
+  roundsExecuted?: number;
+  stopReason?: string;
+  durationMs?: number;
+};
+
+function parseExtendedCounters(
+  raw: Prisma.JsonValue | null | undefined,
+): ExtendedCounters {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    return {};
+  }
+  return raw as ExtendedCounters;
+}
+
+function isDataCollectionRun(row: RunRow): boolean {
+  const ext = parseExtendedCounters(row.extendedCounters);
+  return ext.agentId === "data-collection";
+}
+
+function domainFromUrl(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function bucketTopN<T extends { label: string; value: number }>(
+  items: T[],
+  n: number,
+): T[] {
+  const sorted = [...items].sort((a, b) => b.value - a.value);
+  if (sorted.length <= n) {
+    return sorted;
+  }
+  const top = sorted.slice(0, n);
+  const restValue = sorted.slice(n).reduce((sum, item) => sum + item.value, 0);
+  if (restValue > 0) {
+    return [...top, { label: "Other", value: restValue } as T];
+  }
+  return top;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+  return buckets;
+}
+
+function medianOf(values: number[]): number | null {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round(((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2)
+    : (sorted[mid] ?? 0);
+}
+
+export function createDataCollectionInsightsProvider(
+  deps: DataCollectionInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "data-collection",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      const [allRuns, dataSources] = await Promise.all([
+        deps.dataCollectionRun.findMany({
+          where: {
+            startedAt: { gte: priorStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          orderBy: { startedAt: "asc" },
+          select: {
+            id: true,
+            tickerId: true,
+            startedAt: true,
+            status: true,
+            fetchSuccess: true,
+            searchSuccess: true,
+            searchFailed: true,
+            queriesTotal: true,
+            extendedCounters: true,
+          },
+        }),
+        deps.dataSource.findMany({
+          where: {
+            createdAt: { gte: windowStart },
+            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+          },
+          select: {
+            tickerId: true,
+            url: true,
+            createdAt: true,
+            ticker: { select: { symbol: true } },
+          },
+          take: 2000,
+        }),
+      ]);
+
+      // Scope to data-collection runs only
+      const runs = allRuns.filter(
+        (r) => r.startedAt >= windowStart && isDataCollectionRun(r),
+      );
+      const priorWindowRuns = allRuns.filter(
+        (r) =>
+          r.startedAt >= priorStart &&
+          r.startedAt < windowStart &&
+          isDataCollectionRun(r),
+      );
+
+      const windowRunIds = runs.map((r) => r.id);
+      const failures =
+        windowRunIds.length > 0
+          ? await deps.dataCollectionFailure.findMany({
+              where: { runId: { in: windowRunIds } },
+              select: {
+                runId: true,
+                stage: true,
+                provider: true,
+                errorCategory: true,
+              },
+            })
+          : [];
+
+      // ─── Aggregated counters ─────────────────────────────────────────────
+
+      const totalRuns = runs.length;
+      const successfulRuns = runs.filter(
+        (r) => r.status === "success" || r.status === "partial_success",
+      ).length;
+      const totalArticles = runs.reduce((sum, r) => sum + r.fetchSuccess, 0);
+      const priorArticles = priorWindowRuns.reduce(
+        (sum, r) => sum + r.fetchSuccess,
+        0,
+      );
+      const totalQueries = runs.reduce((sum, r) => sum + r.queriesTotal, 0);
+      const totalSearchSuccess = runs.reduce(
+        (sum, r) => sum + r.searchSuccess,
+        0,
+      );
+      const totalSearchFailed = runs.reduce(
+        (sum, r) => sum + r.searchFailed,
+        0,
+      );
+      const totalSearchAttempts = totalSearchSuccess + totalSearchFailed;
+
+      let totalDiscovered = 0;
+      let totalAfterPrefilter = 0;
+      let totalPersisted = 0;
+      let totalDroppedByRelevance = 0;
+      let totalDroppedByFreshness = 0;
+      let totalDroppedByDeadUrl = 0;
+      let totalDroppedByHostErrorRate = 0;
+      let totalDroppedByPerQueryBudget = 0;
+      let totalDroppedByPerRunBudget = 0;
+      let totalDroppedByUrlNoise = 0;
+      let totalDroppedByExistingCanonical = 0;
+      let totalDroppedByDuplicateCanonical = 0;
+      const totalDroppedByContentQuality: Record<string, number> = {};
+      const durationMsList: number[] = [];
+
+      for (const run of runs) {
+        const ext = parseExtendedCounters(run.extendedCounters);
+        totalDiscovered += ext.discovered ?? run.searchSuccess;
+        totalAfterPrefilter += ext.afterPrefilter ?? run.searchSuccess;
+        totalPersisted += ext.persisted ?? run.fetchSuccess;
+        totalDroppedByRelevance += ext.droppedByRelevance ?? 0;
+        totalDroppedByFreshness += ext.droppedByFreshness ?? 0;
+        totalDroppedByDeadUrl += ext.droppedByDeadUrl ?? 0;
+        totalDroppedByHostErrorRate += ext.droppedByHostErrorRate ?? 0;
+        totalDroppedByPerQueryBudget += ext.droppedByPerQueryBudget ?? 0;
+        totalDroppedByPerRunBudget += ext.droppedByPerRunBudget ?? 0;
+        totalDroppedByUrlNoise += ext.droppedByUrlNoise ?? 0;
+        totalDroppedByExistingCanonical +=
+          ext.droppedByExistingCanonicalUrl ?? 0;
+        totalDroppedByDuplicateCanonical +=
+          ext.droppedByDuplicateCanonicalUrl ?? 0;
+
+        for (const [reason, count] of Object.entries(
+          ext.droppedByContentQuality ?? {},
+        )) {
+          totalDroppedByContentQuality[reason] =
+            (totalDroppedByContentQuality[reason] ?? 0) + count;
+        }
+
+        if (ext.durationMs !== undefined) {
+          durationMsList.push(ext.durationMs);
+        }
+      }
+
+      // ─── KPIs ────────────────────────────────────────────────────────────
+
+      const successRate =
+        totalRuns > 0 ? Math.round((successfulRuns / totalRuns) * 100) : 0;
+      const searchSuccessRate =
+        totalSearchAttempts > 0
+          ? Math.round((totalSearchSuccess / totalSearchAttempts) * 100)
+          : 0;
+      const fetchSuccessRate =
+        totalArticles + failures.length > 0
+          ? Math.round(
+              (totalArticles / (totalArticles + failures.length)) * 100,
+            )
+          : 0;
+      const articleDelta = totalArticles - priorArticles;
+      const medianDurationMs = medianOf(durationMsList);
+
+      const kpis: KpiCard[] = [
+        {
+          id: "runs",
+          label: "Runs",
+          value: totalRuns,
+          delta: totalRuns - priorWindowRuns.length,
+        },
+        {
+          id: "success_rate",
+          label: "Success rate",
+          value: successRate,
+          unit: "%",
+        },
+        {
+          id: "articles_collected",
+          label: "Articles collected",
+          value: totalArticles,
+          delta: articleDelta,
+        },
+        {
+          id: "search_success_rate",
+          label: "Search success rate",
+          value: searchSuccessRate,
+          unit: "%",
+        },
+        ...(medianDurationMs !== null
+          ? [
+              {
+                id: "median_duration_ms",
+                label: "Median run duration",
+                value: medianDurationMs,
+                unit: "ms",
+              } satisfies KpiCard,
+            ]
+          : []),
+      ];
+
+      // ─── Alerts ──────────────────────────────────────────────────────────
+
+      const alerts: InsightAlert[] = [];
+
+      if (failures.length > 0) {
+        const stageFailCounts = new Map<string, number>();
+        for (const f of failures) {
+          stageFailCounts.set(f.stage, (stageFailCounts.get(f.stage) ?? 0) + 1);
+        }
+        for (const [stage, count] of stageFailCounts) {
+          if (count > 5) {
+            alerts.push({
+              id: `stage-failure-${stage}`,
+              severity: "warning",
+              message: `${count} failures at stage "${stage}" in the window`,
+              sectionRef: "why-failure-category",
+            });
+          }
+        }
+      }
+
+      const totalDropped =
+        totalDroppedByRelevance +
+        totalDroppedByFreshness +
+        totalDroppedByDeadUrl +
+        totalDroppedByHostErrorRate +
+        totalDroppedByPerQueryBudget +
+        totalDroppedByPerRunBudget +
+        totalDroppedByUrlNoise +
+        totalDroppedByExistingCanonical +
+        totalDroppedByDuplicateCanonical +
+        Object.values(totalDroppedByContentQuality).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+      if (
+        totalAfterPrefilter > 10 &&
+        totalDropped / totalAfterPrefilter > 0.6
+      ) {
+        alerts.push({
+          id: "high-drop-rate",
+          severity: "warning",
+          message: `More than 60% of fetched results are being dropped`,
+          sectionRef: "why-drop-reasons",
+        });
+      }
+
+      if (searchSuccessRate < 50 && totalSearchAttempts > 5) {
+        alerts.push({
+          id: "low-search-success",
+          severity: "warning",
+          message: `Search success rate is low: ${searchSuccessRate}%`,
+          sectionRef: "what-funnel",
+        });
+      }
+
+      if (totalRuns > 0) {
+        const staleThresholdMs =
+          ctx.window === "24h" ? 6 * 60 * 60 * 1000 : 48 * 60 * 60 * 1000;
+        const lastRun = runs[runs.length - 1];
+        if (
+          lastRun &&
+          now.getTime() - lastRun.startedAt.getTime() > staleThresholdMs
+        ) {
+          alerts.push({
+            id: "stale-last-run",
+            severity: "info",
+            message: `No run in the last ${ctx.window === "24h" ? "6 hours" : "48 hours"}`,
+          });
+        }
+      }
+
+      // ─── Sections ────────────────────────────────────────────────────────
+
+      const sections: InsightSection[] = [];
+
+      // What — collection funnel
+      sections.push({
+        id: "what-funnel",
+        category: "what",
+        title: "Collection funnel",
+        insight: "Articles from web search hits through to persistence.",
+        widget: {
+          kind: "funnel",
+          stages: [
+            { label: "Queries", value: totalQueries },
+            { label: "Search hits", value: totalDiscovered },
+            { label: "Fetched", value: totalArticles },
+            { label: "Persisted", value: totalPersisted },
+          ],
+        },
+      });
+
+      // When — articles per day
+      const dailyBuckets = buildWindowDates(windowStart, now);
+      for (const run of runs) {
+        const dayKey = run.startedAt.toISOString().slice(0, 10);
+        if (dailyBuckets.has(dayKey)) {
+          dailyBuckets.set(
+            dayKey,
+            (dailyBuckets.get(dayKey) ?? 0) + run.fetchSuccess,
+          );
+        }
+      }
+      sections.push({
+        id: "when-timeseries",
+        category: "when",
+        title: "Articles over time",
+        widget: {
+          kind: "timeSeries",
+          points: Array.from(dailyBuckets.entries()).map(([ts, value]) => ({
+            ts: `${ts}T00:00:00.000Z`,
+            value,
+          })),
+          unit: "articles",
+        },
+      });
+
+      // Where — top publishers by article count
+      const publisherCounts = new Map<string, number>();
+      for (const source of dataSources) {
+        const publisher = domainFromUrl(source.url);
+        publisherCounts.set(
+          publisher,
+          (publisherCounts.get(publisher) ?? 0) + 1,
+        );
+      }
+      if (publisherCounts.size > 0) {
+        sections.push({
+          id: "where-publishers",
+          category: "where",
+          title: "Articles by publisher",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(publisherCounts.entries()).map(([label, value]) => ({
+                label,
+                value,
+              })),
+              TOP_N,
+            ),
+            unit: "articles",
+          },
+        });
+      }
+
+      // Who — per-ticker article counts
+      const tickerArticleCounts = new Map<string, number>();
+      for (const source of dataSources) {
+        const symbol = source.ticker.symbol;
+        tickerArticleCounts.set(
+          symbol,
+          (tickerArticleCounts.get(symbol) ?? 0) + 1,
+        );
+      }
+      if (tickerArticleCounts.size > 0) {
+        sections.push({
+          id: "who-per-ticker",
+          category: "who",
+          title: "Articles by ticker",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(tickerArticleCounts.entries()).map(
+                ([label, value]) => ({
+                  label,
+                  value,
+                }),
+              ),
+              TOP_N,
+            ),
+            unit: "articles",
+          },
+        });
+      }
+
+      // Why — drop reason breakdown
+      const dropEntries: Array<[string, number]> = [
+        ["Relevance", totalDroppedByRelevance],
+        ["Freshness", totalDroppedByFreshness],
+        ["Dead URL", totalDroppedByDeadUrl],
+        ["Host error rate", totalDroppedByHostErrorRate],
+        ["Per-query budget", totalDroppedByPerQueryBudget],
+        ["Per-run budget", totalDroppedByPerRunBudget],
+        ["URL noise", totalDroppedByUrlNoise],
+        ["Existing canonical", totalDroppedByExistingCanonical],
+        ["Duplicate canonical", totalDroppedByDuplicateCanonical],
+        ...Object.entries(totalDroppedByContentQuality).map(
+          ([reason, count]) =>
+            [`Content: ${reason}`, count] as [string, number],
+        ),
+      ];
+      const totalDroppedAll = dropEntries.reduce((sum, [, v]) => sum + v, 0);
+      const dropReasons = dropEntries
+        .filter(([, value]) => value > 0)
+        .map(([label, value]) => ({
+          label,
+          value,
+          fraction: totalDroppedAll > 0 ? value / totalDroppedAll : 0,
+        }));
+      if (dropReasons.length > 0) {
+        sections.push({
+          id: "why-drop-reasons",
+          category: "why",
+          title: "Drop reasons",
+          widget: {
+            kind: "breakdown",
+            slices: dropReasons,
+          },
+        });
+      }
+
+      // Why — failure category breakdown
+      if (failures.length > 0) {
+        const failCatCounts = new Map<string, number>();
+        for (const f of failures) {
+          failCatCounts.set(
+            f.errorCategory,
+            (failCatCounts.get(f.errorCategory) ?? 0) + 1,
+          );
+        }
+        const failTotal = failures.length;
+        sections.push({
+          id: "why-failure-category",
+          category: "why",
+          title: "Failure categories",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(failCatCounts.entries()).map(
+              ([label, value]) => ({
+                label,
+                value,
+                fraction: failTotal > 0 ? value / failTotal : 0,
+              }),
+            ),
+          },
+        });
+      }
+
+      // How — provider mix (from failure stage/provider data)
+      const providerMix = new Map<string, number>();
+      for (const f of failures) {
+        providerMix.set(f.provider, (providerMix.get(f.provider) ?? 0) + 1);
+      }
+      if (providerMix.size > 0) {
+        const providerTotal = Array.from(providerMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        sections.push({
+          id: "how-provider-mix",
+          category: "how",
+          title: "Provider failure mix",
+          widget: {
+            kind: "breakdown",
+            slices: Array.from(providerMix.entries()).map(([label, value]) => ({
+              label,
+              value,
+              fraction: providerTotal > 0 ? value / providerTotal : 0,
+            })),
+          },
+        });
+      }
+
+      // How — search success rate stat
+      if (totalSearchAttempts > 0) {
+        sections.push({
+          id: "how-search-success-rate",
+          category: "how",
+          title: "Search success rate",
+          widget: {
+            kind: "stat",
+            value: searchSuccessRate,
+            unit: "%",
+          },
+        });
+      }
+
+      // How — fetch success rate stat
+      if (totalArticles > 0 || failures.length > 0) {
+        sections.push({
+          id: "how-fetch-success-rate",
+          category: "how",
+          title: "Fetch success rate",
+          widget: {
+            kind: "stat",
+            value: fetchSuccessRate,
+            unit: "%",
+          },
+        });
+      }
+
+      return {
+        agentId: "data-collection",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}

--- a/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts
@@ -104,6 +104,7 @@ type ExtendedCounters = {
   droppedByUrlNoise?: number;
   persisted?: number;
   durationMs?: number;
+  agentId?: string;
 };
 
 function parseExtendedCounters(raw: Prisma.JsonValue | null): ExtendedCounters {
@@ -163,64 +164,76 @@ export function createPageCollectionInsightsProvider(
       const windowStart = new Date(now.getTime() - windowMs);
       const priorStart = new Date(windowStart.getTime() - windowMs);
 
-      const [runs, priorRuns, sourceHealth, dataSources] = await Promise.all([
-        deps.dataCollectionRun.findMany({
-          where: {
-            startedAt: { gte: windowStart },
-            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
-          },
-          orderBy: { startedAt: "asc" },
-          select: {
-            tickerId: true,
-            startedAt: true,
-            status: true,
-            fetchSuccess: true,
-            extendedCounters: true,
-          },
-        }),
-        deps.dataCollectionRun.findMany({
-          where: {
-            startedAt: { gte: priorStart },
-            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
-          },
-          orderBy: { startedAt: "asc" },
-          select: {
-            tickerId: true,
-            startedAt: true,
-            status: true,
-            fetchSuccess: true,
-            extendedCounters: true,
-          },
-        }),
-        deps.discoverySourceHealth.findMany({
-          where: { runDate: { gte: windowStart } },
-          select: {
-            listingUrl: true,
-            runDate: true,
-            discovered: true,
-            itemCount: true,
-            winningStrategy: true,
-            failureCount: true,
-          },
-        }),
-        deps.dataSource.findMany({
-          where: {
-            createdAt: { gte: windowStart },
-            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
-          },
-          select: {
-            tickerId: true,
-            url: true,
-            createdAt: true,
-            metadata: true,
-            ticker: { select: { symbol: true } },
-          },
-          take: 2000,
-        }),
-      ]);
+      const [allRuns, priorRuns, sourceHealth, dataSources] = await Promise.all(
+        [
+          deps.dataCollectionRun.findMany({
+            where: {
+              startedAt: { gte: windowStart },
+              ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+            },
+            orderBy: { startedAt: "asc" },
+            select: {
+              tickerId: true,
+              startedAt: true,
+              status: true,
+              fetchSuccess: true,
+              extendedCounters: true,
+            },
+          }),
+          deps.dataCollectionRun.findMany({
+            where: {
+              startedAt: { gte: priorStart },
+              ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+            },
+            orderBy: { startedAt: "asc" },
+            select: {
+              tickerId: true,
+              startedAt: true,
+              status: true,
+              fetchSuccess: true,
+              extendedCounters: true,
+            },
+          }),
+          deps.discoverySourceHealth.findMany({
+            where: { runDate: { gte: windowStart } },
+            select: {
+              listingUrl: true,
+              runDate: true,
+              discovered: true,
+              itemCount: true,
+              winningStrategy: true,
+              failureCount: true,
+            },
+          }),
+          deps.dataSource.findMany({
+            where: {
+              createdAt: { gte: windowStart },
+              ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+            },
+            select: {
+              tickerId: true,
+              url: true,
+              createdAt: true,
+              metadata: true,
+              ticker: { select: { symbol: true } },
+            },
+            take: 2000,
+          }),
+        ],
+      );
 
+      // Scope to page-collection runs only; old runs without agentId are attributed to page-collection.
+      const isPageCollectionRun = (r: RunRow) => {
+        const ext = parseExtendedCounters(r.extendedCounters);
+        return ext.agentId === undefined || ext.agentId === "page-collection";
+      };
+
+      const runs = allRuns.filter(isPageCollectionRun);
       const priorWindowRuns = priorRuns.filter(
-        (r) => r.startedAt >= priorStart && r.startedAt < windowStart,
+        (r) =>
+          r.startedAt >= priorStart &&
+          r.startedAt < windowStart &&
+          isPageCollectionRun(r),
       );
 
       // ─── Aggregated run counters ─────────────────────────────────────────

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -618,6 +618,11 @@ export async function runDataCollection(
     runPolicy,
   });
 
+  const droppedByUrlNoiseTotal = Object.values(droppedByUrlReason).reduce(
+    (sum, count) => sum + count,
+    0,
+  );
+
   const counters: RunCounters = {
     queriesTotal: queries.length,
     urlsTotal: searchSuccessCount,
@@ -628,6 +633,20 @@ export async function runDataCollection(
     retryCount: 0,
     droppedByRelevance,
     throttleEvents,
+    agentId: "data-collection",
+    persisted: persistedThisRunCount,
+    droppedByPerQueryBudget,
+    droppedByPerRunBudget,
+    droppedByDeadUrl: droppedByDeadUrlCache,
+    droppedByHostErrorRate,
+    droppedByFreshness,
+    droppedByDuplicateCanonicalUrl,
+    droppedByExistingCanonicalUrl,
+    droppedByUrlNoise: droppedByUrlNoiseTotal,
+    droppedByContentQuality: { ...droppedByContentQuality },
+    roundsExecuted,
+    stopReason: refillStopReason ?? undefined,
+    durationMs: Date.now() - startedAt.getTime(),
   };
 
   const runPayload = {

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -630,6 +630,7 @@ export async function runPageCollection(
     persisted: persistedCount,
     deadlineHit,
     durationMs: Date.now() - startedAt.getTime(),
+    agentId: "page-collection",
   };
 
   const runPayload = {

--- a/packages/shared/agent-data-api-contract/src/data-collection-run.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-run.ts
@@ -42,6 +42,11 @@ export const dataCollectionRunInputSchema = z.object({
     persisted: z.number().int().nonnegative().optional(),
     deadlineHit: z.boolean().optional(),
     durationMs: z.number().int().nonnegative().optional(),
+    agentId: z.string().optional(),
+    roundsExecuted: z.number().int().nonnegative().optional(),
+    stopReason: z.string().optional(),
+    droppedByPerQueryBudget: z.number().int().nonnegative().optional(),
+    droppedByPerRunBudget: z.number().int().nonnegative().optional(),
   }),
 });
 

--- a/packages/shared/agent-ingestion/src/run-status.ts
+++ b/packages/shared/agent-ingestion/src/run-status.ts
@@ -36,6 +36,11 @@ export type RunCounters = {
   persisted?: number;
   deadlineHit?: boolean;
   durationMs?: number;
+  agentId?: string;
+  roundsExecuted?: number;
+  stopReason?: string;
+  droppedByPerQueryBudget?: number;
+  droppedByPerRunBudget?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds the `data-collection` insights provider (plan 115) with KPIs, alerts, and seven insight sections
- Stamps `agentId` into `extendedCounters` JSON on both the `data-collection` and `page-collection` agents, so the shared `DataCollectionRun` table can be split without a migration
- Widens `RunCounters` and the Zod `counters` schema to carry granular drop-reason fields that the data-collection run already computes

## Related issues

Closes #727

## Important changes

- `run-status.ts` and `data-collection-run.ts` — new optional fields: `agentId`, `roundsExecuted`, `stopReason`, `droppedByPerQueryBudget`, `droppedByPerRunBudget`
- `data-collection/src/run.ts` — full set of drop counters now written into `RunCounters` along with `agentId: "data-collection"`
- `page-collection/src/run.ts` — adds `agentId: "page-collection"` to the run
- `page-collection-insights-provider.ts` — filters using `isPageCollectionRun()` predicate (backward-compatible: old runs with no `agentId` stay attributed to page-collection)
- `data-collection-insights-provider.ts` — new provider with KPIs (runs, success_rate, articles_collected, search_success_rate, median_duration_ms), alerts (stage-failure-*, high-drop-rate, low-search-success, stale-last-run), and sections (funnel, timeseries, publishers, per-ticker, drop-reasons, failure-categories, search/fetch stats)
- Failures are now scoped to real run IDs by including `id` in the `dataCollectionRun` select

## Other changes

- Removes unused `Prisma` import from `query-analysis-insights-provider.ts` (no behavior change)

## Key files to review

- [data-collection-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts)
- [data-collection-insights-provider.test.ts](apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.test.ts)
- [page-collection-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/page-collection-insights-provider.ts)
- [run-status.ts](packages/shared/agent-ingestion/src/run-status.ts)
- [data-collection-run.ts](packages/shared/agent-data-api-contract/src/data-collection-run.ts)

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — all 191 tests pass
2. `pnpm --filter @mediapulse/data-collection test` — all 63 tests pass
3. `pnpm --filter @mediapulse/page-collection test` — all 36 tests pass
4. `pnpm --filter @mediapulse/agent-data-api exec tsc --noEmit` — no errors
