### PR TITLE
Remove stale budget drop counters from contract and insights provider

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts
@@ -104,8 +104,6 @@ type ExtendedCounters = {
   droppedByFreshnessReason?: Record<string, number>;
   droppedByDeadUrl?: number;
   droppedByHostErrorRate?: number;
-  droppedByPerQueryBudget?: number;
-  droppedByPerRunBudget?: number;
   droppedByExistingCanonicalUrl?: number;
   droppedByDuplicateCanonicalUrl?: number;
   droppedByUrlNoise?: number;
@@ -276,8 +274,6 @@ export function createDataCollectionInsightsProvider(
       let totalDroppedByFreshness = 0;
       let totalDroppedByDeadUrl = 0;
       let totalDroppedByHostErrorRate = 0;
-      let totalDroppedByPerQueryBudget = 0;
-      let totalDroppedByPerRunBudget = 0;
       let totalDroppedByUrlNoise = 0;
       let totalDroppedByExistingCanonical = 0;
       let totalDroppedByDuplicateCanonical = 0;
@@ -294,8 +290,6 @@ export function createDataCollectionInsightsProvider(
         totalDroppedByFreshness += ext.droppedByFreshness ?? 0;
         totalDroppedByDeadUrl += ext.droppedByDeadUrl ?? 0;
         totalDroppedByHostErrorRate += ext.droppedByHostErrorRate ?? 0;
-        totalDroppedByPerQueryBudget += ext.droppedByPerQueryBudget ?? 0;
-        totalDroppedByPerRunBudget += ext.droppedByPerRunBudget ?? 0;
         totalDroppedByUrlNoise += ext.droppedByUrlNoise ?? 0;
         totalDroppedByExistingCanonical +=
           ext.droppedByExistingCanonicalUrl ?? 0;
@@ -447,8 +441,6 @@ export function createDataCollectionInsightsProvider(
         totalPostFetchDropped +
         totalDroppedByDeadUrl +
         totalDroppedByHostErrorRate +
-        totalDroppedByPerQueryBudget +
-        totalDroppedByPerRunBudget +
         totalDroppedByUrlNoise +
         totalDroppedByExistingCanonical +
         totalDroppedByDuplicateCanonical;
@@ -625,8 +617,6 @@ export function createDataCollectionInsightsProvider(
         ["Freshness", totalDroppedByFreshness],
         ["Dead URL", totalDroppedByDeadUrl],
         ["Host error rate", totalDroppedByHostErrorRate],
-        ["Per-query budget", totalDroppedByPerQueryBudget],
-        ["Per-run budget", totalDroppedByPerRunBudget],
         ["URL noise", totalDroppedByUrlNoise],
         ["Existing canonical", totalDroppedByExistingCanonical],
         ["Duplicate canonical", totalDroppedByDuplicateCanonical],

--- a/packages/shared/agent-data-api-contract/src/data-collection-run.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-run.ts
@@ -45,8 +45,6 @@ export const dataCollectionRunInputSchema = z.object({
     agentId: z.string().optional(),
     roundsExecuted: z.number().int().nonnegative().optional(),
     stopReason: z.string().optional(),
-    droppedByPerQueryBudget: z.number().int().nonnegative().optional(),
-    droppedByPerRunBudget: z.number().int().nonnegative().optional(),
   }),
 });
 

--- a/packages/shared/agent-ingestion/src/run-status.ts
+++ b/packages/shared/agent-ingestion/src/run-status.ts
@@ -42,8 +42,6 @@ export type RunCounters = {
   agentId?: string;
   roundsExecuted?: number;
   stopReason?: string;
-  droppedByPerQueryBudget?: number;
-  droppedByPerRunBudget?: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

After #744 removed the fetch budget caps, `droppedByPerQueryBudget` and `droppedByPerRunBudget` were never emitted again. This follow-up removes those stale counter fields from the shared run-status type, the API contract, and the insights provider, keeping all three layers consistent with what the agent actually produces.

## Related issues

Closes #745

## Important changes

- `droppedByPerQueryBudget` and `droppedByPerRunBudget` removed from the `RunCounters` type in `agent-ingestion/src/run-status.ts`
- Both fields removed from the `dataCollectionRunInputSchema` Zod schema in the API contract
- Removed from `ExtendedCounters`, the two accumulators, the `totalDropped` sum, and the two `dropEntries` rows in the insights provider

## Other changes

No dashboard renderer changes — the provider already filters zero-value reasons so the budget rows had already stopped appearing in the breakdown chart after #744 shipped.

## Key files to review

- `packages/shared/agent-ingestion/src/run-status.ts` — two optional fields removed from `RunCounters`
- `packages/shared/agent-data-api-contract/src/data-collection-run.ts` — two optional Zod fields removed
- `apps/mediapulse/agent-data-api/src/services/insights/data-collection-insights-provider.ts` — `ExtendedCounters`, accumulators, sum, and drop rows cleaned up

## How to test

1. Run `pnpm --filter @workspace/agent-ingestion --filter @workspace/agent-data-api-contract --filter @mediapulse/agent-data-api test` — all tests should pass
2. Confirm `grep -r "droppedByPerQueryBudget\|droppedByPerRunBudget" packages/shared apps/mediapulse/agent-data-api` returns nothing in source files
3. Confirm the insights drop-reason breakdown still renders correctly for existing windows (Relevance, Freshness, Dead URL, etc. all still appear)
