### PR TITLE
fix(worker): isolate per-pipeline concurrency by default

### DIFF
--- a/apps/hermes/worker/src/index.ts
+++ b/apps/hermes/worker/src/index.ts
@@ -30,12 +30,7 @@ const controlPlaneBatch = Math.max(
   controlPlaneConc,
   Number.parseInt(env.HERMES_CONTROL_PLANE_BATCH_SIZE ?? "5", 10) || 5,
 );
-const groupConcurrency = (() => {
-  const raw = env.HERMES_GROUP_CONCURRENCY?.trim();
-  if (!raw) return undefined;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n >= 1 ? n : undefined;
-})();
+const groupConcurrency = dataPlaneConc;
 
 // ─── Module-level shutdown hook ───────────────────────────────────────────────
 // Set inside main() once the processor/supervisor are running.

--- a/packages/hermes/env/env.hermes-worker.example
+++ b/packages/hermes/env/env.hermes-worker.example
@@ -41,9 +41,7 @@ PROCESSOR_CONCURRENCY=3 # optional
 HERMES_CONTROL_PLANE_CONCURRENCY= # optional #number
 # Max jobs fetched per poll for the control-plane processor. Default 5.
 HERMES_CONTROL_PLANE_BATCH_SIZE= # optional #number
-# Optional: max concurrent invoke_agent jobs per pipeline group (global across all worker instances).
-# Set to the max parallel agent invocations you allow per pipeline (e.g. same as PROCESSOR_CONCURRENCY).
-HERMES_GROUP_CONCURRENCY= # optional #number
+# Per-pipeline group concurrency is fixed to PROCESSOR_CONCURRENCY — not configurable.
 
 # Optional: DataQueue max attempts for invoke_agent (transport / 5xx retries). Omit for library default (3).
 HERMES_INVOKE_AGENT_MAX_ATTEMPTS= # optional

--- a/packages/hermes/env/src/hermes-worker.ts
+++ b/packages/hermes/env/src/hermes-worker.ts
@@ -25,7 +25,6 @@ export const env = createEnv({
     HERMES_INVOKE_AGENT_CANCEL_POLL_MS: z.string().optional(),
     HERMES_CONTROL_PLANE_CONCURRENCY: z.string().optional(),
     HERMES_CONTROL_PLANE_BATCH_SIZE: z.string().optional(),
-    HERMES_GROUP_CONCURRENCY: z.string().optional(),
     HERMES_SCHEDULE_RECOVERY_GRACE_MS: z.number({ coerce: true }).optional(),
   },
   client: {


### PR DESCRIPTION
## Summary

The Hermes worker shares a single concurrency pool across all pipelines. When one pipeline's agents run slowly, they hold all available slots and every other pipeline waits — sometimes for an hour until the stuck jobs time out. `HERMES_GROUP_CONCURRENCY` existed to cap this per pipeline, but it was opt-in and never set in production.

This change makes per-pipeline isolation the default by hardcoding `groupConcurrency = dataPlaneConc`, and removes the env var entirely.

## Related issues

Closes #737

## Important changes

- `groupConcurrency` is now always `dataPlaneConc` instead of `undefined`. The dataqueue library activates a window-function SQL claiming query that counts how many jobs each pipeline group already has in `processing` state, and skips a group once it hits the cap. Other pipelines fill the freed slots immediately.
- `HERMES_GROUP_CONCURRENCY` removed from the env schema and example — the behavior is no longer configurable.

## Other changes

- `env.hermes-worker.example` updated to document that per-pipeline group concurrency matches `PROCESSOR_CONCURRENCY` and is not a separate knob.

## Key files to review

- [apps/hermes/worker/src/index.ts](apps/hermes/worker/src/index.ts) — one-line change: the IIFE parsing the env var is replaced with `const groupConcurrency = dataPlaneConc`
- [packages/hermes/env/src/hermes-worker.ts](packages/hermes/env/src/hermes-worker.ts) — `HERMES_GROUP_CONCURRENCY` field removed from the Zod schema

## How to test

1. Run two pipelines simultaneously where one has slow or hung agent invocations.
2. Confirm the slow pipeline's jobs accumulate up to `PROCESSOR_CONCURRENCY` in `processing` state but do not grow beyond it.
3. Confirm the second pipeline's jobs are claimed and reach `processing` state without waiting for the first pipeline to finish.
4. Check `job_queue` in the dataqueue DB: `SELECT group_id, status, COUNT(*) FROM job_queue WHERE status = 'processing' GROUP BY group_id, status` — no single `group_id` should exceed `PROCESSOR_CONCURRENCY`.
