### PR TITLE
Apply invoke_agent timeout cap to manual pipeline runs

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts
@@ -2,8 +2,24 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { HERMES_ENQUEUE_CORRELATION_METADATA_KEY } from "@hermes/scheduler/enqueue-diagnostics-correlation";
+import {
+  DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+  type InvokeAgentJobPayload,
+} from "@hermes/scheduler";
 
 let mockXRequestId: string | null | undefined;
+
+const { addJobsMock, editJobMock } = vi.hoisted(() => ({
+  addJobsMock: vi.fn(),
+  editJobMock: vi.fn(),
+}));
+
+vi.mock("@/lib/hermes-job-queue", () => ({
+  getHermesJobQueue: () => ({
+    addJobs: addJobsMock,
+    editJob: editJobMock,
+  }),
+}));
 
 vi.mock("next/headers", async (importOriginal) => {
   const actual = await importOriginal<typeof import("next/headers")>();
@@ -21,6 +37,7 @@ vi.mock("next/headers", async (importOriginal) => {
 import {
   agentHttpBodyToRawString,
   createRunPipelineHandler,
+  defaultEnqueueManualAgentInvocations,
   detailFromAgentErrorBody,
 } from "./route.post.config";
 
@@ -462,5 +479,64 @@ describe("createRunPipelineHandler", () => {
       payload: { manualExecutionId: string };
     }>;
     expect(batch).toHaveLength(FAN_OUT);
+  });
+});
+
+describe("defaultEnqueueManualAgentInvocations", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const makePayload = (
+    overrides: Partial<InvokeAgentJobPayload> = {},
+  ): InvokeAgentJobPayload => ({
+    jobId: "job-1",
+    executionId: "exec-1",
+    manualExecutionId: "manual-exec-1",
+    pipelineId: "pipeline-1",
+    pipelineStepId: "step-1",
+    domainIntegrationId: "di-1",
+    agentId: "data-collection",
+    agentVersion: "1.0.0",
+    endpointUrl: "https://agent.example/invoke",
+    body: { input: {}, config: {} },
+    timeoutMs: 10_800_000,
+    priority: 0,
+    ...overrides,
+  });
+
+  it("caps the DataQueue job timeout so a hung invoke cannot stall the processor batch", async () => {
+    addJobsMock.mockResolvedValue([101]);
+    editJobMock.mockResolvedValue(undefined);
+
+    // Pipeline configured with a 3-hour agent timeout (e.g. the Data Collection Pipeline).
+    const payload = makePayload({ timeoutMs: 10_800_000 });
+
+    await defaultEnqueueManualAgentInvocations([{ payload }]);
+
+    expect(addJobsMock).toHaveBeenCalledTimes(1);
+    const jobDefs = addJobsMock.mock.calls[0]?.[0] as Array<{
+      timeoutMs: number;
+      payload: InvokeAgentJobPayload;
+    }>;
+
+    expect(jobDefs[0]?.timeoutMs).toBe(DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS);
+    // The agent HTTP deadline on the payload is left untouched.
+    expect(jobDefs[0]?.payload.timeoutMs).toBe(10_800_000);
+  });
+
+  it("keeps the configured timeout when it is already below the cap", async () => {
+    addJobsMock.mockResolvedValue([102]);
+    editJobMock.mockResolvedValue(undefined);
+
+    const payload = makePayload({ timeoutMs: 60_000 });
+
+    await defaultEnqueueManualAgentInvocations([{ payload }]);
+
+    const jobDefs = addJobsMock.mock.calls[0]?.[0] as Array<{
+      timeoutMs: number;
+    }>;
+
+    expect(jobDefs[0]?.timeoutMs).toBe(60_000);
   });
 });

