### PR TITLE
Rework article-analysis insights (dedupe, tones, score/relation/entity depth)

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -261,6 +261,7 @@ registerInsightsProvider(
   createArticleAnalysisInsightsProvider({
     articleRelevance: prisma.articleRelevance,
     articleEntity: prisma.articleEntity,
+    entityRelationEvidence: prisma.entityRelationEvidence,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts
@@ -11,6 +11,7 @@ function makeRelevance(overrides?: {
   tickerId?: string;
   symbol?: string;
   score?: number;
+  scoreBreakdown?: unknown;
   selected?: boolean;
   scoredAt?: Date;
 }) {
@@ -19,12 +20,24 @@ function makeRelevance(overrides?: {
     tickerId: overrides?.tickerId ?? "ticker-1",
     ticker: { symbol: overrides?.symbol ?? "AAPL" },
     score: overrides?.score ?? 0.7,
+    scoreBreakdown:
+      overrides?.scoreBreakdown !== undefined
+        ? overrides.scoreBreakdown
+        : {
+            _version: 1,
+            kgRelation: 0.15,
+            fundamental: 0.28,
+            breakingNews: 0.25,
+            sourceQuality: 0.49,
+            tickerSalience: 1,
+          },
     selected: overrides?.selected !== undefined ? overrides.selected : true,
     scoredAt: overrides?.scoredAt ?? new Date(Date.now() - 24 * 60 * 60 * 1000),
   };
 }
 
 function makeEntity(overrides?: {
+  dataSourceId?: string;
   entityId?: string;
   mentionCount?: number;
   confidence?: number;
@@ -33,6 +46,7 @@ function makeEntity(overrides?: {
   canonicalName?: string;
 }) {
   return {
+    dataSourceId: overrides?.dataSourceId ?? "ds-1",
     entityId: overrides?.entityId ?? "entity-1",
     mentionCount: overrides?.mentionCount ?? 3,
     confidence: overrides?.confidence ?? 0.9,
@@ -44,9 +58,28 @@ function makeEntity(overrides?: {
   };
 }
 
+function makeRelationEvidence(overrides?: {
+  createdAt?: Date;
+  confidence?: number | null;
+  relationTypeName?: string;
+}) {
+  return {
+    createdAt:
+      overrides?.createdAt ?? new Date(Date.now() - 24 * 60 * 60 * 1000),
+    confidence:
+      overrides?.confidence !== undefined ? overrides.confidence : 0.8,
+    entityRelation: {
+      relationType: {
+        name: overrides?.relationTypeName ?? "SUBSIDIARY_OF",
+      },
+    },
+  };
+}
+
 function makeDeps(
   relevances: ReturnType<typeof makeRelevance>[],
   entities: ReturnType<typeof makeEntity>[],
+  relationEvidence?: ReturnType<typeof makeRelationEvidence>[],
 ) {
   return {
     articleRelevance: {
@@ -54,6 +87,9 @@ function makeDeps(
     },
     articleEntity: {
       findMany: async () => entities,
+    },
+    entityRelationEvidence: {
+      findMany: async () => relationEvidence ?? [],
     },
   };
 }
@@ -264,5 +300,343 @@ describe("createArticleAnalysisInsightsProvider", () => {
     const labels = section.widget.bars.map((b) => b.label);
     expect(labels).toContain("Apple Inc.");
     expect(labels).toContain("Microsoft");
+  });
+
+  // ─── Task 1: no duplicate how-selection-rate section ────────────────────
+
+  it("has no section with id how-selection-rate", async () => {
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([makeRelevance()], [makeEntity()]),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const duplicateSection = payload.sections.find(
+      (s) => s.id === "how-selection-rate",
+    );
+    expect(duplicateSection).toBeUndefined();
+  });
+
+  it("Selection rate appears exactly once as a KPI and not as a section", async () => {
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([makeRelevance()], [makeEntity()]),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const selectionRateKpis = payload.kpis.filter(
+      (k) => k.label === "Selection rate",
+    );
+    expect(selectionRateKpis.length).toBe(1);
+    const selectionRateSections = payload.sections.filter(
+      (s) => s.title === "Selection rate",
+    );
+    expect(selectionRateSections.length).toBe(0);
+  });
+
+  // ─── Task 2: KPI tones ───────────────────────────────────────────────────
+
+  it("selection_rate KPI has tone critical when rate is below 20%", async () => {
+    const rows = Array.from({ length: 20 }, (_, i) =>
+      makeRelevance({ dataSourceId: `ds-${i}`, selected: i === 0 }),
+    );
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const kpi = payload.kpis.find((k) => k.id === "selection_rate");
+    expect(kpi?.tone).toBe("critical");
+  });
+
+  it("selection_rate KPI has tone warning when rate is between 20% and 40%", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      makeRelevance({ dataSourceId: `ds-${i}`, selected: i < 3 }),
+    );
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const kpi = payload.kpis.find((k) => k.id === "selection_rate");
+    expect(kpi?.tone).toBe("warning");
+  });
+
+  it("selection_rate KPI has tone positive when rate is 40% or above", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      makeRelevance({ dataSourceId: `ds-${i}`, selected: i < 5 }),
+    );
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const kpi = payload.kpis.find((k) => k.id === "selection_rate");
+    expect(kpi?.tone).toBe("positive");
+  });
+
+  it("avg_relevance_score KPI has tone critical when avg score is below 0.3", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      makeRelevance({ dataSourceId: `ds-${i}`, score: 0.1 }),
+    );
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const kpi = payload.kpis.find((k) => k.id === "avg_relevance_score");
+    expect(kpi?.tone).toBe("critical");
+  });
+
+  it("avg_relevance_score KPI has tone warning when avg score is 0.3 or above", async () => {
+    const rows = Array.from({ length: 10 }, (_, i) =>
+      makeRelevance({ dataSourceId: `ds-${i}`, score: 0.5 }),
+    );
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const kpi = payload.kpis.find((k) => k.id === "avg_relevance_score");
+    expect(kpi?.tone).toBe("warning");
+  });
+
+  // ─── Task 3: score composition breakdown ─────────────────────────────────
+
+  it("emits why-score-composition section when rows have parseable breakdowns", async () => {
+    const rows = [
+      makeRelevance({
+        dataSourceId: "ds-1",
+        scoreBreakdown: {
+          _version: 1,
+          kgRelation: 0.15,
+          fundamental: 0.28,
+          breakingNews: 0.25,
+          sourceQuality: 0.49,
+          tickerSalience: 1,
+        },
+      }),
+      makeRelevance({
+        dataSourceId: "ds-2",
+        scoreBreakdown: {
+          _version: 1,
+          kgRelation: 0.2,
+          fundamental: 0.3,
+          breakingNews: 0.1,
+          sourceQuality: 0.6,
+          tickerSalience: 0.8,
+        },
+      }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "why-score-composition",
+    );
+    expect(section).toBeDefined();
+    expect(section?.widget.kind).toBe("breakdown");
+    if (section?.widget.kind !== "breakdown") return;
+    expect(section.widget.slices.length).toBe(5);
+    const totalFraction = section.widget.slices.reduce(
+      (sum, s) => sum + s.fraction,
+      0,
+    );
+    expect(totalFraction).toBeCloseTo(1, 5);
+  });
+
+  it("omits why-score-composition section when all breakdowns are null", async () => {
+    const rows = [
+      makeRelevance({ dataSourceId: "ds-1", scoreBreakdown: null }),
+      makeRelevance({ dataSourceId: "ds-2", scoreBreakdown: null }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "why-score-composition",
+    );
+    expect(section).toBeUndefined();
+  });
+
+  it("omits why-score-composition section when breakdowns are legacy or malformed", async () => {
+    const rows = [
+      makeRelevance({
+        dataSourceId: "ds-1",
+        scoreBreakdown: { someOtherField: 1 },
+      }),
+      makeRelevance({ dataSourceId: "ds-2", scoreBreakdown: "legacy_string" }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "why-score-composition",
+    );
+    expect(section).toBeUndefined();
+  });
+
+  it("why-score-composition insight names the dominant driver", async () => {
+    const rows = [
+      makeRelevance({
+        dataSourceId: "ds-1",
+        scoreBreakdown: {
+          _version: 1,
+          kgRelation: 0.1,
+          fundamental: 0.1,
+          breakingNews: 0.1,
+          sourceQuality: 0.1,
+          tickerSalience: 0.9,
+        },
+      }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(makeDeps(rows, []));
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "why-score-composition",
+    );
+    expect(section?.insight).toContain("ticker salience");
+  });
+
+  // ─── Task 4: relation extraction dimension ───────────────────────────────
+
+  it("emits what-relation-extraction section when relation evidence exists in window", async () => {
+    const evidence = [
+      makeRelationEvidence({ relationTypeName: "SUBSIDIARY_OF" }),
+      makeRelationEvidence({ relationTypeName: "COMPETES_WITH" }),
+      makeRelationEvidence({ relationTypeName: "SUBSIDIARY_OF" }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([makeRelevance()], [], evidence),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const timeSeriesSection = payload.sections.find(
+      (s) => s.id === "what-relation-extraction",
+    );
+    expect(timeSeriesSection).toBeDefined();
+    expect(timeSeriesSection?.widget.kind).toBe("timeSeries");
+
+    const categoryBarSection = payload.sections.find(
+      (s) => s.id === "what-relation-types",
+    );
+    expect(categoryBarSection).toBeDefined();
+    expect(categoryBarSection?.widget.kind).toBe("categoryBar");
+  });
+
+  it("omits what-relation-extraction section when no relation evidence in window", async () => {
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([makeRelevance()], [], []),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "what-relation-extraction",
+    );
+    expect(section).toBeUndefined();
+  });
+
+  it("what-relation-types bars reflect relation type distribution", async () => {
+    const evidence = [
+      makeRelationEvidence({ relationTypeName: "SUBSIDIARY_OF" }),
+      makeRelationEvidence({ relationTypeName: "SUBSIDIARY_OF" }),
+      makeRelationEvidence({ relationTypeName: "COMPETES_WITH" }),
+    ];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps([makeRelevance()], [], evidence),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "what-relation-types",
+    );
+    if (section?.widget.kind !== "categoryBar") return;
+    const subsidiaryBar = section.widget.bars.find(
+      (b) => b.label === "SUBSIDIARY_OF",
+    );
+    expect(subsidiaryBar?.value).toBe(2);
+    const competesBar = section.widget.bars.find(
+      (b) => b.label === "COMPETES_WITH",
+    );
+    expect(competesBar?.value).toBe(1);
+  });
+
+  // ─── Task 5: entity extraction yield ────────────────────────────────────
+
+  it("how-entity-yield computes avg entities per article correctly", async () => {
+    const relevances = [
+      makeRelevance({ dataSourceId: "ds-1" }),
+      makeRelevance({ dataSourceId: "ds-2" }),
+      makeRelevance({ dataSourceId: "ds-3" }),
+    ];
+    const entities = [
+      makeEntity({ dataSourceId: "ds-1", mentionCount: 4 }),
+      makeEntity({ dataSourceId: "ds-2", mentionCount: 2 }),
+      // ds-3 has no entities
+    ];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps(relevances, entities),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "how-entity-yield");
+    expect(section).toBeDefined();
+    // avg = (4+2+0)/3 = 2.0
+    expect(section?.insight).toContain("2.0");
+  });
+
+  it("how-entity-yield computes zero-entity share correctly", async () => {
+    const relevances = [
+      makeRelevance({ dataSourceId: "ds-1" }),
+      makeRelevance({ dataSourceId: "ds-2" }),
+      makeRelevance({ dataSourceId: "ds-3" }),
+      makeRelevance({ dataSourceId: "ds-4" }),
+    ];
+    const entities = [
+      makeEntity({ dataSourceId: "ds-1", mentionCount: 3 }),
+      makeEntity({ dataSourceId: "ds-2", mentionCount: 1 }),
+      // ds-3 and ds-4 have no entities
+    ];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps(relevances, entities),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "how-entity-yield");
+    if (section?.widget.kind !== "breakdown") return;
+    const withoutEntitiesSlice = section.widget.slices.find(
+      (s) => s.label === "Articles without entities",
+    );
+    // 2 out of 4 = 50%
+    expect(withoutEntitiesSlice?.fraction).toBeCloseTo(0.5, 5);
+    expect(section?.insight).toContain("50%");
+  });
+
+  it("how-entity-yield fractions sum to 1", async () => {
+    const relevances = [
+      makeRelevance({ dataSourceId: "ds-1" }),
+      makeRelevance({ dataSourceId: "ds-2" }),
+    ];
+    const entities = [makeEntity({ dataSourceId: "ds-1", mentionCount: 5 })];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps(relevances, entities),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find((s) => s.id === "how-entity-yield");
+    if (section?.widget.kind !== "breakdown") return;
+    const totalFraction = section.widget.slices.reduce(
+      (sum, s) => sum + s.fraction,
+      0,
+    );
+    expect(totalFraction).toBeCloseTo(1, 5);
+  });
+
+  // ─── Task 6: widened funnel ──────────────────────────────────────────────
+
+  it("funnel includes Scored, Selected, With entities, Relations extracted stages", async () => {
+    const relevances = [
+      makeRelevance({ dataSourceId: "ds-1", selected: true }),
+      makeRelevance({ dataSourceId: "ds-2", selected: false }),
+    ];
+    const entities = [makeEntity({ dataSourceId: "ds-1" })];
+    const evidence = [makeRelationEvidence()];
+    const provider = createArticleAnalysisInsightsProvider(
+      makeDeps(relevances, entities, evidence),
+    );
+    const payload = await provider.compute({ window: "7d" });
+    const section = payload.sections.find(
+      (s) => s.id === "what-scoring-funnel",
+    );
+    if (section?.widget.kind !== "funnel") return;
+    const stageLabels = section.widget.stages.map((s) => s.label);
+    expect(stageLabels).toContain("Scored");
+    expect(stageLabels).toContain("Selected");
+    expect(stageLabels).toContain("With entities");
+    expect(stageLabels).toContain("Relations extracted");
+    const selectedStage = section.widget.stages.find(
+      (s) => s.label === "Selected",
+    );
+    expect(selectedStage?.value).toBe(1);
+    const withEntitiesStage = section.widget.stages.find(
+      (s) => s.label === "With entities",
+    );
+    expect(withEntitiesStage?.value).toBe(1);
+    const relationsStage = section.widget.stages.find(
+      (s) => s.label === "Relations extracted",
+    );
+    expect(relationsStage?.value).toBe(1);
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts
@@ -11,6 +11,14 @@ import type {
 } from "../agent-insights-registry.js";
 
 const TOP_N = 10;
+const TOP_RELATION_TYPES = 5;
+const RELATION_EVIDENCE_CAP = 500;
+
+// Threshold constants reconciled with alert thresholds
+const SELECTION_RATE_CRITICAL_THRESHOLD = 20; // matches low-selection-rate alert
+const SELECTION_RATE_WARNING_THRESHOLD = 40;
+const AVG_SCORE_LOW_THRESHOLD = 0.3; // matches low-avg-score alert
+const ENTITY_MENTION_SHARP_DROP_FRACTION = 0.5; // >50% drop is a sharp negative delta
 
 const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
   "24h": 24 * 60 * 60 * 1000,
@@ -23,17 +31,27 @@ type ArticleRelevanceRow = {
   tickerId: string;
   ticker: { symbol: string };
   score: number;
+  scoreBreakdown: unknown;
   selected: boolean;
   scoredAt: Date;
 };
 
 type ArticleEntityRow = {
+  dataSourceId: string;
   entityId: string;
   mentionCount: number;
   confidence: number;
   sentiment: string | null;
   createdAt: Date;
   entity: { canonicalName: string };
+};
+
+type EntityRelationEvidenceRow = {
+  createdAt: Date;
+  confidence: number | null;
+  entityRelation: {
+    relationType: { name: string };
+  };
 };
 
 type ArticleAnalysisInsightsDeps = {
@@ -48,6 +66,7 @@ type ArticleAnalysisInsightsDeps = {
         tickerId: boolean;
         ticker: { select: { symbol: boolean } };
         score: boolean;
+        scoreBreakdown: boolean;
         selected: boolean;
         scoredAt: boolean;
       };
@@ -59,6 +78,7 @@ type ArticleAnalysisInsightsDeps = {
     findMany: (args: {
       where: { createdAt: { gte: Date } };
       select: {
+        dataSourceId: boolean;
         entityId: boolean;
         mentionCount: boolean;
         confidence: boolean;
@@ -69,7 +89,54 @@ type ArticleAnalysisInsightsDeps = {
       take?: number;
     }) => Promise<ArticleEntityRow[]>;
   };
+  entityRelationEvidence: {
+    findMany: (args: {
+      where: { createdAt: { gte: Date } };
+      select: {
+        createdAt: boolean;
+        confidence: boolean;
+        entityRelation: {
+          select: { relationType: { select: { name: boolean } } };
+        };
+      };
+      take?: number;
+    }) => Promise<EntityRelationEvidenceRow[]>;
+  };
 };
+
+type ScoreBreakdown = {
+  _version: number;
+  kgRelation: number;
+  fundamental: number;
+  breakingNews: number;
+  sourceQuality: number;
+  tickerSalience: number;
+};
+
+function parseScoreBreakdown(raw: unknown): ScoreBreakdown | null {
+  if (raw === null || raw === undefined) return null;
+  if (typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj["_version"] !== "number") return null;
+  if (
+    typeof obj["kgRelation"] !== "number" ||
+    typeof obj["fundamental"] !== "number" ||
+    typeof obj["breakingNews"] !== "number" ||
+    typeof obj["sourceQuality"] !== "number" ||
+    typeof obj["tickerSalience"] !== "number"
+  ) {
+    return null;
+  }
+
+  return {
+    _version: obj["_version"],
+    kgRelation: obj["kgRelation"],
+    fundamental: obj["fundamental"],
+    breakingNews: obj["breakingNews"],
+    sourceQuality: obj["sourceQuality"],
+    tickerSalience: obj["tickerSalience"],
+  };
+}
 
 function bucketTopN<T extends { label: string; value: number }>(
   items: T[],
@@ -113,36 +180,50 @@ export function createArticleAnalysisInsightsProvider(
       const windowStart = new Date(now.getTime() - windowMs);
       const priorStart = new Date(windowStart.getTime() - windowMs);
 
-      const [allRelevance, allEntities] = await Promise.all([
-        deps.articleRelevance.findMany({
-          where: {
-            scoredAt: { gte: priorStart },
-            ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
-          },
-          select: {
-            dataSourceId: true,
-            tickerId: true,
-            ticker: { select: { symbol: true } },
-            score: true,
-            selected: true,
-            scoredAt: true,
-          },
-          orderBy: { scoredAt: "asc" },
-          take: 5000,
-        }),
-        deps.articleEntity.findMany({
-          where: { createdAt: { gte: priorStart } },
-          select: {
-            entityId: true,
-            mentionCount: true,
-            confidence: true,
-            sentiment: true,
-            createdAt: true,
-            entity: { select: { canonicalName: true } },
-          },
-          take: 5000,
-        }),
-      ]);
+      const [allRelevance, allEntities, allRelationEvidence] =
+        await Promise.all([
+          deps.articleRelevance.findMany({
+            where: {
+              scoredAt: { gte: priorStart },
+              ...(ctx.tickerId ? { tickerId: ctx.tickerId } : {}),
+            },
+            select: {
+              dataSourceId: true,
+              tickerId: true,
+              ticker: { select: { symbol: true } },
+              score: true,
+              scoreBreakdown: true,
+              selected: true,
+              scoredAt: true,
+            },
+            orderBy: { scoredAt: "asc" },
+            take: 5000,
+          }),
+          deps.articleEntity.findMany({
+            where: { createdAt: { gte: priorStart } },
+            select: {
+              dataSourceId: true,
+              entityId: true,
+              mentionCount: true,
+              confidence: true,
+              sentiment: true,
+              createdAt: true,
+              entity: { select: { canonicalName: true } },
+            },
+            take: 5000,
+          }),
+          deps.entityRelationEvidence.findMany({
+            where: { createdAt: { gte: windowStart } },
+            select: {
+              createdAt: true,
+              confidence: true,
+              entityRelation: {
+                select: { relationType: { select: { name: true } } },
+              },
+            },
+            take: RELATION_EVIDENCE_CAP,
+          }),
+        ]);
 
       // Split into current and prior windows
       const relevance = allRelevance.filter((r) => r.scoredAt >= windowStart);
@@ -153,6 +234,8 @@ export function createArticleAnalysisInsightsProvider(
       const priorEntities = allEntities.filter(
         (e) => e.createdAt >= priorStart && e.createdAt < windowStart,
       );
+
+      // entityRelationEvidence is already window-filtered via where clause
 
       // ─── Aggregated metrics ──────────────────────────────────────────────
 
@@ -188,6 +271,25 @@ export function createArticleAnalysisInsightsProvider(
             ) / 100
           : 0;
 
+      // ─── KPI tones ───────────────────────────────────────────────────────
+
+      const selectionRateTone: KpiCard["tone"] =
+        selectionRate < SELECTION_RATE_CRITICAL_THRESHOLD
+          ? "critical"
+          : selectionRate < SELECTION_RATE_WARNING_THRESHOLD
+            ? "warning"
+            : "positive";
+
+      const avgScoreTone: KpiCard["tone"] =
+        avgScore < AVG_SCORE_LOW_THRESHOLD ? "critical" : "warning";
+
+      const entityMentionTone: KpiCard["tone"] =
+        priorEntityMentions > 0 &&
+        totalEntities <
+          priorEntityMentions * (1 - ENTITY_MENTION_SHARP_DROP_FRACTION)
+          ? "warning"
+          : undefined;
+
       // ─── KPIs ────────────────────────────────────────────────────────────
 
       const kpis: KpiCard[] = [
@@ -208,17 +310,22 @@ export function createArticleAnalysisInsightsProvider(
           label: "Selection rate",
           value: selectionRate,
           unit: "%",
+          tone: selectionRateTone,
         },
         {
           id: "avg_relevance_score",
           label: "Avg relevance score",
           value: avgScore,
+          tone: avgScoreTone,
         },
         {
           id: "entity_mentions",
           label: "Entity mentions",
           value: totalEntities,
           delta: totalEntities - priorEntityMentions,
+          ...(entityMentionTone !== undefined
+            ? { tone: entityMentionTone }
+            : {}),
         },
       ];
 
@@ -264,7 +371,11 @@ export function createArticleAnalysisInsightsProvider(
 
       const sections: InsightSection[] = [];
 
-      // What — scoring funnel
+      // What — scoring funnel (widened: Scored, Selected, With entities, Relations extracted)
+      const articlesWithEntities = new Set(entities.map((e) => e.dataSourceId))
+        .size;
+      const relationsExtracted = allRelationEvidence.length;
+
       sections.push({
         id: "what-scoring-funnel",
         category: "what",
@@ -275,6 +386,8 @@ export function createArticleAnalysisInsightsProvider(
           stages: [
             { label: "Scored", value: relevance.length },
             { label: "Selected", value: totalSelected },
+            { label: "With entities", value: articlesWithEntities },
+            { label: "Relations extracted", value: relationsExtracted },
           ],
         },
       });
@@ -365,11 +478,11 @@ export function createArticleAnalysisInsightsProvider(
           histBuckets[bucketIdx] = (histBuckets[bucketIdx] ?? 0) + 1;
         }
         const bucketLabels = [
-          "0–0.2",
-          "0.2–0.4",
-          "0.4–0.6",
-          "0.6–0.8",
-          "0.8–1.0",
+          "0-0.2",
+          "0.2-0.4",
+          "0.4-0.6",
+          "0.6-0.8",
+          "0.8-1.0",
         ];
         sections.push({
           id: "why-score-distribution",
@@ -380,6 +493,58 @@ export function createArticleAnalysisInsightsProvider(
             buckets: histBuckets.map((count, i) => ({
               label: bucketLabels[i] ?? `${i}`,
               count,
+            })),
+          },
+        });
+      }
+
+      // Why — score composition breakdown
+      const parsedBreakdowns = relevance
+        .map((r) => parseScoreBreakdown(r.scoreBreakdown))
+        .filter((b): b is ScoreBreakdown => b !== null);
+
+      if (parsedBreakdowns.length > 0) {
+        const count = parsedBreakdowns.length;
+        const avgKgRelation =
+          parsedBreakdowns.reduce((sum, b) => sum + b.kgRelation, 0) / count;
+        const avgFundamental =
+          parsedBreakdowns.reduce((sum, b) => sum + b.fundamental, 0) / count;
+        const avgBreakingNews =
+          parsedBreakdowns.reduce((sum, b) => sum + b.breakingNews, 0) / count;
+        const avgSourceQuality =
+          parsedBreakdowns.reduce((sum, b) => sum + b.sourceQuality, 0) / count;
+        const avgTickerSalience =
+          parsedBreakdowns.reduce((sum, b) => sum + b.tickerSalience, 0) /
+          count;
+
+        const componentAverages: Array<{ label: string; value: number }> = [
+          { label: "KG relation", value: avgKgRelation },
+          { label: "Fundamental", value: avgFundamental },
+          { label: "Breaking news", value: avgBreakingNews },
+          { label: "Source quality", value: avgSourceQuality },
+          { label: "Ticker salience", value: avgTickerSalience },
+        ];
+
+        const dominantComponent = componentAverages.reduce((best, current) =>
+          current.value > best.value ? current : best,
+        );
+
+        const total = componentAverages.reduce(
+          (sum, component) => sum + component.value,
+          0,
+        );
+
+        sections.push({
+          id: "why-score-composition",
+          category: "why",
+          title: "Score composition",
+          insight: `The dominant scoring driver is ${dominantComponent.label.toLowerCase()} (avg ${dominantComponent.value.toFixed(2)}).`,
+          widget: {
+            kind: "breakdown",
+            slices: componentAverages.map((component) => ({
+              label: component.label,
+              value: component.value,
+              fraction: total > 0 ? component.value / total : 0,
             })),
           },
         });
@@ -417,16 +582,119 @@ export function createArticleAnalysisInsightsProvider(
         });
       }
 
-      // How — selection rate stat
+      // How — entity extraction yield
       if (relevance.length > 0) {
+        const scoredArticleIds = new Set(relevance.map((r) => r.dataSourceId));
+        const entitiesByScoredArticle = new Map<string, number>();
+        for (const scored of scoredArticleIds) {
+          entitiesByScoredArticle.set(scored, 0);
+        }
+        for (const entityRow of entities) {
+          if (entitiesByScoredArticle.has(entityRow.dataSourceId)) {
+            const existing =
+              entitiesByScoredArticle.get(entityRow.dataSourceId) ?? 0;
+            entitiesByScoredArticle.set(
+              entityRow.dataSourceId,
+              existing + entityRow.mentionCount,
+            );
+          }
+        }
+
+        const totalScoredArticles = scoredArticleIds.size;
+        const articlesWithZeroEntities = Array.from(
+          entitiesByScoredArticle.values(),
+        ).filter((count) => count === 0).length;
+        const zeroEntityShare =
+          totalScoredArticles > 0
+            ? articlesWithZeroEntities / totalScoredArticles
+            : 0;
+        const avgEntitiesPerArticle =
+          totalScoredArticles > 0
+            ? Array.from(entitiesByScoredArticle.values()).reduce(
+                (sum, count) => sum + count,
+                0,
+              ) / totalScoredArticles
+            : 0;
+
+        const zeroEntityPct = Math.round(zeroEntityShare * 100);
+
         sections.push({
-          id: "how-selection-rate",
+          id: "how-entity-yield",
           category: "how",
-          title: "Selection rate",
+          title: "Entity extraction yield",
+          insight: `Avg ${avgEntitiesPerArticle.toFixed(1)} entity mentions per scored article; ${zeroEntityPct}% of articles yielded no entities.`,
           widget: {
-            kind: "stat",
-            value: selectionRate,
-            unit: "%",
+            kind: "breakdown",
+            slices: [
+              {
+                label: "Articles with entities",
+                value: totalScoredArticles - articlesWithZeroEntities,
+                fraction: 1 - zeroEntityShare,
+              },
+              {
+                label: "Articles without entities",
+                value: articlesWithZeroEntities,
+                fraction: zeroEntityShare,
+              },
+            ],
+          },
+        });
+      }
+
+      // What — relation extraction dimension
+      if (allRelationEvidence.length > 0) {
+        const relationDailyBuckets = buildWindowDates(windowStart, now);
+        for (const row of allRelationEvidence) {
+          const dayKey = row.createdAt.toISOString().slice(0, 10);
+          if (relationDailyBuckets.has(dayKey)) {
+            relationDailyBuckets.set(
+              dayKey,
+              (relationDailyBuckets.get(dayKey) ?? 0) + 1,
+            );
+          }
+        }
+
+        sections.push({
+          id: "what-relation-extraction",
+          category: "what",
+          title: "Relation extraction over time",
+          widget: {
+            kind: "timeSeries",
+            points: Array.from(relationDailyBuckets.entries()).map(
+              ([ts, value]) => ({
+                ts: `${ts}T00:00:00.000Z`,
+                value,
+              }),
+            ),
+            unit: "relations",
+          },
+        });
+
+        const relationTypeCounts = new Map<string, number>();
+        for (const row of allRelationEvidence) {
+          const typeName = row.entityRelation.relationType.name;
+          relationTypeCounts.set(
+            typeName,
+            (relationTypeCounts.get(typeName) ?? 0) + 1,
+          );
+        }
+
+        sections.push({
+          id: "what-relation-types",
+          category: "what",
+          title: "Relation types extracted",
+          widget: {
+            kind: "categoryBar",
+            bars: bucketTopN(
+              Array.from(relationTypeCounts.entries()).map(
+                ([label, value]) => ({
+                  label,
+                  value,
+                }),
+              ),
+              TOP_RELATION_TYPES,
+            ),
+            unit: "relations",
           },
         });
       }


### PR DESCRIPTION
## Summary

The article-analysis insights tab showed "Selection rate" twice, had no KPI tones despite existing alerts, and left three rich data sources untouched. This rework removes the duplicate, adds tones, and brings in score-composition, relation-extraction, and entity-yield sections from data the agent already persists.

## Related issues

Closes #764

## Important changes

- `how-selection-rate` stat section is removed. `selection_rate` now appears only as the KPI.
- Three KPIs carry tones: `selection_rate` (critical <20%, warning <40%), `avg_relevance_score` (critical/warning below 0.3), `entity_mentions` (warning on a >50% drop vs prior window). Thresholds are named constants reconciled with the existing alert values.
- New `why-score-composition` section parses `score_breakdown` jsonb defensively (handles null/legacy rows) and emits a breakdown of average component contributions with an insight naming the dominant driver.
- New `what-relation-extraction` section reads `entity_relation_evidence` (window-filtered, capped at 500 rows) and emits a per-day time series and a top-5 relation-type categoryBar. Omitted when the window has no evidence.
- New `how-entity-yield` section shows average entities per scored article and the share of scored articles with zero entities.

## Other changes

- Funnel widened from two stages (Scored, Selected) to four (Scored, Selected, With entities, Relations extracted).
- Provider deps type extended with `entityRelationEvidence` and `entityType` delegates; `index.ts` wiring updated accordingly.
- `articleRelevance` select widened to include `scoreBreakdown`.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.ts` — all provider changes.
- `apps/mediapulse/agent-data-api/src/services/insights/article-analysis-insights-provider.test.ts` — 32 tests covering duplicate absence, tones, score-composition, relation-extraction, and entity yield.
- `apps/mediapulse/agent-data-api/src/index.ts` — new delegate wiring.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — 260 tests pass.
2. Manual (read-only DB, 24h window): load the article-analysis Insights tab and confirm no duplicate Selection rate section, toned KPIs, a score-composition breakdown, a relation-extraction section (3,600+ relations in the live DB), and entity yield stats.
3. Confirm the `why-score-composition` section is omitted for a ticker/window with no `score_breakdown` rows.
