### PR TITLE
Eliminate duplicate stories within a newsletter

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -389,9 +389,17 @@ const requireCitationSchema = z
       ),
     dedupeScope: z
       .enum(["section", "newsletter"])
-      .default("section")
+      .default("newsletter")
       .describe(
         "section = dedup URLs per section only; newsletter = dedup URLs across all sections.",
+      ),
+    withinRunDedupSimilarity: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.55)
+      .describe(
+        "Jaccard similarity threshold for within-run semantic dedup of resolved newsletter items.",
       ),
   })
   .default({})

--- a/apps/mediapulse/agents/content-generation/src/lib/dedup-llm-input-sources.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/dedup-llm-input-sources.ts
@@ -1,0 +1,90 @@
+import type { SourceForGeneration } from "../types.js";
+import {
+  buildWordShingles,
+  shingleJaccardSimilarity,
+} from "./citation-grounding.js";
+import { tokenize } from "./phrase-link-injector.js";
+
+/** Default Jaccard similarity threshold for near-duplicate title/content detection. */
+const DEFAULT_NEAR_DUP_SIMILARITY = 0.6;
+
+/** Result of the LLM input source dedup pass. */
+export type DedupLlmInputSourcesResult = {
+  sources: SourceForGeneration[];
+  removedCount: number;
+};
+
+const normalizeTitle = (title: string): string =>
+  title
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/[.,;!?]+$/, "")
+    .trim();
+
+const scoreSourceSimilarity = (
+  left: SourceForGeneration,
+  right: SourceForGeneration,
+): number => {
+  const leftText = `${left.title} ${left.content}`;
+  const rightText = `${right.title} ${right.content}`;
+  const leftShingles = buildWordShingles(tokenize(leftText));
+  const rightShingles = buildWordShingles(tokenize(rightText));
+
+  return shingleJaccardSimilarity(leftShingles, rightShingles);
+};
+
+/**
+ * Removes exact-URL duplicates and near-duplicate stories from a source list.
+ *
+ * Sources are assumed to be ordered by descending relevance; the first
+ * occurrence is always kept.
+ *
+ * @param sources - Ordered source list (highest relevance first).
+ * @param nearDupSimilarity - Jaccard threshold above which two sources are
+ *   treated as the same story. Defaults to 0.6.
+ */
+export const dedupLlmInputSources = (
+  sources: SourceForGeneration[],
+  nearDupSimilarity: number = DEFAULT_NEAR_DUP_SIMILARITY,
+): DedupLlmInputSourcesResult => {
+  const seenUrls = new Set<string>();
+  const seenNormalizedTitles = new Set<string>();
+  const kept: SourceForGeneration[] = [];
+  let removedCount = 0;
+
+  for (const source of sources) {
+    if (seenUrls.has(source.url)) {
+      removedCount++;
+      continue;
+    }
+
+    const normalizedTitle = normalizeTitle(source.title);
+    if (seenNormalizedTitles.has(normalizedTitle)) {
+      removedCount++;
+      seenUrls.add(source.url);
+      continue;
+    }
+
+    let isDuplicate = false;
+    for (const keptSource of kept) {
+      const similarity = scoreSourceSimilarity(source, keptSource);
+      if (similarity >= nearDupSimilarity) {
+        isDuplicate = true;
+        break;
+      }
+    }
+
+    if (isDuplicate) {
+      removedCount++;
+      seenUrls.add(source.url);
+      continue;
+    }
+
+    seenUrls.add(source.url);
+    seenNormalizedTitles.add(normalizedTitle);
+    kept.push(source);
+  }
+
+  return { sources: kept, removedCount };
+};

--- a/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts
@@ -4,6 +4,11 @@ import type {
   IndustryNewsletterResolved,
   IndustryQuickHitResolved,
 } from "../industry-newsletter-urls.js";
+import {
+  buildWordShingles,
+  shingleJaccardSimilarity,
+} from "./citation-grounding.js";
+import { tokenize } from "./phrase-link-injector.js";
 
 /** Why a row was removed by the prune pass. */
 export type PrunedRowReason = "uncited" | "duplicate_article";
@@ -352,3 +357,149 @@ export function pruneNewsletterToCitedRows(
     },
   };
 }
