### PR TITLE
Add per-item titles to newsletter bullets and quick hits

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/format-industry-newsletter.ts
@@ -18,6 +18,7 @@ const PROSE = "PROSE";
 const FORMAT = "FORMAT";
 const BULLET = "BULLET";
 const ITEM = "ITEM";
+const TITLE = "TITLE";
 
 /**
  * Collapses internal whitespace so display headings stay a single wire line.
@@ -94,7 +95,7 @@ export const formatIndustryNewsletterWire = (
   const pushBulletSection = (
     machineKey: string,
     displayHeading: string,
-    bullets: ReadonlyArray<{ text: string; url?: string }>,
+    bullets: ReadonlyArray<{ title?: string; text: string; url?: string }>,
   ): void => {
     const lines: string[] = [
       `${BEGIN} ${machineKey}`,
@@ -102,10 +103,11 @@ export const formatIndustryNewsletterWire = (
       collapseHeadingLine(displayHeading),
     ];
     for (const b of bullets) {
-      lines.push(
-        BULLET,
-        withOptionalReadLine(stripArticleMarkers(b.text), b.url),
-      );
+      lines.push(BULLET);
+      if (b.title !== undefined && b.title.trim().length > 0) {
+        lines.push(`${TITLE} ${b.title.trim()}`);
+      }
+      lines.push(withOptionalReadLine(stripArticleMarkers(b.text), b.url));
     }
     lines.push(END);
     pushBlock(lines.join("\n"));
@@ -177,10 +179,11 @@ export const formatIndustryNewsletterWire = (
           "bullets",
         ];
         for (const b of d.bullets) {
-          lines.push(
-            BULLET,
-            withOptionalReadLine(stripArticleMarkers(b.text), b.url),
-          );
+          lines.push(BULLET);
+          if (b.title !== undefined && b.title.trim().length > 0) {
+            lines.push(`${TITLE} ${b.title.trim()}`);
+          }
+          lines.push(withOptionalReadLine(stripArticleMarkers(b.text), b.url));
         }
         lines.push(END);
         pushBlock(lines.join("\n"));
@@ -199,8 +202,11 @@ export const formatIndustryNewsletterWire = (
         collapseHeadingLine(briefing.quickHits.displayHeading),
       ];
       for (const item of briefing.quickHits.items) {
+        qhLines.push(ITEM);
+        if (item.title !== undefined && item.title.trim().length > 0) {
+          qhLines.push(`${TITLE} ${item.title.trim()}`);
+        }
         qhLines.push(
-          ITEM,
           withOptionalReadLine(stripArticleMarkers(item.text), item.url),
         );
       }

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.test.ts
@@ -50,15 +50,18 @@ describe("industryNewsletterStructureSchema", () => {
       industryPulse: { displayHeading: "L", prose: "p" },
       competitiveLandscape: {
         displayHeading: "C",
-        bullets: [{ text: "b1", articleIndex: 1 }, { text: "b2" }],
+        bullets: [
+          { title: "T1", text: "b1", articleIndex: 1 },
+          { title: "T2", text: "b2" },
+        ],
       },
       dealsAndMovements: {
         displayHeading: "D",
-        bullets: [{ text: "d1" }],
+        bullets: [{ title: "T3", text: "d1" }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "R",
-        bullets: [{ text: "r1" }],
+        bullets: [{ title: "T4", text: "r1" }],
       },
       disruptorsOrTech: {
         format: "prose",
@@ -68,11 +71,11 @@ describe("industryNewsletterStructureSchema", () => {
       quickHits: {
         displayHeading: "Q",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 1 },
-          { text: "h4", articleIndex: 2 },
-          { text: "h5", articleIndex: 1 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 1 },
+          { title: "Q4", text: "h4", articleIndex: 2 },
+          { title: "Q5", text: "h5", articleIndex: 1 },
         ],
       },
     });
@@ -88,29 +91,29 @@ describe("industryNewsletterStructureSchema", () => {
         industryPulse: { displayHeading: "L", prose: "p" },
         competitiveLandscape: {
           displayHeading: "C",
-          bullets: [{ text: "only", articleIndex: 1 }],
+          bullets: [{ title: "T1", text: "only", articleIndex: 1 }],
         },
         dealsAndMovements: {
           displayHeading: "D",
-          bullets: [{ text: "d1" }],
+          bullets: [{ title: "T2", text: "d1" }],
         },
         regulatoryPolicyWatch: {
           displayHeading: "R",
-          bullets: [{ text: "r1" }],
+          bullets: [{ title: "T3", text: "r1" }],
         },
         disruptorsOrTech: {
           format: "bullets",
           displayHeading: "X",
-          bullets: [{ text: "b" }],
+          bullets: [{ title: "T4", text: "b" }],
         },
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "h1", articleIndex: 1 },
-            { text: "h2", articleIndex: 1 },
-            { text: "h3", articleIndex: 1 },
-            { text: "h4", articleIndex: 1 },
-            { text: "h5", articleIndex: 1 },
+            { title: "Q1", text: "h1", articleIndex: 1 },
+            { title: "Q2", text: "h2", articleIndex: 1 },
+            { title: "Q3", text: "h3", articleIndex: 1 },
+            { title: "Q4", text: "h4", articleIndex: 1 },
+            { title: "Q5", text: "h5", articleIndex: 1 },
           ],
         },
       }),
@@ -144,17 +147,17 @@ describe("industryNewsletterStructureLlmSchema", () => {
       competitiveLandscape: {
         displayHeading: "C",
         bullets: [
-          { text: "b1", articleIndex: 1 },
-          { text: "b2", articleIndex: null },
+          { title: "T1", text: "b1", articleIndex: 1 },
+          { title: "T2", text: "b2", articleIndex: null },
         ],
       },
       dealsAndMovements: {
         displayHeading: "D",
-        bullets: [{ text: "d1", articleIndex: null }],
+        bullets: [{ title: "T3", text: "d1", articleIndex: null }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "R",
-        bullets: [{ text: "r1", articleIndex: 2 }],
+        bullets: [{ title: "T4", text: "r1", articleIndex: 2 }],
       },
       disruptorsOrTech: {
         format: "prose",
@@ -164,17 +167,20 @@ describe("industryNewsletterStructureLlmSchema", () => {
       quickHits: {
         displayHeading: "Q",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 1 },
-          { text: "h4", articleIndex: 2 },
-          { text: "h5", articleIndex: 1 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 1 },
+          { title: "Q4", text: "h4", articleIndex: 2 },
+          { title: "Q5", text: "h5", articleIndex: 1 },
         ],
       },
     });
 
     expect(industryNewsletterStructureSchema.parse(parsed)).toEqual(parsed);
-    expect(parsed.competitiveLandscape.bullets[1]).toEqual({ text: "b2" });
+    expect(parsed.competitiveLandscape.bullets[1]).toEqual({
+      title: "T2",
+      text: "b2",
+    });
     expect(parsed.industryPulse.articleIndex).toBeUndefined();
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts
@@ -5,12 +5,14 @@ const articleIndexSchema = z.number().int().positive();
 
 /** A bullet that may optionally cite a source article by index. */
 export const industryBriefBulletSchema = z.object({
+  title: z.string().min(1),
   text: z.string().min(1),
   articleIndex: articleIndexSchema.optional(),
 });
 
 /** Quick hit line; every hit must cite an article for grounded links. */
 export const industryQuickHitSchema = z.object({
+  title: z.string().min(1),
   text: z.string().min(1),
   articleIndex: articleIndexSchema,
 });
@@ -76,15 +78,20 @@ const normalizeOptionalArticleIndex = (
 /** OpenAI strict JSON schema requires every property key in `required`; bullets use null when uncited. */
 const industryBriefBulletLlmSchema = z
   .object({
+    title: z.string().min(1),
     text: z.string().min(1),
     articleIndex: z.union([articleIndexSchema, z.null()]),
   })
   .transform(
-    ({ text, articleIndex }): z.infer<typeof industryBriefBulletSchema> => {
+    ({
+      title,
+      text,
+      articleIndex,
+    }): z.infer<typeof industryBriefBulletSchema> => {
       const normalizedIndex = normalizeOptionalArticleIndex(articleIndex);
       return normalizedIndex === undefined
-        ? { text }
-        : { text, articleIndex: normalizedIndex };
+        ? { title, text }
+        : { title, text, articleIndex: normalizedIndex };
     },
   );
 

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-urls.ts
@@ -7,12 +7,14 @@ export type IndustryNewsletterSourceRow = {
 
 /** Bullet with an optional grounded article URL. */
 export type IndustryBulletResolved = {
+  title?: string;
   text: string;
   url?: string;
 };
 
 /** Quick hit with a grounded article URL when the index resolves. */
 export type IndustryQuickHitResolved = {
+  title?: string;
   text: string;
   url?: string;
 };
@@ -89,17 +91,21 @@ export const attachIndustryNewsletterSourceUrls = (
   sources: ReadonlyArray<IndustryNewsletterSourceRow>,
 ): IndustryNewsletterResolved => {
   const mapBullet = (b: {
+    title: string;
     text: string;
     articleIndex?: number;
   }): IndustryBulletResolved => ({
+    title: b.title,
     text: b.text,
     url: resolveArticleUrlForIndustryNewsletter(b.articleIndex, sources),
   });
 
   const mapHit = (h: {
+    title: string;
     text: string;
     articleIndex: number;
   }): IndustryQuickHitResolved => ({
+    title: h.title,
     text: h.text,
     url: resolveArticleUrlForIndustryNewsletter(h.articleIndex, sources),
   });

--- a/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/industry-newsletter-wire.test.ts
@@ -38,19 +38,28 @@ describe("industryNewsletterStructureSchema — industryPulse articleIndex", () 
       industryPulse: { displayHeading: "L", prose: "p" },
       competitiveLandscape: {
         displayHeading: "C",
-        bullets: [{ text: "b1" }, { text: "b2" }],
+        bullets: [
+          { title: "T1", text: "b1" },
+          { title: "T2", text: "b2" },
+        ],
       },
-      dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
-      regulatoryPolicyWatch: { displayHeading: "R", bullets: [{ text: "r1" }] },
+      dealsAndMovements: {
+        displayHeading: "D",
+        bullets: [{ title: "T3", text: "d1" }],
+      },
+      regulatoryPolicyWatch: {
+        displayHeading: "R",
+        bullets: [{ title: "T4", text: "r1" }],
+      },
       disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
       quickHits: {
         displayHeading: "Q",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 1 },
-          { text: "h3", articleIndex: 1 },
-          { text: "h4", articleIndex: 1 },
-          { text: "h5", articleIndex: 1 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 1 },
+          { title: "Q3", text: "h3", articleIndex: 1 },
+          { title: "Q4", text: "h4", articleIndex: 1 },
+          { title: "Q5", text: "h5", articleIndex: 1 },
         ],
       },
     });
@@ -66,19 +75,28 @@ describe("industryNewsletterStructureSchema — industryPulse articleIndex", () 
       industryPulse: { displayHeading: "L", prose: "p", articleIndex: 2 },
       competitiveLandscape: {
         displayHeading: "C",
-        bullets: [{ text: "b1" }, { text: "b2" }],
+        bullets: [
+          { title: "T1", text: "b1" },
+          { title: "T2", text: "b2" },
+        ],
       },
-      dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
-      regulatoryPolicyWatch: { displayHeading: "R", bullets: [{ text: "r1" }] },
+      dealsAndMovements: {
+        displayHeading: "D",
+        bullets: [{ title: "T3", text: "d1" }],
+      },
+      regulatoryPolicyWatch: {
+        displayHeading: "R",
+        bullets: [{ title: "T4", text: "r1" }],
+      },
       disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
       quickHits: {
         displayHeading: "Q",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 1 },
-          { text: "h3", articleIndex: 1 },
-          { text: "h4", articleIndex: 1 },
-          { text: "h5", articleIndex: 1 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 1 },
+          { title: "Q3", text: "h3", articleIndex: 1 },
+          { title: "Q4", text: "h4", articleIndex: 1 },
+          { title: "Q5", text: "h5", articleIndex: 1 },
         ],
       },
     });
