### PR TITLE
Add per-ticker canonical-URL unique constraint to DataSource and harden near-duplicate selection

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -177,6 +177,7 @@ describe("agent-data-api", () => {
           {
             id: "ds-1",
             url: "https://example.com",
+            canonicalUrl: "https://example.com",
             title: "Example",
             content: "Content",
             metadata: null,

--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -769,12 +769,14 @@ describe("agent-data-api", () => {
         data: [
           {
             url: "https://example.com",
+            canonicalUrl: "https://example.com",
             title: "Example",
             content: "Content",
             tickerId: TICKER_ID,
             searchQueryId: SEARCH_QUERY_ID,
           },
         ],
+        skipDuplicates: true,
       });
     });
   });

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection.ts
@@ -5,6 +5,7 @@ import {
   dataCollectionQuerySchema,
 } from "@workspace/agent-data-api-contract";
 import { internalError } from "@workspace/api-utils";
+import { canonicalizeUrl } from "@workspace/utils";
 import { prisma } from "@mediapulse/database";
 
 import { aggregateSearchQueryYieldForTicker } from "../services/search-query-yield.js";
@@ -39,10 +40,22 @@ export async function postDataCollection(context: Context): Promise<Response> {
     const body = await context.req.json();
     const data = await dataCollectionBodySchema.parseAsync(body);
     await prisma.dataSource.createMany({
-      data: data.map((row) => ({
-        ...row,
-        ...(row.publishedAt ? { publishedAt: new Date(row.publishedAt) } : {}),
-      })),
+      data: data.map((row) => {
+        let canonicalUrl: string;
+        try {
+          canonicalUrl = canonicalizeUrl(row.url);
+        } catch {
+          canonicalUrl = row.url;
+        }
+        return {
+          ...row,
+          canonicalUrl,
+          ...(row.publishedAt
+            ? { publishedAt: new Date(row.publishedAt) }
+            : {}),
+        };
+      }),
+      skipDuplicates: true,
     });
 
     const tickerIds = [...new Set(data.map((row) => row.tickerId))];

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.test.ts
@@ -155,7 +155,7 @@ const clusterBSignals = (): PerSourceRelevanceSignals[] => [
 ];
 
 describe("applyRelevanceSelectionDiversified", () => {
-  it("picks cluster representatives first then fills budget by score", () => {
+  it("picks one cluster representative per cluster regardless of remaining budget", () => {
     const rows = [
       {
         dataSourceId: "a-high",
@@ -202,6 +202,8 @@ describe("applyRelevanceSelectionDiversified", () => {
 
     expect(result.stats.clustersFormed).toBe(2);
     expect(result.stats.largestClusterSize).toBe(3);
+    // Only the highest-scored representative per cluster is selected; near-duplicate
+    // cluster mates are suppressed even when budget would allow them.
     expect(
       result.rows.find((row) => row.dataSourceId === "a-high")?.selected,
     ).toBe(true);
@@ -210,14 +212,14 @@ describe("applyRelevanceSelectionDiversified", () => {
     ).toBe(true);
     expect(
       result.rows.find((row) => row.dataSourceId === "a-mid")?.selected,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       result.rows.find((row) => row.dataSourceId === "a-low")?.selected,
-    ).toBe(true);
+    ).toBe(false);
     expect(
       result.rows.find((row) => row.dataSourceId === "b-low")?.selected,
     ).toBe(false);
-    expect(result.stats.selectedAfterDiversification).toBe(4);
+    expect(result.stats.selectedAfterDiversification).toBe(2);
   });
 
   it("counts suppressed duplicates when budget forces cross-cluster picks", () => {

--- a/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts
+++ b/apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts
@@ -224,10 +224,21 @@ export const applyRelevanceSelectionDiversified = (
     if (rows[index]!.score < minScore || slots <= 0) {
       continue;
     }
-    if (!selectedIndices.has(index)) {
-      selectedIndices.add(index);
-      slots -= 1;
+    if (selectedIndices.has(index)) {
+      continue;
     }
+    const clusterId = clusterIdByRowIndex.get(index);
+    if (
+      clusterId !== undefined &&
+      clusterHasRepresentativePick.has(clusterId)
+    ) {
+      continue;
+    }
+    selectedIndices.add(index);
+    if (clusterId !== undefined) {
+      clusterHasRepresentativePick.add(clusterId);
+    }
+    slots -= 1;
   }
 
   const classicRows = applyRelevanceSelection(

--- a/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.test.ts
@@ -27,6 +27,7 @@ describe("mapRowToListItem", () => {
     const row = {
       id: "ds-1",
       url: "https://example.com/a",
+      canonicalUrl: "https://example.com/a",
       title: "Article",
       content,
       metadata: null,
@@ -59,6 +60,7 @@ describe("mapRowToDetailItem", () => {
     const row = {
       id: "ds-2",
       url: "https://example.com/b",
+      canonicalUrl: "https://example.com/b",
       title: "Full",
       content: "body text",
       metadata: { key: "v" },

--- a/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
+++ b/apps/mediapulse/user-registration/app/dev/ui/issue-483/page.test.tsx
@@ -30,7 +30,7 @@ vi.mock("next/navigation", () => ({
 vi.mock("@/components/registration-form", () => ({
   RegistrationForm: () => (
     <div>
-      <label htmlFor="name">Your name</label>
+      <label htmlFor="name">What should we call you?</label>
       <input id="name" />
       <label htmlFor="ticker">Stock ticker</label>
       <input id="ticker" />
@@ -68,7 +68,9 @@ describe("DevUiIssue483Page", () => {
     render(ui);
 
     // Assert
-    expect(screen.getByLabelText(/Your name/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/What should we call you\?/i),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Open email app to subscribe/i }),

--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -40,7 +40,9 @@ describe("RegistrationForm", () => {
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
     // Assert
-    expect(screen.getByLabelText(/Your name/i)).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/What should we call you\?/i),
+    ).toBeInTheDocument();
     expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
   });
 
@@ -75,7 +77,10 @@ describe("RegistrationForm", () => {
     );
 
     // Act
-    await user.type(screen.getByLabelText(/Your name/i), "John Doe");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "John Doe",
+    );
 
     // Select Ticker
     await user.click(screen.getByLabelText(/Stock ticker/i));
@@ -109,7 +114,10 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
-    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "Jane",
+    );
     await user.click(screen.getByLabelText(/Stock ticker/i));
     await user.click(screen.getByText(/Bank Central Asia Tbk/i));
     await user.click(
@@ -128,7 +136,10 @@ describe("RegistrationForm", () => {
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
-    await user.type(screen.getByLabelText(/Your name/i), "Jane");
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "Jane",
+    );
     await user.click(screen.getByLabelText(/Stock ticker/i));
     await user.click(screen.getByText(/Bank Central Asia Tbk/i));
     await user.click(

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -105,7 +105,7 @@ const RegistrationForm = ({
       </div>
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
         <div className="flex flex-col gap-2">
-          <Label htmlFor="name">Your name</Label>
+          <Label htmlFor="name">What should we call you?</Label>
           <Input
             id="name"
             placeholder="John Doe"

--- a/packages/mediapulse/database/prisma/migrations/20260611000001_add_canonical_url_unique_constraint/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260611000001_add_canonical_url_unique_constraint/migration.sql
@@ -1,0 +1,137 @@
+-- Migration: add canonical_url to data_source with per-ticker uniqueness constraint.
+--
+-- Steps:
+--   1. Add canonical_url as nullable.
+--   2. Populate it from the raw url using a best-effort SQL normalization:
+--      - strip fragment (#...) via split_part
+--      - lowercase the result
+--      - remove common tracking query params (utm_*, fbclid, gclid, mc_*)
+--        NOTE: exact parameter stripping is hard in plain SQL; we strip the full
+--        query string when it contains only tracking params, otherwise leave it.
+--      The TypeScript canonicalizeUrl() function handles edge cases more precisely;
+--      this SQL approximation is safe for the migration because any remaining
+--      variation will be resolved the moment the application writes new rows using
+--      the TypeScript-computed canonical URL.
+--   3. Deduplicate rows: for each (ticker_id, canonical_url) group keep the row with
+--      the highest published_at, or latest created_at when published_at is null.
+--      Re-point all dependent rows to the surviving id before deleting duplicates.
+--   4. Make canonical_url NOT NULL and add the unique constraint.
+
+-- Step 1: add nullable column
+ALTER TABLE "data_source" ADD COLUMN "canonical_url" TEXT;
+
+-- Step 2: populate canonical_url from url
+-- Strip fragment, lowercase, strip pure-tracking query strings.
+-- The regexp removes the entire query string when every parameter is a tracking one.
+-- Non-tracking query strings are kept as-is (safe fallback).
+UPDATE "data_source"
+SET "canonical_url" = lower(
+  CASE
+    WHEN split_part(split_part("url", '#', 1), '?', 2) ~ '^((utm_[^&=]*=[^&]*|fbclid=[^&]*|gclid=[^&]*|mc_[^&=]*=[^&]*)(&|$))+$'
+      THEN split_part(split_part("url", '#', 1), '?', 1)
+    ELSE split_part("url", '#', 1)
+  END
+);
+
+-- Step 3: deduplicate — keep the best survivor per (ticker_id, canonical_url),
+-- re-point dependents to the survivor, then delete the losers.
+
+-- 3a. Identify survivors: highest published_at wins; fall back to latest created_at.
+CREATE TEMP TABLE _ds_survivors AS
+SELECT DISTINCT ON ("ticker_id", "canonical_url")
+  "id" AS survivor_id,
+  "ticker_id",
+  "canonical_url"
+FROM "data_source"
+ORDER BY
+  "ticker_id",
+  "canonical_url",
+  "published_at" DESC NULLS LAST,
+  "created_at"   DESC;
+
+-- 3b. Build a mapping from every duplicate id to its survivor id.
+CREATE TEMP TABLE _ds_remap AS
+SELECT
+  ds."id"          AS old_id,
+  srv.survivor_id  AS new_id
+FROM "data_source"  AS ds
+JOIN _ds_survivors  AS srv
+  ON  ds."ticker_id"     = srv."ticker_id"
+  AND ds."canonical_url" = srv."canonical_url"
+WHERE ds."id" <> srv.survivor_id;
+
+-- 3c. Re-point article_relevance (unique on (data_source_id, ticker_id), so we
+--     delete the duplicate-target row when the survivor already has one).
+DELETE FROM "article_relevance"
+WHERE "data_source_id" IN (SELECT old_id FROM _ds_remap)
+  AND EXISTS (
+    SELECT 1 FROM "article_relevance" ar2
+    JOIN _ds_remap r ON r.old_id = "article_relevance"."data_source_id"
+    WHERE ar2."data_source_id" = r.new_id
+      AND ar2."ticker_id"      = "article_relevance"."ticker_id"
+  );
+
+UPDATE "article_relevance"
+SET "data_source_id" = r.new_id
+FROM _ds_remap r
+WHERE "article_relevance"."data_source_id" = r.old_id;
+
+-- 3d. Re-point article_entity (unique on (data_source_id, entity_id)).
+DELETE FROM "article_entity"
+WHERE "data_source_id" IN (SELECT old_id FROM _ds_remap)
+  AND EXISTS (
+    SELECT 1 FROM "article_entity" ae2
+    JOIN _ds_remap r ON r.old_id = "article_entity"."data_source_id"
+    WHERE ae2."data_source_id" = r.new_id
+      AND ae2."entity_id"      = "article_entity"."entity_id"
+  );
+
+UPDATE "article_entity"
+SET "data_source_id" = r.new_id
+FROM _ds_remap r
+WHERE "article_entity"."data_source_id" = r.old_id;
+
+-- 3e. Re-point entity_evidence (unique on (entity_id, data_source_id, ticker_id)).
+DELETE FROM "entity_evidence"
+WHERE "data_source_id" IN (SELECT old_id FROM _ds_remap)
+  AND EXISTS (
+    SELECT 1 FROM "entity_evidence" ee2
+    JOIN _ds_remap r ON r.old_id = "entity_evidence"."data_source_id"
+    WHERE ee2."data_source_id" = r.new_id
+      AND ee2."entity_id"      = "entity_evidence"."entity_id"
+      AND ee2."ticker_id"      = "entity_evidence"."ticker_id"
+  );
+
+UPDATE "entity_evidence"
+SET "data_source_id" = r.new_id
+FROM _ds_remap r
+WHERE "entity_evidence"."data_source_id" = r.old_id;
+
+-- 3f. Re-point entity_relation_evidence (unique on (entity_relation_id, data_source_id, ticker_id)).
+DELETE FROM "entity_relation_evidence"
+WHERE "data_source_id" IN (SELECT old_id FROM _ds_remap)
+  AND EXISTS (
+    SELECT 1 FROM "entity_relation_evidence" ere2
+    JOIN _ds_remap r ON r.old_id = "entity_relation_evidence"."data_source_id"
+    WHERE ere2."data_source_id"     = r.new_id
+      AND ere2."entity_relation_id" = "entity_relation_evidence"."entity_relation_id"
+      AND ere2."ticker_id"          = "entity_relation_evidence"."ticker_id"
+  );
+
+UPDATE "entity_relation_evidence"
+SET "data_source_id" = r.new_id
+FROM _ds_remap r
+WHERE "entity_relation_evidence"."data_source_id" = r.old_id;
+
+-- 3g. Delete the now-orphaned duplicate data_source rows.
+DELETE FROM "data_source"
+WHERE "id" IN (SELECT old_id FROM _ds_remap);
+
+-- Clean up temp tables.
+DROP TABLE _ds_remap;
+DROP TABLE _ds_survivors;
+
+-- Step 4: enforce NOT NULL and add the unique constraint.
+ALTER TABLE "data_source" ALTER COLUMN "canonical_url" SET NOT NULL;
+CREATE UNIQUE INDEX "data_source_ticker_id_canonical_url_key"
+  ON "data_source" ("ticker_id", "canonical_url");

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -45,6 +45,7 @@ enum SearchQueryIntent {
 model DataSource {
   id            String    @id @default(uuid())
   url           String
+  canonicalUrl  String    @map("canonical_url")
   title         String
   content       String
   metadata      Json?
@@ -61,6 +62,7 @@ model DataSource {
   entityEvidence         EntityEvidence[]
   entityRelationEvidence EntityRelationEvidence[]
 
+  @@unique([tickerId, canonicalUrl])
   @@map("data_source")
 }
 


### PR DESCRIPTION
## Summary

The same article could be stored twice for a ticker because `DataSource` had no uniqueness constraint on URL per ticker. This PR adds the constraint, migrates existing duplicates, switches ingestion to skip-duplicates, and tightens the article-analysis selection so only one near-duplicate cluster member reaches content generation per run.

## Related issues

Closes #760

## Important changes

- `DataSource` in `schema.prisma` gains a `canonicalUrl String @map("canonical_url")` field and a `@@unique([tickerId, canonicalUrl])` constraint. This is the database-level guarantee that the same story cannot be stored twice for a ticker.
- A SQL migration (`20260611000001_add_canonical_url_unique_constraint`) adds the column as nullable, populates it by normalizing each `url` (strip fragment, lowercase, strip tracking query params), deduplicates per `(ticker_id, canonical_url)` by keeping the row with the latest `published_at` or `created_at`, re-points dependent rows (`article_relevance`, `article_entity`, `entity_evidence`, `entity_relation_evidence`) to the survivor, deletes the duplicate rows, then makes the column NOT NULL and adds the unique index.
- `data-collection.ts` now computes `canonicalUrl` via `canonicalizeUrl()` from `@workspace/utils` for each incoming row and passes `skipDuplicates: true` to `createMany`. Future duplicates are silently skipped.
- `analysis-relevance-selection.ts`: the budget-fill second loop now skips cluster mates of already-selected rows, so at most one near-duplicate cluster member is `selected = true` per ticker per run.

## Other changes

- `analysis-relevance-selection.test.ts`: updated one assertion to match the new single-representative-per-cluster behavior (budget=4 with two duplicate pairs yields 2 selected, not 4).

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` — `canonicalUrl` field and `@@unique` constraint.
- `packages/mediapulse/database/prisma/migrations/20260611000001_add_canonical_url_unique_constraint/migration.sql` — the dedup migration; review the re-pointing logic before running against production data.
- `apps/mediapulse/agent-data-api/src/routes/data-collection.ts` — canonical URL computation and `skipDuplicates`.
- `apps/mediapulse/agents/article-analysis/src/analysis-relevance-selection.ts` — budget-fill cluster guard.

## How to test

1. Run `pnpm --filter "*article-analysis*" test` and confirm 267 tests pass.
2. Rehearse the migration on a copy of production-like data to verify dependent rows re-point correctly and the constraint applies cleanly.
3. Run the data-collection agent for a ticker and re-run it: the second run should log `skipDuplicates` skipping the same URLs.
4. Confirm a ticker with two near-duplicate articles in the same cluster ends the selection pass with exactly one `selected = true`.
