### PR TITLE
fix(scheduler): mark execution cancelled when no step rows exist on cancel

### DIFF
--- a/packages/hermes/scheduler/src/cancel-execution.test.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.test.ts
@@ -69,6 +69,12 @@ describe("cancel-execution", () => {
     );
   });
 
+  it("resolveRunStatusForSettledCancelledExecution returns cancelled when there are no jobs", () => {
+    expect(resolveRunStatusForSettledCancelledExecution([])).toBe(
+      ScheduleRunStatus.cancelled,
+    );
+  });
+
   it("errorIndicatesUserCancel detects structured cancel errors", () => {
     expect(errorIndicatesUserCancel({ cancelled: true })).toBe(true);
     expect(errorIndicatesUserCancel({ message: "x" })).toBe(false);

--- a/packages/hermes/scheduler/src/cancel-execution.ts
+++ b/packages/hermes/scheduler/src/cancel-execution.ts
@@ -148,6 +148,9 @@ export function resolveRunStatusForSettledCancelledExecution(
     error: Prisma.JsonValue | null;
   }>,
 ): ScheduleRunStatus {
+  if (jobs.length === 0) {
+    return ScheduleRunStatus.cancelled;
+  }
   const hasCompleted = jobs.some(
     (j) => j.status === AgentJobExecutionStatus.completed,
   );
@@ -509,7 +512,7 @@ export const cancelScheduleExecution = async (
       },
     });
     const allStepsTerminal =
-      stepsAfter.length > 0 &&
+      stepsAfter.length === 0 ||
       stepsAfter.every(
         (row) =>
           row.succeededCount + row.failedCount >= row.expectedInvocationCount,
@@ -639,7 +642,7 @@ export const cancelHttpTriggerExecution = async (
       },
     });
     const allStepsTerminal =
-      stepsAfter.length > 0 &&
+      stepsAfter.length === 0 ||
       stepsAfter.every(
         (row) =>
           row.succeededCount + row.failedCount >= row.expectedInvocationCount,
@@ -749,7 +752,7 @@ export const finalizeCancelledExecutionIfSettled = async (
         });
 
     const allStepsTerminal =
-      stepsAfter.length > 0 &&
+      stepsAfter.length === 0 ||
       stepsAfter.every(
         (row) =>
           row.succeededCount + row.failedCount >= row.expectedInvocationCount,


### PR DESCRIPTION
## Summary

When a schedule (or HTTP trigger) execution is cancelled while still in `pending` state with no step execution rows, the cancel path sets `cancelledAt` but never updates `run_status`. The execution stays non-terminal forever, and every subsequent scheduler tick is skipped with `"prior execution is still non-terminal"`. In production this locked out a schedule for over two months.

The root cause is an over-strict guard: `allStepsTerminal` required `stepsAfter.length > 0`, which is always false when no steps exist. Separately, `resolveRunStatusForSettledCancelledExecution` fell through to `failed` when called with an empty jobs array.

## Related issues

Closes #731

## Important changes

- `resolveRunStatusForSettledCancelledExecution`: returns `cancelled` immediately when `jobs` is empty, instead of falling through to the `failed` fallback
- `allStepsTerminal` guard in `cancelScheduleExecution`, `cancelHttpTriggerExecution`, and `finalizeCancelledExecutionIfSettled`: changed from `stepsAfter.length > 0 && stepsAfter.every(...)` to `stepsAfter.length === 0 || stepsAfter.every(...)` — an empty steps array is vacuously terminal

## Other changes

- Added a unit test: `resolveRunStatusForSettledCancelledExecution([])` returns `cancelled`

## Key files to review

- [packages/hermes/scheduler/src/cancel-execution.ts](packages/hermes/scheduler/src/cancel-execution.ts) — three `allStepsTerminal` fixes and the empty-jobs guard
- [packages/hermes/scheduler/src/cancel-execution.test.ts](packages/hermes/scheduler/src/cancel-execution.test.ts) — new test covering the empty-jobs case

## How to test

1. Create a schedule with one step and trigger an execution.
2. Before the dataqueue job is picked up, delete the `agent_job_execution` rows for that execution to simulate a lost job.
3. Cancel the execution via the dashboard.
4. Confirm `run_status` is set to `cancelled` (not left as `pending`) in `schedule_execution`.
5. Confirm subsequent scheduler ticks create a new execution instead of skipping.