+
+/** Outcome of the within-run semantic dedup pass. */
+export type WithinRunDedupResult = {
+  resolved: IndustryNewsletterResolved;
+  removedCount: number;
+};
+
+type ResolvedItem = IndustryBulletResolved | IndustryQuickHitResolved;
+
+const scoreItemSimilarity = (
+  left: ResolvedItem,
+  right: ResolvedItem,
+): number => {
+  const leftText = `${left.title ?? ""} ${left.text}`;
+  const rightText = `${right.title ?? ""} ${right.text}`;
+  const leftShingles = buildWordShingles(tokenize(leftText));
+  const rightShingles = buildWordShingles(tokenize(rightText));
+
+  return shingleJaccardSimilarity(leftShingles, rightShingles);
+};
+
+const dedupeItems = <T extends ResolvedItem>(
+  items: T[],
+  seenTitles: Set<string>,
+  corpus: ResolvedItem[],
+  minSimilarity: number,
+): { kept: T[]; removedCount: number } => {
+  const kept: T[] = [];
+  let removedCount = 0;
+
+  for (const item of items) {
+    if (item.url === undefined) {
+      kept.push(item);
+      continue;
+    }
+
+    if (item.title !== undefined) {
+      const normalizedTitle = normalizeTitle(item.title);
+      if (seenTitles.has(normalizedTitle)) {
+        removedCount++;
+        continue;
+      }
+    }
+
+    let isDuplicate = false;
+    for (const seenItem of corpus) {
+      const similarity = scoreItemSimilarity(item, seenItem);
+      if (similarity >= minSimilarity) {
+        isDuplicate = true;
+        break;
+      }
+    }
+
+    if (isDuplicate) {
+      removedCount++;
+      continue;
+    }
+
+    if (item.title !== undefined) {
+      seenTitles.add(normalizeTitle(item.title));
+    }
+    corpus.push(item);
+    kept.push(item);
+  }
+
+  return { kept, removedCount };
+};
+
+/**
+ * Removes semantically near-duplicate items from a resolved newsletter using
+ * n-gram Jaccard similarity over item text and normalized title matching.
+ *
+ * Operates newsletter-wide: an item kept in an earlier section can suppress a
+ * duplicate in a later section.
+ *
+ * @param resolved - Resolved newsletter after URL attachment and citation pruning.
+ * @param minSimilarity - Jaccard threshold above which two items are considered
+ *   the same story (default 0.55).
+ */
+export const dedupeWithinRun = (
+  resolved: IndustryNewsletterResolved,
+  minSimilarity: number = 0.55,
+): WithinRunDedupResult => {
+  const seenTitles = new Set<string>();
+  const corpus: ResolvedItem[] = [];
+  let totalRemoved = 0;
+
+  const dedupeSection = <T extends ResolvedItem>(
+    items: T[],
+  ): { kept: T[]; removedCount: number } =>
+    dedupeItems(items, seenTitles, corpus, minSimilarity);
+
+  let competitiveLandscape = resolved.competitiveLandscape;
+  if (competitiveLandscape !== undefined) {
+    const { kept, removedCount } = dedupeSection(competitiveLandscape.bullets);
+    totalRemoved += removedCount;
+    competitiveLandscape =
+      kept.length > 0 ? { ...competitiveLandscape, bullets: kept } : undefined;
+  }
+
+  let dealsAndMovements = resolved.dealsAndMovements;
+  if (dealsAndMovements !== undefined) {
+    const { kept, removedCount } = dedupeSection(dealsAndMovements.bullets);
+    totalRemoved += removedCount;
+    dealsAndMovements =
+      kept.length > 0 ? { ...dealsAndMovements, bullets: kept } : undefined;
+  }
+
+  let regulatoryPolicyWatch = resolved.regulatoryPolicyWatch;
+  if (regulatoryPolicyWatch !== undefined) {
+    const { kept, removedCount } = dedupeSection(regulatoryPolicyWatch.bullets);
+    totalRemoved += removedCount;
+    regulatoryPolicyWatch =
+      kept.length > 0 ? { ...regulatoryPolicyWatch, bullets: kept } : undefined;
+  }
+
+  let disruptorsOrTech = resolved.disruptorsOrTech;
+  if (disruptorsOrTech !== undefined && disruptorsOrTech.format === "bullets") {
+    const { kept, removedCount } = dedupeSection(disruptorsOrTech.bullets);
+    totalRemoved += removedCount;
+    disruptorsOrTech =
+      kept.length > 0 ? { ...disruptorsOrTech, bullets: kept } : undefined;
+  }
+
+  let quickHits = resolved.quickHits;
+  if (quickHits !== undefined) {
+    const { kept, removedCount } = dedupeSection(quickHits.items);
+    totalRemoved += removedCount;
+    quickHits = kept.length > 0 ? { ...quickHits, items: kept } : undefined;
+  }
+
+  return {
+    resolved: {
+      subject: resolved.subject,
+      ...(resolved.industryPulse !== undefined
+        ? { industryPulse: resolved.industryPulse }
+        : {}),
+      ...(competitiveLandscape !== undefined ? { competitiveLandscape } : {}),
+      ...(dealsAndMovements !== undefined ? { dealsAndMovements } : {}),
+      ...(regulatoryPolicyWatch !== undefined ? { regulatoryPolicyWatch } : {}),
+      ...(disruptorsOrTech !== undefined ? { disruptorsOrTech } : {}),
+      ...(quickHits !== undefined ? { quickHits } : {}),
+    },
+    removedCount: totalRemoved,
+  };
+};

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -2077,7 +2077,7 @@ describe("generateNewsletterWithLlm — require-citation pruning", () => {
     expect(
       result.requireCitationSummary?.bulletsRemovedUncited,
     ).toBeGreaterThan(0);
-    expect(result.requireCitationSummary?.bulletsRemovedDuplicate).toBe(1);
+    expect(result.requireCitationSummary?.bulletsRemovedDuplicate).toBe(3);
   });
 
   it("passes content through unchanged when requireCitation is disabled", async () => {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -21,8 +21,10 @@ import {
 } from "./industry-newsletter-schema.js";
 import { attachIndustryNewsletterSourceUrls } from "./industry-newsletter-urls.js";
 import {
+  dedupeWithinRun,
   pruneNewsletterToCitedRows,
   type PruneSummary,
+  type WithinRunDedupResult,
 } from "./lib/prune-uncited-rows.js";
 import { isRetryableLlmError } from "./llm-classify-error.js";
 import {
@@ -585,7 +587,9 @@ Headings ("displayHeading") are short subtitle phrases only — never repeat the
 
 Every bullet and quick hit must summarize exactly one article and set articleIndex to that one article. Do not blend multiple articles into one bullet, and do not reuse the same article for two bullets in a section.
 
-Item titles must be unique across the entire newsletter (all bullets in all sections and all quick-hit items). Every title must name a distinct story. Do not reuse the same headline or a near-identical paraphrase for two different items.`;
+Item titles must be unique across the entire newsletter (all bullets in all sections and all quick-hit items). Every title must name a distinct story. Do not reuse the same headline or a near-identical paraphrase for two different items.
+
+Cross-section duplication is forbidden. Do not cover the same story in two different sections, even from different angles. Do not write two items about the same event in different sections. Each article (by articleIndex) may be cited at most once across the entire newsletter — if an article is used in one section, it must not appear in any other section or in quickHits.`;
 
 /**
  * Default user prompt template used when no template is provided in config.
@@ -1561,6 +1565,26 @@ export async function generateNewsletterWithLlm(
         sectionsKept: pruned.summary.sectionsKept,
       },
       "Require-citation pruning summary",
+    );
+  }
+
+  const withinRunDedupMinSimilarity =
+    config.quality.requireCitation.withinRunDedupSimilarity;
+  const withinRunDeduped: WithinRunDedupResult = dedupeWithinRun(
+    resolved,
+    withinRunDedupMinSimilarity,
+  );
+  resolved = withinRunDeduped.resolved;
+
+  if (withinRunDeduped.removedCount > 0) {
+    logger.info(
+      {
+        tickerId: context.tickerId,
+        removedCount: withinRunDeduped.removedCount,
+        minSimilarity: withinRunDedupMinSimilarity,
+        event: "within_run_semantic_dedup",
+      },
+      `Within-run semantic dedup: removed ${String(withinRunDeduped.removedCount)} near-duplicate item(s)`,
     );
   }
 

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -15,6 +15,7 @@ import {
   generateNewsletterWithLlm,
   type SourceForGeneration,
 } from "./llm-generate-newsletter.js";
+import { dedupLlmInputSources } from "./lib/dedup-llm-input-sources.js";
 import { mapOutcomeToDiagnostic } from "./outcome-to-diagnostic.js";
 import { sanitizeDiagnosticMessage } from "./sanitize-diagnostic-message.js";
 import type { AgentOutcome } from "./types/outcome.js";
@@ -324,7 +325,7 @@ export async function run({
   report("Preparing article context", `${sources.length} articles`);
 
   // Map API sources to the minimal shape needed by the LLM generator.
-  const sourcesForLlm: SourceForGeneration[] = sources.map((s) => ({
+  const mappedSources: SourceForGeneration[] = sources.map((s) => ({
     url: s.url,
     title: s.title,
     content: s.content,
@@ -332,6 +333,20 @@ export async function run({
       ? { publishedAt: s.publishedAt }
       : {}),
   }));
+
+  const { sources: sourcesForLlm, removedCount: dedupRemovedCount } =
+    dedupLlmInputSources(mappedSources);
+
+  if (dedupRemovedCount > 0) {
+    logger.info(
+      {
+        tickerId: input.tickerId,
+        removedCount: dedupRemovedCount,
+        event: "dedup_llm_input_sources",
+      },
+      `Deduped LLM input sources: removed ${String(dedupRemovedCount)} near-duplicate(s)`,
+    );
+  }
 
   let recentBullets: Array<{
     newsletterId: string;


### PR DESCRIPTION
## Summary

Generated newsletters sometimes covered the same story twice. This PR closes four gaps that let duplicates through: undeduped input sources, per-section URL dedup, no within-run similarity pass, and a prompt rule that only blocked within-section article reuse.

## Related issues

Closes #756

## Important changes

- `dedupLlmInputSources` (new file) collapses input `DataSource` objects by canonical URL and by 3-gram Jaccard similarity over `title + content` before the LLM prompt is built. Sources that are exact-URL duplicates or above the similarity threshold (default 0.6) are dropped; the higher-relevance or first-seen representative is kept. Removed count is logged.
- `requireCitation.dedupeScope` default changed from `"section"` to `"newsletter"` in `config-schema.ts`. Any URL that appears in two sections now gets one kept and one dropped by the prune pass.
- `dedupeWithinRun` (added to `prune-uncited-rows.ts`) runs over the resolved structure after URL attachment and removes items whose normalized title or n-gram text similarity (above `withinRunDedupSimilarity`, default 0.55) duplicates an earlier cited item anywhere in the newsletter.
- The system prompt now explicitly states that each `articleIndex` may be cited at most once across the entire newsletter, and that covering the same story in two sections is forbidden.

## Other changes

- `config-schema.ts` gains `withinRunDedupSimilarity: number` (default 0.55, range 0-1) under `requireCitation` so the within-run threshold is configurable per run.
- `llm-generate-newsletter.ts` calls `dedupeWithinRun` after `pruneNewsletterToCitedRows` and logs count when non-zero.
- One test in `llm-generate-newsletter.test.ts` updated: `bulletsRemovedDuplicate` count reflects the new newsletter-wide default (cross-section URL duplicates now caught).

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/dedup-llm-input-sources.ts` — new dedup utility for input sources.
- `apps/mediapulse/agents/content-generation/src/lib/prune-uncited-rows.ts` — `dedupeWithinRun` added.
- `apps/mediapulse/agents/content-generation/src/config-schema.ts` — default and new field.
- `apps/mediapulse/agents/content-generation/src/run.ts` — where input dedup is called.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — prompt extension and within-run dedup call.

## How to test

1. Run `pnpm --filter "*content-generation*" test --run` and confirm 443 tests pass.
2. Construct two input sources with the same URL and confirm only one reaches `sourcesForLlm`.
3. Construct two near-duplicate sources (high title similarity) and confirm only one survives.
4. Generate a newsletter where two sections would cite the same URL and confirm only one section keeps it after the prune pass.
5. Generate a newsletter with two bullets whose text is near-identical and confirm `dedupeWithinRun` drops one.
