### PR TITLE
Fix data-collection search failures, fetch-yield visibility, and relevance gate

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -95,10 +95,13 @@ type ExtendedCounters = {
   agentId?: string;
   discovered?: number;
   afterPrefilter?: number;
+  fetched?: number;
   persisted?: number;
+  searchEmpty?: number;
   droppedByRelevance?: number;
   droppedByContentQuality?: Record<string, number>;
   droppedByFreshness?: number;
+  droppedByFreshnessReason?: Record<string, number>;
   droppedByDeadUrl?: number;
   droppedByHostErrorRate?: number;
   droppedByPerQueryBudget?: number;
@@ -267,6 +270,7 @@ export function createDataCollectionInsightsProvider(
 
       let totalDiscovered = 0;
       let totalAfterPrefilter = 0;
+      let totalFetched = 0;
       let totalPersisted = 0;
       let totalDroppedByRelevance = 0;
       let totalDroppedByFreshness = 0;
@@ -284,6 +288,7 @@ export function createDataCollectionInsightsProvider(
         const ext = parseExtendedCounters(run.extendedCounters);
         totalDiscovered += ext.discovered ?? run.searchSuccess;
         totalAfterPrefilter += ext.afterPrefilter ?? run.searchSuccess;
+        totalFetched += ext.fetched ?? ext.persisted ?? run.fetchSuccess;
         totalPersisted += ext.persisted ?? run.fetchSuccess;
         totalDroppedByRelevance += ext.droppedByRelevance ?? 0;
         totalDroppedByFreshness += ext.droppedByFreshness ?? 0;
@@ -384,24 +389,23 @@ export function createDataCollectionInsightsProvider(
         }
       }
 
-      const totalDropped =
+      const totalPostFetchDropped =
         totalDroppedByRelevance +
         totalDroppedByFreshness +
+        Object.values(totalDroppedByContentQuality).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+      const totalDropped =
+        totalPostFetchDropped +
         totalDroppedByDeadUrl +
         totalDroppedByHostErrorRate +
         totalDroppedByPerQueryBudget +
         totalDroppedByPerRunBudget +
         totalDroppedByUrlNoise +
         totalDroppedByExistingCanonical +
-        totalDroppedByDuplicateCanonical +
-        Object.values(totalDroppedByContentQuality).reduce(
-          (sum, v) => sum + v,
-          0,
-        );
-      if (
-        totalAfterPrefilter > 10 &&
-        totalDropped / totalAfterPrefilter > 0.6
-      ) {
+        totalDroppedByDuplicateCanonical;
+      if (totalFetched > 10 && totalPostFetchDropped / totalFetched > 0.6) {
         alerts.push({
           id: "high-drop-rate",
           severity: "warning",
@@ -450,7 +454,7 @@ export function createDataCollectionInsightsProvider(
           stages: [
             { label: "Queries", value: totalQueries },
             { label: "Search hits", value: totalDiscovered },
-            { label: "Fetched", value: totalArticles },
+            { label: "Fetched", value: totalFetched },
             { label: "Persisted", value: totalPersisted },
           ],
         },

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -25,7 +25,11 @@ import {
   extractPublishedDate,
   isFresh,
 } from "@workspace/agent-ingestion";
-import { performWebSearch } from "./utilities/web-search";
+import {
+  performWebSearch,
+  type WebSearchEmptyResult,
+  type WebSearchFailure,
+} from "./utilities/web-search";
 import { classifyNoisyUrl, type UrlNoiseReason } from "@workspace/utils";
 import { applyFetchBudget } from "./utilities/hit-ranker";
 
@@ -183,14 +187,11 @@ export async function runDataCollection(
   let persistedThisRunCount = 0;
   let searchSuccessCount = 0;
   let searchFailedCount = 0;
+  let searchEmptyCount = 0;
   let fetchSuccessCount = 0;
+  let fetchedCount = 0;
   let fetchFailedCount = 0;
-  const searchFailures: Array<
-    Extract<
-      Awaited<ReturnType<typeof performWebSearch>>[number],
-      { success: false }
-    >
-  > = [];
+  const searchFailures: WebSearchFailure[] = [];
   const fetchFailures: Array<
     Awaited<ReturnType<typeof performWebFetch>>[number]["failures"][number]
   > = [];
@@ -208,7 +209,11 @@ export async function runDataCollection(
   let droppedByPerRunBudget = 0;
   let droppedByDeadUrlCache = 0;
   let droppedByHostErrorRate = 0;
-  let droppedByFreshness = 0;
+  const droppedByFreshnessReason: Record<string, number> = {
+    too_old: 0,
+    future_dated: 0,
+    unknown_date: 0,
+  };
   let throttleEvents = 0;
 
   if (queries.length === 0) {
@@ -246,10 +251,14 @@ export async function runDataCollection(
       const roundSearchSuccesses = searchAttemptResults
         .filter((r) => r.success)
         .map((r) => r.data);
+      const roundSearchEmpties = searchAttemptResults.filter(
+        (r): r is WebSearchEmptyResult => !r.success && r.empty === true,
+      );
       const roundSearchFailures = searchAttemptResults.filter(
-        (r) => !r.success,
+        (r): r is WebSearchFailure => !r.success && !r.empty,
       );
       searchSuccessCount += roundSearchSuccesses.length;
+      searchEmptyCount += roundSearchEmpties.length;
       searchFailedCount += roundSearchFailures.length;
       searchFailures.push(...roundSearchFailures);
 
@@ -257,6 +266,7 @@ export async function runDataCollection(
         {
           round,
           searchHitCount: roundSearchSuccesses.length,
+          searchEmpty: roundSearchEmpties.length,
           searchFailed: roundSearchFailures.length,
         },
         "web search stage finished",
@@ -414,6 +424,7 @@ export async function runDataCollection(
       const roundFailedUrlCount = fetchAttemptResults.filter(
         (outcome) => outcome.success === null,
       ).length;
+      fetchedCount += roundFetchSuccesses.length;
       fetchFailedCount += roundFailedUrlCount;
       fetchFailures.push(...roundFetchFailures);
 
@@ -482,7 +493,8 @@ export async function runDataCollection(
             allowUnknown: freshnessGateConfig.allowUnknown,
           });
           if (!freshnessDecision.fresh) {
-            droppedByFreshness += 1;
+            droppedByFreshnessReason[freshnessDecision.reason] =
+              (droppedByFreshnessReason[freshnessDecision.reason] ?? 0) + 1;
             log.info(
               {
                 round,
@@ -528,7 +540,7 @@ export async function runDataCollection(
           droppedByPerRunBudget,
           droppedByDeadUrlCache,
           droppedByHostErrorRate,
-          droppedByFreshness,
+          droppedByFreshnessReason,
           throttleEvents,
         },
         "web fetch stage finished",
@@ -623,12 +635,18 @@ export async function runDataCollection(
     0,
   );
 
+  const droppedByFreshnessTotalCount = Object.values(
+    droppedByFreshnessReason,
+  ).reduce((sum, count) => sum + count, 0);
+
   const counters: RunCounters = {
     queriesTotal: queries.length,
     urlsTotal: searchSuccessCount,
     searchSuccess: searchSuccessCount,
     searchFailed: searchFailedCount,
+    searchEmpty: searchEmptyCount,
     fetchSuccess: fetchSuccessCount,
+    fetched: fetchedCount,
     fetchFailed: fetchFailedCount,
     retryCount: 0,
     droppedByRelevance,
@@ -639,7 +657,8 @@ export async function runDataCollection(
     droppedByPerRunBudget,
     droppedByDeadUrl: droppedByDeadUrlCache,
     droppedByHostErrorRate,
-    droppedByFreshness,
+    droppedByFreshness: droppedByFreshnessTotalCount,
+    droppedByFreshnessReason: { ...droppedByFreshnessReason },
     droppedByDuplicateCanonicalUrl,
     droppedByExistingCanonicalUrl,
     droppedByUrlNoise: droppedByUrlNoiseTotal,
@@ -676,13 +695,16 @@ export async function runDataCollection(
     totalSources,
     status,
     searchSuccess: searchSuccessCount,
+    searchEmpty: searchEmptyCount,
+    fetched: fetchedCount,
     fetchSuccess: fetchSuccessCount,
     droppedByRelevance,
     droppedByPerQueryBudget,
     droppedByPerRunBudget,
     droppedByDeadUrlCache,
     droppedByHostErrorRate,
-    droppedByFreshness,
+    droppedByFreshness: droppedByFreshnessTotalCount,
+    droppedByFreshnessReason: { ...droppedByFreshnessReason },
     throttleEvents,
     refill: {
       roundsExecuted,

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -88,7 +88,7 @@ describe("dataCollectionAgentConfigSchema", () => {
     });
     expect(parsed.gates.relevance).toEqual({
       enabled: true,
-      headChars: 3000,
+      headChars: 6000,
       minMatches: 1,
     });
     expect(parsed.gates.freshness).toEqual({

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -272,7 +272,7 @@ const relevanceGateSchema = z.object({
     .number()
     .int()
     .positive()
-    .default(3000)
+    .default(6000)
     .describe(
       "Number of leading content characters scanned for alias matches.",
     ),

--- a/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/web-search.ts
@@ -42,6 +42,7 @@ export interface WebSearchSuccess {
 
 export interface WebSearchFailure {
   success: false;
+  empty?: never;
   queryId: string;
   queryText: string;
   tickerId: string;
@@ -51,7 +52,19 @@ export interface WebSearchFailure {
   httpStatus?: number;
 }
 
-export type WebSearchAttemptResult = WebSearchSuccess | WebSearchFailure;
+/** Serper returned a valid response but no items for this query — not a failure. */
+export interface WebSearchEmptyResult {
+  success: false;
+  empty: true;
+  queryId: string;
+  queryText: string;
+  tickerId: string;
+}
+
+export type WebSearchAttemptResult =
+  | WebSearchSuccess
+  | WebSearchFailure
+  | WebSearchEmptyResult;
 
 /** Minimal structured logger for web-search (e.g. pino or pino child). */
 export type WebSearchLogger = {
@@ -70,14 +83,14 @@ export interface WebSearchDeps {
 
 /** Zod schema for Serper.dev API organic search result item. */
 const serperOrganicItemSchema = z.object({
-  link: z.string().url().optional(),
+  link: z.string().optional(),
   title: z.string().optional(),
   snippet: z.string().optional(),
 });
 
 /** Zod schema for Serper.dev API news result item. */
 const serperNewsItemSchema = z.object({
-  link: z.string().url().optional(),
+  link: z.string().optional(),
   title: z.string().optional(),
   snippet: z.string().optional(),
   date: z.string().optional(),
@@ -145,15 +158,25 @@ const searchOneQuery = async (
         config.query.type === "news"
           ? (parsed.data.news ?? [])
           : (parsed.data.organic ?? []);
-      if (items.length === 0) {
-        throw new Error("Semantic validation failed");
-      }
       return items;
     };
 
     const serpItems = config.retry
       ? await withRetry(fetchTask, config.retry, isRetryableError)
       : await fetchTask();
+
+    if (serpItems.length === 0) {
+      log.info({ queryId: query.id }, "web search: query returned no results");
+      return [
+        {
+          success: false,
+          empty: true,
+          queryId: query.id,
+          queryText: query.text,
+          tickerId: query.tickerId,
+        },
+      ];
+    }
 
     const queryResults: WebSearchAttemptResult[] = [];
     for (const [serpIndex, item] of serpItems.entries()) {

--- a/packages/shared/agent-ingestion/src/run-status.ts
+++ b/packages/shared/agent-ingestion/src/run-status.ts
@@ -26,6 +26,7 @@ export type RunCounters = {
   cacheMisses?: number;
   droppedByContentQuality?: Record<string, number>;
   droppedByFreshness?: number;
+  droppedByFreshnessReason?: Record<string, number>;
   droppedByDeadUrl?: number;
   droppedByHostErrorRate?: number;
   droppedByFetchBudget?: number;
@@ -33,6 +34,8 @@ export type RunCounters = {
   droppedByExistingCanonicalUrl?: number;
   droppedByDuplicateCanonicalUrl?: number;
   droppedByUrlNoise?: number;
+  fetched?: number;
+  searchEmpty?: number;
   persisted?: number;
   deadlineHit?: boolean;
   durationMs?: number;

--- a/packages/shared/agent-ingestion/src/ticker-relevance-gate.ts
+++ b/packages/shared/agent-ingestion/src/ticker-relevance-gate.ts
@@ -17,7 +17,7 @@ export type RelevanceGateOptions = {
   minMatches?: number;
 };
 
-const DEFAULT_HEAD_CHARS = 1500;
+const DEFAULT_HEAD_CHARS = 6000;
 const DEFAULT_MIN_MATCHES = 1;
 
 /**


### PR DESCRIPTION
## Summary

Three bugs were hitting the data-collection pipeline at once. Empty Serper responses were throwing and logging as search failures. One bad URL in a response batch was failing the whole batch via strict Zod validation. And the "Fetched" counter in the insights funnel equaled "Persisted" — there was no way to see how many articles were being dropped before persistence. This PR fixes all three and widens the relevance gate scan window from 1500 to 6000 chars so the gate has more body text to match aliases against.

## Related issues

Closes #733

## Important changes

- Return `WebSearchEmptyResult` when Serper has zero results instead of throwing — empty responses are counted separately, not recorded as failures
- Relax `link` field in Serper response schema from `z.string().url()` to `z.string()`, so one malformed URL no longer rejects the whole organic/news batch
- Track `fetchedCount` before the gate loop so the insights funnel's "Fetched" stage shows true pre-gate volume rather than post-gate persisted count
- Widen `DEFAULT_HEAD_CHARS` in `ticker-relevance-gate.ts` from 1500 to 6000; align `headChars` default in config-schema to match

## Other changes

- Break freshness drops into per-reason counters (`too_old`, `future_dated`, `unknown_date`) stored in `extendedCounters`
- Insights provider drop-rate alert now divides by `fetchedCount` rather than `persisted`
- `searchEmpty` counter stored in `extendedCounters` alongside existing counters

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/web-search.ts` — `WebSearchEmptyResult` type and relaxed URL validation
- `apps/mediapulse/agents/data-collection/src/run.ts` — counter changes and new type guards separating empties from failures
- `packages/shared/agent-ingestion/src/ticker-relevance-gate.ts` — `DEFAULT_HEAD_CHARS` constant
- `apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts` — funnel "Fetched" stage and drop-rate denominator

## How to test

1. `pnpm --filter @mediapulse/data-collection test` — 63 tests pass
2. `pnpm --filter @workspace/agent-ingestion test` — 116 tests pass
3. `pnpm --filter @mediapulse/agent-data-api test` — 233 tests pass
4. Trigger a data-collection run for any ticker. Check `extendedCounters` on the resulting `DataCollectionRun` row — `fetched`, `searchEmpty`, and `droppedByFreshnessReason` fields should appear alongside the existing counters
5. Open the data-collection insights panel. The "Fetched" bar should reflect pre-gate fetch volume, not persisted count