--- a/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
+++ b/apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts
@@ -13,6 +13,7 @@ import {
   diagnosticFromCaughtError,
   mergeExecutionConfig,
   planPipelineInvocations,
+  resolveInvokeAgentJobTimeoutMs,
   type EnqueueDiagnosticEntry,
   type EnqueueInvokeAgentItem,
   type ExpandStepInputs,
@@ -171,7 +172,7 @@ export const agentHttpBodyToRawString = (
  *
  * @param items - Planned invocations with optional same-batch `dependsOn` indices.
  */
-const defaultEnqueueManualAgentInvocations = async (
+export const defaultEnqueueManualAgentInvocations = async (
   items: EnqueueInvokeAgentItem[],
 ): Promise<void> => {
   if (items.length === 0) {
@@ -183,7 +184,10 @@ const defaultEnqueueManualAgentInvocations = async (
     payload: item.payload,
     priority: item.payload.priority,
     idempotencyKey: item.payload.jobId,
-    timeoutMs: item.payload.timeoutMs,
+    // Cap the DataQueue job timeout below the agent HTTP deadline (which may be hours) so a hung
+    // invoke frees the processor batch and the supervisor reclaims within minutes, not hours.
+    // Matches the schedule and HTTP-trigger enqueue paths in the worker's job-handlers.
+    timeoutMs: resolveInvokeAgentJobTimeoutMs(item.payload.timeoutMs),
     dependsOn:
       item.dependsOnBatchIndices && item.dependsOnBatchIndices.length > 0
         ? {

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -16,11 +16,13 @@ import { createAgentTokenClient } from "@workspace/agent-auth-client";
 import { DEFAULT_TAKE, MAX_TAKE } from "@hermes/step-input-syntax";
 import {
   applyInvocationCompletion,
+  DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
   executeSchedule,
   getDueSchedules,
   invokeAgentPost,
   parseAgentResponseEnvelope,
   parseHttpErrorBodyMessage,
+  resolveInvokeAgentJobTimeoutMs,
   willRetryAfterTransientFailure,
   type ExpandStepInputs,
   type InvokeAgentHttpClient,
@@ -31,8 +33,9 @@ import { executeHttpTrigger } from "./execute-http-trigger";
 import { cleanupOrphanedExecutions } from "./cleanup-orphaned-executions";
 import { reconcileOrphanedPendingExecutions } from "./reconcile-orphaned-pending";
 
-/** Default cap for DataQueue `invoke_agent` job timeout (abort + supervisor reclaim). */
-export const DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS = 1_800_000;
+// Re-exported from `@hermes/scheduler` so the cap lives in one place shared by every
+// `invoke_agent` enqueue path (worker schedule/HTTP trigger + dashboard manual run).
+export { DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS, resolveInvokeAgentJobTimeoutMs };
 
 type ResolvedDataQueueJob = {
   id: number;
@@ -65,20 +68,6 @@ export const resolveDataQueueJob = async (
   );
   return result.rows[0] ?? null;
 };
-
-/**
- * Caps DataQueue job-level timeout so a hung agent invoke cannot block the processor batch
- * for the full agent HTTP deadline (which may be hours).
- *
- * @param agentTimeoutMs - Agent HTTP timeout from pipeline/schedule config.
- * @param capMs - Optional override cap in milliseconds.
- * @returns Min of agent timeout and cap.
- */
-export const resolveInvokeAgentJobTimeoutMs = (
-  agentTimeoutMs: number,
-  capMs?: number,
-): number =>
-  Math.min(agentTimeoutMs, capMs ?? DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS);
 
 /**
  * Parses optional positive integer env strings (DataQueue retry delay fields are in seconds).

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -96,3 +96,7 @@ export {
   type InvokeAgentPostOptions,
   type InvokeAgentPostResult,
 } from "./invoke-agent";
+export {
+  DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+  resolveInvokeAgentJobTimeoutMs,
+} from "./invoke-agent-job-timeout";

--- a/packages/hermes/scheduler/src/invoke-agent-job-timeout.test.ts
+++ b/packages/hermes/scheduler/src/invoke-agent-job-timeout.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+  resolveInvokeAgentJobTimeoutMs,
+} from "./invoke-agent-job-timeout";
+
+describe("resolveInvokeAgentJobTimeoutMs", () => {
+  it("returns the agent timeout when it is below the default cap", () => {
+    expect(resolveInvokeAgentJobTimeoutMs(60_000)).toBe(60_000);
+  });
+
+  it("clamps to the default cap when the agent timeout is larger", () => {
+    expect(resolveInvokeAgentJobTimeoutMs(10_800_000)).toBe(
+      DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS,
+    );
+  });
+
+  it("honors an explicit cap override", () => {
+    expect(resolveInvokeAgentJobTimeoutMs(7_200_000, 1_800_000)).toBe(
+      1_800_000,
+    );
+  });
+});

--- a/packages/hermes/scheduler/src/invoke-agent-job-timeout.ts
+++ b/packages/hermes/scheduler/src/invoke-agent-job-timeout.ts
@@ -1,0 +1,20 @@
+/** Default cap for DataQueue `invoke_agent` job timeout (abort + supervisor reclaim). */
+export const DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS = 1_800_000;
+
+/**
+ * Caps the DataQueue job-level timeout so a hung agent invoke cannot block the processor batch
+ * for the full agent HTTP deadline (which may be hours).
+ *
+ * - Important: every `invoke_agent` enqueue path (schedule, HTTP trigger, manual run) must apply
+ *   this cap. The DataQueue processor runs a serialized batch loop, so one job left running for the
+ *   full agent deadline stalls all other pending jobs (including other pipelines) until it settles.
+ *
+ * @param agentTimeoutMs - Agent HTTP timeout from pipeline/schedule config.
+ * @param capMs - Optional override cap in milliseconds.
+ * @returns Min of agent timeout and cap.
+ */
+export const resolveInvokeAgentJobTimeoutMs = (
+  agentTimeoutMs: number,
+  capMs?: number,
+): number =>
+  Math.min(agentTimeoutMs, capMs ?? DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS);


### PR DESCRIPTION
## Summary

The dashboard's manual pipeline run path passed the agent timeout straight through to the DataQueue job with no cap. The worker's schedule and HTTP-trigger enqueue paths both clamp it to 30 minutes via `resolveInvokeAgentJobTimeoutMs` — manual runs didn't.

DataQueue's processor batch loop is serialized. One hung job blocks every pending job across all pipelines until the supervisor reclaims it. The supervisor also checks `GREATEST(stuckJobsTimeoutMinutes, timeout_ms)`, so a job with a 3-hour `timeout_ms` won't be reclaimed for 3 hours. One stuck `data-collection` invoke locked 15 pending jobs across two pipelines and motivated this fix.

The cap helper and constant are now in `@hermes/scheduler` so all three enqueue paths share one source. The worker re-exports them for backward compatibility. Regression tests cover the capped and under-cap cases.

## Related issues

Closes #748

## Important changes

- `defaultEnqueueManualAgentInvocations` in the dashboard now applies `resolveInvokeAgentJobTimeoutMs`, capping the DataQueue job `timeout_ms` at 30 minutes regardless of the pipeline's agent HTTP deadline
- `DEFAULT_INVOKE_AGENT_JOB_TIMEOUT_MS` and `resolveInvokeAgentJobTimeoutMs` moved from `apps/hermes/worker/src/job-handlers.ts` into `packages/hermes/scheduler/src/invoke-agent-job-timeout.ts`, then exported from `@hermes/scheduler`

## Other changes

- `defaultEnqueueManualAgentInvocations` changed from `const` to `export const` to support direct testing
- `apps/hermes/worker/src/job-handlers.ts` re-exports the helpers from `@hermes/scheduler` for backward compatibility
- 3 unit tests added for the cap helper in `packages/hermes/scheduler/src/invoke-agent-job-timeout.test.ts`
- 2 regression tests added in the dashboard's `route.post.config.test.ts` — one verifying the cap is applied, one verifying sub-cap timeouts pass through unchanged

## Key files to review

- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.ts` — the bug fix: the line where `timeoutMs` is now capped before being set on the DataQueue job
- `packages/hermes/scheduler/src/invoke-agent-job-timeout.ts` — the shared helper and constant (previously defined only in `job-handlers.ts`)
- `apps/hermes/dashboard/app/dashboard/pipelines/actions/run-pipeline/route.post.config.test.ts` — regression tests for the cap in the manual-run path

## How to test

1. Run `pnpm --filter @hermes/scheduler test` — the 3 cap tests should pass
2. Run `pnpm --filter hermes-dashboard test` — the `defaultEnqueueManualAgentInvocations` describe block should pass
3. Trigger a manual pipeline run where the agent timeout config is > 30 min; check the `dataqueue.job_queue` table and confirm `timeout_ms` is ≤ 1,800,000 for the enqueued jobs
