### PR TITLE
Remove fetch budget caps, gate data collection on relevance only

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -63,8 +63,6 @@ const baseConfig = dataCollectionAgentConfigSchema.parse({
   collection: {
     targetDailySuccessfulSources: 1,
     maxRefillRounds: 3,
-    perQueryFetchBudget: 3,
-    perRunFetchBudget: 40,
   },
   runPolicy: {
     minSuccessfulSources: 1,
@@ -397,10 +395,6 @@ describe("runDataCollection", () => {
     const result = await runDataCollection(
       createContext({
         config: withTestConfig({
-          collection: {
-            perQueryFetchBudget: 20,
-            perRunFetchBudget: 100,
-          },
           runPolicy: {
             minSuccessfulSources: 0,
             failOnZeroSuccess: false,
@@ -1090,11 +1084,11 @@ describe("runDataCollection", () => {
     ).toBe("max_rounds_reached");
   });
 
-  it("applies per-query and per-run fetch budgets before issuing fetches", async () => {
-    // Setup
+  it("fetches all hygiene-surviving candidates without a per-query cap", async () => {
+    // Setup: 4 queries × 3 hits each = 12 total candidates
     const queryIds = ["sq-1", "sq-2", "sq-3", "sq-4"];
     const searchHits = queryIds.flatMap((searchQueryId, queryIndex) =>
-      Array.from({ length: 8 }, (_, hitIndex) => ({
+      Array.from({ length: 3 }, (_, hitIndex) => ({
         success: true as const,
         data: {
           url: `https://example.com/q${queryIndex}-h${hitIndex}`,
@@ -1122,26 +1116,14 @@ describe("runDataCollection", () => {
     await runDataCollection(
       createContext({
         config: withTestConfig({
-          collection: {
-            perQueryFetchBudget: 2,
-            perRunFetchBudget: 6,
-          },
           runPolicy: { minSuccessfulSources: 0, failOnZeroSuccess: false },
         }),
       }),
     );
 
-    // Assert
+    // Assert: all 12 hygiene-surviving candidates are passed to fetch with no budget cap
     expect(performWebFetch).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(performWebFetch).mock.calls[0]?.[0]).toHaveLength(6);
-    expect(mockRunLog.info).toHaveBeenCalledWith(
-      expect.objectContaining({
-        selectedForFetch: 6,
-        droppedByPerQueryBudget: 24,
-        droppedByPerRunBudget: 2,
-      }),
-      "applied pre-fetch ranking and fetch budgets",
-    );
+    expect(vi.mocked(performWebFetch).mock.calls[0]?.[0]).toHaveLength(12);
   });
 });
 

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -41,7 +41,6 @@ import {
   type WebSearchFailure,
 } from "./utilities/web-search";
 import { classifyNoisyUrl, type UrlNoiseReason } from "@workspace/utils";
-import { applyFetchBudget } from "./utilities/hit-ranker";
 
 /**
  * Executes the data-collection pipeline: load search queries, run web search and fetch,
@@ -126,8 +125,6 @@ export async function runDataCollection(
   const webSearchConfig = config.providers.search;
   const webFetchConfig = config.providers.fetch;
   const relevanceGateConfig = config.gates.relevance;
-  const perQueryFetchBudget = config.collection.perQueryFetchBudget;
-  const perRunFetchBudget = config.collection.perRunFetchBudget;
   const deadUrlCacheConfig = config.resilience.deadUrlCache;
   const hostErrorBreakerConfig = config.resilience.hostErrorBreaker;
   const freshnessGateConfig = config.gates.freshness;
@@ -216,8 +213,6 @@ export async function runDataCollection(
   let droppedByExistingCanonicalUrl = 0;
   const droppedByContentQuality = createEmptyQualityCounters();
   let droppedByRelevance = 0;
-  let droppedByPerQueryBudget = 0;
-  let droppedByPerRunBudget = 0;
   let droppedByDeadUrlCache = 0;
   let droppedByHostErrorRate = 0;
   const droppedByFreshnessReason: Record<string, number> = {
@@ -394,42 +389,20 @@ export async function runDataCollection(
         ),
       );
 
-      const budgetSelection = applyFetchBudget(
-        searchSuccessesAfterHostBreaker,
-        {
-          tickerAliases,
-          hostCounts,
-          perQueryFetchBudget,
-          perRunFetchBudget,
-        },
+      report(
+        ...narrativeFetchStart(subject, searchSuccessesAfterHostBreaker.length),
       );
-      droppedByPerQueryBudget += budgetSelection.droppedByPerQueryBudget;
-      droppedByPerRunBudget += budgetSelection.droppedByPerRunBudget;
-      if (
-        budgetSelection.droppedByPerQueryBudget > 0 ||
-        budgetSelection.droppedByPerRunBudget > 0
-      ) {
-        log.info(
-          {
-            round,
-            selectedForFetch: budgetSelection.hits.length,
-            droppedByPerQueryBudget: budgetSelection.droppedByPerQueryBudget,
-            droppedByPerRunBudget: budgetSelection.droppedByPerRunBudget,
-            skippedByQuery: budgetSelection.skippedByQuery,
-          },
-          "applied pre-fetch ranking and fetch budgets",
-        );
-      }
-
-      report(...narrativeFetchStart(subject, budgetSelection.hits.length));
 
       const fetchThrottleStats = { throttleEvents: 0 };
-      const fetchAttemptResults = await performWebFetch(budgetSelection.hits, {
-        config: webFetchConfig,
-        logger: log,
-        throttleStats: fetchThrottleStats,
-        hostErrorTracker,
-      });
+      const fetchAttemptResults = await performWebFetch(
+        searchSuccessesAfterHostBreaker,
+        {
+          config: webFetchConfig,
+          logger: log,
+          throttleStats: fetchThrottleStats,
+          hostErrorTracker,
+        },
+      );
       throttleEvents += fetchThrottleStats.throttleEvents;
       const roundFetchSuccesses = fetchAttemptResults
         .filter((outcome) => outcome.success !== null)
@@ -549,8 +522,6 @@ export async function runDataCollection(
           droppedByExistingCanonicalUrl,
           droppedByContentQuality,
           droppedByRelevance,
-          droppedByPerQueryBudget,
-          droppedByPerRunBudget,
           droppedByDeadUrlCache,
           droppedByHostErrorRate,
           droppedByFreshnessReason,
@@ -671,8 +642,6 @@ export async function runDataCollection(
     throttleEvents,
     agentId: "data-collection",
     persisted: persistedThisRunCount,
-    droppedByPerQueryBudget,
-    droppedByPerRunBudget,
     droppedByDeadUrl: droppedByDeadUrlCache,
     droppedByHostErrorRate,
     droppedByFreshness: droppedByFreshnessTotalCount,
@@ -717,8 +686,6 @@ export async function runDataCollection(
     fetched: fetchedCount,
     fetchSuccess: fetchSuccessCount,
     droppedByRelevance,
-    droppedByPerQueryBudget,
-    droppedByPerRunBudget,
     droppedByDeadUrlCache,
     droppedByHostErrorRate,
     droppedByFreshness: droppedByFreshnessTotalCount,
@@ -793,8 +760,6 @@ export async function runDataCollection(
       totalSources,
       failureCount: failuresPayload.length,
       droppedByRelevance,
-      droppedByPerQueryBudget,
-      droppedByPerRunBudget,
       throttleEvents,
     },
     completionMessage,

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -82,8 +82,6 @@ describe("dataCollectionAgentConfigSchema", () => {
     expect(parsed.collection).toEqual({
       targetDailySuccessfulSources: 5,
       maxRefillRounds: 3,
-      perQueryFetchBudget: 5,
-      perRunFetchBudget: 40,
     });
     expect(parsed.gates.relevance).toEqual({
       enabled: true,
@@ -133,15 +131,26 @@ describe("dataCollectionAgentConfigSchema", () => {
   it("keeps other defaults when only one collection field is overridden", () => {
     const parsed = dataCollectionAgentConfigSchema.parse({
       collection: {
-        perRunFetchBudget: 12,
+        maxRefillRounds: 5,
       },
     });
 
-    expect(parsed.collection.perRunFetchBudget).toBe(12);
-    expect(parsed.collection.perQueryFetchBudget).toBe(5);
+    expect(parsed.collection.maxRefillRounds).toBe(5);
     expect(parsed.collection.targetDailySuccessfulSources).toBe(5);
     expect(parsed.providers.fetch.providers).toHaveLength(4);
     expect(parsed.runPolicy.failOnZeroSuccess).toBe(false);
+  });
+
+  it("strips unknown collection fields like legacy budget keys", () => {
+    const parsed = dataCollectionAgentConfigSchema.parse({
+      collection: {
+        perQueryFetchBudget: 5,
+        perRunFetchBudget: 40,
+      },
+    });
+
+    expect(parsed.collection).not.toHaveProperty("perQueryFetchBudget");
+    expect(parsed.collection).not.toHaveProperty("perRunFetchBudget");
   });
 
   it("accepts ordered fetch providers under providers.fetch.providers", () => {

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -245,18 +245,6 @@ const collectionSchema = z
       .describe(
         "Additional search-and-fetch rounds after the initial round when the daily target is not yet met.",
       ),
-    perQueryFetchBudget: z
-      .number()
-      .int()
-      .positive()
-      .default(5)
-      .describe("Maximum URLs fetched per search query after ranking."),
-    perRunFetchBudget: z
-      .number()
-      .int()
-      .positive()
-      .default(40)
-      .describe("Maximum URLs fetched across all queries in one round."),
   })
   .default({})
   .describe("Collection volume and refill behavior.");

--- a/apps/mediapulse/agents/data-collection/src/utilities/hit-ranker.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/hit-ranker.test.ts
@@ -3,11 +3,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { WebSearchResult } from "./web-search";
-import {
-  applyFetchBudget,
-  rankSearchHits,
-  snippetMatchScore,
-} from "./hit-ranker";
+import { rankSearchHits, snippetMatchScore } from "./hit-ranker";
 
 const aliases = ["bbca", "bank central asia"];
 
@@ -83,64 +79,5 @@ describe("rankSearchHits", () => {
 
     // Assert
     expect(ranked[0]?.url).toBe("https://www.marketwatch.com/fresh");
-  });
-});
-
-describe("applyFetchBudget", () => {
-  it("keeps three hits per query across two queries", () => {
-    // Setup
-    const hits = [
-      ...Array.from({ length: 5 }, (_, index) =>
-        makeHit({
-          url: `https://example.com/a-${index}`,
-          searchQueryId: "sq-1",
-          serpIndex: index,
-        }),
-      ),
-      ...Array.from({ length: 5 }, (_, index) =>
-        makeHit({
-          url: `https://example.com/b-${index}`,
-          searchQueryId: "sq-2",
-          serpIndex: index,
-        }),
-      ),
-    ];
-
-    // Act
-    const result = applyFetchBudget(hits, {
-      tickerAliases: aliases,
-      hostCounts: {},
-      perQueryFetchBudget: 3,
-      perRunFetchBudget: 40,
-    });
-
-    // Assert
-    expect(result.hits).toHaveLength(6);
-    expect(result.droppedByPerQueryBudget).toBe(4);
-    expect(result.droppedByPerRunBudget).toBe(0);
-  });
-
-  it("caps the round at the per-run fetch budget", () => {
-    // Setup
-    const hits = Array.from({ length: 8 }, (_, index) =>
-      makeHit({
-        url: `https://example.com/${index}`,
-        searchQueryId: `sq-${index % 4}`,
-        serpIndex: index,
-      }),
-    );
-
-    // Act
-    const result = applyFetchBudget(hits, {
-      tickerAliases: aliases,
-      hostCounts: {},
-      perQueryFetchBudget: 2,
-      perRunFetchBudget: 6,
-    });
-
-    // Assert
-    expect(result.hits).toHaveLength(6);
-    expect(result.droppedByPerQueryBudget).toBe(0);
-    expect(result.droppedByPerRunBudget).toBe(2);
   });
 });

--- a/apps/mediapulse/agents/data-collection/src/utilities/hit-ranker.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/hit-ranker.ts
@@ -57,18 +57,6 @@ export type RankSearchHitsOptions = {
   hostCounts: Record<string, number>;
 };
 
-export type ApplyFetchBudgetOptions = RankSearchHitsOptions & {
-  perQueryFetchBudget: number;
-  perRunFetchBudget: number;
-};
-
-export type ApplyFetchBudgetResult = {
-  hits: RankedHit[];
-  droppedByPerQueryBudget: number;
-  droppedByPerRunBudget: number;
-  skippedByQuery: Record<string, number>;
-};
-
 /**
  * Counts distinct ticker alias matches inside a title and snippet.
  *
@@ -132,46 +120,3 @@ export const rankSearchHits = (
       score: computeHitScore(hit, options),
     }))
     .sort((left, right) => right.score - left.score);
-
-/**
- * Applies per-query and per-run fetch budgets to ranked search hits.
- *
- * @param hits - Candidate hits grouped across queries.
- * @param options - Ranking inputs and budget caps.
- * @returns Selected hits plus intentional skip counters.
- */
-export const applyFetchBudget = (
-  hits: readonly WebSearchResult[],
-  options: ApplyFetchBudgetOptions,
-): ApplyFetchBudgetResult => {
-  const hitsByQuery = new Map<string, WebSearchResult[]>();
-  for (const hit of hits) {
-    const group = hitsByQuery.get(hit.searchQueryId) ?? [];
-    group.push(hit);
-    hitsByQuery.set(hit.searchQueryId, group);
-  }
-
-  const perQuerySelected: RankedHit[] = [];
-  const skippedByQuery: Record<string, number> = {};
-  let droppedByPerQueryBudget = 0;
-
-  for (const [queryId, queryHits] of hitsByQuery) {
-    const ranked = rankSearchHits(queryHits, options);
-    const kept = ranked.slice(0, options.perQueryFetchBudget);
-    const skipped = queryHits.length - kept.length;
-    skippedByQuery[queryId] = skipped;
-    droppedByPerQueryBudget += skipped;
-    perQuerySelected.push(...kept);
-  }
-
-  perQuerySelected.sort((left, right) => right.score - left.score);
-  const selected = perQuerySelected.slice(0, options.perRunFetchBudget);
-  const droppedByPerRunBudget = perQuerySelected.length - selected.length;
-
-  return {
-    hits: selected,
-    droppedByPerQueryBudget,
-    droppedByPerRunBudget,
-    skippedByQuery,
-  };
-};


### PR DESCRIPTION
## Summary

The data-collection pipeline was dropping ~37% of search candidates before fetching them due to a per-query budget cap (default 5 per query). That cap discarded results by rank position within a query rather than by whether they're relevant to the ticker. This removes both the per-query and per-run fetch budget caps so all hygiene-surviving candidates get fetched, and the post-fetch relevance gate becomes the only filter that decides what gets inserted.

## Related issues

Closes #743

## Important changes

- `applyFetchBudget` and its types (`ApplyFetchBudgetOptions`, `ApplyFetchBudgetResult`) deleted from `hit-ranker.ts`
- `collection.perQueryFetchBudget` and `collection.perRunFetchBudget` removed from the config schema — stored agent configs carrying these keys still parse cleanly since Zod strips unknown fields
- `run.ts` no longer reads either budget, accumulates `droppedByPerQueryBudget` / `droppedByPerRunBudget` counters, or emits them into `extendedCounters`
- The post-fetch relevance gate is now the sole insert/skip decision; the daily-target and refill-round loop remain the volume control

## Other changes

- `hit-ranker.test.ts`: removed the `applyFetchBudget` describe block
- `config-schema.test.ts`: updated collection defaults assertion, replaced the budget-field test with a legacy-key-strips test
- `run.test.ts`: removed budget fields from fixtures, replaced the budget cap test with a "fetches all hygiene-surviving candidates" assertion

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/hit-ranker.ts` — `applyFetchBudget` and types removed
- `apps/mediapulse/agents/data-collection/src/run.ts` — budget call site, counters, and log fields removed
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — two collection fields removed
- `apps/mediapulse/agents/data-collection/src/run.test.ts` — new no-cap assertion verifying all 12 candidates are passed to fetch

## How to test

1. Run `pnpm --filter @mediapulse/data-collection test` — all 77 tests should pass
2. Trigger a data-collection run for any ticker and confirm `extendedCounters` no longer contains `droppedByPerQueryBudget` or `droppedByPerRunBudget`
3. Confirm the insights drop-reason breakdown no longer shows "Per-query budget" for new runs (the row decays as old runs age out of the window)
4. Confirm a stored agent config that still has `perQueryFetchBudget` / `perRunFetchBudget` fields runs without a validation error