@@ -96,31 +114,31 @@ describe("attachIndustryNewsletterSourceUrls", () => {
     competitiveLandscape: {
       displayHeading: "C",
       bullets: [
-        { text: "b1", articleIndex: 1 },
-        { text: "b2", articleIndex: 99 },
+        { title: "T1", text: "b1", articleIndex: 1 },
+        { title: "T2", text: "b2", articleIndex: 99 },
       ],
     },
     dealsAndMovements: {
       displayHeading: "D",
-      bullets: [{ text: "d1" }],
+      bullets: [{ title: "T3", text: "d1" }],
     },
     regulatoryPolicyWatch: {
       displayHeading: "R",
-      bullets: [{ text: "r1" }],
+      bullets: [{ title: "T4", text: "r1" }],
     },
     disruptorsOrTech: {
       format: "bullets",
       displayHeading: "X",
-      bullets: [{ text: "x", articleIndex: 2 }],
+      bullets: [{ title: "T5", text: "x", articleIndex: 2 }],
     },
     quickHits: {
       displayHeading: "Q",
       items: [
-        { text: "h1", articleIndex: 1 },
-        { text: "h2", articleIndex: 2 },
-        { text: "h3", articleIndex: 1 },
-        { text: "h4", articleIndex: 2 },
-        { text: "h5", articleIndex: 1 },
+        { title: "Q1", text: "h1", articleIndex: 1 },
+        { title: "Q2", text: "h2", articleIndex: 2 },
+        { title: "Q3", text: "h3", articleIndex: 1 },
+        { title: "Q4", text: "h4", articleIndex: 2 },
+        { title: "Q5", text: "h5", articleIndex: 1 },
       ],
     },
   });
