### PR TITLE
Change registration name-field label to warmer copy

### DIFF
--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
@@ -30,7 +30,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/components/registration-form", () => ({
   RegistrationForm: () => (
     <div>
-      <label htmlFor="name">Your name</label>
+      <label htmlFor="name">What should we call you?</label>
       <input id="name" />
       <label htmlFor="ticker">Stock ticker</label>
       <input id="ticker" />
@@ -68,7 +68,9 @@ describe("DevUiIssue483Page", () => {
     render(ui);
 
     // Assert
-    expect(screen.getByLabelText(/Your name/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/What should we call you\?/i),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Open email app to subscribe/i }),

--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -40,7 +40,9 @@ describe("RegistrationForm", () => {
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
     // Assert
-    expect(screen.getByLabelText(/Your name/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/What should we call you\?/i),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
   });
 
@@ -75,7 +77,10 @@ describe("RegistrationForm", () => {
     );
 
     // Act
-    await user.type(screen.getByLabelText(/Your name/i), "John Doe");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "John Doe",
+    );
 
     // Select Ticker
     await user.click(screen.getByLabelText(/Stock ticker/i));
@@ -109,7 +114,10 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
-    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "Jane",
+    );
     await user.click(screen.getByLabelText(/Stock ticker/i));
     await user.click(screen.getByText(/Bank Central Asia Tbk/i));
     await user.click(
@@ -128,7 +136,10 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
-    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "Jane",
+    );
     await user.click(screen.getByLabelText(/Stock ticker/i));
     await user.click(screen.getByText(/Bank Central Asia Tbk/i));
     await user.click(

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -105,7 +105,7 @@ const RegistrationForm = ({
       </div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="name">Your name</Label>
+          <Label htmlFor="name">What should we call you?</Label>
           <Input
             id="name"
             placeholder="John Doe"


### PR DESCRIPTION
## Summary

The registration form's name field asked "Your name", which is flat. It now asks "What should we call you?" — same field, warmer tone. Tests that matched the old label string are updated.

## Related issues

Closes #758

## Important changes

- `registration-form.tsx` line ~108: label text changed from "Your name" to "What should we call you?".

## Other changes

- `registration-form.test.tsx`: four `getByLabelText(/Your name/i)` calls updated to `/What should we call you\?/i`.
- `page.test.tsx` (issue-483 dev page): mock label text and `getByLabelText` call updated to match.

## Key files to review

- `apps/mediapulse/user-registration/components/registration-form.tsx` — the one-line label change.
- `apps/mediapulse/user-registration/components/registration-form.test.tsx` — updated matchers.

## How to test

1. Run `pnpm --filter "*user-registration*" test` and confirm 50 tests pass.
2. Open the registration page and confirm the name field reads "What should we call you?" and still accepts input, validates, and submits correctly.
