### PR TITLE
Replace ID-bearing data-collection activity reports with reasoning narratives

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -379,10 +379,17 @@ export function createDataCollectionInsightsProvider(
         }
         for (const [stage, count] of stageFailCounts) {
           if (count > 5) {
+            const stageFailures = failures.filter((f) => f.stage === stage);
+            const catCounts = new Map<string, number>();
+            for (const f of stageFailures) {
+              catCounts.set(f.errorCategory, (catCounts.get(f.errorCategory) ?? 0) + 1);
+            }
+            const dominantCategory =
+              [...catCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "unknown";
             alerts.push({
               id: `stage-failure-${stage}`,
               severity: "warning",
-              message: `${count} failures at stage "${stage}" in the window`,
+              message: `${count} ${stage} failures in the window — most are "${dominantCategory}" errors.`,
               sectionRef: "why-failure-category",
             });
           }
@@ -406,10 +413,18 @@ export function createDataCollectionInsightsProvider(
         totalDroppedByExistingCanonical +
         totalDroppedByDuplicateCanonical;
       if (totalFetched > 10 && totalPostFetchDropped / totalFetched > 0.6) {
+        const dropPercent = Math.round((totalPostFetchDropped / totalFetched) * 100);
+        const contentQualitySum = Object.values(totalDroppedByContentQuality).reduce((s, v) => s + v, 0);
+        const dominantReason =
+          totalDroppedByRelevance >= totalDroppedByFreshness && totalDroppedByRelevance >= contentQualitySum
+            ? "relevance"
+            : totalDroppedByFreshness >= contentQualitySum
+              ? "freshness"
+              : "content quality";
         alerts.push({
           id: "high-drop-rate",
           severity: "warning",
-          message: `More than 60% of fetched results are being dropped`,
+          message: `${dropPercent}% of fetched articles were dropped before saving. The ${dominantReason} gate accounts for most of the loss.`,
           sectionRef: "why-drop-reasons",
         });
       }
@@ -448,7 +463,7 @@ export function createDataCollectionInsightsProvider(
         id: "what-funnel",
         category: "what",
         title: "Collection funnel",
-        insight: "Articles from web search hits through to persistence.",
+        insight: `${totalQueries} search queries ran across ${totalRuns} run${totalRuns === 1 ? "" : "s"}; ${totalFetched} articles were fetched and ${totalPersisted} were saved.`,
         widget: {
           kind: "funnel",
           stages: [
@@ -495,10 +510,15 @@ export function createDataCollectionInsightsProvider(
         );
       }
       if (publisherCounts.size > 0) {
+        const topPublishers = Array.from(publisherCounts.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([label]) => label);
         sections.push({
           id: "where-publishers",
           category: "where",
           title: "Articles by publisher",
+          insight: topPublishers.length > 0 ? `Top sources: ${topPublishers.join(", ")}.` : undefined,
           widget: {
             kind: "categoryBar",
             bars: bucketTopN(
@@ -523,10 +543,15 @@ export function createDataCollectionInsightsProvider(
         );
       }
       if (tickerArticleCounts.size > 0) {
+        const topTickers = Array.from(tickerArticleCounts.entries())
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 3)
+          .map(([symbol]) => symbol);
         sections.push({
           id: "who-per-ticker",
           category: "who",
           title: "Articles by ticker",
+          insight: topTickers.length > 0 ? `Top tickers: ${topTickers.join(", ")}.` : undefined,
           widget: {
             kind: "categoryBar",
             bars: bucketTopN(

--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -382,10 +382,14 @@ export function createDataCollectionInsightsProvider(
             const stageFailures = failures.filter((f) => f.stage === stage);
             const catCounts = new Map<string, number>();
             for (const f of stageFailures) {
-              catCounts.set(f.errorCategory, (catCounts.get(f.errorCategory) ?? 0) + 1);
+              catCounts.set(
+                f.errorCategory,
+                (catCounts.get(f.errorCategory) ?? 0) + 1,
+              );
             }
             const dominantCategory =
-              [...catCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? "unknown";
+              [...catCounts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ??
+              "unknown";
             alerts.push({
               id: `stage-failure-${stage}`,
               severity: "warning",
@@ -413,10 +417,15 @@ export function createDataCollectionInsightsProvider(
         totalDroppedByExistingCanonical +
         totalDroppedByDuplicateCanonical;
       if (totalFetched > 10 && totalPostFetchDropped / totalFetched > 0.6) {
-        const dropPercent = Math.round((totalPostFetchDropped / totalFetched) * 100);
-        const contentQualitySum = Object.values(totalDroppedByContentQuality).reduce((s, v) => s + v, 0);
+        const dropPercent = Math.round(
+          (totalPostFetchDropped / totalFetched) * 100,
+        );
+        const contentQualitySum = Object.values(
+          totalDroppedByContentQuality,
+        ).reduce((s, v) => s + v, 0);
         const dominantReason =
-          totalDroppedByRelevance >= totalDroppedByFreshness && totalDroppedByRelevance >= contentQualitySum
+          totalDroppedByRelevance >= totalDroppedByFreshness &&
+          totalDroppedByRelevance >= contentQualitySum
             ? "relevance"
             : totalDroppedByFreshness >= contentQualitySum
               ? "freshness"
@@ -518,7 +527,10 @@ export function createDataCollectionInsightsProvider(
           id: "where-publishers",
           category: "where",
           title: "Articles by publisher",
-          insight: topPublishers.length > 0 ? `Top sources: ${topPublishers.join(", ")}.` : undefined,
+          insight:
+            topPublishers.length > 0
+              ? `Top sources: ${topPublishers.join(", ")}.`
+              : undefined,
           widget: {
             kind: "categoryBar",
             bars: bucketTopN(
@@ -551,7 +563,10 @@ export function createDataCollectionInsightsProvider(
           id: "who-per-ticker",
           category: "who",
           title: "Articles by ticker",
-          insight: topTickers.length > 0 ? `Top tickers: ${topTickers.join(", ")}.` : undefined,
+          insight:
+            topTickers.length > 0
+              ? `Top tickers: ${topTickers.join(", ")}.`
+              : undefined,
           widget: {
             kind: "categoryBar",
             bars: bucketTopN(

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -8,6 +8,16 @@ import crypto from "node:crypto";
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
 import {
+  narrativeRunStart,
+  narrativeQueriesLoaded,
+  narrativeDailyQuota,
+  narrativeSearchRound,
+  narrativeFilteredResults,
+  narrativeFetchStart,
+  narrativeSavingSources,
+  narrativeRunComplete,
+} from "./utilities/build-activity-narrative";
+import {
   performWebFetch,
   createEmptyQualityCounters,
   runQualityGate,
@@ -97,18 +107,6 @@ export async function runDataCollection(
     }
   };
 
-  report("Fetching search queries", `ticker ${input.tickerId}`);
-
-  const webSearchConfig = config.providers.search;
-  const webFetchConfig = config.providers.fetch;
-  const relevanceGateConfig = config.gates.relevance;
-  const perQueryFetchBudget = config.collection.perQueryFetchBudget;
-  const perRunFetchBudget = config.collection.perRunFetchBudget;
-  const deadUrlCacheConfig = config.resilience.deadUrlCache;
-  const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
-  const freshnessGateConfig = config.gates.freshness;
-  const hostErrorTracker = new HostErrorTracker(hostErrorBreakerConfig);
-
   const tickerRecord = await dataApiClient.ticker.get({
     tickerId: input.tickerId,
   });
@@ -121,10 +119,20 @@ export async function runDataCollection(
     tickerRecord.sector,
     tickerRecord.industry,
   );
-  report(
-    "Loaded ticker context",
-    `${tickerAliases.length} ticker aliases, ${industryAliases.length} industry terms`,
-  );
+  const subject = { symbol: tickerRecord.symbol, name: tickerRecord.name };
+
+  report(...narrativeRunStart(subject));
+
+  const webSearchConfig = config.providers.search;
+  const webFetchConfig = config.providers.fetch;
+  const relevanceGateConfig = config.gates.relevance;
+  const perQueryFetchBudget = config.collection.perQueryFetchBudget;
+  const perRunFetchBudget = config.collection.perRunFetchBudget;
+  const deadUrlCacheConfig = config.resilience.deadUrlCache;
+  const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
+  const freshnessGateConfig = config.gates.freshness;
+  const hostErrorTracker = new HostErrorTracker(hostErrorBreakerConfig);
+
   if (tickerAliases.length === 0 && industryAliases.length === 0) {
     log.warn(
       { tickerId: input.tickerId },
@@ -144,7 +152,7 @@ export async function runDataCollection(
     tickerId: input.tickerId,
   });
 
-  report("Loaded search queries", `${queries.length} queries`);
+  report(...narrativeQueriesLoaded(subject, queries.length));
 
   log.info(
     { queryCount: queries.length },
@@ -171,10 +179,7 @@ export async function runDataCollection(
   });
   const existingTodaySourceCount = baselineToday.dataSourceTotalCount;
 
-  report(
-    "Checking daily quota",
-    `${existingTodaySourceCount} sources today, target ${targetDailySuccessfulSources}`,
-  );
+  report(...narrativeDailyQuota(subject, existingTodaySourceCount, targetDailySuccessfulSources));
 
   let roundsExecuted = 0;
   let refillStopReason:
@@ -218,27 +223,24 @@ export async function runDataCollection(
 
   if (queries.length === 0) {
     report(
-      "No search queries available",
-      `ticker ${input.tickerId} has no active queries`,
+      "No search queries configured",
+      `${subject.symbol} (${subject.name}) has no active search queries. Skipping collection.`,
       "completed",
     );
     refillStopReason = "no_queries";
   } else if (existingTodaySourceCount >= targetDailySuccessfulSources) {
     report(
       "Daily target already met",
-      `${existingTodaySourceCount} sources already today`,
+      `${subject.symbol} already has ${existingTodaySourceCount} saved source${existingTodaySourceCount === 1 ? "" : "s"} today, meeting the target of ${targetDailySuccessfulSources}. Skipping collection.`,
       "completed",
     );
     refillStopReason = "daily_target_met_before_start";
   } else {
-    report(
-      "Running web searches",
-      `${queries.length} queries for ${input.tickerId}`,
-    );
+    report(...narrativeSearchRound(subject, queries.length, 1, maxTotalRounds));
 
     for (let round = 1; round <= maxTotalRounds; round += 1) {
       if (round > 1) {
-        report("Search refill round", `round ${round} of ${maxTotalRounds}`);
+        report(...narrativeSearchRound(subject, queries.length, round, maxTotalRounds));
       }
       roundsExecuted += 1;
       const searchThrottleStats = { throttleEvents: 0 };
@@ -370,10 +372,8 @@ export async function runDataCollection(
         );
       }
 
-      report(
-        "Filtered search results",
-        `${searchSuccessesAfterHostBreaker.length} URLs after dedup, existing-URL and dead-cache checks`,
-      );
+      const roundDroppedBeforeFetch = roundSearchSuccesses.length - searchSuccessesAfterHostBreaker.length;
+      report(...narrativeFilteredResults(searchSuccessesAfterHostBreaker.length, roundDroppedBeforeFetch));
 
       const budgetSelection = applyFetchBudget(
         searchSuccessesAfterHostBreaker,
@@ -402,10 +402,7 @@ export async function runDataCollection(
         );
       }
 
-      report(
-        "Fetching article content",
-        `${budgetSelection.hits.length} candidate URLs`,
-      );
+      report(...narrativeFetchStart(subject, budgetSelection.hits.length));
 
       const fetchThrottleStats = { throttleEvents: 0 };
       const fetchAttemptResults = await performWebFetch(budgetSelection.hits, {
@@ -430,10 +427,7 @@ export async function runDataCollection(
 
       let persistedThisRoundCount = 0;
       const roundQualityDrops: QualityDropForDeadUrl[] = [];
-      report(
-        "Saving sources to database",
-        `${roundFetchSuccesses.length} deduplicated sources`,
-      );
+      report(...narrativeSavingSources(subject, roundFetchSuccesses.length));
       for (const page of roundFetchSuccesses) {
         const urlDecision = classifyNoisyUrl(page.url);
         if (urlDecision.blocked) {
@@ -639,6 +633,11 @@ export async function runDataCollection(
     droppedByFreshnessReason,
   ).reduce((sum, count) => sum + count, 0);
 
+  const contentQualityDropped = Object.values(droppedByContentQuality).reduce(
+    (sum, v) => sum + v,
+    0,
+  );
+
   const counters: RunCounters = {
     queriesTotal: queries.length,
     urlsTotal: searchSuccessCount,
@@ -737,8 +736,17 @@ export async function runDataCollection(
     );
 
     report(
-      "Data collection complete",
-      `${totalSources} saved, ${failuresPayload.length} failed`,
+      ...narrativeRunComplete(subject, {
+        status,
+        persisted: totalSources,
+        droppedByRelevance,
+        droppedByFreshness: droppedByFreshnessTotalCount,
+        contentQualityDropped,
+        failureCount: failuresPayload.length,
+        stopReason: refillStopReason,
+        roundsExecuted,
+        targetDailySuccessfulSources,
+      }),
       "completed",
     );
 
@@ -774,8 +782,17 @@ export async function runDataCollection(
   );
 
   report(
-    "Data collection complete",
-    `${totalSources} saved, ${failuresPayload.length} failed`,
+    ...narrativeRunComplete(subject, {
+      status,
+      persisted: totalSources,
+      droppedByRelevance,
+      droppedByFreshness: droppedByFreshnessTotalCount,
+      contentQualityDropped,
+      failureCount: failuresPayload.length,
+      stopReason: refillStopReason,
+      roundsExecuted,
+      targetDailySuccessfulSources,
+    }),
     "completed",
   );
 

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -179,7 +179,13 @@ export async function runDataCollection(
   });
   const existingTodaySourceCount = baselineToday.dataSourceTotalCount;
 
-  report(...narrativeDailyQuota(subject, existingTodaySourceCount, targetDailySuccessfulSources));
+  report(
+    ...narrativeDailyQuota(
+      subject,
+      existingTodaySourceCount,
+      targetDailySuccessfulSources,
+    ),
+  );
 
   let roundsExecuted = 0;
   let refillStopReason:
@@ -240,7 +246,14 @@ export async function runDataCollection(
 
     for (let round = 1; round <= maxTotalRounds; round += 1) {
       if (round > 1) {
-        report(...narrativeSearchRound(subject, queries.length, round, maxTotalRounds));
+        report(
+          ...narrativeSearchRound(
+            subject,
+            queries.length,
+            round,
+            maxTotalRounds,
+          ),
+        );
       }
       roundsExecuted += 1;
       const searchThrottleStats = { throttleEvents: 0 };
@@ -372,8 +385,14 @@ export async function runDataCollection(
         );
       }
 
-      const roundDroppedBeforeFetch = roundSearchSuccesses.length - searchSuccessesAfterHostBreaker.length;
-      report(...narrativeFilteredResults(searchSuccessesAfterHostBreaker.length, roundDroppedBeforeFetch));
+      const roundDroppedBeforeFetch =
+        roundSearchSuccesses.length - searchSuccessesAfterHostBreaker.length;
+      report(
+        ...narrativeFilteredResults(
+          searchSuccessesAfterHostBreaker.length,
+          roundDroppedBeforeFetch,
+        ),
+      );
 
       const budgetSelection = applyFetchBudget(
         searchSuccessesAfterHostBreaker,

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
@@ -1,0 +1,194 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  narrativeDailyQuota,
+  narrativeFilteredResults,
+  narrativeFetchStart,
+  narrativeQueriesLoaded,
+  narrativeRunComplete,
+  narrativeRunStart,
+  narrativeSearchRound,
+  narrativeSavingSources,
+} from "./build-activity-narrative";
+
+const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}/;
+
+const subject = { symbol: "BUVA", name: "Bukit Uluwatu Villa" };
+
+describe("narrativeRunStart", () => {
+  it("title contains the symbol", () => {
+    const [title] = narrativeRunStart(subject);
+    expect(title).toContain("BUVA");
+  });
+
+  it("description contains the symbol and name", () => {
+    const [, description] = narrativeRunStart(subject);
+    expect(description).toContain("BUVA");
+    expect(description).toContain("Bukit Uluwatu Villa");
+  });
+
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeRunStart(subject);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeQueriesLoaded", () => {
+  it("returns correct title and description when queryCount is 0", () => {
+    const [title, description] = narrativeQueriesLoaded(subject, 0);
+    expect(title).toBe("No search queries configured");
+    expect(description).toContain("BUVA");
+  });
+
+  it("uses singular form when queryCount is 1", () => {
+    const [, description] = narrativeQueriesLoaded(subject, 1);
+    expect(description).toContain("1 search query");
+    expect(description).not.toContain("queries");
+  });
+
+  it("uses plural form when queryCount is 5", () => {
+    const [, description] = narrativeQueriesLoaded(subject, 5);
+    expect(description).toContain("5 search queries");
+  });
+
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeQueriesLoaded(subject, 3);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeDailyQuota", () => {
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeDailyQuota(subject, 3, 10);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeSearchRound", () => {
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeSearchRound(subject, 5, 1, 3);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeFilteredResults", () => {
+  it("mentions URL count and no removal when droppedCount is 0", () => {
+    const [, description] = narrativeFilteredResults(10, 0);
+    expect(description).toContain("10 URLs");
+    expect(description).not.toContain("removing");
+  });
+
+  it("mentions both readyCount and droppedCount when droppedCount is positive", () => {
+    const [, description] = narrativeFilteredResults(7, 5);
+    expect(description).toContain("7");
+    expect(description).toContain("5");
+  });
+
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeFilteredResults(10, 3);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeFetchStart", () => {
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeFetchStart(subject, 5);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeSavingSources", () => {
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeSavingSources(subject, 8);
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});
+
+describe("narrativeRunComplete", () => {
+  it("mentions the symbol and saved count when persisted is 5 with relevance drops", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "success",
+      persisted: 5,
+      droppedByRelevance: 3,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: null,
+      roundsExecuted: 1,
+      targetDailySuccessfulSources: 5,
+    });
+    expect(description).toContain("BUVA");
+    expect(description).toContain("5 new sources");
+    expect(description).toContain("3 did not mention BUVA");
+  });
+
+  it("starts with 'No new sources' when persisted is 0", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "partial_success",
+      persisted: 0,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: null,
+      roundsExecuted: 1,
+      targetDailySuccessfulSources: 5,
+    });
+    expect(description).toContain("No new sources");
+  });
+
+  it("mentions target number when stopReason is daily_target_met", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "success",
+      persisted: 5,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: "daily_target_met",
+      roundsExecuted: 1,
+      targetDailySuccessfulSources: 10,
+    });
+    expect(description).toContain("10");
+  });
+
+  it("title is 'Collection failed' when status is failed", () => {
+    const [title] = narrativeRunComplete(subject, {
+      status: "failed",
+      persisted: 0,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 2,
+      stopReason: null,
+      roundsExecuted: 1,
+      targetDailySuccessfulSources: 5,
+    });
+    expect(title).toBe("Collection failed");
+  });
+
+  it("does not contain a UUID pattern", () => {
+    const [title, description] = narrativeRunComplete(subject, {
+      status: "success",
+      persisted: 3,
+      droppedByRelevance: 1,
+      droppedByFreshness: 1,
+      contentQualityDropped: 1,
+      failureCount: 0,
+      stopReason: null,
+      roundsExecuted: 2,
+      targetDailySuccessfulSources: 5,
+    });
+    expect(title).not.toMatch(UUID_PATTERN);
+    expect(description).not.toMatch(UUID_PATTERN);
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
@@ -61,10 +61,7 @@ export function narrativeFilteredResults(
   droppedCount: number,
 ): [string, string] {
   if (droppedCount === 0) {
-    return [
-      "Filtering results",
-      `${n(readyCount, "URL")} ready to fetch.`,
-    ];
+    return ["Filtering results", `${n(readyCount, "URL")} ready to fetch.`];
   }
   return [
     "Filtering results",
@@ -106,7 +103,8 @@ export function narrativeRunComplete(
     targetDailySuccessfulSources: number;
   },
 ): [string, string] {
-  const title = opts.status === "failed" ? "Collection failed" : "Collection complete";
+  const title =
+    opts.status === "failed" ? "Collection failed" : "Collection complete";
 
   const savedClause =
     opts.persisted > 0
@@ -115,7 +113,9 @@ export function narrativeRunComplete(
 
   const dropParts: string[] = [];
   if (opts.droppedByRelevance > 0) {
-    dropParts.push(`${opts.droppedByRelevance} did not mention ${subject.symbol}`);
+    dropParts.push(
+      `${opts.droppedByRelevance} did not mention ${subject.symbol}`,
+    );
   }
   if (opts.droppedByFreshness > 0) {
     dropParts.push(`${opts.droppedByFreshness} were stale`);
@@ -128,7 +128,10 @@ export function narrativeRunComplete(
     dropParts.length > 0 ? `; ${dropParts.join(", ")} and were dropped` : "";
 
   let stopClause = "";
-  if (opts.stopReason === "daily_target_met" || opts.stopReason === "daily_target_met_before_start") {
+  if (
+    opts.stopReason === "daily_target_met" ||
+    opts.stopReason === "daily_target_met_before_start"
+  ) {
     stopClause = ` The daily target of ${opts.targetDailySuccessfulSources} was reached.`;
   } else if (opts.stopReason === "max_rounds_reached") {
     stopClause = ` The maximum number of search rounds was reached.`;

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
@@ -1,0 +1,147 @@
+export type TickerSubject = { symbol: string; name: string };
+
+function n(count: number, singular: string, pluralForm?: string): string {
+  return `${count} ${count === 1 ? singular : (pluralForm ?? `${singular}s`)}`;
+}
+
+export function narrativeRunStart(subject: TickerSubject): [string, string] {
+  return [
+    `Collecting news for ${subject.symbol}`,
+    `Loading search queries and context for ${subject.symbol} (${subject.name}).`,
+  ];
+}
+
+export function narrativeQueriesLoaded(
+  subject: TickerSubject,
+  queryCount: number,
+): [string, string] {
+  if (queryCount === 0) {
+    return [
+      "No search queries configured",
+      `${subject.symbol} (${subject.name}) has no active search queries. Skipping collection.`,
+    ];
+  }
+  return [
+    "Search queries loaded",
+    `${n(queryCount, "search query", "search queries")} ready for ${subject.symbol}.`,
+  ];
+}
+
+export function narrativeDailyQuota(
+  subject: TickerSubject,
+  existingCount: number,
+  target: number,
+): [string, string] {
+  return [
+    "Checking daily quota",
+    `${subject.symbol} has ${n(existingCount, "saved source")} today against a target of ${target}.`,
+  ];
+}
+
+export function narrativeSearchRound(
+  subject: TickerSubject,
+  queryCount: number,
+  round: number,
+  maxRounds: number,
+): [string, string] {
+  if (round === 1) {
+    return [
+      "Searching the web",
+      `Running ${n(queryCount, "search query", "search queries")} for ${subject.symbol}.`,
+    ];
+  }
+  return [
+    "Search refill round",
+    `Refill round ${round} of ${maxRounds}: running ${n(queryCount, "search query", "search queries")} for ${subject.symbol} to reach the daily target.`,
+  ];
+}
+
+export function narrativeFilteredResults(
+  readyCount: number,
+  droppedCount: number,
+): [string, string] {
+  if (droppedCount === 0) {
+    return [
+      "Filtering results",
+      `${n(readyCount, "URL")} ready to fetch.`,
+    ];
+  }
+  return [
+    "Filtering results",
+    `${n(readyCount, "URL")} ready to fetch, after removing ${n(droppedCount, "result")} that were already saved, noisy, or known to be dead.`,
+  ];
+}
+
+export function narrativeFetchStart(
+  subject: TickerSubject,
+  urlCount: number,
+): [string, string] {
+  return [
+    "Fetching articles",
+    `Downloading ${n(urlCount, "candidate URL")} for ${subject.symbol}.`,
+  ];
+}
+
+export function narrativeSavingSources(
+  subject: TickerSubject,
+  fetchedCount: number,
+): [string, string] {
+  return [
+    "Saving sources",
+    `Applying relevance, freshness, and quality checks to ${n(fetchedCount, "fetched page")} for ${subject.symbol}.`,
+  ];
+}
+
+export function narrativeRunComplete(
+  subject: TickerSubject,
+  opts: {
+    status: "success" | "partial_success" | "failed";
+    persisted: number;
+    droppedByRelevance: number;
+    droppedByFreshness: number;
+    contentQualityDropped: number;
+    failureCount: number;
+    stopReason: string | null;
+    roundsExecuted: number;
+    targetDailySuccessfulSources: number;
+  },
+): [string, string] {
+  const title = opts.status === "failed" ? "Collection failed" : "Collection complete";
+
+  const savedClause =
+    opts.persisted > 0
+      ? `Saved ${n(opts.persisted, "new source")} for ${subject.symbol}`
+      : `No new sources were saved for ${subject.symbol}`;
+
+  const dropParts: string[] = [];
+  if (opts.droppedByRelevance > 0) {
+    dropParts.push(`${opts.droppedByRelevance} did not mention ${subject.symbol}`);
+  }
+  if (opts.droppedByFreshness > 0) {
+    dropParts.push(`${opts.droppedByFreshness} were stale`);
+  }
+  if (opts.contentQualityDropped > 0) {
+    dropParts.push(`${opts.contentQualityDropped} failed quality checks`);
+  }
+
+  const dropClause =
+    dropParts.length > 0 ? `; ${dropParts.join(", ")} and were dropped` : "";
+
+  let stopClause = "";
+  if (opts.stopReason === "daily_target_met" || opts.stopReason === "daily_target_met_before_start") {
+    stopClause = ` The daily target of ${opts.targetDailySuccessfulSources} was reached.`;
+  } else if (opts.stopReason === "max_rounds_reached") {
+    stopClause = ` The maximum number of search rounds was reached.`;
+  } else if (opts.stopReason === "no_progress") {
+    stopClause = ` No new articles were found in the last round.`;
+  }
+
+  const failureClause =
+    opts.failureCount > 0
+      ? ` ${opts.failureCount} fetch error${opts.failureCount === 1 ? "" : "s"} recorded.`
+      : "";
+
+  const description = `${savedClause}${dropClause}.${stopClause}${failureClause}`;
+
+  return [title, description];
+}


### PR DESCRIPTION
## Summary

The data-collection activity timeline was showing terse, UUID-stamped steps like "ticker 908adfed-6093-…" because the ticker record wasn't loaded until after the first `report()` fired. This PR moves the ticker load earlier, rewrites all 11 report call sites with reasoning-style descriptions, and improves the insights provider's alert and section text along the same lines.

## Related issues

Closes #739

## Important changes

- Ticker record is now loaded before the first `report()` call, so the opening step reads "Collecting news for BUVA (Bukit Uluwatu Villa)" instead of a raw UUID
- New `build-activity-narrative.ts` helper with typed `[title, description]` tuple functions for each pipeline milestone — unit-tested across zero/partial/full/failed states
- All 11 `report()` call sites rewritten; grep confirms no `input.tickerId` remains in any user-facing string
- Drop-rate alert now shows the actual drop percentage and the dominant gate ("relevance", "freshness", or "content quality")
- Stage-failure alert now names the dominant error category
- Collection funnel, publisher, and ticker sections gain an `insight` sentence naming top entities

## Other changes

- `build-activity-narrative.test.ts` — 19 tests covering singular/plural, symbol/name presence, stop-reason text, and UUID-free output

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts` — narrative helper; check that pluralization and description shapes look right
- `apps/mediapulse/agents/data-collection/src/run.ts` — verify ticker load moved above first `report()` and all call sites updated
- `apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts` — alert messages and section insights

## How to test

1. `pnpm --filter @mediapulse/data-collection test` — 78 tests pass
2. `pnpm --filter @mediapulse/agent-data-api test` — 233 tests pass
3. Trigger a data-collection run, open the activity dialog in the dashboard — steps should read as a narrative with ticker symbol/name and no UUIDs
4. Open the agent Insights tab — drop-rate alert should show a percentage and name a gate; section insights should name publishers and tickers
