### PR TITLE
Improve data-collection insights dashboard visual scannability

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.tsx
@@ -19,6 +19,22 @@ const SEVERITY_STYLES: Record<string, string> = {
   critical: "border-red-200 bg-red-50 text-red-800",
 };
 
+const KPI_CARD_STYLES: Record<string, string> = {
+  neutral: "border-border/50 bg-muted/25",
+  positive:
+    "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950/40",
+  warning:
+    "border-yellow-200 bg-yellow-50 dark:border-yellow-900 dark:bg-yellow-950/40",
+  critical: "border-red-200 bg-red-50 dark:border-red-900 dark:bg-red-950/40",
+};
+
+const KPI_VALUE_STYLES: Record<string, string> = {
+  neutral: "text-foreground",
+  positive: "text-green-700 dark:text-green-400",
+  warning: "text-yellow-700 dark:text-yellow-400",
+  critical: "text-red-700 dark:text-red-400",
+};
+
 /**
  * Renders the Insights tab for an agent detail page.
  *
@@ -88,16 +104,22 @@ export const InsightsTab = ({ payload, window }: InsightsTabProps) => {
                   : kpi.delta >= 0
                     ? "text-green-600"
                     : "text-red-600";
+              const cardStyle =
+                KPI_CARD_STYLES[kpi.tone ?? "neutral"] ??
+                KPI_CARD_STYLES["neutral"];
+              const valueStyle =
+                KPI_VALUE_STYLES[kpi.tone ?? "neutral"] ??
+                KPI_VALUE_STYLES["neutral"];
 
               return (
                 <div
                   key={kpi.id}
-                  className="rounded-lg border border-border/50 bg-muted/25 px-4 py-3"
+                  className={`rounded-lg border px-4 py-3 ${cardStyle}`}
                 >
                   <div className="text-xs text-muted-foreground">
                     {kpi.label}
                   </div>
-                  <div className="mt-1 text-xl font-bold text-foreground">
+                  <div className={`mt-1 text-xl font-bold ${valueStyle}`}>
                     {kpi.value}
                     {kpi.unit && (
                       <span className="ml-1 text-sm font-normal text-muted-foreground">

--- a/apps/hermes/dashboard/components/insights/widget-renderer.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.tsx
@@ -219,12 +219,23 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
     return (
       <ul className="space-y-2.5 py-2">
         {widget.stages.map((stage, index) => {
+          const prevValue = widget.stages[index - 1]?.value ?? 0;
+          const drop = index > 0 ? prevValue - stage.value : 0;
+          const dropPct =
+            index > 0 && prevValue > 0
+              ? Math.round((drop / prevValue) * 100)
+              : 0;
           const percentage =
             firstValue > 0 ? Math.round((stage.value / firstValue) * 100) : 100;
           const color = CHART_COLORS[index % CHART_COLORS.length];
 
           return (
             <li key={stage.label} className="space-y-1">
+              {index > 0 && drop > 0 && (
+                <p className="pb-0.5 text-right text-xs leading-none text-muted-foreground/60">
+                  {`−${drop.toLocaleString()} (${dropPct}% dropped)`}
+                </p>
+              )}
               <div className="flex items-center justify-between text-xs">
                 <span className="text-muted-foreground">{stage.label}</span>
                 <span className="tabular-nums font-medium text-foreground">
@@ -248,6 +259,13 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   }
 
   if (widget.kind === "breakdown") {
+    const dominantIndex = widget.slices.reduce(
+      (maxIndex, slice, index) =>
+        slice.fraction > (widget.slices[maxIndex]?.fraction ?? 0)
+          ? index
+          : maxIndex,
+      0,
+    );
     const config: ChartConfig = Object.fromEntries(
       widget.slices.map((slice, index) => [
         slice.label,
@@ -298,14 +316,17 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
           {widget.slices.map((slice, index) => {
             const percentage = Math.round(slice.fraction * 100);
             const color = CHART_COLORS[index % CHART_COLORS.length];
+            const isDominant = index === dominantIndex;
 
             return (
               <li key={slice.label} className="flex items-center gap-2 text-xs">
                 <span
-                  className="h-2 w-2 shrink-0 rounded-sm"
+                  className={`shrink-0 rounded-sm ${isDominant ? "h-2.5 w-2.5" : "h-2 w-2"}`}
                   style={{ backgroundColor: color }}
                 />
-                <span className="flex-1 text-muted-foreground">
+                <span
+                  className={`flex-1 ${isDominant ? "font-medium text-foreground" : "text-muted-foreground"}`}
+                >
                   {slice.label}
                 </span>
                 <span className="tabular-nums font-medium text-foreground">

--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -328,6 +328,17 @@ export function createDataCollectionInsightsProvider(
               (totalArticles / (totalArticles + failures.length)) * 100,
             )
           : 0;
+      const totalPostFetchDropped =
+        totalDroppedByRelevance +
+        totalDroppedByFreshness +
+        Object.values(totalDroppedByContentQuality).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+      const dropRate =
+        totalFetched > 0
+          ? Math.round((totalPostFetchDropped / totalFetched) * 100)
+          : 0;
       const articleDelta = totalArticles - priorArticles;
       const medianDurationMs = medianOf(durationMsList);
 
@@ -356,6 +367,38 @@ export function createDataCollectionInsightsProvider(
           value: searchSuccessRate,
           unit: "%",
         },
+        ...(totalArticles > 0 || failures.length > 0
+          ? [
+              {
+                id: "fetch_success_rate",
+                label: "Fetch success rate",
+                value: fetchSuccessRate,
+                unit: "%",
+                tone:
+                  fetchSuccessRate >= 80
+                    ? ("positive" as const)
+                    : fetchSuccessRate < 50
+                      ? ("warning" as const)
+                      : ("neutral" as const),
+              } satisfies KpiCard,
+            ]
+          : []),
+        ...(totalFetched > 0
+          ? [
+              {
+                id: "drop_rate",
+                label: "Drop rate",
+                value: dropRate,
+                unit: "%",
+                tone:
+                  dropRate >= 70
+                    ? ("critical" as const)
+                    : dropRate >= 40
+                      ? ("warning" as const)
+                      : ("neutral" as const),
+              } satisfies KpiCard,
+            ]
+          : []),
         ...(medianDurationMs !== null
           ? [
               {
@@ -400,13 +443,6 @@ export function createDataCollectionInsightsProvider(
         }
       }
 
-      const totalPostFetchDropped =
-        totalDroppedByRelevance +
-        totalDroppedByFreshness +
-        Object.values(totalDroppedByContentQuality).reduce(
-          (sum, v) => sum + v,
-          0,
-        );
       const totalDropped =
         totalPostFetchDropped +
         totalDroppedByDeadUrl +
@@ -667,34 +703,6 @@ export function createDataCollectionInsightsProvider(
               value,
               fraction: providerTotal > 0 ? value / providerTotal : 0,
             })),
-          },
-        });
-      }
-
-      // How — search success rate stat
-      if (totalSearchAttempts > 0) {
-        sections.push({
-          id: "how-search-success-rate",
-          category: "how",
-          title: "Search success rate",
-          widget: {
-            kind: "stat",
-            value: searchSuccessRate,
-            unit: "%",
-          },
-        });
-      }
-
-      // How — fetch success rate stat
-      if (totalArticles > 0 || failures.length > 0) {
-        sections.push({
-          id: "how-fetch-success-rate",
-          category: "how",
-          title: "Fetch success rate",
-          widget: {
-            kind: "stat",
-            value: fetchSuccessRate,
-            unit: "%",
           },
         });
       }

--- a/packages/shared/agent-data-api-contract/src/agent-insights.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-insights.ts
@@ -59,6 +59,7 @@ export const kpiCardSchema = z.object({
   unit: z.string().optional(),
   delta: z.number().optional(),
   sparkline: z.array(z.number()).optional(),
+  tone: z.enum(["neutral", "positive", "warning", "critical"]).optional(),
 });
 
 export const insightAlertSchema = z.object({


### PR DESCRIPTION
## Summary

- Adds a `tone` field to the `KpiCard` contract so any agent can colour-code a metric as positive, warning, or critical
- Moves fetch success rate into the KPI grid and adds a new drop-rate card with automatic tone colouring
- Removes the duplicate `how-search-success-rate` and `how-fetch-success-rate` stat sections that duplicated what is already in the KPI grid
- KPI cards now render with tinted backgrounds and value colours that match their tone
- Funnel widget shows how many articles drop between each consecutive pair of stages
- Dominant slice in breakdown legends is bolded so the biggest contributor stands out without digging into percentages

## Related issues

Closes #741

## Important changes

**`packages/shared/agent-data-api-contract`** — `kpiCardSchema` gains an optional `tone: "neutral" | "positive" | "warning" | "critical"` field. Existing agents that omit `tone` are unaffected.

**`apps/mediapulse/agent-data-api`** — `data-collection-insights-provider.ts`:
- `totalPostFetchDropped` is now computed in the KPI block (hoisted from the alerts block) so `dropRate` can be derived there
- `fetch_success_rate` KPI: positive when ≥ 80 %, warning when < 50 %
- `drop_rate` KPI: warning when ≥ 40 %, critical when ≥ 70 %
- `how-search-success-rate` and `how-fetch-success-rate` stat sections removed

**`apps/hermes/dashboard`**:
- `insights-tab.tsx` — `KPI_CARD_STYLES` and `KPI_VALUE_STYLES` maps; each KPI card reads `kpi.tone` to pick border/background/value colour
- `widget-renderer.tsx` — funnel renders a `−N (X% dropped)` label above each non-first stage; breakdown computes `dominantIndex` and bolds that row in the legend

## Other changes

No schema migrations, no new dependencies, no API surface changes beyond the optional `tone` field.

## Key files to review

- [agent-insights.ts](packages/shared/agent-data-api-contract/src/agent-insights.ts) — contract change
- [data-collection-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts) — KPI additions and section removals
- [insights-tab.tsx](apps/hermes/dashboard/app/dashboard/agents/%5Bid%5D/insights/insights-tab.tsx) — tone-aware KPI card rendering
- [widget-renderer.tsx](apps/hermes/dashboard/components/insights/widget-renderer.tsx) — funnel drops + breakdown emphasis

## How to test

1. Open the Insights tab for an agent with data-collection runs.
2. Confirm `Fetch success rate` and `Drop rate` KPI cards appear.
3. Cards with low fetch success rate or high drop rate should render with a yellow or red tinted background.
4. The collection funnel should show `−N (X% dropped)` between each pair of stages.
5. The dominant slice in any breakdown widget legend should be bold.
6. Confirm no `Search success rate` or `Fetch success rate` stat sections appear in the "how" category.
