### PR TITLE
Label per-ticker insight bars with ticker symbols

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
@@ -9,6 +9,7 @@ import { createArticleAnalysisInsightsProvider } from "./article-analysis-insigh
 function makeRelevance(overrides?: {
   dataSourceId?: string;
   tickerId?: string;
+  symbol?: string;
   score?: number;
   selected?: boolean;
   scoredAt?: Date;
@@ -16,6 +17,7 @@ function makeRelevance(overrides?: {
   return {
     dataSourceId: overrides?.dataSourceId ?? "ds-1",
     tickerId: overrides?.tickerId ?? "ticker-1",
+    ticker: { symbol: overrides?.symbol ?? "AAPL" },
     score: overrides?.score ?? 0.7,
     selected: overrides?.selected !== undefined ? overrides.selected : true,
     scoredAt: overrides?.scoredAt ?? new Date(Date.now() - 24 * 60 * 60 * 1000),
@@ -181,9 +183,40 @@ describe("createArticleAnalysisInsightsProvider", () => {
     expect(total).toBeCloseTo(1, 5);
   });
 
+  it("labels per-ticker bars with ticker symbol", async () => {
+    const rows = [
+      makeRelevance({ tickerId: "t1", symbol: "AAPL" }),
+      makeRelevance({ tickerId: "t1", symbol: "AAPL" }),
+      makeRelevance({ tickerId: "t2", symbol: "MSFT" }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "where-per-ticker");
+    if (section?.widget.kind !== "categoryBar") return;
+    const labels = section.widget.bars.map((b) => b.label);
+    expect(labels).toContain("AAPL");
+    expect(labels).toContain("MSFT");
+    expect(labels).not.toContain("t1");
+    expect(labels).not.toContain("t2");
+  });
+
+  it("falls back to tickerId when ticker symbol is missing", async () => {
+    const row = makeRelevance({ tickerId: "orphan-id", symbol: undefined });
+    // Simulate missing symbol by overriding ticker
+    const rowWithNoSymbol = { ...row, ticker: { symbol: undefined as unknown as string } };
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([rowWithNoSymbol], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "where-per-ticker");
+    if (section?.widget.kind !== "categoryBar") return;
+    const labels = section.widget.bars.map((b) => b.label);
+    expect(labels).toContain("orphan-id");
+  });
+
   it("caps per-ticker bars to TOP_N + Other", async () => {
     const rows = Array.from({ length: 15 }, (_, i) =>
-      makeRelevance({ dataSourceId: `ds-${i}`, tickerId: `ticker-${i}` }),
+      makeRelevance({ dataSourceId: `ds-${i}`, tickerId: `ticker-${i}`, symbol: `SYM${i}` }),
     );
     const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
     const payload = await provider.compute({ window: "7d" });

--- a/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
@@ -203,7 +203,10 @@ describe("createArticleAnalysisInsightsProvider", () => {
   it("falls back to tickerId when ticker symbol is missing", async () => {
     const row = makeRelevance({ tickerId: "orphan-id", symbol: undefined });
     // Simulate missing symbol by overriding ticker
-    const rowWithNoSymbol = { ...row, ticker: { symbol: undefined as unknown as string } };
+    const rowWithNoSymbol = {
+      ...row,
+      ticker: { symbol: undefined as unknown as string },
+    };
     const provider = createArticleAnalysisInsightsProvider(
       makeDeps([rowWithNoSymbol], []),
     );
@@ -216,7 +219,11 @@ describe("createArticleAnalysisInsightsProvider", () => {
 
   it("caps per-ticker bars to TOP_N + Other", async () => {
     const rows = Array.from({ length: 15 }, (_, i) =>
-      makeRelevance({ dataSourceId: `ds-${i}`, tickerId: `ticker-${i}`, symbol: `SYM${i}` }),
+      makeRelevance({
+        dataSourceId: `ds-${i}`,
+        tickerId: `ticker-${i}`,
+        symbol: `SYM${i}`,
+      }),
     );
     const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
     const payload = await provider.compute({ window: "7d" });

--- a/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts
@@ -21,6 +21,7 @@ const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
 type ArticleRelevanceRow = {
   dataSourceId: string;
   tickerId: string;
+  ticker: { symbol: string };
   score: number;
   selected: boolean;
   scoredAt: Date;
@@ -45,6 +46,7 @@ type ArticleAnalysisInsightsDeps = {
       select: {
         dataSourceId: boolean;
         tickerId: boolean;
+        ticker: { select: { symbol: boolean } };
         score: boolean;
         selected: boolean;
         scoredAt: boolean;
@@ -120,6 +122,7 @@ export function createArticleAnalysisInsightsProvider(
           select: {
             dataSourceId: true,
             tickerId: true,
+            ticker: { select: { symbol: true } },
             score: true,
             selected: true,
             scoredAt: true,
@@ -301,10 +304,8 @@ export function createArticleAnalysisInsightsProvider(
       // Where — articles scored per ticker
       const tickerCounts = new Map<string, number>();
       for (const row of relevance) {
-        tickerCounts.set(
-          row.tickerId,
-          (tickerCounts.get(row.tickerId) ?? 0) + 1,
-        );
+        const label = row.ticker?.symbol ?? row.tickerId;
+        tickerCounts.set(label, (tickerCounts.get(label) ?? 0) + 1);
       }
       if (tickerCounts.size > 0) {
         sections.push({

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
@@ -329,7 +329,10 @@ describe("createContentGenerationInsightsProvider", () => {
 
   it("falls back to tickerId when newsletter ticker symbol is missing", async () => {
     const newsletter = makeNewsletter({ tickerId: "orphan-id" });
-    const newsletterWithNoSymbol = { ...newsletter, ticker: { symbol: undefined as unknown as string } };
+    const newsletterWithNoSymbol = {
+      ...newsletter,
+      ticker: { symbol: undefined as unknown as string },
+    };
 
     const provider = createContentGenerationInsightsProvider(
       makeDeps({ newsletters: [newsletterWithNoSymbol] }),

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
@@ -32,12 +32,14 @@ function makeRun(overrides?: {
 
 function makeNewsletter(overrides?: {
   tickerId?: string;
+  symbol?: string;
   createdAt?: Date;
   model?: string | null;
   totalTokens?: number | null;
 }) {
   return {
     tickerId: overrides?.tickerId ?? "ticker-1",
+    ticker: { symbol: overrides?.symbol ?? "AAPL" },
     createdAt: overrides?.createdAt ?? new Date("2026-06-07T08:00:00.000Z"),
     model: overrides?.model !== undefined ? overrides.model : "gpt-4o",
     totalTokens:
@@ -301,9 +303,50 @@ describe("createContentGenerationInsightsProvider", () => {
     expect(typeof runsKpi!.delta).toBe("number");
   });
 
+  it("labels per-ticker newsletter bars with ticker symbol", async () => {
+    const newsletters = [
+      makeNewsletter({ tickerId: "t1", symbol: "AAPL" }),
+      makeNewsletter({ tickerId: "t1", symbol: "AAPL" }),
+      makeNewsletter({ tickerId: "t2", symbol: "MSFT" }),
+    ];
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({ newsletters }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    expect(tickerBar).toBeDefined();
+    if (tickerBar!.widget.kind === "categoryBar") {
+      const labels = tickerBar!.widget.bars.map((b) => b.label);
+      expect(labels).toContain("AAPL");
+      expect(labels).toContain("MSFT");
+      expect(labels).not.toContain("t1");
+      expect(labels).not.toContain("t2");
+    }
+  });
+
+  it("falls back to tickerId when newsletter ticker symbol is missing", async () => {
+    const newsletter = makeNewsletter({ tickerId: "orphan-id" });
+    const newsletterWithNoSymbol = { ...newsletter, ticker: { symbol: undefined as unknown as string } };
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({ newsletters: [newsletterWithNoSymbol] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    if (tickerBar?.widget.kind === "categoryBar") {
+      const labels = tickerBar.widget.bars.map((b) => b.label);
+      expect(labels).toContain("orphan-id");
+    }
+  });
+
   it("caps per-ticker bars at TOP_N + Other bucket", async () => {
     const manyNewsletters = Array.from({ length: 15 }, (_, index) =>
-      makeNewsletter({ tickerId: `ticker-${index}` }),
+      makeNewsletter({ tickerId: `ticker-${index}`, symbol: `SYM${index}` }),
     );
 
     const provider = createContentGenerationInsightsProvider(

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
@@ -35,6 +35,7 @@ type CgRunRow = {
 
 type NewsletterRow = {
   tickerId: string;
+  ticker: { symbol: string };
   createdAt: Date;
   model: string | null;
   totalTokens: number | null;
@@ -70,6 +71,7 @@ type ContentGenerationInsightsDeps = {
       orderBy: { createdAt: "asc" };
       select: {
         tickerId: boolean;
+        ticker: { select: { symbol: boolean } };
         createdAt: boolean;
         model: boolean;
         totalTokens: boolean;
@@ -201,6 +203,7 @@ export function createContentGenerationInsightsProvider(
           orderBy: { createdAt: "asc" },
           select: {
             tickerId: true,
+            ticker: { select: { symbol: true } },
             createdAt: true,
             model: true,
             totalTokens: true,
@@ -482,9 +485,10 @@ export function createContentGenerationInsightsProvider(
       // Where — newsletters by ticker (top-N)
       const tickerNewsletterCounts = new Map<string, number>();
       for (const newsletter of newsletters) {
+        const label = newsletter.ticker?.symbol ?? newsletter.tickerId;
         tickerNewsletterCounts.set(
-          newsletter.tickerId,
-          (tickerNewsletterCounts.get(newsletter.tickerId) ?? 0) + 1,
+          label,
+          (tickerNewsletterCounts.get(label) ?? 0) + 1,
         );
       }
       if (tickerNewsletterCounts.size > 0) {

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
@@ -299,7 +299,10 @@ describe("createDeliveryInsightsProvider", () => {
 
   it("falls back to tickerId when ticker symbol is missing", async () => {
     const run = makeRun({ tickerId: "orphan-id" });
-    const runWithNoSymbol = { ...run, ticker: { symbol: undefined as unknown as string } };
+    const runWithNoSymbol = {
+      ...run,
+      ticker: { symbol: undefined as unknown as string },
+    };
 
     const provider = createDeliveryInsightsProvider(
       makeDeps({ runs: [runWithNoSymbol] }),

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.test.ts
@@ -21,6 +21,7 @@ function makeRecipient(overrides?: {
 
 function makeRun(overrides?: {
   tickerId?: string;
+  symbol?: string;
   outcome?: string;
   stage?: string | null;
   successCount?: number;
@@ -33,6 +34,7 @@ function makeRun(overrides?: {
 }) {
   return {
     tickerId: overrides?.tickerId ?? "ticker-1",
+    ticker: { symbol: overrides?.symbol ?? "AAPL" },
     outcome: overrides?.outcome ?? "success",
     stage: overrides?.stage !== undefined ? overrides.stage : null,
     successCount: overrides?.successCount ?? 3,
@@ -274,9 +276,47 @@ describe("createDeliveryInsightsProvider", () => {
     expect(typeof recipientsKpi!.delta).toBe("number");
   });
 
+  it("labels per-ticker delivery bars with ticker symbol", async () => {
+    const runs = [
+      makeRun({ tickerId: "t1", symbol: "AAPL" }),
+      makeRun({ tickerId: "t1", symbol: "AAPL" }),
+      makeRun({ tickerId: "t2", symbol: "MSFT" }),
+    ];
+
+    const provider = createDeliveryInsightsProvider(makeDeps({ runs }));
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    expect(tickerBar).toBeDefined();
+    if (tickerBar!.widget.kind === "categoryBar") {
+      const labels = tickerBar!.widget.bars.map((b) => b.label);
+      expect(labels).toContain("AAPL");
+      expect(labels).toContain("MSFT");
+      expect(labels).not.toContain("t1");
+      expect(labels).not.toContain("t2");
+    }
+  });
+
+  it("falls back to tickerId when ticker symbol is missing", async () => {
+    const run = makeRun({ tickerId: "orphan-id" });
+    const runWithNoSymbol = { ...run, ticker: { symbol: undefined as unknown as string } };
+
+    const provider = createDeliveryInsightsProvider(
+      makeDeps({ runs: [runWithNoSymbol] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tickerBar = payload.sections.find((s) => s.id === "where-per-ticker");
+
+    if (tickerBar?.widget.kind === "categoryBar") {
+      const labels = tickerBar.widget.bars.map((b) => b.label);
+      expect(labels).toContain("orphan-id");
+    }
+  });
+
   it("caps per-ticker delivery bars at TOP_N + Other bucket", async () => {
     const manyRuns = Array.from({ length: 15 }, (_, index) =>
-      makeRun({ tickerId: `ticker-${index}` }),
+      makeRun({ tickerId: `ticker-${index}`, symbol: `SYM${index}` }),
     );
 
     const provider = createDeliveryInsightsProvider(

--- a/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts
@@ -31,6 +31,7 @@ type RecipientRow = {
 
 type DeliveryRunRow = {
   tickerId: string;
+  ticker: { symbol: string };
   outcome: string;
   stage: string | null;
   successCount: number;
@@ -53,6 +54,7 @@ type DeliveryInsightsDeps = {
       orderBy: { createdAt: "asc" };
       select: {
         tickerId: boolean;
+        ticker: { select: { symbol: boolean } };
         outcome: boolean;
         stage: boolean;
         successCount: boolean;
@@ -134,6 +136,7 @@ export function createDeliveryInsightsProvider(
 
       const runSelect = {
         tickerId: true,
+        ticker: { select: { symbol: true } },
         outcome: true,
         stage: true,
         successCount: true,
@@ -402,9 +405,10 @@ export function createDeliveryInsightsProvider(
       // Where — per-ticker delivery counts (categoryBar, top-N)
       const tickerDeliveryCounts = new Map<string, number>();
       for (const run of runs) {
+        const label = run.ticker?.symbol ?? run.tickerId;
         tickerDeliveryCounts.set(
-          run.tickerId,
-          (tickerDeliveryCounts.get(run.tickerId) ?? 0) + 1,
+          label,
+          (tickerDeliveryCounts.get(label) ?? 0) + 1,
         );
       }
       if (tickerDeliveryCounts.size > 0) {


### PR DESCRIPTION
## Summary

Three of the six insights providers were labeling their "by ticker" category bars with raw `tickerId` UUIDs instead of human-readable ticker symbols. This PR brings article-analysis, delivery, and content-generation in line with the three providers that already label by `ticker.symbol`, so every "by ticker" chart on the Insights page shows symbols like "AAPL" or "MSFT".

## Related issues

Closes #752

## Important changes

- Each of the three providers now includes `ticker: { select: { symbol: true } }` in its relevant query select. No extra queries — the symbol comes from the same relation fetch.
- The per-ticker aggregation keys on `ticker?.symbol ?? tickerId` so a row with a missing symbol falls back gracefully rather than crashing or being dropped.
- The local row types (`ArticleRelevanceRow`, `DeliveryRunRow`, `NewsletterRow`) are updated with `ticker: { symbol: string }` to keep the type and the select in lockstep.

## Other changes

- Provider tests updated: factory helpers (`makeRelevance`, `makeRun`, `makeNewsletter`) now produce `ticker: { symbol }` fixtures; existing "caps per-ticker bars" tests pass symbols; new "labels bars with ticker symbol" and "falls back to tickerId" tests added to each file.

## Key files to review

- [article-analysis-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts) — `ArticleRelevanceRow` type, query select, aggregation loop
- [delivery-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/delivery-insights-provider.ts) — `DeliveryRunRow` type, `runSelect` constant, aggregation loop
- [content-generation-insights-provider.ts](apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts) — `NewsletterRow` type, query select, aggregation loop

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — all 239 tests should pass including the new symbol-label and fallback cases.
2. Open an article-analysis, delivery, or content-generation agent in the Hermes dashboard, go to Insights, and confirm the "by ticker" bar chart labels show symbols (e.g. "AAPL") rather than UUID strings.
3. Cross-check against a data-collection agent (already worked before this PR) for visual consistency.