@@ -170,7 +188,7 @@ describe("stripArticleMarkers", () => {
 });
 
 describe("formatIndustryNewsletterWire", () => {
-  it("starts with the wire marker and emits read lines", () => {
+  it("starts with the wire marker and emits read lines with item titles", () => {
     const resolved = attachIndustryNewsletterSourceUrls(
       industryNewsletterStructureSchema.parse({
         subject: "S",
@@ -178,17 +196,17 @@ describe("formatIndustryNewsletterWire", () => {
         competitiveLandscape: {
           displayHeading: "C",
           bullets: [
-            { text: "b1", articleIndex: 1 },
-            { text: "b2", articleIndex: 1 },
+            { title: "Rival A Launches", text: "b1", articleIndex: 1 },
+            { title: "Rival B Expands", text: "b2", articleIndex: 1 },
           ],
         },
         dealsAndMovements: {
           displayHeading: "D",
-          bullets: [{ text: "d1" }],
+          bullets: [{ title: "Deal Closed", text: "d1" }],
         },
         regulatoryPolicyWatch: {
           displayHeading: "R",
-          bullets: [{ text: "r1" }],
+          bullets: [{ title: "New Rule", text: "r1" }],
         },
         disruptorsOrTech: {
           format: "prose",
@@ -198,11 +216,11 @@ describe("formatIndustryNewsletterWire", () => {
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "h1", articleIndex: 1 },
-            { text: "h2", articleIndex: 1 },
-            { text: "h3", articleIndex: 1 },
-            { text: "h4", articleIndex: 1 },
-            { text: "h5", articleIndex: 1 },
+            { title: "Hit One", text: "h1", articleIndex: 1 },
+            { title: "Hit Two", text: "h2", articleIndex: 1 },
+            { title: "Hit Three", text: "h3", articleIndex: 1 },
+            { title: "Hit Four", text: "h4", articleIndex: 1 },
+            { title: "Hit Five", text: "h5", articleIndex: 1 },
           ],
         },
       }),
@@ -212,6 +230,8 @@ describe("formatIndustryNewsletterWire", () => {
     const wire = formatIndustryNewsletterWire(resolved);
 
     expect(wire.startsWith(`${INDUSTRY_NEWSLETTER_WIRE_MARKER}\n`)).toBe(true);
+    expect(wire).toContain("TITLE Rival A Launches");
+    expect(wire).toContain("TITLE Hit One");
     expect(wire).toContain("Read the full article: https://src.example");
   });
 
@@ -229,10 +249,12 @@ describe("formatIndustryNewsletterWire", () => {
           displayHeading: "Competition",
           bullets: [
             {
+              title: "Rivals Underbid",
               text: "Rivals underbid on packages but the consortium still won (Article 1).",
               articleIndex: 1,
             },
             {
+              title: "Fleet Oversupply",
               text: "Fleet oversupply is squeezing day-rate spreads across contractors (Article 4).",
               articleIndex: 2,
             },
@@ -242,6 +264,7 @@ describe("formatIndustryNewsletterWire", () => {
           displayHeading: "Deals",
           bullets: [
             {
+              title: "Award Locks Revenue",
               text: "The award locks in multi-year revenue  (article  12).",
               articleIndex: 2,
             },
@@ -251,6 +274,7 @@ describe("formatIndustryNewsletterWire", () => {
           displayHeading: "Policy",
           bullets: [
             {
+              title: "Permit Acceleration",
               text: "Permit acceleration usually precedes a civil-works spike (Article 5).",
               articleIndex: 1,
             },
@@ -261,6 +285,7 @@ describe("formatIndustryNewsletterWire", () => {
           displayHeading: "Tech",
           bullets: [
             {
+              title: "Electricity Pricing",
               text: "Electricity pricing is the gating item for new capacity (Article 2).",
               articleIndex: 2,
             },
@@ -270,22 +295,27 @@ describe("formatIndustryNewsletterWire", () => {
           displayHeading: "Quick hits",
           items: [
             {
+              title: "Consortium Signs Dredging Package",
               text: "Consortium signed the dredging package (Article 1).",
               articleIndex: 1,
             },
             {
+              title: "JV Delays on Tariff Talks",
               text: "JV pushed startup as tariff talks dragged (Article 2).",
               articleIndex: 2,
             },
             {
+              title: "Export Levy Splits Peers",
               text: "Export levy split plantation peers (Article 3).",
               articleIndex: 1,
             },
             {
+              title: "Equipment Spreads Narrow",
               text: "Equipment spreads narrowed (Article 4).",
               articleIndex: 2,
             },
             {
+              title: "Industrial Permits on Fast Track",
               text: "Industrial permits on a fast track (Article 5).",
               articleIndex: 1,
             },
@@ -356,15 +386,18 @@ describe("formatIndustryNewsletterWire", () => {
         industryPulse: { displayHeading: "Lead", prose: "Pulse prose." },
         competitiveLandscape: {
           displayHeading: "C",
-          bullets: [{ text: "c1", articleIndex: 1 }, { text: "c2" }],
+          bullets: [
+            { title: "T1", text: "c1", articleIndex: 1 },
+            { title: "T2", text: "c2" },
+          ],
         },
         dealsAndMovements: {
           displayHeading: "Deals",
-          bullets: [{ text: "d1" }],
+          bullets: [{ title: "T3", text: "d1" }],
         },
         regulatoryPolicyWatch: {
           displayHeading: "R",
-          bullets: [{ text: "r1" }],
+          bullets: [{ title: "T4", text: "r1" }],
         },
         disruptorsOrTech: {
           format: "prose",
@@ -374,11 +407,11 @@ describe("formatIndustryNewsletterWire", () => {
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "h1", articleIndex: 1 },
-            { text: "h2", articleIndex: 1 },
-            { text: "h3", articleIndex: 1 },
-            { text: "h4", articleIndex: 1 },
-            { text: "h5", articleIndex: 1 },
+            { title: "Q1", text: "h1", articleIndex: 1 },
+            { title: "Q2", text: "h2", articleIndex: 1 },
+            { title: "Q3", text: "h3", articleIndex: 1 },
+            { title: "Q4", text: "h4", articleIndex: 1 },
+            { title: "Q5", text: "h5", articleIndex: 1 },
           ],
         },
       }),
@@ -417,24 +450,27 @@ describe("formatIndustryNewsletterWire", () => {
         competitiveLandscape: {
           displayHeading: "C",
           bullets: [
-            { text: "c1", articleIndex: 1 },
-            { text: "c2", articleIndex: 1 },
+            { title: "T1", text: "c1", articleIndex: 1 },
+            { title: "T2", text: "c2", articleIndex: 1 },
           ],
         },
-        dealsAndMovements: { displayHeading: "D", bullets: [{ text: "d1" }] },
+        dealsAndMovements: {
+          displayHeading: "D",
+          bullets: [{ title: "T3", text: "d1" }],
+        },
         regulatoryPolicyWatch: {
           displayHeading: "R",
-          bullets: [{ text: "r1" }],
+          bullets: [{ title: "T4", text: "r1" }],
         },
         disruptorsOrTech: { format: "prose", displayHeading: "X", prose: "pr" },
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "h1", articleIndex: 1 },
-            { text: "h2", articleIndex: 1 },
-            { text: "h3", articleIndex: 1 },
-            { text: "h4", articleIndex: 1 },
-            { text: "h5", articleIndex: 1 },
+            { title: "Q1", text: "h1", articleIndex: 1 },
+            { title: "Q2", text: "h2", articleIndex: 1 },
+            { title: "Q3", text: "h3", articleIndex: 1 },
+            { title: "Q4", text: "h4", articleIndex: 1 },
+            { title: "Q5", text: "h5", articleIndex: 1 },
           ],
         },
       }),
@@ -507,17 +543,17 @@ describe("formatIndustryNewsletterWire", () => {
         competitiveLandscape: {
           displayHeading: "C",
           bullets: [
-            { text: "Clean bullet.", articleIndex: 1 },
-            { text: "Second clean bullet.", articleIndex: 1 },
+            { title: "T1", text: "Clean bullet.", articleIndex: 1 },
+            { title: "T2", text: "Second clean bullet.", articleIndex: 1 },
           ],
         },
         dealsAndMovements: {
           displayHeading: "D",
-          bullets: [{ text: "Another clean bullet." }],
+          bullets: [{ title: "T3", text: "Another clean bullet." }],
         },
         regulatoryPolicyWatch: {
           displayHeading: "R",
-          bullets: [{ text: "Policy bullet." }],
+          bullets: [{ title: "T4", text: "Policy bullet." }],
         },
         disruptorsOrTech: {
           format: "prose",
@@ -527,11 +563,11 @@ describe("formatIndustryNewsletterWire", () => {
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "Hit one", articleIndex: 1 },
-            { text: "Hit two", articleIndex: 1 },
-            { text: "Hit three", articleIndex: 1 },
-            { text: "Hit four", articleIndex: 1 },
-            { text: "Hit five", articleIndex: 1 },
+            { title: "Q1", text: "Hit one", articleIndex: 1 },
+            { title: "Q2", text: "Hit two", articleIndex: 1 },
+            { title: "Q3", text: "Hit three", articleIndex: 1 },
+            { title: "Q4", text: "Hit four", articleIndex: 1 },
+            { title: "Q5", text: "Hit five", articleIndex: 1 },
           ],
         },
       }),

--- a/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.test.ts
@@ -29,17 +29,17 @@ const minimalStructure = (
   competitiveLandscape: {
     displayHeading: "Competitive",
     bullets: [
-      { text: "Peer A expanded share.", articleIndex: 1 },
-      { text: "Peer B held steady.", articleIndex: 1 },
+      { title: "T1", text: "Peer A expanded share.", articleIndex: 1 },
+      { title: "T2", text: "Peer B held steady.", articleIndex: 1 },
     ],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "No major deals.", articleIndex: 1 }],
+    bullets: [{ title: "T3", text: "No major deals.", articleIndex: 1 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Policy",
-    bullets: [{ text: "Rules unchanged.", articleIndex: 1 }],
+    bullets: [{ title: "T4", text: "Rules unchanged.", articleIndex: 1 }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -49,11 +49,11 @@ const minimalStructure = (
   quickHits: {
     displayHeading: "Hits",
     items: [
-      { text: "Hit 1", articleIndex: 1 },
-      { text: "Hit 2", articleIndex: 1 },
-      { text: "Hit 3", articleIndex: 1 },
-      { text: "Hit 4", articleIndex: 1 },
-      { text: "Hit 5", articleIndex: 1 },
+      { title: "Q1", text: "Hit 1", articleIndex: 1 },
+      { title: "Q2", text: "Hit 2", articleIndex: 1 },
+      { title: "Q3", text: "Hit 3", articleIndex: 1 },
+      { title: "Q4", text: "Hit 4", articleIndex: 1 },
+      { title: "Q5", text: "Hit 5", articleIndex: 1 },
     ],
   },
   ...patch,
@@ -91,10 +91,15 @@ describe("groundNewsletterCitations", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "BCA reported Q1 net profit of Rp 12.4 trillion",
             articleIndex: 1,
           },
-          { text: "Unrelated mining shipment volumes rose.", articleIndex: 2 },
+          {
+            title: "T2",
+            text: "Unrelated mining shipment volumes rose.",
+            articleIndex: 2,
+          },
         ],
       },
     });
@@ -127,8 +132,13 @@ describe("groundNewsletterCitations", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "Unrelated mining shipment volumes rose.", articleIndex: 1 },
           {
+            title: "T1",
+            text: "Unrelated mining shipment volumes rose.",
+            articleIndex: 1,
+          },
+          {
+            title: "T2",
             text: "Another unrelated nickel export headline.",
             articleIndex: 1,
           },
@@ -136,20 +146,36 @@ describe("groundNewsletterCitations", () => {
       },
       dealsAndMovements: {
         displayHeading: "Deals",
-        bullets: [{ text: "No major deals this week." }],
+        bullets: [{ title: "T3", text: "No major deals this week." }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Policy",
-        bullets: [{ text: "Rules unchanged this week." }],
+        bullets: [{ title: "T4", text: "Rules unchanged this week." }],
       },
       quickHits: {
         displayHeading: "Hits",
         items: [
-          { text: "Nickel ore volumes increased.", articleIndex: 1 },
-          { text: "Smelter demand picked up.", articleIndex: 1 },
-          { text: "Mining contractors shipped more ore.", articleIndex: 1 },
-          { text: "Eastern Indonesia output rose.", articleIndex: 1 },
-          { text: "Higher nickel ore volumes noted.", articleIndex: 1 },
+          {
+            title: "Q1",
+            text: "Nickel ore volumes increased.",
+            articleIndex: 1,
+          },
+          { title: "Q2", text: "Smelter demand picked up.", articleIndex: 1 },
+          {
+            title: "Q3",
+            text: "Mining contractors shipped more ore.",
+            articleIndex: 1,
+          },
+          {
+            title: "Q4",
+            text: "Eastern Indonesia output rose.",
+            articleIndex: 1,
+          },
+          {
+            title: "Q5",
+            text: "Higher nickel ore volumes noted.",
+            articleIndex: 1,
+          },
         ],
       },
     });

--- a/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/citation-grounding.ts
@@ -183,15 +183,18 @@ export const percentile = (values: readonly number[], p: number): number => {
  * @param bullet - Bullet with optional citation.
  * @param decision - Grounding decision for this row.
  */
-const applyOptionalBulletDecision = (
-  bullet: { text: string; articleIndex?: number },
+const applyOptionalBulletDecision = <
+  T extends { text: string; articleIndex?: number },
+>(
+  bullet: T,
   decision: GroundingDecision,
-): { text: string; articleIndex?: number } | null => {
+): Omit<T, "articleIndex"> | T | null => {
   if (decision.kind === "drop") {
     return null;
   }
   if (decision.kind === "unlink") {
-    return { text: bullet.text };
+    const { articleIndex: _articleIndex, ...rest } = bullet;
+    return rest as Omit<T, "articleIndex">;
   }
   return bullet;
 };
@@ -343,8 +346,8 @@ export const groundNewsletterCitations = (
 
   const applyBulletArray = (
     sectionKey: string,
-    bullets: Array<{ text: string; articleIndex?: number }>,
-  ): Array<{ text: string; articleIndex?: number }> => {
+    bullets: Array<{ title: string; text: string; articleIndex?: number }>,
+  ): Array<{ title: string; text: string; articleIndex?: number }> => {
     return bullets.flatMap((bullet, bulletIndex) => {
       if (bullet.articleIndex === undefined) {
         return [bullet];

--- a/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/competitive-landscape-focus.test.ts
@@ -25,11 +25,11 @@ const makeStructure = (
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "Deal A", articleIndex: 1 }],
+    bullets: [{ title: "Deal A", text: "Deal A", articleIndex: 1 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Regulatory",
-    bullets: [{ text: "Rule B" }],
+    bullets: [{ title: "Rule B", text: "Rule B" }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -39,11 +39,11 @@ const makeStructure = (
   quickHits: {
     displayHeading: "Quick Hits",
     items: [
-      { text: "h1", articleIndex: 1 },
-      { text: "h2", articleIndex: 2 },
-      { text: "h3", articleIndex: 3 },
-      { text: "h4", articleIndex: 4 },
-      { text: "h5", articleIndex: 5 },
+      { title: "h1", text: "h1", articleIndex: 1 },
+      { title: "h2", text: "h2", articleIndex: 2 },
+      { title: "h3", text: "h3", articleIndex: 3 },
+      { title: "h4", text: "h4", articleIndex: 4 },
+      { title: "h5", text: "h5", articleIndex: 5 },
     ],
   },
 });
@@ -96,8 +96,13 @@ describe("mentionsAny — mention detection", () => {
 describe("enforceCompetitiveFocus — issuer-only drop", () => {
   it("drops an issuer-only bullet under drop policy", () => {
     const structure = makeStructure([
-      { text: "BBCA expanded its digital channels", articleIndex: 1 },
       {
+        title: "BBCA digital expansion",
+        text: "BBCA expanded its digital channels",
+        articleIndex: 1,
+      },
+      {
+        title: "Mandiri SME rate cut pressures BBCA",
         text: "Bank Mandiri cut SME lending rates, pressuring BBCA",
         articleIndex: 2,
       },
@@ -122,10 +127,12 @@ describe("enforceCompetitiveFocus — issuer-only drop", () => {
   it("keeps a bullet that mentions both issuer and competitor", () => {
     const structure = makeStructure([
       {
+        title: "Mandiri undercuts BBCA on SME rates",
         text: "Bank Mandiri undercut BBCA on SME rates",
         articleIndex: 1,
       },
       {
+        title: "BRI gains share at BCA's expense",
         text: "BRI gained digital market share at BCA's expense",
         articleIndex: 2,
       },
@@ -145,8 +152,16 @@ describe("enforceCompetitiveFocus — issuer-only drop", () => {
 
   it("keeps a generic bullet that mentions neither issuer nor competitor", () => {
     const structure = makeStructure([
-      { text: "Sector-wide credit tightening continues", articleIndex: 1 },
-      { text: "Regulatory reform may reshape lending", articleIndex: 2 },
+      {
+        title: "Sector-wide credit tightening",
+        text: "Sector-wide credit tightening continues",
+        articleIndex: 1,
+      },
+      {
+        title: "Regulatory reform ahead",
+        text: "Regulatory reform may reshape lending",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -163,8 +178,16 @@ describe("enforceCompetitiveFocus — issuer-only drop", () => {
 
   it("flags an issuer-only bullet under flag policy (prepends marker)", () => {
     const structure = makeStructure([
-      { text: "BBCA expanded its digital channels", articleIndex: 1 },
-      { text: "Bank Mandiri launched a new SME product", articleIndex: 2 },
+      {
+        title: "BBCA digital expansion",
+        text: "BBCA expanded its digital channels",
+        articleIndex: 1,
+      },
+      {
+        title: "Mandiri new SME product",
+        text: "Bank Mandiri launched a new SME product",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -183,8 +206,16 @@ describe("enforceCompetitiveFocus — issuer-only drop", () => {
 
   it("does not drop bullets under warn policy", () => {
     const structure = makeStructure([
-      { text: "BBCA expanded its digital channels", articleIndex: 1 },
-      { text: "BCA internal strategy unchanged", articleIndex: 2 },
+      {
+        title: "BBCA digital expansion",
+        text: "BBCA expanded its digital channels",
+        articleIndex: 1,
+      },
+      {
+        title: "BCA internal strategy unchanged",
+        text: "BCA internal strategy unchanged",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -206,8 +237,16 @@ describe("enforceCompetitiveFocus — issuer-only drop", () => {
 describe("enforceCompetitiveFocus — empty competitors is a no-op", () => {
   it("returns unchanged structure with evaluated=0 when competitors is empty", () => {
     const structure = makeStructure([
-      { text: "BBCA expanded its digital channels", articleIndex: 1 },
-      { text: "BCA raised its dividend yield", articleIndex: 2 },
+      {
+        title: "BBCA digital expansion",
+        text: "BBCA expanded its digital channels",
+        articleIndex: 1,
+      },
+      {
+        title: "BCA raised dividend yield",
+        text: "BCA raised its dividend yield",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -231,8 +270,16 @@ describe("enforceCompetitiveFocus — empty competitors is a no-op", () => {
 describe("enforceCompetitiveFocus — floor vs prune handoff", () => {
   it("downgrades drops to flags when require-citation is OFF and all bullets are issuer-only", () => {
     const structure = makeStructure([
-      { text: "BBCA launched a new savings product", articleIndex: 1 },
-      { text: "Bank Central Asia expanded branch network", articleIndex: 2 },
+      {
+        title: "BBCA new savings product",
+        text: "BBCA launched a new savings product",
+        articleIndex: 1,
+      },
+      {
+        title: "BCA branch network expanded",
+        text: "Bank Central Asia expanded branch network",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -254,9 +301,21 @@ describe("enforceCompetitiveFocus — floor vs prune handoff", () => {
 
   it("drops one bullet and flags the rest when require-citation is OFF and 3 of 3 are issuer-only", () => {
     const structure = makeStructure([
-      { text: "BBCA opened new branches", articleIndex: 1 },
-      { text: "BCA upgraded its mobile app", articleIndex: 2 },
-      { text: "Bank Central Asia raised its dividend", articleIndex: 3 },
+      {
+        title: "BBCA new branch openings",
+        text: "BBCA opened new branches",
+        articleIndex: 1,
+      },
+      {
+        title: "BCA mobile app upgrade",
+        text: "BCA upgraded its mobile app",
+        articleIndex: 2,
+      },
+      {
+        title: "BCA raised dividend",
+        text: "Bank Central Asia raised its dividend",
+        articleIndex: 3,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {
@@ -274,8 +333,16 @@ describe("enforceCompetitiveFocus — floor vs prune handoff", () => {
 
   it("drops all issuer-only bullets when require-citation is ON, allowing the section to empty", () => {
     const structure = makeStructure([
-      { text: "BBCA launched a new savings product", articleIndex: 1 },
-      { text: "Bank Central Asia expanded branch network", articleIndex: 2 },
+      {
+        title: "BBCA new savings product",
+        text: "BBCA launched a new savings product",
+        articleIndex: 1,
+      },
+      {
+        title: "BCA branch network expanded",
+        text: "Bank Central Asia expanded branch network",
+        articleIndex: 2,
+      },
     ]);
 
     const result = enforceCompetitiveFocus(structure, {

--- a/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.test.ts
@@ -17,17 +17,17 @@ const minimalStructure = (
   competitiveLandscape: {
     displayHeading: "Competitive",
     bullets: [
-      { text: "B1", articleIndex: 1 },
-      { text: "B2", articleIndex: 2 },
+      { title: "T1", text: "B1", articleIndex: 1 },
+      { title: "T2", text: "B2", articleIndex: 2 },
     ],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "D1", articleIndex: 3 }],
+    bullets: [{ title: "T3", text: "D1", articleIndex: 3 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Regulatory",
-    bullets: [{ text: "R1" }],
+    bullets: [{ title: "T4", text: "R1" }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -37,11 +37,11 @@ const minimalStructure = (
   quickHits: {
     displayHeading: "Quick",
     items: [
-      { text: "h1", articleIndex: 1 },
-      { text: "h2", articleIndex: 2 },
-      { text: "h3", articleIndex: 3 },
-      { text: "h4", articleIndex: 1 },
-      { text: "h5", articleIndex: 2 },
+      { title: "Q1", text: "h1", articleIndex: 1 },
+      { title: "Q2", text: "h2", articleIndex: 2 },
+      { title: "Q3", text: "h3", articleIndex: 3 },
+      { title: "Q4", text: "h4", articleIndex: 1 },
+      { title: "Q5", text: "h5", articleIndex: 2 },
     ],
   },
   ...patch,
@@ -112,10 +112,11 @@ describe("dedupBullets — mark policy", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "Policy rates held steady while lenders expanded mortgage books across major cities",
             articleIndex: 1,
           },
-          { text: "Fresh angle on exports", articleIndex: 2 },
+          { title: "T2", text: "Fresh angle on exports", articleIndex: 2 },
         ],
       },
     });
@@ -163,32 +164,36 @@ describe("dedupBullets — lowInformationDay", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: `BCA reported ${duplicateText}`, articleIndex: 1 },
-          { text: `Again ${duplicateText}`, articleIndex: 1 },
+          {
+            title: "T1",
+            text: `BCA reported ${duplicateText}`,
+            articleIndex: 1,
+          },
+          { title: "T2", text: `Again ${duplicateText}`, articleIndex: 1 },
         ],
       },
       dealsAndMovements: {
         displayHeading: "Deals",
         bullets: [
-          { text: duplicateText, articleIndex: 2 },
-          { text: `More on ${duplicateText}`, articleIndex: 2 },
+          { title: "T3", text: duplicateText, articleIndex: 2 },
+          { title: "T4", text: `More on ${duplicateText}`, articleIndex: 2 },
         ],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
         bullets: [
-          { text: duplicateText },
-          { text: `Regulatory ${duplicateText}` },
+          { title: "T5", text: duplicateText },
+          { title: "T6", text: `Regulatory ${duplicateText}` },
         ],
       },
       quickHits: {
         displayHeading: "Quick",
         items: [
-          { text: duplicateText, articleIndex: 1 },
-          { text: duplicateText, articleIndex: 2 },
-          { text: duplicateText, articleIndex: 3 },
-          { text: "Unique mining headline", articleIndex: 1 },
-          { text: "Another unique headline", articleIndex: 2 },
+          { title: "Q1", text: duplicateText, articleIndex: 1 },
+          { title: "Q2", text: duplicateText, articleIndex: 2 },
+          { title: "Q3", text: duplicateText, articleIndex: 3 },
+          { title: "Q4", text: "Unique mining headline", articleIndex: 1 },
+          { title: "Q5", text: "Another unique headline", articleIndex: 2 },
         ],
       },
     });
@@ -220,10 +225,11 @@ describe("dedupBullets — lowInformationDay", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "BCA quarterly net profit growth remained strong across retail",
             articleIndex: 1,
           },
-          { text: "Unique export story", articleIndex: 2 },
+          { title: "T2", text: "Unique export story", articleIndex: 2 },
         ],
       },
     });

--- a/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.ts
@@ -308,8 +308,8 @@ export const dedupBullets = (
 
   const applyBulletArray = (
     sectionKey: string,
-    bullets: Array<{ text: string; articleIndex?: number }>,
-  ): Array<{ text: string; articleIndex?: number }> => {
+    bullets: Array<{ title: string; text: string; articleIndex?: number }>,
+  ): Array<{ title: string; text: string; articleIndex?: number }> => {
     return bullets.flatMap((bullet, bulletIndex) => {
       const key = `${sectionKey}:${String(bulletIndex)}`;
       const decision = initialDecisions.get(key) ?? { kind: "unique" as const };

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.test.ts
@@ -174,10 +174,12 @@ describe("detectExemplarPlagiarism", () => {
         displayHeading: "Share shifts",
         bullets: [
           {
+            title: "Vietnam widget exports steady",
             text: "Widget exporters in Vietnam reported steady shipment volumes without pricing concessions to distributors overseas.",
             articleIndex: 1,
           },
           {
+            title: "Clinic software pilot expansions without consolidation",
             text: "Clinic software vendors saw pilot expansions but no consolidation deals among regional hospital groups.",
             articleIndex: 2,
           },
@@ -187,6 +189,7 @@ describe("detectExemplarPlagiarism", () => {
         displayHeading: "Deal tape",
         bullets: [
           {
+            title: "Logistics tuck-in closed at undisclosed terms",
             text: "A small logistics tuck-in closed at undisclosed terms without strategic impact on sector leaders.",
             articleIndex: 3,
           },
@@ -196,6 +199,7 @@ describe("detectExemplarPlagiarism", () => {
         displayHeading: "Policy",
         bullets: [
           {
+            title: "Telecom rules still in consultation",
             text: "Draft telecom rules stayed in consultation with no enforcement timeline published yet.",
             articleIndex: 1,
           },
@@ -210,11 +214,31 @@ describe("detectExemplarPlagiarism", () => {
       quickHits: {
         displayHeading: "Hits",
         items: [
-          { text: "Widget exports steady", articleIndex: 1 },
-          { text: "Clinic pilots expanded", articleIndex: 2 },
-          { text: "Logistics tuck-in closed", articleIndex: 3 },
-          { text: "Telecom draft unchanged", articleIndex: 1 },
-          { text: "Robotics trials only", articleIndex: 2 },
+          {
+            title: "Widget exports steady",
+            text: "Widget exports steady",
+            articleIndex: 1,
+          },
+          {
+            title: "Clinic pilots expanded",
+            text: "Clinic pilots expanded",
+            articleIndex: 2,
+          },
+          {
+            title: "Logistics tuck-in closed",
+            text: "Logistics tuck-in closed",
+            articleIndex: 3,
+          },
+          {
+            title: "Telecom draft unchanged",
+            text: "Telecom draft unchanged",
+            articleIndex: 1,
+          },
+          {
+            title: "Robotics trials only",
+            text: "Robotics trials only",
+            articleIndex: 2,
+          },
         ],
       },
     };

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-exemplars.ts
@@ -66,14 +66,17 @@ const industrialExemplar: NewsletterExemplar = {
       displayHeading: "Who is stealing share quietly",
       bullets: [
         {
+          title: "Port contract landed despite rival underbids",
           text: "Regional dredging rivals underbid on two Kalimantan packages last month, but INDX's consortium still landed the $420M port contract by bundling financing with local content guarantees cited in the tender documents.",
           articleIndex: 1,
         },
         {
+          title: "Fleet oversupply dents day-rate spreads",
           text: "Fleet oversupply in rented excavators and haul trucks is squeezing day-rate spreads for every contractor serving smelter builds, which explains why even market leaders are talking about utilization before volume growth.",
           articleIndex: 4,
         },
         {
+          title: "Plantation peers split on levy impact",
           text: "Plantation peers diverged after the export-levy tweak: integrated processors with domestic refining capacity framed the change as neutral, while pure exporters warned margin pressure into the second half.",
           articleIndex: 3,
         },
@@ -83,10 +86,12 @@ const industrialExemplar: NewsletterExemplar = {
       displayHeading: "Capital in motion",
       bullets: [
         {
+          title: "Kalimantan dredging award anchors multi-year revenue",
           text: "The Kalimantan dredging award is the week's clearest deal signal — it locks in multi-year earthworks revenue and gives INDX a reference project when bidding the next wave of port upgrades along the nickel corridor.",
           articleIndex: 1,
         },
         {
+          title: "Capex shifting from coal to downstream metals",
           text: "Miners reallocating capex from thermal coal toward downstream metals are reshaping the supplier queue: equipment lessors and EPC firms that leaned on coal maintenance contracts are now pitching modular smelter packages instead.",
           articleIndex: 6,
         },
@@ -96,10 +101,12 @@ const industrialExemplar: NewsletterExemplar = {
       displayHeading: "Permits and levies",
       bullets: [
         {
+          title: "Batam permit acceleration lifts equipment demand outlook",
           text: "Batam industrial-estate permit acceleration is the policy story to watch for heavy-equipment demand — faster land release usually precedes a six-to-nine-month spike in civil works and crane rentals across the region.",
           articleIndex: 5,
         },
         {
+          title: "Palm oil levy revision remains cash-flow swing factor",
           text: "Palm oil levy revisions remain the swing factor for plantation cash flows this quarter; the split reaction among peers suggests investors should track who hedged export exposure versus who stayed spot-heavy.",
           articleIndex: 3,
         },
@@ -110,10 +117,12 @@ const industrialExemplar: NewsletterExemplar = {
       displayHeading: "Power and process tech",
       bullets: [
         {
+          title: "Power tariffs gate smelter startups more than ore grades",
           text: "Nickel smelter JV startup delays tied to power-tariff negotiations highlight how electricity pricing — not ore grades — is becoming the gating item for new Indonesian processing capacity.",
           articleIndex: 2,
         },
         {
+          title: "Modular smelters and fleet telemetry lead contractor pitches",
           text: "Modular smelter designs and digital fleet telemetry are the two technologies contractors cite most when pitching shorter build cycles to miners pivoting away from coal.",
           articleIndex: 6,
         },
@@ -123,26 +132,32 @@ const industrialExemplar: NewsletterExemplar = {
       displayHeading: "Quick hits",
       items: [
         {
+          title: "$420M Kalimantan dredging contract signed",
           text: "INDX-led consortium signed the $420M Kalimantan dredging package.",
           articleIndex: 1,
         },
         {
+          title: "Nickel JV startup delayed by tariff talks",
           text: "Nickel JV pushed commercial startup as tariff talks with the utility dragged.",
           articleIndex: 2,
         },
         {
+          title: "Levy change split plantation margin outlook",
           text: "Export levy change split plantation peers on margin outlook.",
           articleIndex: 3,
         },
         {
+          title: "Equipment rental spreads narrowed on oversupply",
           text: "Equipment rental spreads narrowed on fleet oversupply.",
           articleIndex: 4,
         },
         {
+          title: "Batam industrial permits fast-tracked",
           text: "Batam industrial permits on a fast track.",
           articleIndex: 5,
         },
         {
+          title: "Coal softness accelerates downstream capex shift",
           text: "Coal benchmark softness accelerated capex shifts to downstream metals.",
           articleIndex: 6,
         },
@@ -178,14 +193,17 @@ const consumerFinancialExemplar: NewsletterExemplar = {
       displayHeading: "Share fights without price wars",
       bullets: [
         {
+          title: "FMCG trade spend pivots to promo efficiency",
           text: "FMCG brands are redeploying trade spend toward promo efficiency rather than list-price cuts, a tell that input-cost relief is reaching shelves but volume growth remains fragile across categories.",
           articleIndex: 2,
         },
         {
+          title: "Department stores gain footfall but not basket size",
           text: "Department stores logged footfall gains while average basket size flatlined — a pattern that favors operators with loyalty data and private-label mix over pure square-meter expansion plays.",
           articleIndex: 4,
         },
         {
+          title: "Wallet growth stalls in tier-2 cities",
           text: "Digital wallet growth cooling in tier-2 cities suggests the easy user-acquisition phase is over; incumbents are competing on merchant rebates and cross-sell into lending rather than raw transaction counts.",
           articleIndex: 3,
         },
@@ -195,10 +213,12 @@ const consumerFinancialExemplar: NewsletterExemplar = {
       displayHeading: "Balance-sheet moves",
       bullets: [
         {
+          title: "NIM guidance raised on deposit repricing, not loan demand",
           text: "Lenders raising net interest margin guidance while the policy rate stays unchanged implies deposit repricing and asset-yield mix shifts — not necessarily stronger loan demand — which matters for how you read upcoming earnings beats.",
           articleIndex: 1,
         },
         {
+          title: "KYC audits may consolidate micro-lending to incumbents",
           text: "Micro-lending platforms facing tighter KYC audits may consolidate origination volumes toward balance-sheet lenders with compliance headroom, a subtle share shift for consumer finance incumbents.",
           articleIndex: 5,
         },
@@ -208,10 +228,12 @@ const consumerFinancialExemplar: NewsletterExemplar = {
       displayHeading: "Rates and rules",
       bullets: [
         {
+          title: "Rate hold steadies borrowing costs but NIM pressure lingers",
           text: "The hold on benchmark rates keeps consumer borrowing costs predictable in the near term, but lenders' widened NIM outlook signals they still expect funding-cost pressure from deposit competition.",
           articleIndex: 1,
         },
         {
+          title: "Stricter KYC links wallet slowdowns to origination risk",
           text: "Stricter KYC enforcement on micro-lenders is the regulatory thread tying together wallet slowdowns and origination risk — expect more partnership models with licensed banks rather than standalone apps.",
           articleIndex: 5,
         },
@@ -227,26 +249,32 @@ const consumerFinancialExemplar: NewsletterExemplar = {
       displayHeading: "Quick hits",
       items: [
         {
+          title: "Rate held; NIM guidance lifted",
           text: "Policy rate unchanged; lenders guided wider NIMs.",
           articleIndex: 1,
         },
         {
+          title: "FMCG promos optimized on easing input costs",
           text: "FMCG promos tuned for efficiency as input costs eased.",
           articleIndex: 2,
         },
         {
+          title: "Wallet growth slowed in tier-2 cities",
           text: "Wallet transaction growth slowed in tier-2 cities.",
           articleIndex: 3,
         },
         {
+          title: "Department store traffic up, baskets flat",
           text: "Department store traffic up, baskets flat.",
           articleIndex: 4,
         },
         {
+          title: "Micro-lenders face tighter KYC scrutiny",
           text: "Micro-lenders face tighter KYC audits.",
           articleIndex: 5,
         },
         {
+          title: "Consumer confidence up on stable food prices",
           text: "Consumer confidence improved on stable food prices.",
           articleIndex: 6,
         },

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-polish.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-polish.test.ts
@@ -12,17 +12,17 @@ const minimalStructure = (
   competitiveLandscape: {
     displayHeading: "Competitive",
     bullets: [
-      { text: "B1", articleIndex: 1 },
-      { text: "B2", articleIndex: 2 },
+      { title: "T1", text: "B1", articleIndex: 1 },
+      { title: "T2", text: "B2", articleIndex: 2 },
     ],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "D1", articleIndex: 3 }],
+    bullets: [{ title: "T3", text: "D1", articleIndex: 3 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Regulatory",
-    bullets: [{ text: "R1" }],
+    bullets: [{ title: "T4", text: "R1" }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -32,11 +32,11 @@ const minimalStructure = (
   quickHits: {
     displayHeading: "Quick",
     items: [
-      { text: "h1", articleIndex: 1 },
-      { text: "h2", articleIndex: 2 },
-      { text: "h3", articleIndex: 3 },
-      { text: "h4", articleIndex: 1 },
-      { text: "h5", articleIndex: 2 },
+      { title: "Q1", text: "h1", articleIndex: 1 },
+      { title: "Q2", text: "h2", articleIndex: 2 },
+      { title: "Q3", text: "h3", articleIndex: 3 },
+      { title: "Q4", text: "h4", articleIndex: 1 },
+      { title: "Q5", text: "h5", articleIndex: 2 },
     ],
   },
   ...patch,
@@ -50,10 +50,11 @@ describe("polishNewsletter filler removal", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "It's worth noting that BCA grew profit by 12%",
             articleIndex: 1,
           },
-          { text: "B2", articleIndex: 2 },
+          { title: "T2", text: "B2", articleIndex: 2 },
         ],
       },
     });
@@ -76,7 +77,12 @@ describe("polishNewsletter filler removal", () => {
     const structure = minimalStructure({
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
-        bullets: [{ text: "Importantly, the regulator approved the merger" }],
+        bullets: [
+          {
+            title: "T1",
+            text: "Importantly, the regulator approved the merger",
+          },
+        ],
       },
     });
 
@@ -101,17 +107,25 @@ describe("polishNewsletter hedge collapse", () => {
       dealsAndMovements: {
         displayHeading: "Deals",
         bullets: [
-          { text: "The deal could potentially close in Q3", articleIndex: 1 },
+          {
+            title: "T1",
+            text: "The deal could potentially close in Q3",
+            articleIndex: 1,
+          },
         ],
       },
       quickHits: {
         displayHeading: "Quick",
         items: [
-          { text: "Earnings may possibly disappoint", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 3 },
-          { text: "h4", articleIndex: 1 },
-          { text: "h5", articleIndex: 2 },
+          {
+            title: "Q1",
+            text: "Earnings may possibly disappoint",
+            articleIndex: 1,
+          },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 3 },
+          { title: "Q4", text: "h4", articleIndex: 1 },
+          { title: "Q5", text: "h5", articleIndex: 2 },
         ],
       },
     });
@@ -138,10 +152,10 @@ describe("polishNewsletter overused words", () => {
   it("replaces robust in exactly one bullet when tier is aggressive and 4 bullets repeat it", () => {
     // Setup
     const robustBullets = [
-      { text: "First robust growth outlook", articleIndex: 1 },
-      { text: "Second robust growth outlook", articleIndex: 2 },
-      { text: "Third robust growth outlook", articleIndex: 3 },
-      { text: "Fourth robust growth outlook", articleIndex: 1 },
+      { title: "T1", text: "First robust growth outlook", articleIndex: 1 },
+      { title: "T2", text: "Second robust growth outlook", articleIndex: 2 },
+      { title: "T3", text: "Third robust growth outlook", articleIndex: 3 },
+      { title: "T4", text: "Fourth robust growth outlook", articleIndex: 1 },
     ];
     const structure = minimalStructure({
       competitiveLandscape: {
@@ -190,6 +204,7 @@ describe("polishNewsletter disabled rules", () => {
         displayHeading: "Deals",
         bullets: [
           {
+            title: "T1",
             text: "It's worth noting that BCA grew profit by 12%",
             articleIndex: 1,
           },
@@ -198,11 +213,15 @@ describe("polishNewsletter disabled rules", () => {
       quickHits: {
         displayHeading: "Quick",
         items: [
-          { text: "Earnings may possibly disappoint", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 3 },
-          { text: "h4", articleIndex: 1 },
-          { text: "h5", articleIndex: 2 },
+          {
+            title: "Q1",
+            text: "Earnings may possibly disappoint",
+            articleIndex: 1,
+          },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 3 },
+          { title: "Q4", text: "h4", articleIndex: 1 },
+          { title: "Q5", text: "h5", articleIndex: 2 },
         ],
       },
     });

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.test.ts
@@ -13,18 +13,18 @@ const tenBulletStructure = (): IndustryNewsletterStructure => ({
   competitiveLandscape: {
     displayHeading: "Competitive",
     bullets: [
-      { text: "Weak bullet one.", articleIndex: 1 },
-      { text: "Weak bullet two.", articleIndex: 1 },
-      { text: "Weak bullet three.", articleIndex: 1 },
+      { title: "T1", text: "Weak bullet one.", articleIndex: 1 },
+      { title: "T2", text: "Weak bullet two.", articleIndex: 1 },
+      { title: "T3", text: "Weak bullet three.", articleIndex: 1 },
     ],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "Deal bullet.", articleIndex: 1 }],
+    bullets: [{ title: "T4", text: "Deal bullet.", articleIndex: 1 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Policy",
-    bullets: [{ text: "Policy bullet.", articleIndex: 1 }],
+    bullets: [{ title: "T5", text: "Policy bullet.", articleIndex: 1 }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -34,11 +34,11 @@ const tenBulletStructure = (): IndustryNewsletterStructure => ({
   quickHits: {
     displayHeading: "Hits",
     items: [
-      { text: "Hit 1", articleIndex: 1 },
-      { text: "Hit 2", articleIndex: 1 },
-      { text: "Hit 3", articleIndex: 1 },
-      { text: "Hit 4", articleIndex: 1 },
-      { text: "Hit 5", articleIndex: 1 },
+      { title: "Q1", text: "Hit 1", articleIndex: 1 },
+      { title: "Q2", text: "Hit 2", articleIndex: 1 },
+      { title: "Q3", text: "Hit 3", articleIndex: 1 },
+      { title: "Q4", text: "Hit 4", articleIndex: 1 },
+      { title: "Q5", text: "Hit 5", articleIndex: 1 },
     ],
   },
 });
@@ -97,8 +97,8 @@ describe("applyNewsletterCritiqueResults", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "Weak one.", articleIndex: 1 },
-          { text: "Weak two.", articleIndex: 1 },
+          { title: "T1", text: "Weak one.", articleIndex: 1 },
+          { title: "T2", text: "Weak two.", articleIndex: 1 },
         ],
       },
     };

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
@@ -424,8 +424,8 @@ export const applyNewsletterCritiqueResults = (
 
   const applyToBullets = (
     sectionKey: string,
-    bullets: Array<{ text: string; articleIndex?: number }>,
-  ): Array<{ text: string; articleIndex?: number }> => {
+    bullets: Array<{ title: string; text: string; articleIndex?: number }>,
+  ): Array<{ title: string; text: string; articleIndex?: number }> => {
     return bullets.flatMap((bullet, bulletIndex) => {
       const key = candidateKey(sectionKey, bulletIndex);
       const rewrite = rewriteTargets.get(key);

--- a/apps/mediapulse/agents/content-generation/src/lib/numeric-anchors.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/numeric-anchors.test.ts
@@ -22,15 +22,15 @@ const minimalStructure = (
   industryPulse: { displayHeading: "Pulse", prose: "Lead." },
   competitiveLandscape: {
     displayHeading: "Competitive",
-    bullets: [{ text: "B1" }],
+    bullets: [{ title: "B1", text: "B1" }],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "D1" }],
+    bullets: [{ title: "D1", text: "D1" }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Regulatory",
-    bullets: [{ text: "R1" }],
+    bullets: [{ title: "R1", text: "R1" }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -40,11 +40,11 @@ const minimalStructure = (
   quickHits: {
     displayHeading: "Quick",
     items: [
-      { text: "h1", articleIndex: 1 },
-      { text: "h2", articleIndex: 1 },
-      { text: "h3", articleIndex: 1 },
-      { text: "h4", articleIndex: 1 },
-      { text: "h5", articleIndex: 1 },
+      { title: "h1", text: "h1", articleIndex: 1 },
+      { title: "h2", text: "h2", articleIndex: 1 },
+      { title: "h3", text: "h3", articleIndex: 1 },
+      { title: "h4", text: "h4", articleIndex: 1 },
+      { title: "h5", text: "h5", articleIndex: 1 },
     ],
   },
   ...patch,
@@ -185,7 +185,11 @@ describe("auditNumbersInBriefing", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "BCA grew net profit to Rp 12.4 trillion", articleIndex: 1 },
+          {
+            title: "BCA net profit grew",
+            text: "BCA grew net profit to Rp 12.4 trillion",
+            articleIndex: 1,
+          },
         ],
       },
     });
@@ -216,7 +220,11 @@ describe("auditNumbersInBriefing", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "BCA grew net profit to Rp 12.4 trillion", articleIndex: 1 },
+          {
+            title: "BCA net profit grew",
+            text: "BCA grew net profit to Rp 12.4 trillion",
+            articleIndex: 1,
+          },
         ],
       },
     });
@@ -245,7 +253,12 @@ describe("applyNumericAnchorPolicy — strip", () => {
     const structure = minimalStructure({
       dealsAndMovements: {
         displayHeading: "Deals",
-        bullets: [{ text: "Net profit hit Rp 12.4 trillion last quarter" }],
+        bullets: [
+          {
+            title: "Net profit hit Rp 12.4 trillion",
+            text: "Net profit hit Rp 12.4 trillion last quarter",
+          },
+        ],
       },
     });
 

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts
@@ -386,4 +386,66 @@ describe("pruneNewsletterToCitedRows — section removal", () => {
     expect(summary.sectionsRemoved).toBe(1);
     expect(summary.sectionsKept).toBe(2);
   });
+
+  it("drops bullets with duplicate normalized titles across sections", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          {
+            title: "Rival A Launches",
+            text: "Rival A launched.",
+            url: CITED_URL_A,
+          },
+          {
+            title: "Market Share Grows",
+            text: "Market share grew.",
+            url: CITED_URL_B,
+          },
+        ],
+      },
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [
+          {
+            title: "Rival A launches.",
+            text: "Rival A deal.",
+            url: CITED_URL_B,
+          },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved);
+
+    const competitiveBullets = pruned.competitiveLandscape?.bullets ?? [];
+    const dealsBullets = pruned.dealsAndMovements?.bullets ?? [];
+
+    expect(competitiveBullets).toHaveLength(2);
+    expect(dealsBullets).toHaveLength(0);
+    expect(summary.bulletsRemovedDuplicateTitle).toBe(1);
+  });
+
+  it("dedupeTitlesWithinNewsletter false skips title dedup", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          { title: "Same Title", text: "First.", url: CITED_URL_A },
+          { title: "Same Title", text: "Second.", url: CITED_URL_B },
+        ],
+      },
+    };
+
+    const { resolved: pruned, summary } = pruneNewsletterToCitedRows(resolved, {
+      dedupeTitlesWithinNewsletter: false,
+    });
+
+    expect(pruned.competitiveLandscape?.bullets).toHaveLength(2);
+    expect(summary.bulletsRemovedDuplicateTitle).toBe(0);
+  });
 });

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
@@ -21,6 +21,7 @@ export type PruneSummary = {
   sectionsRemoved: number;
   bulletsRemovedUncited: number;
   bulletsRemovedDuplicate: number;
+  bulletsRemovedDuplicateTitle: number;
   sectionsKept: number;
 };
 
@@ -42,6 +43,11 @@ export type PruneOptions = {
    * the entire newsletter ('newsletter'). Defaults to 'section'.
    */
   dedupeScope?: "section" | "newsletter";
+  /**
+   * When true, drops items whose normalized title duplicates an earlier item's title
+   * across the entire newsletter. Defaults to true.
+   */
+  dedupeTitlesWithinNewsletter?: boolean;
 };
 
 export type PruneNewsletterResult = {
@@ -60,6 +66,15 @@ const ALL_SECTIONS: ReadonlyArray<PruneSectionKey> = [
 
 /** A row is cited iff `url` resolved to a non-empty string during `attachIndustryNewsletterSourceUrls`. */
 const isRowCited = (row: { url?: string }): boolean => row.url !== undefined;
+
+/** Normalizes a title for uniqueness comparison: lowercase, collapse whitespace, strip trailing punctuation. */
+const normalizeTitle = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.,;!?]+$/, "")
+    .trim();
 
 function pruneRows<T extends { url?: string }>(
   rows: ReadonlyArray<T>,
@@ -107,12 +122,35 @@ export function pruneNewsletterToCitedRows(
   const configuredSections = opts.sections ?? ALL_SECTIONS;
   const dedupeEnabled = opts.dedupeArticlesWithinSection ?? true;
   const dedupeScope = opts.dedupeScope ?? "section";
+  const dedupeTitles = opts.dedupeTitlesWithinNewsletter ?? true;
 
   const reports: PruneReport[] = [];
   let sectionsRemoved = 0;
   let bulletsRemovedUncited = 0;
   let bulletsRemovedDuplicate = 0;
+  let bulletsRemovedDuplicateTitle = 0;
   let sectionsKept = 0;
+
+  const seenTitles = new Set<string>();
+
+  const filterByTitle = <T extends { title?: string }>(rows: T[]): T[] => {
+    if (!dedupeTitles) return rows;
+    const kept: T[] = [];
+    for (const row of rows) {
+      if (row.title === undefined) {
+        kept.push(row);
+        continue;
+      }
+      const normalized = normalizeTitle(row.title);
+      if (seenTitles.has(normalized)) {
+        bulletsRemovedDuplicateTitle++;
+        continue;
+      }
+      seenTitles.add(normalized);
+      kept.push(row);
+    }
+    return kept;
+  };
 
   // Shared URL set used when dedupeScope === 'newsletter'.
   const newsletterSeenUrls = new Set<string>();
@@ -146,13 +184,14 @@ export function pruneNewsletterToCitedRows(
     shouldPrune("competitiveLandscape") &&
     competitiveLandscape !== undefined
   ) {
-    const { kept, removedUncited, removedDuplicate } = pruneRows(
-      competitiveLandscape.bullets,
-      getSeenUrls(),
-      dedupeEnabled,
-    );
+    const {
+      kept: citedKept,
+      removedUncited,
+      removedDuplicate,
+    } = pruneRows(competitiveLandscape.bullets, getSeenUrls(), dedupeEnabled);
     bulletsRemovedUncited += removedUncited;
     bulletsRemovedDuplicate += removedDuplicate;
+    const kept = filterByTitle(citedKept);
     const sectionRemoved = kept.length === 0;
     reports.push({
       sectionKey: "competitiveLandscape",
@@ -172,13 +211,14 @@ export function pruneNewsletterToCitedRows(
   // --- dealsAndMovements ---
   let dealsAndMovements = resolved.dealsAndMovements;
   if (shouldPrune("dealsAndMovements") && dealsAndMovements !== undefined) {
-    const { kept, removedUncited, removedDuplicate } = pruneRows(
-      dealsAndMovements.bullets,
-      getSeenUrls(),
-      dedupeEnabled,
-    );
+    const {
+      kept: citedKept,
+      removedUncited,
+      removedDuplicate,
+    } = pruneRows(dealsAndMovements.bullets, getSeenUrls(), dedupeEnabled);
     bulletsRemovedUncited += removedUncited;
     bulletsRemovedDuplicate += removedDuplicate;
+    const kept = filterByTitle(citedKept);
     const sectionRemoved = kept.length === 0;
     reports.push({
       sectionKey: "dealsAndMovements",
@@ -201,13 +241,14 @@ export function pruneNewsletterToCitedRows(
     shouldPrune("regulatoryPolicyWatch") &&
     regulatoryPolicyWatch !== undefined
   ) {
-    const { kept, removedUncited, removedDuplicate } = pruneRows(
-      regulatoryPolicyWatch.bullets,
-      getSeenUrls(),
-      dedupeEnabled,
-    );
+    const {
+      kept: citedKept,
+      removedUncited,
+      removedDuplicate,
+    } = pruneRows(regulatoryPolicyWatch.bullets, getSeenUrls(), dedupeEnabled);
     bulletsRemovedUncited += removedUncited;
     bulletsRemovedDuplicate += removedDuplicate;
+    const kept = filterByTitle(citedKept);
     const sectionRemoved = kept.length === 0;
     reports.push({
       sectionKey: "regulatoryPolicyWatch",
@@ -239,13 +280,14 @@ export function pruneNewsletterToCitedRows(
         sectionRemoved: true,
       });
     } else {
-      const { kept, removedUncited, removedDuplicate } = pruneRows(
-        disruptorsOrTech.bullets,
-        getSeenUrls(),
-        dedupeEnabled,
-      );
+      const {
+        kept: citedKept,
+        removedUncited,
+        removedDuplicate,
+      } = pruneRows(disruptorsOrTech.bullets, getSeenUrls(), dedupeEnabled);
       bulletsRemovedUncited += removedUncited;
       bulletsRemovedDuplicate += removedDuplicate;
+      const kept = filterByTitle(citedKept);
       const sectionRemoved = kept.length === 0;
       reports.push({
         sectionKey: "disruptorsOrTech",
@@ -266,13 +308,14 @@ export function pruneNewsletterToCitedRows(
   // --- quickHits ---
   let quickHits = resolved.quickHits;
   if (shouldPrune("quickHits") && quickHits !== undefined) {
-    const { kept, removedUncited, removedDuplicate } = pruneRows(
-      quickHits.items,
-      getSeenUrls(),
-      dedupeEnabled,
-    );
+    const {
+      kept: citedKept,
+      removedUncited,
+      removedDuplicate,
+    } = pruneRows(quickHits.items, getSeenUrls(), dedupeEnabled);
     bulletsRemovedUncited += removedUncited;
     bulletsRemovedDuplicate += removedDuplicate;
+    const kept = filterByTitle(citedKept);
     const sectionRemoved = kept.length === 0;
     reports.push({
       sectionKey: "quickHits",
@@ -304,6 +347,7 @@ export function pruneNewsletterToCitedRows(
       sectionsRemoved,
       bulletsRemovedUncited,
       bulletsRemovedDuplicate,
+      bulletsRemovedDuplicateTitle,
       sectionsKept,
     },
   };

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -77,17 +77,17 @@ const minimalIndustryBrief = (
   competitiveLandscape: {
     displayHeading: "Competitive",
     bullets: [
-      { text: "B1", articleIndex: 1 },
-      { text: "B2", articleIndex: 2 },
+      { title: "T1", text: "B1", articleIndex: 1 },
+      { title: "T2", text: "B2", articleIndex: 2 },
     ],
   },
   dealsAndMovements: {
     displayHeading: "Deals",
-    bullets: [{ text: "D1", articleIndex: 3 }],
+    bullets: [{ title: "T3", text: "D1", articleIndex: 3 }],
   },
   regulatoryPolicyWatch: {
     displayHeading: "Regulatory",
-    bullets: [{ text: "R1" }],
+    bullets: [{ title: "T4", text: "R1" }],
   },
   disruptorsOrTech: {
     format: "prose",
@@ -97,11 +97,11 @@ const minimalIndustryBrief = (
   quickHits: {
     displayHeading: "Quick",
     items: [
-      { text: "h1", articleIndex: 1 },
-      { text: "h2", articleIndex: 2 },
-      { text: "h3", articleIndex: 3 },
-      { text: "h4", articleIndex: 1 },
-      { text: "h5", articleIndex: 2 },
+      { title: "Q1", text: "h1", articleIndex: 1 },
+      { title: "Q2", text: "h2", articleIndex: 2 },
+      { title: "Q3", text: "h3", articleIndex: 3 },
+      { title: "Q4", text: "h4", articleIndex: 1 },
+      { title: "Q5", text: "h5", articleIndex: 2 },
     ],
   },
   ...patch,
@@ -189,26 +189,26 @@ describe("generateNewsletterWithLlm — happy path", () => {
       competitiveLandscape: {
         displayHeading: "C",
         bullets: [
-          { text: "b1", articleIndex: 1 },
-          { text: "b2", articleIndex: 2 },
+          { title: "T1", text: "b1", articleIndex: 1 },
+          { title: "T2", text: "b2", articleIndex: 2 },
         ],
       },
       dealsAndMovements: {
         displayHeading: "D",
-        bullets: [{ text: "d1", articleIndex: 1 }],
+        bullets: [{ title: "T3", text: "d1", articleIndex: 1 }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "R",
-        bullets: [{ text: "r1", articleIndex: 2 }],
+        bullets: [{ title: "T4", text: "r1", articleIndex: 2 }],
       },
       quickHits: {
         displayHeading: "Q",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 1 },
-          { text: "h4", articleIndex: 2 },
-          { text: "h5", articleIndex: 1 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 1 },
+          { title: "Q4", text: "h4", articleIndex: 2 },
+          { title: "Q5", text: "h5", articleIndex: 1 },
         ],
       },
     });
@@ -288,10 +288,12 @@ describe("generateNewsletterWithLlm — happy path", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "Big tech posted strong gains for the third consecutive day.",
             articleIndex: 1,
           },
           {
+            title: "T2",
             text: "Federal Reserve held interest rates steady at its latest meeting.",
             articleIndex: 2,
           },
@@ -301,6 +303,7 @@ describe("generateNewsletterWithLlm — happy path", () => {
         displayHeading: "Deals",
         bullets: [
           {
+            title: "T3",
             text: "Crude oil prices fell amid weakening demand concerns.",
             articleIndex: 3,
           },
@@ -668,11 +671,11 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
         quickHits: {
           displayHeading: "Q",
           items: [
-            { text: "a", articleIndex: 1 },
-            { text: "b", articleIndex: 2 },
-            { text: "c", articleIndex: 3 },
-            { text: "d", articleIndex: 1 },
-            { text: "e", articleIndex: 2 },
+            { title: "Q1", text: "a", articleIndex: 1 },
+            { title: "Q2", text: "b", articleIndex: 2 },
+            { title: "Q3", text: "c", articleIndex: 3 },
+            { title: "Q4", text: "d", articleIndex: 1 },
+            { title: "Q5", text: "e", articleIndex: 2 },
           ],
         },
       }),
@@ -1268,10 +1271,15 @@ describe("generateNewsletterWithLlm — two-pass brainstorm", () => {
         displayHeading: "Margins",
         bullets: [
           {
+            title: "T1",
             text: "Net interest margin reached 6.1% as deposit competition intensified (Article 1).",
             articleIndex: 1,
           },
-          { text: "Peer spreads widened on retail funding.", articleIndex: 2 },
+          {
+            title: "T2",
+            text: "Peer spreads widened on retail funding.",
+            articleIndex: 2,
+          },
         ],
       },
     };
@@ -1318,6 +1326,7 @@ describe("generateNewsletterWithLlm — citation grounding", () => {
       content: "Mining contractors shipped higher nickel ore volumes.",
     };
     const badQuickHits = Array.from({ length: 5 }, (_, index) => ({
+      title: `Q${String(index + 1)}`,
       text: `Unrelated widget headline ${String(index)}`,
       articleIndex: 1,
     }));
@@ -1391,9 +1400,9 @@ describe("generateNewsletterWithLlm — self-critique", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "Weak one.", articleIndex: 1 },
-          { text: "Weak two.", articleIndex: 1 },
-          { text: "Weak three.", articleIndex: 1 },
+          { title: "T1", text: "Weak one.", articleIndex: 1 },
+          { title: "T2", text: "Weak two.", articleIndex: 1 },
+          { title: "T3", text: "Weak three.", articleIndex: 1 },
         ],
       },
     });
@@ -1464,8 +1473,8 @@ describe("generateNewsletterWithLlm — self-critique", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: "Weak one.", articleIndex: 1 },
-          { text: "Weak two.", articleIndex: 1 },
+          { title: "T1", text: "Weak one.", articleIndex: 1 },
+          { title: "T2", text: "Weak two.", articleIndex: 1 },
         ],
       },
     });
@@ -1677,20 +1686,30 @@ describe("generateNewsletterWithLlm — numeric anchors", () => {
       competitiveLandscape: {
         displayHeading: "Competitive",
         bullets: [
-          { text: `Revenue ${quotedFigures[0] ?? ""}`, articleIndex: 1 },
-          { text: `Growth ${quotedFigures[1] ?? ""}`, articleIndex: 1 },
+          {
+            title: "T1",
+            text: `Revenue ${quotedFigures[0] ?? ""}`,
+            articleIndex: 1,
+          },
+          {
+            title: "T2",
+            text: `Growth ${quotedFigures[1] ?? ""}`,
+            articleIndex: 1,
+          },
         ],
       },
       dealsAndMovements: {
         displayHeading: "Deals",
         bullets: [
-          { text: quotedFigures[2] ?? "Deal", articleIndex: 2 },
-          { text: quotedFigures[3] ?? "Move", articleIndex: 3 },
+          { title: "T3", text: quotedFigures[2] ?? "Deal", articleIndex: 2 },
+          { title: "T4", text: quotedFigures[3] ?? "Move", articleIndex: 3 },
         ],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
-        bullets: [{ text: quotedFigures[4] ?? "Policy", articleIndex: 4 }],
+        bullets: [
+          { title: "T5", text: quotedFigures[4] ?? "Policy", articleIndex: 4 },
+        ],
       },
       industryPulse: {
         displayHeading: "Pulse",
@@ -1840,10 +1859,15 @@ describe("generateNewsletterWithLlm — style polish", () => {
         displayHeading: "Competitive",
         bullets: [
           {
+            title: "T1",
             text: "It's worth noting that BCA grew profit by 12%",
             articleIndex: 1,
           },
-          { text: "Peer spreads widened on retail funding.", articleIndex: 2 },
+          {
+            title: "T2",
+            text: "Peer spreads widened on retail funding.",
+            articleIndex: 2,
+          },
         ],
       },
     };
@@ -1999,29 +2023,34 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
       },
       competitiveLandscape: {
         displayHeading: "Competition",
-        bullets: [{ text: "Uncited A" }, { text: "Uncited B" }],
+        bullets: [
+          { title: "T1", text: "Uncited A" },
+          { title: "T2", text: "Uncited B" },
+        ],
       },
       dealsAndMovements: {
         displayHeading: "Deals",
-        bullets: [{ text: "Cited deal", articleIndex: 1 }],
+        bullets: [{ title: "T3", text: "Cited deal", articleIndex: 1 }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
-        bullets: [{ text: "Uncited regulatory" }],
+        bullets: [{ title: "T4", text: "Uncited regulatory" }],
       },
       disruptorsOrTech: {
         format: "bullets",
         displayHeading: "Disruptors",
-        bullets: [{ text: "Innovation forward.", articleIndex: 2 }],
+        bullets: [
+          { title: "T5", text: "Innovation forward.", articleIndex: 2 },
+        ],
       },
       quickHits: {
         displayHeading: "Quick Hits",
         items: [
-          { text: "Hit with source", articleIndex: 1 },
-          { text: "Hit with source 2", articleIndex: 2 },
-          { text: "Hit with source 3", articleIndex: 3 },
-          { text: "Hit uncited", articleIndex: 99 },
-          { text: "Hit duplicate", articleIndex: 1 },
+          { title: "Q1", text: "Hit with source", articleIndex: 1 },
+          { title: "Q2", text: "Hit with source 2", articleIndex: 2 },
+          { title: "Q3", text: "Hit with source 3", articleIndex: 3 },
+          { title: "Q4", text: "Hit uncited", articleIndex: 99 },
+          { title: "Q5", text: "Hit duplicate", articleIndex: 1 },
         ],
       },
     });
@@ -2055,15 +2084,15 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
     const generateObjectFn = makeSuccessfulGenerateFn({
       competitiveLandscape: {
         displayHeading: "Competition",
-        bullets: [{ text: "Uncited" }],
+        bullets: [{ title: "T1", text: "Uncited" }],
       },
       dealsAndMovements: {
         displayHeading: "Deals",
-        bullets: [{ text: "Uncited" }],
+        bullets: [{ title: "T2", text: "Uncited" }],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
-        bullets: [{ text: "Uncited" }],
+        bullets: [{ title: "T3", text: "Uncited" }],
       },
     });
 
@@ -2142,11 +2171,14 @@ describe("generateNewsletterWithLlm — sectionFillSnapshot", () => {
       },
       competitiveLandscape: {
         displayHeading: "Competition",
-        bullets: [{ text: "Uncited A" }, { text: "Uncited B" }],
+        bullets: [
+          { title: "T1", text: "Uncited A" },
+          { title: "T2", text: "Uncited B" },
+        ],
       },
       regulatoryPolicyWatch: {
         displayHeading: "Regulatory",
-        bullets: [{ text: "Uncited regulatory" }],
+        bullets: [{ title: "T3", text: "Uncited regulatory" }],
       },
     });
 
@@ -2169,20 +2201,20 @@ describe("generateNewsletterWithLlm — sectionFillSnapshot", () => {
       competitiveLandscape: {
         displayHeading: "Comp",
         bullets: [
-          { text: "B1", articleIndex: 1 },
-          { text: "B2", articleIndex: 2 },
-          { text: "B3", articleIndex: 3 },
+          { title: "T1", text: "B1", articleIndex: 1 },
+          { title: "T2", text: "B2", articleIndex: 2 },
+          { title: "T3", text: "B3", articleIndex: 3 },
         ],
       },
       quickHits: {
         displayHeading: "Quick",
         items: [
-          { text: "h1", articleIndex: 1 },
-          { text: "h2", articleIndex: 2 },
-          { text: "h3", articleIndex: 3 },
-          { text: "h4", articleIndex: 1 },
-          { text: "h5", articleIndex: 2 },
-          { text: "h6", articleIndex: 3 },
+          { title: "Q1", text: "h1", articleIndex: 1 },
+          { title: "Q2", text: "h2", articleIndex: 2 },
+          { title: "Q3", text: "h3", articleIndex: 3 },
+          { title: "Q4", text: "h4", articleIndex: 1 },
+          { title: "Q5", text: "h5", articleIndex: 2 },
+          { title: "Q6", text: "h6", articleIndex: 3 },
         ],
       },
     });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -575,15 +575,17 @@ You receive exactly {{topNewsCount}} numbered articles (Article 1 … Article {{
 Return JSON matching this shape (camelCase keys):
 - "subject": short email subject (under ~60 chars), sector-relevant, may mention {{tickerName}} or {{tickerSymbol}} once if natural.
 - "industryPulse": { "displayHeading", "prose", "articleIndex" } — short lead framing the industry story (no bullet characters in prose). Set "articleIndex" to the single most representative article the lead summarizes; use null when the lead does not lean on a specific article.
-- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets about {{tickerName}}'s COMPETITORS, not {{tickerName}} itself — peer positioning, rival launches, share shifts, competitive threats. Each bullet should name a competitor. Each bullet { "text", "articleIndex" } where articleIndex is a 1-based article number or null when uncited.
-- "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
-- "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same articleIndex rule.
-- "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (same articleIndex rule).
-- "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "text", "articleIndex" } (index required for every quick hit).
+- "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets about {{tickerName}}'s COMPETITORS, not {{tickerName}} itself — peer positioning, rival launches, share shifts, competitive threats. Each bullet should name a competitor. Each bullet { "title", "text", "articleIndex" } where "title" is a short headline (under 60 chars) naming the story, "text" is the full bullet sentence, and articleIndex is a 1-based article number or null when uncited.
+- "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; each bullet { "title", "text", "articleIndex" } with the same title and articleIndex rules.
+- "regulatoryPolicyWatch": { "displayHeading", "bullets" } — 1–3 bullets; same title and articleIndex rules.
+- "disruptorsOrTech": either { "format": "prose", "displayHeading", "prose" } OR { "format": "bullets", "displayHeading", "bullets" } with 1–3 bullets (each bullet has "title", "text", "articleIndex" with the same rules).
+- "quickHits": { "displayHeading", "items" } — 5–7 items; each item { "title", "text", "articleIndex" } where "title" is a short headline (under 60 chars), "text" is the sentence, and articleIndex is required.
 
 Headings ("displayHeading") are short subtitle phrases only — never repeat the section label or use "Label / Subtitle" format. Keep JSON valid; use null for optional blocks and uncited articleIndex values.
 
-Every bullet and quick hit must summarize exactly one article and set articleIndex to that one article. Do not blend multiple articles into one bullet, and do not reuse the same article for two bullets in a section.`;
+Every bullet and quick hit must summarize exactly one article and set articleIndex to that one article. Do not blend multiple articles into one bullet, and do not reuse the same article for two bullets in a section.
+
+Item titles must be unique across the entire newsletter (all bullets in all sections and all quick-hit items). Every title must name a distinct story. Do not reuse the same headline or a near-identical paraphrase for two different items.`;
 
 /**
  * Default user prompt template used when no template is provided in config.

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -205,25 +205,28 @@ export const DefaultNewsletterEmail = ({
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
           {renderSectionHeader(section.machineKey, section.displayHeading)}
-          {section.bullets.map((bullet, bulletIndex) => (
-            <Section
-              key={`${String(section.machineKey)}-b-${String(bulletIndex)}`}
-            >
-              <Text style={newsItemSummary}>
-                {renderInlineMarkdownLinks(bullet.text, link)}
-              </Text>
-              {bullet.url !== undefined && bullet.url !== "" ? (
-                <Text style={newsItemSourceLink}>
-                  <Link href={bullet.url} style={link}>
-                    Read the full article
-                  </Link>
+          {section.bullets.map((bullet, bulletIndex) => {
+            const bulletCtaLabel = bullet.title ?? bullet.text;
+            return (
+              <Section
+                key={`${String(section.machineKey)}-b-${String(bulletIndex)}`}
+              >
+                <Text style={newsItemSummary}>
+                  {renderInlineMarkdownLinks(bullet.text, link)}
                 </Text>
-              ) : null}
-              {bulletIndex < section.bullets.length - 1 ? (
-                <Hr style={itemSeparator} />
-              ) : null}
-            </Section>
-          ))}
+                {bullet.url !== undefined && bullet.url !== "" ? (
+                  <Text style={newsItemSourceLink}>
+                    <Link href={bullet.url} style={link}>
+                      Read {bulletCtaLabel}
+                    </Link>
+                  </Text>
+                ) : null}
+                {bulletIndex < section.bullets.length - 1 ? (
+                  <Hr style={itemSeparator} />
+                ) : null}
+              </Section>
+            );
+          })}
         </Section>
       );
     }
@@ -232,23 +235,26 @@ export const DefaultNewsletterEmail = ({
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
           {renderSectionHeader(section.machineKey, section.displayHeading)}
-          {section.items.map((item, itemIndex) => (
-            <Section key={`qh-${String(itemIndex)}`}>
-              <Text style={newsItemTitle}>
-                {itemIndex + 1}. {item.text}
-              </Text>
-              {item.url !== undefined && item.url !== "" ? (
-                <Text style={newsItemSourceLink}>
-                  <Link href={item.url} style={link}>
-                    Read the full article
-                  </Link>
+          {section.items.map((item, itemIndex) => {
+            const itemCtaLabel = item.title ?? item.text;
+            return (
+              <Section key={`qh-${String(itemIndex)}`}>
+                <Text style={newsItemTitle}>
+                  {itemIndex + 1}. {item.text}
                 </Text>
-              ) : null}
-              {itemIndex < section.items.length - 1 ? (
-                <Hr style={itemSeparator} />
-              ) : null}
-            </Section>
-          ))}
+                {item.url !== undefined && item.url !== "" ? (
+                  <Text style={newsItemSourceLink}>
+                    <Link href={item.url} style={link}>
+                      Read {itemCtaLabel}
+                    </Link>
+                  </Text>
+                ) : null}
+                {itemIndex < section.items.length - 1 ? (
+                  <Hr style={itemSeparator} />
+                ) : null}
+              </Section>
+            );
+          })}
         </Section>
       );
     }
@@ -285,7 +291,7 @@ export const DefaultNewsletterEmail = ({
                 {industryPulseSection.url !== undefined ? (
                   <Text style={newsItemSourceLink}>
                     <Link href={industryPulseSection.url} style={link}>
-                      Read the full article
+                      Read {industryPulseSection.displayHeading}
                     </Link>
                   </Text>
                 ) : null}
@@ -330,7 +336,7 @@ export const DefaultNewsletterEmail = ({
                       {item.url !== undefined && item.url !== "" ? (
                         <Text style={newsItemSourceLink}>
                           <Link href={item.url} style={link}>
-                            Read the full article
+                            Read {item.title}
                           </Link>
                         </Text>
                       ) : null}

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts
@@ -158,4 +158,53 @@ describe("parseIndustryNewsletterWire", () => {
       "quick-hits",
     ]);
   });
+
+  it("parses TITLE lines on bullets and items into the title field", () => {
+    const wire = [
+      INDUSTRY_NEWSLETTER_WIRE_MARKER,
+      "",
+      "BEGIN competitive-landscape",
+      "DISPLAY_HEADING",
+      "Competition",
+      "BULLET",
+      "TITLE Rival A Launches",
+      "Rival A launched a competing product.",
+      "BULLET",
+      "No title bullet.",
+      "END",
+      "",
+      "BEGIN quick-hits",
+      "DISPLAY_HEADING",
+      "Quick Hits",
+      "ITEM",
+      "TITLE Hit One",
+      "First quick hit.",
+      "ITEM",
+      "Second hit with no title.",
+      "END",
+      "",
+    ].join("\n");
+
+    const parsed = parseIndustryNewsletterWire(wire);
+
+    expect(parsed).not.toBeUndefined();
+    const landscape = parsed?.sections.find(
+      (s) => s.machineKey === "competitive-landscape",
+    );
+    const quickHits = parsed?.sections.find(
+      (s) => s.machineKey === "quick-hits",
+    );
+
+    expect(landscape?.machineKey).toBe("competitive-landscape");
+    if (landscape?.machineKey === "competitive-landscape") {
+      expect(landscape.bullets[0]?.title).toBe("Rival A Launches");
+      expect(landscape.bullets[1]?.title).toBeUndefined();
+    }
+
+    expect(quickHits?.machineKey).toBe("quick-hits");
+    if (quickHits?.machineKey === "quick-hits") {
+      expect(quickHits.items[0]?.title).toBe("Hit One");
+      expect(quickHits.items[1]?.title).toBeUndefined();
+    }
+  });
 });

--- a/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
+++ b/packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts
@@ -7,6 +7,8 @@ export const INDUSTRY_NEWSLETTER_WIRE_MARKER = "MP_NEWSLETTER";
 
 const READ_FULL_ARTICLE_LABEL = "Read the full article";
 
+const TITLE_PREFIX = "TITLE ";
+
 const READ_FULL_ARTICLE_LINE_REGEX = new RegExp(
   String.raw`(?:^|\n)\s*` + READ_FULL_ARTICLE_LABEL + String.raw`:\s*(\S+)\s*$`,
   "i",
@@ -28,7 +30,7 @@ export type ParsedIndustryBulletSection = {
     | "regulatory-policy-watch"
     | "disruptors-or-tech";
   displayHeading: string;
-  bullets: Array<{ text: string; url?: string }>;
+  bullets: Array<{ title?: string; text: string; url?: string }>;
 };
 
 /** Parsed disruptors-or-tech prose variant. */
@@ -42,7 +44,7 @@ export type ParsedIndustryDisruptorsProseSection = {
 export type ParsedIndustryQuickHitsSection = {
   machineKey: "quick-hits";
   displayHeading: string;
-  items: Array<{ text: string; url?: string }>;
+  items: Array<{ title?: string; text: string; url?: string }>;
 };
 
 export type ParsedIndustrySection =
@@ -169,11 +171,21 @@ export const parseIndustryNewsletterWire = (
       machineKey === "deals-and-movements" ||
       machineKey === "regulatory-policy-watch"
     ) {
-      const bullets: Array<{ text: string; url?: string }> = [];
+      const bullets: Array<{ title?: string; text: string; url?: string }> = [];
       while (i < lines.length && (lines[i] ?? "").trim() === "BULLET") {
         i += 1;
+        let title: string | undefined;
+        const maybeTitleLine = (lines[i] ?? "").trim();
+        if (maybeTitleLine.startsWith(TITLE_PREFIX)) {
+          title = maybeTitleLine.slice(TITLE_PREFIX.length).trim();
+          if (title.length === 0) {
+            title = undefined;
+          }
+          i += 1;
+        }
         const body = readUntilToken(new Set(["BULLET", "END"]));
-        bullets.push(splitTrailingReadLine(body));
+        const { text, url } = splitTrailingReadLine(body);
+        bullets.push({ ...(title !== undefined ? { title } : {}), text, url });
       }
       if ((lines[i] ?? "").trim() !== "END") {
         return undefined;
@@ -213,11 +225,26 @@ export const parseIndustryNewsletterWire = (
         continue;
       }
       if (fmt === "bullets") {
-        const bullets: Array<{ text: string; url?: string }> = [];
+        const bullets: Array<{ title?: string; text: string; url?: string }> =
+          [];
         while (i < lines.length && (lines[i] ?? "").trim() === "BULLET") {
           i += 1;
+          let title: string | undefined;
+          const maybeTitleLine = (lines[i] ?? "").trim();
+          if (maybeTitleLine.startsWith(TITLE_PREFIX)) {
+            title = maybeTitleLine.slice(TITLE_PREFIX.length).trim();
+            if (title.length === 0) {
+              title = undefined;
+            }
+            i += 1;
+          }
           const body = readUntilToken(new Set(["BULLET", "END"]));
-          bullets.push(splitTrailingReadLine(body));
+          const { text, url } = splitTrailingReadLine(body);
+          bullets.push({
+            ...(title !== undefined ? { title } : {}),
+            text,
+            url,
+          });
         }
         if ((lines[i] ?? "").trim() !== "END") {
           return undefined;
@@ -234,11 +261,21 @@ export const parseIndustryNewsletterWire = (
     }
 
     if (machineKey === "quick-hits") {
-      const items: Array<{ text: string; url?: string }> = [];
+      const items: Array<{ title?: string; text: string; url?: string }> = [];
       while (i < lines.length && (lines[i] ?? "").trim() === "ITEM") {
         i += 1;
+        let title: string | undefined;
+        const maybeTitleLine = (lines[i] ?? "").trim();
+        if (maybeTitleLine.startsWith(TITLE_PREFIX)) {
+          title = maybeTitleLine.slice(TITLE_PREFIX.length).trim();
+          if (title.length === 0) {
+            title = undefined;
+          }
+          i += 1;
+        }
         const body = readUntilToken(new Set(["ITEM", "END"]));
-        items.push(splitTrailingReadLine(body));
+        const { text, url } = splitTrailingReadLine(body);
+        items.push({ ...(title !== undefined ? { title } : {}), text, url });
       }
       if ((lines[i] ?? "").trim() !== "END") {
         return undefined;

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -325,7 +325,7 @@ describe("renderNewsletterEmail", () => {
     expect(brandingIndex).toBeLessThan(footerNoteIndex);
   });
 
-  it("renders a 'Read the full article' link below each top-news item that has a source URL", async () => {
+  it("renders a CTA link with the item title below each top-news item that has a source URL", async () => {
     // Setup
     const structuredBody = [
       "EXECUTIVE SUMMARY",
@@ -355,8 +355,11 @@ describe("renderNewsletterEmail", () => {
       bodyText: structuredBody,
     });
 
-    // Assert — three anchors with the expected label, one per source.
-    expect(html.match(/Read the full article/g)?.length).toBe(3);
+    // Assert — three anchors, one per source, labelled with the item title.
+    // React inserts <!-- --> between static and dynamic text nodes in JSX.
+    expect(html).toMatch(/Read <!-- -->Fed holds rates steady/);
+    expect(html).toMatch(/Read <!-- -->Apple beats estimates/);
+    expect(html).toMatch(/Read <!-- -->Oil prices dip/);
     expect(html).toContain('href="https://example.com/fed"');
     expect(html).toContain('href="https://example.com/apple"');
     expect(html).toContain('href="https://example.com/oil"');
@@ -390,13 +393,13 @@ describe("renderNewsletterEmail", () => {
       bodyText: structuredBody,
     });
 
-    // Assert — only one anchor with the new label, no empty href.
-    expect(html.match(/Read the full article/g)?.length).toBe(1);
+    // Assert — only one anchor (for the item with URL), labelled with the item title.
+    expect(html).toMatch(/Read <!-- -->With URL/);
     expect(html).toContain('href="https://example.com/with-url"');
     expect(html).not.toMatch(/href=""/);
   });
 
-  it("keeps top-news summaries free of leftover 'Read the full article' label text", async () => {
+  it("strips the raw source-link line from top-news summary paragraphs", async () => {
     // Setup
     const structuredBody = [
       "EXECUTIVE SUMMARY",
@@ -453,7 +456,7 @@ describe("renderNewsletterEmail", () => {
     expect(text).toContain(articleUrl);
   });
 
-  it("renders a 'Read the full article' link below the industry-pulse standfirst when the lead has a url", async () => {
+  it("renders a Read link below the industry-pulse standfirst when the lead has a url", async () => {
     const industryBody = [
       "MP_NEWSLETTER",
       "",


### PR DESCRIPTION
## Summary

Every bullet and quick-hit item in the industry newsletter now carries a short title the LLM writes as part of generation. That title becomes the CTA label in the email ("Read Rival A Launches" instead of "Read the full article") and a dedup key that drops items covering the same story twice across sections.

## Related issues

Closes #754

## Important changes

- `industryBriefBulletSchema` and `industryQuickHitSchema` now require a `title: string` field. Any code that constructs bullets or items must supply one.
- The wire format gains a `TITLE <text>` line after each `BULLET` or `ITEM` token. Old wire data without TITLE lines still parses correctly, with `title` returning as `undefined`.
- `pruneNewsletterToCitedRows` runs a title-dedup pass after URL dedup. Items whose normalized title (lowercase, collapsed whitespace, stripped trailing punctuation) duplicates an earlier item in the newsletter are dropped. The new `bulletsRemovedDuplicateTitle` counter in `PruneSummary` tracks this.
- The LLM system prompt now states that titles must be unique across the entire newsletter and that near-identical paraphrases of the same story are not allowed.

## Other changes

- `default-newsletter.tsx` CTA labels: bullets use `bullet.title ?? bullet.text`, quick-hits use `item.title ?? item.text`, industry-pulse uses the section `displayHeading`, and legacy top-news uses `item.title`.
- `citation-grounding.ts` and `cross-run-dedup.ts` use spread-based reconstruction (`{ articleIndex: _ai, ...rest }`) to preserve `title` when stripping `articleIndex`.
- Newsletter exemplars updated with `title` fields on all bullets and quick-hit items.
- All test fixtures updated to include `title`; new tests cover TITLE line parsing and title deduplication.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/industry-newsletter-schema.ts` — `title` field added to both bullet schemas and the LLM variant.
- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts` — `filterByTitle` closure and `seenTitles` set.
- `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.ts` — TITLE line parsing in bullet and item loops.
- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` — CTA label logic for all four section types.
- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.test.ts` — new title dedup tests.
- `packages/shared/email-templates/src/newsletter/parse-industry-newsletter-wire.test.ts` — new TITLE parsing test.

## How to test

1. Run `pnpm --filter "*content-generation*" test --run` and confirm 443 tests pass.
2. Run `pnpm --filter "*email-templates*" test --run` and confirm 77 tests pass.
3. In a local newsletter generation run, check that `briefing.competitiveLandscape.bullets[n].title` is populated and non-empty.
4. Format a resolved newsletter with `formatIndustryNewsletterWire` and confirm `TITLE <text>` lines appear after each `BULLET` and `ITEM` token.
5. Parse the wire back with `parseIndustryNewsletterWire` and verify `bullet.title` and `item.title` round-trip correctly.
6. Render a newsletter email and confirm each CTA link reads "Read [title]" rather than "Read the full article".
