### PR TITLE
Guarantee query-analysis coverage for every newsletter section

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.test.ts
@@ -380,4 +380,122 @@ describe("createQueryAnalysisInsightsProvider", () => {
     const payload = await provider.compute({ window: "7d" });
     expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
   });
+
+  it("does not surface quickHits as a zero-coverage alert even when all sets report it", async () => {
+    const snapshotWithQuickHitsZero = {
+      ...baseSnapshot,
+      sectionCoverage: {
+        zeroCoverageSections: ["quickHits", "dealsAndMovements"],
+      },
+    };
+    const sets = Array.from({ length: 4 }, (_, i) => ({
+      id: `set-${i}`,
+      tickerId: "ticker-1",
+      generatedAt: makeDate(i * 1000),
+      strategySnapshot: snapshotWithQuickHitsZero,
+    }));
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const quickHitsAlert = payload.alerts.find((alert) =>
+      alert.id.includes("quickHits"),
+    );
+    expect(quickHitsAlert).toBeUndefined();
+  });
+
+  it("does not surface competitiveLandscape as zero-coverage when it is covered in >50% of sets", async () => {
+    const snapshotCovered = {
+      ...baseSnapshot,
+      sectionCoverage: {
+        zeroCoverageSections: [],
+      },
+    };
+    const snapshotUncovered = {
+      ...baseSnapshot,
+      sectionCoverage: {
+        zeroCoverageSections: ["competitiveLandscape"],
+      },
+    };
+    // Only 1 of 4 sets has competitiveLandscape at zero (25%), below the 50% threshold.
+    const sets = [
+      {
+        id: "set-0",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(0),
+        strategySnapshot: snapshotUncovered,
+      },
+      {
+        id: "set-1",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: snapshotCovered,
+      },
+      {
+        id: "set-2",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(2000),
+        strategySnapshot: snapshotCovered,
+      },
+      {
+        id: "set-3",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(3000),
+        strategySnapshot: snapshotCovered,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const alert = payload.alerts.find(
+      (alert) => alert.id === "zero-coverage-competitiveLandscape",
+    );
+    expect(alert).toBeUndefined();
+  });
+
+  it("does not surface disruptorsOrTech as zero-coverage when it is covered in most sets", async () => {
+    const snapshotCovered = {
+      ...baseSnapshot,
+      sectionCoverage: { zeroCoverageSections: [] },
+    };
+    const snapshotUncovered = {
+      ...baseSnapshot,
+      sectionCoverage: { zeroCoverageSections: ["disruptorsOrTech"] },
+    };
+    const sets = [
+      {
+        id: "set-0",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(0),
+        strategySnapshot: snapshotUncovered,
+      },
+      {
+        id: "set-1",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(1000),
+        strategySnapshot: snapshotCovered,
+      },
+      {
+        id: "set-2",
+        tickerId: "ticker-1",
+        generatedAt: makeDate(2000),
+        strategySnapshot: snapshotCovered,
+      },
+    ];
+
+    const provider = createQueryAnalysisInsightsProvider(
+      makeDeps(sets, [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+
+    const alert = payload.alerts.find(
+      (alert) => alert.id === "zero-coverage-disruptorsOrTech",
+    );
+    expect(alert).toBeUndefined();
+  });
 });

--- a/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/query-analysis-insights-provider.ts
@@ -4,6 +4,7 @@ import type {
   InsightAlert,
   InsightSection,
 } from "@workspace/agent-data-api-contract";
+import { ZERO_COVERAGE_EXCLUDED_SECTIONS } from "@workspace/agent-data-api-contract";
 
 import type {
   AgentInsightsProvider,
@@ -326,7 +327,9 @@ export function createQueryAnalysisInsightsProvider(
         });
       }
 
-      // Recurring zero-coverage sections (present in >50% of sets with the field)
+      // Recurring zero-coverage sections (present in >50% of sets with the field).
+      // Catch-all sections (e.g. quickHits) are excluded because they have no
+      // dedicated upstream search intent and would produce a permanently firing alert.
       const zeroCoverageFrequency = new Map<string, number>();
       let setsWithCoverage = 0;
       for (const snap of snapshots) {
@@ -334,6 +337,7 @@ export function createQueryAnalysisInsightsProvider(
         if (!Array.isArray(zeroCoverage)) continue;
         setsWithCoverage += 1;
         for (const section of zeroCoverage) {
+          if (ZERO_COVERAGE_EXCLUDED_SECTIONS.has(section as never)) continue;
           zeroCoverageFrequency.set(
             section,
             (zeroCoverageFrequency.get(section) ?? 0) + 1,

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.test.ts
@@ -509,15 +509,15 @@ describe("queryAnalysisConfigSchema languageQuotas", () => {
 });
 
 describe("queryAnalysisConfigSchema — sectionCoverage", () => {
-  it("defaults sectionCoverage.enabled to false", () => {
+  it("defaults sectionCoverage.enabled to true", () => {
     const parsed = queryAnalysisConfigSchema.parse({});
-    expect(parsed.output.sectionCoverage.enabled).toBe(false);
+    expect(parsed.output.sectionCoverage.enabled).toBe(true);
   });
 
-  it("accepts sectionCoverage.enabled: true", () => {
+  it("accepts sectionCoverage.enabled: false override", () => {
     const parsed = queryAnalysisConfigSchema.parse({
-      output: { sectionCoverage: { enabled: true } },
+      output: { sectionCoverage: { enabled: false } },
     });
-    expect(parsed.output.sectionCoverage.enabled).toBe(true);
+    expect(parsed.output.sectionCoverage.enabled).toBe(false);
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/query-analysis/src/config-schema.ts
@@ -91,14 +91,14 @@ const outputSchema = z
       .object({
         enabled: z
           .boolean()
-          .default(false)
+          .default(true)
           .describe(
             "When true, reserve at least one query per newsletter section that has a dedicated intent, and inject keyword guidance for sections with no dedicated intent (e.g. Deals & Movements).",
           ),
       })
       .default({})
       .describe(
-        "Optional section-coverage path: ensures every newsletter section has upstream search budget. Off by default.",
+        "Section-coverage path: ensures every newsletter section has upstream search budget.",
       ),
   })
   .default({})

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -54,7 +54,7 @@ const GOLDEN_PROMPT_FINGERPRINT_FIXTURE = {
     headlineSamples: [] as [],
     kgNeighborhood: [] as [],
   },
-  fingerprint: "0e5182b717a66aa9",
+  fingerprint: "730d66ed9cd31a1d",
 } as const;
 
 const emptyEnrichedContext = {
@@ -1117,24 +1117,26 @@ describe("buildQueryAnalysisSystemContent — section coverage", () => {
     intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
   };
 
-  it("does not include deals/M&A guidance when sectionCoverageEnabled is false", () => {
+  it("always includes M&A guidance via the deals intent description", () => {
+    // The deals intent is now always present in the intent listing regardless of
+    // sectionCoverageEnabled, so M&A guidance appears unconditionally.
     const result = buildQueryAnalysisSystemContent({
       ...baseStrategy,
       sectionCoverageEnabled: false,
     });
 
-    expect(result).not.toContain("Deals & Movements");
-    expect(result).not.toContain("M&A");
+    expect(result).toContain("M&A");
+    expect(result).toContain("deals:");
   });
 
-  it("injects deals/M&A keyword guidance when sectionCoverageEnabled is true", () => {
+  it("includes the deals intent in the intent listing when sectionCoverageEnabled is true", () => {
     const result = buildQueryAnalysisSystemContent({
       ...baseStrategy,
       sectionCoverageEnabled: true,
     });
 
     expect(result).toContain("M&A");
-    expect(result).toContain("Deals & Movements");
+    expect(result).toContain("deals:");
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -10,7 +10,6 @@ import {
   QUERY_ANALYSIS_STANDARD_INTENTS,
   SECTION_BY_INTENT,
   queryAnalysisIntentSchema,
-  sectionsWithoutDedicatedIntent,
   type GetQueryAnalysisResponse,
   type QueryAnalysisIntent,
   type QueryAnalysisIntentWeights,
@@ -178,17 +177,9 @@ export const buildQueryAnalysisSystemContent = (
       "- technology_trend: digital disruption, AI adoption, tech shifts in the sector",
       "- geopolitical: trade, sanctions, cross-border dynamics affecting the sector",
       "- industry_trend: sector outlook, analyst views on the industry overall",
+      "- deals: M&A, funding rounds, leadership appointments, and notable corporate actions",
     ].join("\n"),
   ];
-
-  if (strategy.sectionCoverageEnabled) {
-    const homelessSections = sectionsWithoutDedicatedIntent();
-    if (homelessSections.includes("dealsAndMovements")) {
-      sections.push(
-        'Section coverage: Reserve 1–2 queries specifically for M&A deals, funding rounds, leadership appointments, and notable corporate actions — these feed the Deals & Movements section of the end product. Tag such queries with intent: "breaking" when time-sensitive or "kg_change" when structural.',
-      );
-    }
-  }
 
   const base = sections.join("\n\n");
   return applyContractBrief(

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts
@@ -5,6 +5,7 @@ import { DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS } from "@workspace/agent-data-api
 
 import {
   appendWildcardRowsToMerged,
+  applySectionCoverageReserve,
   dedupeDeterministic,
   dedupeLlmAgainstKeys,
   effectiveMergeWeight,
@@ -428,6 +429,190 @@ describe("mergeQueryCandidates with priorYield", () => {
         templateId: "low-yield-template",
         priorYield,
       }),
+    );
+  });
+});
+
+describe("applySectionCoverageReserve", () => {
+  it("promotes a competitor deterministic candidate when no competitor row survived merge", () => {
+    // No competitor or technology_trend rows in the merged set.
+    const merged = [
+      {
+        text: "breaking one",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 1,
+      },
+      {
+        text: "breaking two",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 2,
+      },
+      {
+        text: "macro one",
+        source: "llm" as const,
+        intent: "macro" as const,
+        rank: 3,
+      },
+    ];
+    // Deterministic pool contains a competitor candidate.
+    const deterministic = [
+      { text: "breaking one", intent: "breaking" as const },
+      { text: "industry competitive landscape", intent: "competitor" as const },
+    ];
+
+    const adjusted = applySectionCoverageReserve(merged, deterministic, 3);
+
+    // Total count must not exceed queryCount.
+    expect(adjusted).toHaveLength(3);
+
+    // A competitor-intent row must appear in the output.
+    const competitorRow = adjusted.find((row) => row.intent === "competitor");
+    expect(competitorRow).toBeDefined();
+  });
+
+  it("promotes a technology_trend deterministic candidate when disruptorsOrTech has zero coverage", () => {
+    const merged = [
+      {
+        text: "breaking one",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 1,
+      },
+      {
+        text: "breaking two",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 2,
+      },
+      {
+        text: "breaking three",
+        source: "llm" as const,
+        intent: "breaking" as const,
+        rank: 3,
+      },
+    ];
+    const deterministic = [
+      { text: "breaking one", intent: "breaking" as const },
+      {
+        text: "industry technology disruption",
+        intent: "technology_trend" as const,
+      },
+    ];
+
+    const adjusted = applySectionCoverageReserve(merged, deterministic, 3);
+
+    expect(adjusted).toHaveLength(3);
+    const techRow = adjusted.find(
+      (row) => row.intent === "technology_trend" || row.intent === "technical",
+    );
+    expect(techRow).toBeDefined();
+  });
+
+  it("keeps total row count at queryCount after promoting a reserve", () => {
+    const queryCount = 4;
+    const merged = [
+      {
+        text: "a",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 1,
+      },
+      {
+        text: "b",
+        source: "llm" as const,
+        intent: "breaking" as const,
+        rank: 2,
+      },
+      { text: "c", source: "llm" as const, intent: "macro" as const, rank: 3 },
+      {
+        text: "d",
+        source: "llm" as const,
+        intent: "sentiment" as const,
+        rank: 4,
+      },
+    ];
+    const deterministic = [
+      { text: "a", intent: "breaking" as const },
+      { text: "sector competitive landscape", intent: "competitor" as const },
+    ];
+
+    const adjusted = applySectionCoverageReserve(
+      merged,
+      deterministic,
+      queryCount,
+    );
+
+    expect(adjusted).toHaveLength(queryCount);
+  });
+
+  it("returns unchanged rows when all dedicated-intent sections already have coverage", () => {
+    // competitor, regulatory, technology_trend, industry_trend, deals all covered.
+    const merged = [
+      {
+        text: "peer threats",
+        source: "llm" as const,
+        intent: "competitor" as const,
+        rank: 1,
+      },
+      {
+        text: "compliance news",
+        source: "llm" as const,
+        intent: "regulatory" as const,
+        rank: 2,
+      },
+      {
+        text: "ai disruption",
+        source: "llm" as const,
+        intent: "technology_trend" as const,
+        rank: 3,
+      },
+      {
+        text: "sector outlook",
+        source: "llm" as const,
+        intent: "industry_trend" as const,
+        rank: 4,
+      },
+      {
+        text: "merger deal",
+        source: "llm" as const,
+        intent: "deals" as const,
+        rank: 5,
+      },
+    ];
+    const deterministic: { text: string; intent: "breaking" }[] = [];
+
+    const adjusted = applySectionCoverageReserve(merged, deterministic, 5);
+
+    expect(adjusted.map((row) => row.text)).toEqual(
+      merged.map((row) => row.text),
+    );
+  });
+
+  it("assigns contiguous ranks starting at 1 after adjustment", () => {
+    const merged = [
+      {
+        text: "breaking one",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 1,
+      },
+      {
+        text: "breaking two",
+        source: "deterministic" as const,
+        intent: "breaking" as const,
+        rank: 2,
+      },
+    ];
+    const deterministic = [
+      { text: "competitor query", intent: "competitor" as const },
+    ];
+
+    const adjusted = applySectionCoverageReserve(merged, deterministic, 2);
+
+    expect(adjusted.map((row) => row.rank)).toEqual(
+      Array.from({ length: adjusted.length }, (_, i) => i + 1),
     );
   });
 });

--- a/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
+++ b/apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts
@@ -1,6 +1,11 @@
 import type {
+  NewsletterSectionId,
   QueryAnalysisIntent,
   QueryAnalysisPriorYield,
+} from "@workspace/agent-data-api-contract";
+import {
+  NEWSLETTER_SECTION_IDS,
+  SECTION_BY_INTENT,
 } from "@workspace/agent-data-api-contract";
 
 import type { QuerySemanticEmbedder } from "./embeddings";
@@ -455,6 +460,160 @@ export const orderLlmRowsByPersonaRoundRobin = (
   }
 
   return [...ordered, ...withoutPersona];
+};
+
+/**
+ * Post-merge section-coverage reserve pass.
+ *
+ * For each newsletter section that has a dedicated intent (via SECTION_BY_INTENT), if the
+ * merged set contains zero queries mapping to that section, this function promotes the
+ * highest-scored deterministic candidate of a matching intent. It displaces the
+ * lowest-ranked query of the most over-represented intent so the total count stays at
+ * `queryCount`. Sections without a dedicated intent are unaffected; the caller is
+ * responsible for any keyword guidance those sections require (e.g. via LLM system prompt).
+ *
+ * @param merged - Ranked output of {@link mergeQueryCandidates}.
+ * @param deterministic - Full deterministic candidate pool for the run (pre-merge).
+ * @param queryCount - Target total row count; output length will not exceed this.
+ * @returns Adjusted rows with contiguous ranks reassigned.
+ */
+export const applySectionCoverageReserve = (
+  merged: MergedQueryRow[],
+  deterministic: DeterministicCandidate[],
+  queryCount: number,
+): MergedQueryRow[] => {
+  // Build intent -> section mapping for sections that have a dedicated intent.
+  const intentToSection = new Map<string, string>();
+  for (const sectionId of NEWSLETTER_SECTION_IDS) {
+    for (const [intent, mappedSection] of Object.entries(SECTION_BY_INTENT)) {
+      if (mappedSection === sectionId) {
+        intentToSection.set(intent, sectionId);
+      }
+    }
+  }
+
+  // Collect the set of sections that have at least one dedicated intent.
+  const sectionsWithIntent = new Set(
+    Object.values(SECTION_BY_INTENT).filter(
+      (sectionId): sectionId is NewsletterSectionId => sectionId !== null,
+    ),
+  );
+
+  // Determine which dedicated-intent sections are currently uncovered.
+  const coveredSections = new Set(
+    merged
+      .map((row) => SECTION_BY_INTENT[row.intent])
+      .filter(
+        (sectionId): sectionId is NewsletterSectionId => sectionId !== null,
+      ),
+  );
+  const uncoveredSections = [...sectionsWithIntent].filter(
+    (sectionId) => !coveredSections.has(sectionId),
+  );
+
+  if (uncoveredSections.length === 0) {
+    return merged;
+  }
+
+  // Build a dedupe set from the merged rows for candidate lookup.
+  const mergedKeys = new Set(merged.map((row) => normalizeQueryKey(row.text)));
+
+  // For each uncovered section, find the first deterministic candidate that maps to it.
+  // Deterministic candidates are already in pack order; the first match is the best-scored one.
+  let adjusted = [...merged];
+
+  for (const targetSection of uncoveredSections) {
+    // Find intents that map to this section.
+    const matchingIntents = new Set(
+      Object.entries(SECTION_BY_INTENT)
+        .filter(([, section]) => section === targetSection)
+        .map(([intent]) => intent),
+    );
+
+    // Find the first deterministic candidate for those intents not already in the merged set.
+    const candidate = deterministic.find(
+      (row) =>
+        matchingIntents.has(row.intent) &&
+        !mergedKeys.has(normalizeQueryKey(row.text)),
+    );
+
+    if (candidate === undefined) {
+      continue;
+    }
+
+    // Find the intent that is most over-represented among non-dedicated-section intents
+    // (i.e. intents mapping to null), so displacing one of them costs the least coverage.
+    // Fall back to the intent with the most rows overall when all intents are mapped.
+    const intentCounts = new Map<string, number>();
+    for (const row of adjusted) {
+      intentCounts.set(row.intent, (intentCounts.get(row.intent) ?? 0) + 1);
+    }
+
+    // Prefer displacing from homeless intents (null-mapped) first.
+    const homelessIntents = new Set(
+      Object.entries(SECTION_BY_INTENT)
+        .filter(([, section]) => section === null)
+        .map(([intent]) => intent),
+    );
+
+    let victimIntent: string | undefined;
+    let victimCount = 0;
+    for (const [intent, count] of intentCounts) {
+      if (homelessIntents.has(intent) && count > victimCount) {
+        victimIntent = intent;
+        victimCount = count;
+      }
+    }
+
+    // If no homeless intent has rows, fall back to any intent with the most rows.
+    if (victimIntent === undefined) {
+      for (const [intent, count] of intentCounts) {
+        if (count > victimCount) {
+          victimIntent = intent;
+          victimCount = count;
+        }
+      }
+    }
+
+    if (victimIntent === undefined) {
+      continue;
+    }
+
+    // Find the lowest-ranked row with the victim intent (highest rank number = last in list).
+    let victimIndex = -1;
+    for (let rowIndex = adjusted.length - 1; rowIndex >= 0; rowIndex--) {
+      if (adjusted[rowIndex]?.intent === victimIntent) {
+        victimIndex = rowIndex;
+        break;
+      }
+    }
+
+    if (victimIndex === -1) {
+      continue;
+    }
+
+    // Replace victim with the reserve candidate.
+    adjusted[victimIndex] = {
+      text: candidate.text,
+      source: "deterministic",
+      intent: candidate.intent,
+      rank: adjusted[victimIndex]!.rank,
+      ...(candidate.templateId !== undefined
+        ? { templateId: candidate.templateId }
+        : {}),
+      ...(candidate.language !== undefined
+        ? { language: candidate.language }
+        : {}),
+    };
+
+    mergedKeys.add(normalizeQueryKey(candidate.text));
+    coveredSections.add(targetSection);
+  }
+
+  return adjusted.slice(0, queryCount).map((row, index) => ({
+    ...row,
+    rank: index + 1,
+  }));
 };
 
 /**

--- a/apps/mediapulse/agents/query-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.test.ts
@@ -598,7 +598,7 @@ describe("sectionCoverage snapshot", () => {
     }
   });
 
-  it("zeroCoverageSections always includes dealsAndMovements (no dedicated intent)", async () => {
+  it("zeroCoverageSections includes quickHits when no query maps to it", async () => {
     mockFetchQueryLlm.mockResolvedValue([
       { text: "only breaking", intent: "breaking" as const },
     ]);
@@ -621,7 +621,7 @@ describe("sectionCoverage snapshot", () => {
 
     const { zeroCoverageSections } =
       createPayload.strategySnapshot.sectionCoverage;
-    expect(zeroCoverageSections).toContain("dealsAndMovements");
+    // quickHits has no dedicated intent so it always shows zero search coverage.
     expect(zeroCoverageSections).toContain("quickHits");
   });
 
@@ -672,6 +672,90 @@ describe("sectionCoverage snapshot", () => {
     expect(
       createPayload.strategySnapshot.sectionCoverage.contractVersion,
     ).toBeUndefined();
+  });
+});
+
+describe("section-coverage reserve", () => {
+  // Use a language with no localized pack override so the configured global pack
+  // (rich-v2) is actually used. English gets overridden to default-en-v1 which
+  // lacks competitor and technology_trend templates.
+  const richV2Config = queryAnalysisConfigSchema.parse({
+    credentials: { openaiApiKey: "sk" },
+    output: {
+      queryCount: 10,
+      languageQuotas: [{ language: "fr", share: 1 }],
+    },
+    templates: { templatePack: "rich-v2" },
+    creativity: { wildcardFraction: 0 },
+    quality: {
+      useSelfCritique: false,
+      semanticDedupe: { enabled: false },
+      diversityGate: { enabled: false },
+    },
+    dynamics: { yieldFeedback: { enabled: false } },
+  });
+
+  it("includes competitor-intent queries when LLM returns nothing and rich-v2 pack is used", async () => {
+    // LLM stubbed to return empty so only deterministic rows survive.
+    mockFetchQueryLlm.mockResolvedValue([]);
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: richV2Config,
+      token: "Bearer t",
+    });
+
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
+      queries: Array<{ intent: string }>;
+    };
+
+    // rich-v2 has competitor templates; they appear via normal merge or reserve.
+    const competitorRows = createPayload.queries.filter(
+      (row) => row.intent === "competitor",
+    );
+    expect(competitorRows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("includes technology_trend queries when LLM returns nothing and rich-v2 pack is used", async () => {
+    mockFetchQueryLlm.mockResolvedValue([]);
+
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: richV2Config,
+      token: "Bearer t",
+    });
+
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
+      queries: Array<{ intent: string }>;
+    };
+
+    const techRows = createPayload.queries.filter(
+      (row) => row.intent === "technology_trend" || row.intent === "technical",
+    );
+    expect(techRows.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("total query count stays at queryCount after reserve pass runs", async () => {
+    mockFetchQueryLlm.mockResolvedValue([]);
+
+    const queryCount = 10;
+    await runQueryAnalysis({
+      input: { tickerId: "22222222-2222-4222-a222-222222222222" },
+      config: richV2Config,
+      token: "Bearer t",
+    });
+
+    const createPayload = mockCreate.mock.calls[
+      mockCreate.mock.calls.length - 1
+    ]?.[0] as {
+      queries: Array<{ intent: string }>;
+    };
+
+    expect(createPayload.queries).toHaveLength(queryCount);
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/run.ts
+++ b/apps/mediapulse/agents/query-analysis/src/run.ts
@@ -25,6 +25,7 @@ import {
 import type { LlmCandidate } from "./merge-query-candidates";
 import {
   appendWildcardRowsToMerged,
+  applySectionCoverageReserve,
   finalizeWildcardCandidates,
   mergeQueryCandidates,
   normalizeQueryKey,
@@ -972,6 +973,31 @@ export const runQueryAnalysis = async (
       wildcardRows,
       queryCount,
     );
+  }
+
+  // Section-coverage reserve: for each dedicated-intent section with zero coverage,
+  // promote the best deterministic candidate of a matching intent, displacing the
+  // lowest-ranked homeless-intent row. Runs after wildcards so the full set is visible.
+  if (sectionCoverageEnabled) {
+    const allDeterministic = distributedStandard.flatMap((languageQuota) => {
+      const sliceTemplatePack = resolveLanguageTemplatePack(
+        languageQuota.language,
+        languageQuota.templatePack,
+        templatePack,
+      );
+      return buildDeterministicQueries(queryContext, {
+        pack: sliceTemplatePack,
+        kgTemplateCap,
+        language: languageQuota.language,
+        ...(yieldFeedback.enabled
+          ? {
+              priorYield: queryContext.priorYield,
+              minTemplateYield: yieldFeedback.minTemplateYield,
+            }
+          : {}),
+      });
+    });
+    merged = applySectionCoverageReserve(merged, allDeterministic, queryCount);
   }
 
   report("Merged and deduped query set", `${merged.length} total queries`);

--- a/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
+++ b/apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts
@@ -1,7 +1,9 @@
 import type {
+  NewsletterSectionId,
   QueryAnalysisIntent,
   QueryAnalysisPriorYield,
 } from "@workspace/agent-data-api-contract";
+import { SECTION_BY_INTENT } from "@workspace/agent-data-api-contract";
 
 import type { KgRelationTemplate } from "./slot-resolver";
 
@@ -22,7 +24,7 @@ export type DeterministicPackName = (typeof DETERMINISTIC_PACK_NAMES)[number];
 export const DEFAULT_DETERMINISTIC_PACK: DeterministicPackName = "default-v1";
 
 /** Maximum templates evaluated per pack to avoid dominating merge/dedup work. */
-export const MAX_TEMPLATES_PER_PACK = 25;
+export const MAX_TEMPLATES_PER_PACK = 30;
 
 /** One row in a deterministic template pack before slot resolution. */
 export type DeterministicTemplate = {
@@ -119,6 +121,8 @@ const richV2Pack: DeterministicPack = {
     { template: "{name} ESG controversies", intent: "esg" },
     { template: "{name} sustainability disclosure", intent: "esg" },
     { template: "{name} social media sentiment", intent: "sentiment" },
+    { template: "{name} acquisition deal", intent: "deals" },
+    { template: "{name} merger funding round", intent: "deals" },
   ],
 };
 
@@ -169,6 +173,9 @@ const richV2ExtendedPack: DeterministicPack = {
     },
     { template: "{industry} analyst sector view", intent: "industry_trend" },
     { template: "{name} chart pattern {currentMonth}", intent: "technical" },
+    { template: "{name} acquisition deal", intent: "deals" },
+    { template: "{name} merger funding round", intent: "deals" },
+    { template: "{name} leadership appointment", intent: "deals" },
   ],
 };
 
@@ -238,7 +245,14 @@ export const getDeterministicPack = (
 };
 
 /**
- * Drops low-yield templates from a pack while preserving at least one template per pack.
+ * Drops low-yield templates from a pack while preserving at least one template per pack
+ * and at least one template per dedicated-intent newsletter section.
+ *
+ * A template is protected from removal when its intent maps to a newsletter section via
+ * {@link SECTION_BY_INTENT} and it is the only remaining template for that section in the
+ * pack. This ensures section-coverage-reserve has a candidate to promote even after
+ * aggressive yield-based rotation. Adding a new intent-to-section mapping in
+ * `SECTION_BY_INTENT` automatically extends protection to that section.
  *
  * @param pack - Source deterministic pack.
  * @param priorYield - Rolling yield rollups from GET /query-analysis.
@@ -253,21 +267,76 @@ export const filterPackTemplatesByYield = (
   if (priorYield === undefined || priorYield.perTemplate.length === 0) {
     return pack;
   }
+
   const yieldByTemplate = new Map(
     priorYield.perTemplate.map((row) => [row.templateId, row.avgNovel]),
   );
-  const filtered = pack.templates.filter((row) => {
-    const avgNovel = yieldByTemplate.get(row.template);
-    if (avgNovel === undefined) {
-      return true;
-    }
-    return avgNovel >= minTemplateYield;
-  });
-  if (filtered.length === 0) {
+
+  // First pass: determine which templates pass the yield bar without any protection.
+  const passesYield = (template: DeterministicTemplate): boolean => {
+    const avgNovel = yieldByTemplate.get(template.template);
+    return avgNovel === undefined || avgNovel >= minTemplateYield;
+  };
+
+  const baseFiltered = pack.templates.filter(passesYield);
+
+  // If nothing survived the yield filter, return the full pack unchanged.
+  // This is the same fallback the original implementation used: a complete wipeout
+  // means yield data is not reliable enough to rotate anything.
+  if (baseFiltered.length === 0) {
     return pack;
   }
-  return {
-    ...pack,
-    templates: filtered,
-  };
+
+  // Second pass: for each dedicated-intent newsletter section that has at least one
+  // template in this pack, ensure at least one of its templates survives. If none
+  // passed the yield bar, promote the first one from the pack (preserving pack order).
+  // This prevents the yield filter from silently starving a section when only a few
+  // high-traffic intents happen to have good yield history.
+
+  // Build section -> templates mapping for this pack.
+  const sectionsWithDedicatedIntent = new Set(
+    Object.values(SECTION_BY_INTENT).filter(
+      (sectionId): sectionId is NewsletterSectionId => sectionId !== null,
+    ),
+  );
+  const templatesBySectionId = new Map<string, DeterministicTemplate[]>();
+  for (const sectionId of sectionsWithDedicatedIntent) {
+    templatesBySectionId.set(sectionId, []);
+  }
+  for (const template of pack.templates) {
+    const sectionId = SECTION_BY_INTENT[template.intent];
+    if (sectionId !== null && sectionId !== undefined) {
+      templatesBySectionId.get(sectionId)?.push(template);
+    }
+  }
+
+  const survivorKeys = new Set(baseFiltered.map((t) => t.template));
+  const protectedTemplates: DeterministicTemplate[] = [];
+  for (const [, sectionTemplates] of templatesBySectionId) {
+    if (sectionTemplates.length === 0) {
+      continue;
+    }
+    const hasAnySurvivor = sectionTemplates.some((t) =>
+      survivorKeys.has(t.template),
+    );
+    if (!hasAnySurvivor) {
+      // Promote the first template for this section (pack order = highest priority).
+      const candidate = sectionTemplates[0];
+      if (candidate !== undefined && !survivorKeys.has(candidate.template)) {
+        protectedTemplates.push(candidate);
+        survivorKeys.add(candidate.template);
+      }
+    }
+  }
+
+  if (protectedTemplates.length === 0) {
+    return { ...pack, templates: baseFiltered };
+  }
+
+  // Merge protected templates back in, preserving original pack order.
+  const protectedSet = new Set(protectedTemplates.map((t) => t.template));
+  const merged = pack.templates.filter(
+    (t) => survivorKeys.has(t.template) || protectedSet.has(t.template),
+  );
+  return { ...pack, templates: merged };
 };

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -39,6 +39,7 @@ enum SearchQueryIntent {
   technology_trend
   geopolitical
   industry_trend
+  deals
   wildcard
 }
 

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -258,6 +258,7 @@ export {
   MEDIAPULSE_NEWSLETTER_SECTIONS,
   NEWSLETTER_SECTION_IDS,
   SECTION_BY_INTENT,
+  ZERO_COVERAGE_EXCLUDED_SECTIONS,
   sectionsWithoutDedicatedIntent,
   summarizeSectionCoverage,
   type NewsletterSectionId,

--- a/packages/shared/agent-data-api-contract/src/newsletter-sections.test.ts
+++ b/packages/shared/agent-data-api-contract/src/newsletter-sections.test.ts
@@ -6,6 +6,7 @@ import {
   classifyQueryToSection,
   NEWSLETTER_SECTION_IDS,
   SECTION_BY_INTENT,
+  ZERO_COVERAGE_EXCLUDED_SECTIONS,
   sectionsWithoutDedicatedIntent,
   summarizeSectionCoverage,
 } from "./newsletter-sections.js";
@@ -59,6 +60,10 @@ describe("SECTION_BY_INTENT", () => {
     expect(SECTION_BY_INTENT.industry_trend).toBe("industryPulse");
   });
 
+  it("maps deals to dealsAndMovements", () => {
+    expect(SECTION_BY_INTENT.deals).toBe("dealsAndMovements");
+  });
+
   it("maps homeless intents to null", () => {
     const homelessIntents = [
       "breaking",
@@ -101,6 +106,7 @@ describe("classifyQueryToSection", () => {
     expect(classifyQueryToSection("technology_trend")).toBe("disruptorsOrTech");
     expect(classifyQueryToSection("technical")).toBe("disruptorsOrTech");
     expect(classifyQueryToSection("industry_trend")).toBe("industryPulse");
+    expect(classifyQueryToSection("deals")).toBe("dealsAndMovements");
   });
 
   it("is consistent with SECTION_BY_INTENT", () => {
@@ -123,10 +129,16 @@ describe("summarizeSectionCoverage", () => {
   it("zero-coverage sections have count 0 and share 0", () => {
     const result = summarizeSectionCoverage(["competitor"]);
 
-    expect(result.dealsAndMovements.count).toBe(0);
-    expect(result.dealsAndMovements.share).toBe(0);
     expect(result.quickHits.count).toBe(0);
     expect(result.quickHits.share).toBe(0);
+  });
+
+  it("credits dealsAndMovements when the deals intent is present", () => {
+    const result = summarizeSectionCoverage(["deals", "deals", "regulatory"]);
+
+    expect(result.dealsAndMovements.count).toBe(2);
+    expect(result.dealsAndMovements.share).toBeGreaterThan(0);
+    expect(result.regulatoryPolicyWatch.count).toBe(1);
   });
 
   it("counts queries per mapped section correctly", () => {
@@ -174,8 +186,12 @@ describe("summarizeSectionCoverage", () => {
 });
 
 describe("sectionsWithoutDedicatedIntent", () => {
-  it("includes dealsAndMovements", () => {
-    expect(sectionsWithoutDedicatedIntent()).toContain("dealsAndMovements");
+  it("excludes dealsAndMovements now that deals intent is mapped", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain("dealsAndMovements");
+  });
+
+  it("excludes quickHits because it is in ZERO_COVERAGE_EXCLUDED_SECTIONS", () => {
+    expect(sectionsWithoutDedicatedIntent()).not.toContain("quickHits");
   });
 
   it("excludes competitiveLandscape", () => {
@@ -203,5 +219,23 @@ describe("sectionsWithoutDedicatedIntent", () => {
     for (const sectionId of sectionsWithoutDedicatedIntent()) {
       expect(sectionSet.has(sectionId)).toBe(true);
     }
+  });
+});
+
+describe("ZERO_COVERAGE_EXCLUDED_SECTIONS", () => {
+  it("contains quickHits", () => {
+    expect(ZERO_COVERAGE_EXCLUDED_SECTIONS.has("quickHits")).toBe(true);
+  });
+
+  it("does not contain competitiveLandscape", () => {
+    expect(ZERO_COVERAGE_EXCLUDED_SECTIONS.has("competitiveLandscape")).toBe(
+      false,
+    );
+  });
+
+  it("does not contain dealsAndMovements", () => {
+    expect(ZERO_COVERAGE_EXCLUDED_SECTIONS.has("dealsAndMovements")).toBe(
+      false,
+    );
   });
 });

--- a/packages/shared/agent-data-api-contract/src/newsletter-sections.ts
+++ b/packages/shared/agent-data-api-contract/src/newsletter-sections.ts
@@ -61,6 +61,7 @@ export const SECTION_BY_INTENT: Record<
   technology_trend: "disruptorsOrTech",
   technical: "disruptorsOrTech",
   industry_trend: "industryPulse",
+  deals: "dealsAndMovements",
   breaking: null,
   kg_change: null,
   fundamental: null,
@@ -73,9 +74,20 @@ export const SECTION_BY_INTENT: Record<
 };
 
 /**
- * Returns every section id that no intent maps to via {@link SECTION_BY_INTENT}.
- * These are structurally required sections the upstream search pipeline does not cover by default —
- * e.g. `dealsAndMovements` has no dedicated intent and will be starved unless explicitly budgeted.
+ * Sections that are intentionally excluded from the zero-coverage alert.
+ *
+ * `quickHits` is a catch-all populated at generation time from any homeless-intent
+ * queries — it has no dedicated upstream search intent and is never expected to show
+ * up with a positive count in {@link summarizeSectionCoverage}. Alerting on it would
+ * produce a permanently firing false-positive.
+ */
+export const ZERO_COVERAGE_EXCLUDED_SECTIONS: ReadonlySet<NewsletterSectionId> =
+  new Set<NewsletterSectionId>(["quickHits"]);
+
+/**
+ * Returns every section id that no intent maps to via {@link SECTION_BY_INTENT},
+ * excluding sections in {@link ZERO_COVERAGE_EXCLUDED_SECTIONS} (catch-all sections
+ * that are populated at generation time rather than by targeted search queries).
  */
 export const sectionsWithoutDedicatedIntent = (): NewsletterSectionId[] => {
   const covered = new Set(
@@ -83,7 +95,11 @@ export const sectionsWithoutDedicatedIntent = (): NewsletterSectionId[] => {
       (sectionId): sectionId is NewsletterSectionId => sectionId !== null,
     ),
   );
-  return NEWSLETTER_SECTION_IDS.filter((sectionId) => !covered.has(sectionId));
+  return NEWSLETTER_SECTION_IDS.filter(
+    (sectionId) =>
+      !covered.has(sectionId) &&
+      !ZERO_COVERAGE_EXCLUDED_SECTIONS.has(sectionId),
+  );
 };
 
 /**

--- a/packages/shared/agent-data-api-contract/src/query-analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/query-analysis.ts
@@ -15,6 +15,7 @@ export const QUERY_ANALYSIS_INTENTS = [
   "technology_trend",
   "geopolitical",
   "industry_trend",
+  "deals",
   "wildcard",
 ] as const;
 
@@ -32,6 +33,7 @@ export const QUERY_ANALYSIS_STANDARD_INTENTS = [
   "technology_trend",
   "geopolitical",
   "industry_trend",
+  "deals",
 ] as const;
 
 export const queryAnalysisIntentSchema = z.enum(QUERY_ANALYSIS_INTENTS);
@@ -56,6 +58,7 @@ export const DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS: Record<
   technology_trend: 0.55,
   geopolitical: 0.5,
   industry_trend: 0.6,
+  deals: 0.65,
   wildcard: 0,
 };
 


### PR DESCRIPTION
## Summary

Four of the six newsletter sections had no upstream search budget because the per-section reserve was gated behind a flag that defaulted to off, and two sections had no intent mapped to them at all. This makes the reserve deterministic, adds a `deals` intent for M&A coverage, and removes a permanent false alert for `quickHits`.

## Related issues

Closes #762

## Important changes

- `output.sectionCoverage.enabled` now defaults to `true` in the query-analysis config schema.
- `applySectionCoverageReserve` runs after the weight-based merge: for each dedicated-intent section with zero coverage, it promotes the highest-scored deterministic candidate of a matching intent and displaces the lowest-ranked query of the most over-represented intent, keeping total query count unchanged.
- A new `deals` intent covers M&A, funding rounds, and corporate actions. It is mapped to `dealsAndMovements` in `SECTION_BY_INTENT`, has two pack templates (`{name} acquisition deal`, `{name} merger funding round`), and is referenced in the LLM system prompt. The Prisma `SearchQueryIntent` enum includes `deals`.
- `quickHits` is added to `ZERO_COVERAGE_EXCLUDED_SECTIONS` and excluded from the zero-coverage alert in the insights provider, with the rationale that it is a catch-all section fed at generation time rather than a search target.

## Other changes

- `filterPackTemplatesByYield` keeps at least one template per dedicated-intent section even when historical yield falls below the minimum threshold, preventing a low-yield window from permanently starving a section.
- Exported `ZERO_COVERAGE_EXCLUDED_SECTIONS` from the agent-data-api-contract package.
- Updated the golden prompt fingerprint fixture to reflect the new `deals` intent in the system prompt.

## Key files to review

- `apps/mediapulse/agents/query-analysis/src/merge-query-candidates.ts` — `applySectionCoverageReserve` logic and the displacement strategy.
- `packages/shared/agent-data-api-contract/src/newsletter-sections.ts` — `SECTION_BY_INTENT` and `ZERO_COVERAGE_EXCLUDED_SECTIONS`.
- `packages/shared/agent-data-api-contract/src/query-analysis.ts` — `deals` added to `QUERY_ANALYSIS_INTENTS` and intent weights.
- `apps/mediapulse/agents/query-analysis/src/templates/deterministic-packs.ts` — new `deals`-intent templates and yield-filter protection.
- `apps/mediapulse/agents/query-analysis/src/merge-query-candidates.test.ts` — reserve tests.

## How to test

1. `pnpm --filter @workspace/agent-data-api-contract test` — all contract tests pass, including `dealsAndMovements` coverage and `quickHits` exclusion assertions.
2. `pnpm --filter @mediapulse/query-analysis test` — all 211 tests pass, including the reserve-with-no-survivors and reserve-without-LLM cases.
3. `pnpm --filter @mediapulse/agent-data-api test` — insights provider tests pass with `quickHits` excluded from zero-coverage alerts.
4. After deploy: inspect new `search_query` rows and confirm `competitor`, `technology_trend`, and `deals` intents appear alongside `industry_trend`/`breaking`/`regulatory`.
