### PR TITLE
Enrich content-generation insights (dedupe, tones, section-drop, tokens, config-drift)

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts
@@ -36,6 +36,10 @@ function makeNewsletter(overrides?: {
   createdAt?: Date;
   model?: string | null;
   totalTokens?: number | null;
+  promptTokens?: number | null;
+  completionTokens?: number | null;
+  configVersion?: string | null;
+  promptHash?: string | null;
 }) {
   return {
     tickerId: overrides?.tickerId ?? "ticker-1",
@@ -44,6 +48,16 @@ function makeNewsletter(overrides?: {
     model: overrides?.model !== undefined ? overrides.model : "gpt-4o",
     totalTokens:
       overrides?.totalTokens !== undefined ? overrides.totalTokens : 1500,
+    promptTokens:
+      overrides?.promptTokens !== undefined ? overrides.promptTokens : null,
+    completionTokens:
+      overrides?.completionTokens !== undefined
+        ? overrides.completionTokens
+        : null,
+    configVersion:
+      overrides?.configVersion !== undefined ? overrides.configVersion : null,
+    promptHash:
+      overrides?.promptHash !== undefined ? overrides.promptHash : null,
   };
 }
 
@@ -367,13 +381,25 @@ describe("createContentGenerationInsightsProvider", () => {
     }
   });
 
-  it("model mix fractions sum to 1", async () => {
+  it("model mix section is a table with model, configVersion, and promptHash rows", async () => {
     const provider = createContentGenerationInsightsProvider(
       makeDeps({
         newsletters: [
-          makeNewsletter({ model: "gpt-4o" }),
-          makeNewsletter({ model: "gpt-4o" }),
-          makeNewsletter({ model: "gpt-4o-mini" }),
+          makeNewsletter({
+            model: "gpt-4o",
+            configVersion: "v1",
+            promptHash: "abc",
+          }),
+          makeNewsletter({
+            model: "gpt-4o",
+            configVersion: "v1",
+            promptHash: "abc",
+          }),
+          makeNewsletter({
+            model: "gpt-4o-mini",
+            configVersion: "v1",
+            promptHash: "abc",
+          }),
         ],
       }),
     );
@@ -382,16 +408,16 @@ describe("createContentGenerationInsightsProvider", () => {
     const modelSection = payload.sections.find((s) => s.id === "who-model-mix");
 
     expect(modelSection).toBeDefined();
-    if (modelSection!.widget.kind === "breakdown") {
-      const fractionSum = modelSection!.widget.slices.reduce(
-        (sum, s) => sum + s.fraction,
-        0,
+    expect(modelSection!.widget.kind).toBe("table");
+    if (modelSection!.widget.kind === "table") {
+      expect(modelSection!.widget.columns).toContain("dimension");
+      const modelRows = modelSection!.widget.rows.filter(
+        (row) => row[0] === "model",
       );
-      expect(fractionSum).toBeCloseTo(1);
-      const gpt4oSlice = modelSection!.widget.slices.find(
-        (s) => s.label === "gpt-4o",
-      );
-      expect(gpt4oSlice?.value).toBe(2);
+      expect(modelRows.length).toBeGreaterThan(0);
+      const gpt4oRow = modelRows.find((row) => row[1] === "gpt-4o");
+      expect(gpt4oRow).toBeDefined();
+      expect(gpt4oRow![2]).toBe(2);
     }
   });
 
@@ -460,5 +486,547 @@ describe("createContentGenerationInsightsProvider", () => {
     expect(parsed.kpis.length).toBeGreaterThanOrEqual(3);
     expect(parsed.alerts).toHaveLength(0);
     expect(parsed.sections.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Task 1: no how-median-duration section; duration histogram still present
+  it("does not emit how-median-duration section but still emits duration histogram", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success", durationMs: 5000 }),
+          makeRun({ outcome: "success", durationMs: 10000 }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+
+    const medianDurationSection = payload.sections.find(
+      (s) => s.id === "how-median-duration",
+    );
+    const histogramSection = payload.sections.find(
+      (s) => s.id === "how-duration-histogram",
+    );
+
+    expect(medianDurationSection).toBeUndefined();
+    expect(histogramSection).toBeDefined();
+    expect(histogramSection!.widget.kind).toBe("histogram");
+  });
+
+  // Task 2: KPI tones -- success_rate warning when below 80%
+  it("success_rate KPI has warning tone when success rate is below 80%", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const successRateKpi = payload.kpis.find((k) => k.id === "success_rate");
+
+    expect(successRateKpi).toBeDefined();
+    // 1 success out of 5 runs = 20%, which is below 60% (critical threshold) -- not testing critical here
+    // but we can assert tone is set to something other than undefined
+    expect(successRateKpi!.tone).toBeDefined();
+    // 20% success rate is below 60% so critical
+    expect(successRateKpi!.tone).toBe("critical");
+  });
+
+  it("success_rate KPI has warning tone when between 60% and 80%", async () => {
+    // 2 success out of 3 runs = 67%, below 80% but above 60%
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const successRateKpi = payload.kpis.find((k) => k.id === "success_rate");
+
+    expect(successRateKpi).toBeDefined();
+    expect(successRateKpi!.tone).toBe("warning");
+  });
+
+  it("success_rate KPI has no tone when success rate is 80% or above", async () => {
+    // 4 success out of 5 = 80%
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({ outcome: "success" }),
+          makeRun({
+            outcome: "failed",
+            stage: "llm",
+            errorCategory: "retryable_llm",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const successRateKpi = payload.kpis.find((k) => k.id === "success_rate");
+
+    expect(successRateKpi).toBeDefined();
+    expect(successRateKpi!.tone).toBeUndefined();
+  });
+
+  it("median_duration_ms KPI has warning tone when above 2 minutes", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success", durationMs: 130_000 }), // 2 min 10s
+          makeRun({ outcome: "success", durationMs: 150_000 }), // 2 min 30s
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const medianKpi = payload.kpis.find((k) => k.id === "median_duration_ms");
+
+    expect(medianKpi).toBeDefined();
+    expect(medianKpi!.tone).toBe("warning");
+  });
+
+  it("median_duration_ms KPI has no tone when below 2 minutes", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success", durationMs: 10_000 }),
+          makeRun({ outcome: "success", durationMs: 20_000 }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const medianKpi = payload.kpis.find((k) => k.id === "median_duration_ms");
+
+    expect(medianKpi).toBeDefined();
+    expect(medianKpi!.tone).toBeUndefined();
+  });
+
+  // Task 3: section-coverage -- sectionsRemoved surfaced and alert fires when consistently dropped
+  it("what-section-coverage section shows removed counts from sectionsRemoved", async () => {
+    const makeDetailsWithRemoved = (
+      bullets: Record<string, number>,
+      removed: string[],
+    ) => ({
+      sectionFill: {
+        bySection: Object.fromEntries(
+          Object.entries(bullets).map(([k, v]) => [k, { citedBullets: v }]),
+        ),
+        sectionsRemoved: removed,
+      },
+    });
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved({ industryPulse: 3 }, [
+              "regulatoryPolicyWatch",
+            ]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved({ industryPulse: 2 }, [
+              "regulatoryPolicyWatch",
+            ]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved({ industryPulse: 4 }, []),
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const coverageSection = payload.sections.find(
+      (s) => s.id === "what-section-coverage",
+    );
+
+    expect(coverageSection).toBeDefined();
+    expect(coverageSection!.widget.kind).toBe("table");
+    if (coverageSection!.widget.kind === "table") {
+      const regRow = coverageSection!.widget.rows.find(
+        (row) => row[0] === "regulatoryPolicyWatch",
+      );
+      expect(regRow).toBeDefined();
+      expect(regRow![2]).toBe(2); // removed_count
+    }
+  });
+
+  it("fires section-drop alert when a section is removed in >20% of successful runs", async () => {
+    const makeDetailsWithRemoved = (removed: string[]) => ({
+      sectionFill: {
+        bySection: { industryPulse: { citedBullets: 2 } },
+        sectionsRemoved: removed,
+      },
+    });
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          // 3 out of 4 success runs have regulatoryPolicyWatch removed = 75%
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved(["regulatoryPolicyWatch"]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved(["regulatoryPolicyWatch"]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved(["regulatoryPolicyWatch"]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved([]),
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const dropAlert = payload.alerts.find(
+      (a) => a.id === "section-drop-regulatoryPolicyWatch",
+    );
+
+    expect(dropAlert).toBeDefined();
+    expect(dropAlert!.severity).toBe("warning");
+    expect(dropAlert!.sectionRef).toBe("what-section-coverage");
+  });
+
+  it("does not fire section-drop alert when drop rate is at or below 20%", async () => {
+    const makeDetailsWithRemoved = (removed: string[]) => ({
+      sectionFill: {
+        bySection: { industryPulse: { citedBullets: 2 } },
+        sectionsRemoved: removed,
+      },
+    });
+
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          // 1 out of 5 = 20%, which is NOT above the threshold (threshold is >20%)
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved(["regulatoryPolicyWatch"]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved([]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved([]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved([]),
+          }),
+          makeRun({
+            outcome: "success",
+            details: makeDetailsWithRemoved([]),
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const dropAlert = payload.alerts.find(
+      (a) => a.id === "section-drop-regulatoryPolicyWatch",
+    );
+
+    expect(dropAlert).toBeUndefined();
+  });
+
+  it("handles runs with no details gracefully for section coverage", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        runs: [
+          makeRun({ outcome: "success", details: null }),
+          makeRun({ outcome: "success", details: null }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+
+    // No section-fill or coverage sections should appear when details are missing
+    const coverageSection = payload.sections.find(
+      (s) => s.id === "what-section-coverage",
+    );
+    const fillSection = payload.sections.find(
+      (s) => s.id === "how-section-fill",
+    );
+    const parsed = insightsPayloadSchema.parse(payload);
+
+    expect(coverageSection).toBeUndefined();
+    expect(fillSection).toBeUndefined();
+    expect(parsed).toBeDefined();
+  });
+
+  // Task 4: token cost depth
+  it("avg_tokens_per_newsletter KPI is correct", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({ totalTokens: 1000 }),
+          makeNewsletter({ totalTokens: 2000 }),
+          makeNewsletter({ totalTokens: 3000 }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const avgKpi = payload.kpis.find(
+      (k) => k.id === "avg_tokens_per_newsletter",
+    );
+
+    expect(avgKpi).toBeDefined();
+    expect(avgKpi!.value).toBe(2000);
+    expect(avgKpi!.unit).toBe("tokens");
+  });
+
+  it("avg_tokens_per_newsletter KPI is absent when there are no newsletters", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({ runs: [], newsletters: [] }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const avgKpi = payload.kpis.find(
+      (k) => k.id === "avg_tokens_per_newsletter",
+    );
+
+    expect(avgKpi).toBeUndefined();
+  });
+
+  it("prompt vs completion token section shows split when both are present", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({
+            totalTokens: 1000,
+            promptTokens: 800,
+            completionTokens: 200,
+          }),
+          makeNewsletter({
+            totalTokens: 2000,
+            promptTokens: 1600,
+            completionTokens: 400,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tokenSection = payload.sections.find(
+      (s) => s.id === "how-prompt-vs-completion-tokens",
+    );
+
+    expect(tokenSection).toBeDefined();
+    expect(tokenSection!.widget.kind).toBe("breakdown");
+    if (tokenSection!.widget.kind === "breakdown") {
+      const promptSlice = tokenSection!.widget.slices.find(
+        (s) => s.label === "Prompt",
+      );
+      const completionSlice = tokenSection!.widget.slices.find(
+        (s) => s.label === "Completion",
+      );
+      expect(promptSlice).toBeDefined();
+      expect(completionSlice).toBeDefined();
+      expect(promptSlice!.value).toBe(2400); // 800 + 1600
+      expect(completionSlice!.value).toBe(600); // 200 + 400
+      // prompt + completion should reconcile to total
+      expect(promptSlice!.value + completionSlice!.value).toBe(3000);
+      // fractions should sum to 1
+      expect(promptSlice!.fraction + completionSlice!.fraction).toBeCloseTo(1);
+    }
+  });
+
+  it("prompt vs completion token section is absent when all newsletters have null tokens", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({
+            totalTokens: 1500,
+            promptTokens: null,
+            completionTokens: null,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tokenSection = payload.sections.find(
+      (s) => s.id === "how-prompt-vs-completion-tokens",
+    );
+
+    expect(tokenSection).toBeUndefined();
+  });
+
+  it("prompt vs completion token section only counts newsletters with both values", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({
+            totalTokens: 1000,
+            promptTokens: 800,
+            completionTokens: 200,
+          }),
+          // This newsletter has null tokens and should be excluded from the split
+          makeNewsletter({
+            totalTokens: 500,
+            promptTokens: null,
+            completionTokens: null,
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const tokenSection = payload.sections.find(
+      (s) => s.id === "how-prompt-vs-completion-tokens",
+    );
+
+    expect(tokenSection).toBeDefined();
+    if (tokenSection!.widget.kind === "breakdown") {
+      const promptSlice = tokenSection!.widget.slices.find(
+        (s) => s.label === "Prompt",
+      );
+      // Only the first newsletter should be counted
+      expect(promptSlice!.value).toBe(800);
+    }
+  });
+
+  // Task 5: config-version-drift
+  it("config-version-drift alert fires when multiple configVersions are active", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({ configVersion: "v1", promptHash: "abc" }),
+          makeNewsletter({ configVersion: "v2", promptHash: "abc" }),
+          makeNewsletter({ configVersion: "v1", promptHash: "abc" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const driftAlert = payload.alerts.find(
+      (a) => a.id === "config-version-drift",
+    );
+
+    expect(driftAlert).toBeDefined();
+    expect(driftAlert!.severity).toBe("warning");
+    expect(driftAlert!.sectionRef).toBe("who-model-mix");
+  });
+
+  it("prompt-hash-drift alert fires when multiple promptHashes are active", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({ configVersion: "v1", promptHash: "abc" }),
+          makeNewsletter({ configVersion: "v1", promptHash: "def" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const driftAlert = payload.alerts.find((a) => a.id === "prompt-hash-drift");
+
+    expect(driftAlert).toBeDefined();
+    expect(driftAlert!.severity).toBe("warning");
+  });
+
+  it("no config-version-drift alert when all newsletters share the same configVersion", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({ configVersion: "v1", promptHash: "abc" }),
+          makeNewsletter({ configVersion: "v1", promptHash: "abc" }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const driftAlert = payload.alerts.find(
+      (a) => a.id === "config-version-drift",
+    );
+    const promptDriftAlert = payload.alerts.find(
+      (a) => a.id === "prompt-hash-drift",
+    );
+
+    expect(driftAlert).toBeUndefined();
+    expect(promptDriftAlert).toBeUndefined();
+  });
+
+  it("who-model-mix table includes configVersion and promptHash rows", async () => {
+    const provider = createContentGenerationInsightsProvider(
+      makeDeps({
+        newsletters: [
+          makeNewsletter({
+            model: "gpt-4o",
+            configVersion: "v1",
+            promptHash: "hash1",
+          }),
+          makeNewsletter({
+            model: "gpt-4o",
+            configVersion: "v2",
+            promptHash: "hash2",
+          }),
+        ],
+      }),
+    );
+
+    const payload = await provider.compute({ window: "7d" });
+    const modelSection = payload.sections.find((s) => s.id === "who-model-mix");
+
+    expect(modelSection).toBeDefined();
+    expect(modelSection!.widget.kind).toBe("table");
+    if (modelSection!.widget.kind === "table") {
+      const configVersionRows = modelSection!.widget.rows.filter(
+        (row) => row[0] === "configVersion",
+      );
+      const promptHashRows = modelSection!.widget.rows.filter(
+        (row) => row[0] === "promptHash",
+      );
+      expect(configVersionRows.length).toBeGreaterThan(0);
+      expect(promptHashRows.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts
@@ -5,6 +5,7 @@ import type {
   InsightAlert,
   InsightSection,
 } from "@workspace/agent-data-api-contract";
+import { NEWSLETTER_SECTION_IDS } from "@workspace/agent-data-api-contract";
 
 import type {
   AgentInsightsProvider,
@@ -15,6 +16,14 @@ const TOP_N = 10;
 const FAILURE_RATE_THRESHOLD = 0.2;
 const STALE_THRESHOLD_24H_MS = 6 * 60 * 60 * 1000;
 const STALE_THRESHOLD_DEFAULT_MS = 48 * 60 * 60 * 1000;
+
+// KPI tone thresholds
+const SUCCESS_RATE_CRITICAL_THRESHOLD = 60; // below this -> critical
+const SUCCESS_RATE_WARNING_THRESHOLD = 80; // below this -> warning (matches FAILURE_RATE_THRESHOLD = 20%)
+const MEDIAN_DURATION_WARNING_THRESHOLD_MS = 120_000; // 2 minutes
+
+// Section drop alert threshold: alert when a section is dropped in >20% of successful runs
+const SECTION_DROP_RATE_THRESHOLD = 0.2;
 
 const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
   "24h": 24 * 60 * 60 * 1000,
@@ -39,6 +48,10 @@ type NewsletterRow = {
   createdAt: Date;
   model: string | null;
   totalTokens: number | null;
+  promptTokens: number | null;
+  completionTokens: number | null;
+  configVersion: string | null;
+  promptHash: string | null;
 };
 
 type ContentGenerationInsightsDeps = {
@@ -75,6 +88,10 @@ type ContentGenerationInsightsDeps = {
         createdAt: boolean;
         model: boolean;
         totalTokens: boolean;
+        promptTokens: boolean;
+        completionTokens: boolean;
+        configVersion: boolean;
+        promptHash: boolean;
       };
     }) => Promise<NewsletterRow[]>;
   };
@@ -153,6 +170,35 @@ function extractCgFillBySection(
   return bySection as Record<string, { citedBullets: number }>;
 }
 
+function extractCgSectionsRemoved(
+  details: Prisma.JsonValue | null,
+): string[] | null {
+  if (
+    details === null ||
+    typeof details !== "object" ||
+    Array.isArray(details)
+  ) {
+    return null;
+  }
+  const sectionFill = (details as Record<string, unknown>).sectionFill;
+  if (
+    sectionFill === null ||
+    typeof sectionFill !== "object" ||
+    Array.isArray(sectionFill)
+  ) {
+    return null;
+  }
+  const sectionsRemoved = (sectionFill as Record<string, unknown>)
+    .sectionsRemoved;
+  if (!Array.isArray(sectionsRemoved)) {
+    return null;
+  }
+
+  return sectionsRemoved.filter(
+    (item): item is string => typeof item === "string",
+  );
+}
+
 export function createContentGenerationInsightsProvider(
   deps: ContentGenerationInsightsDeps,
 ): AgentInsightsProvider {
@@ -207,6 +253,10 @@ export function createContentGenerationInsightsProvider(
             createdAt: true,
             model: true,
             totalTokens: true,
+            promptTokens: true,
+            completionTokens: true,
+            configVersion: true,
+            promptHash: true,
           },
         }),
       ]);
@@ -245,6 +295,27 @@ export function createContentGenerationInsightsProvider(
         0,
       );
 
+      const newsletterCount = newsletters.length;
+      const avgTokensPerNewsletter =
+        newsletterCount > 0 ? Math.round(totalTokens / newsletterCount) : null;
+
+      // Determine tones for success_rate and median_duration_ms
+      const successRateTone = (() => {
+        if (totalRuns === 0) return undefined;
+        if (successRate < SUCCESS_RATE_CRITICAL_THRESHOLD)
+          return "critical" as const;
+        if (successRate < SUCCESS_RATE_WARNING_THRESHOLD)
+          return "warning" as const;
+        return undefined;
+      })();
+
+      const medianDurationTone = (() => {
+        if (medianDuration === null) return undefined;
+        if (medianDuration > MEDIAN_DURATION_WARNING_THRESHOLD_MS)
+          return "warning" as const;
+        return undefined;
+      })();
+
       const kpis: KpiCard[] = [
         {
           id: "runs",
@@ -257,6 +328,7 @@ export function createContentGenerationInsightsProvider(
           label: "Success rate",
           value: successRate,
           unit: "%",
+          ...(successRateTone !== undefined ? { tone: successRateTone } : {}),
         },
         {
           id: "newsletters",
@@ -271,6 +343,9 @@ export function createContentGenerationInsightsProvider(
                 label: "Median duration",
                 value: medianDuration,
                 unit: "ms",
+                ...(medianDurationTone !== undefined
+                  ? { tone: medianDurationTone }
+                  : {}),
               } satisfies KpiCard,
             ]
           : []),
@@ -279,6 +354,16 @@ export function createContentGenerationInsightsProvider(
           label: "Total tokens",
           value: totalTokens,
         },
+        ...(avgTokensPerNewsletter !== null
+          ? [
+              {
+                id: "avg_tokens_per_newsletter",
+                label: "Avg tokens per newsletter",
+                value: avgTokensPerNewsletter,
+                unit: "tokens",
+              } satisfies KpiCard,
+            ]
+          : []),
       ];
 
       // ─── Alerts ──────────────────────────────────────────────────────────
@@ -292,7 +377,7 @@ export function createContentGenerationInsightsProvider(
         alerts.push({
           id: "high-failure-rate",
           severity: "warning",
-          message: `Failure rate is ${Math.round((failedRuns.length / totalRuns) * 100)}% — above the ${FAILURE_RATE_THRESHOLD * 100}% threshold`,
+          message: `Failure rate is ${Math.round((failedRuns.length / totalRuns) * 100)}% -- above the ${FAILURE_RATE_THRESHOLD * 100}% threshold`,
           sectionRef: "why-failure-by-stage",
         });
       }
@@ -332,7 +417,7 @@ export function createContentGenerationInsightsProvider(
         alerts.push({
           id: "recurring-no-sources",
           severity: "warning",
-          message: `"no_sources" skip occurred ${noSourcesCount} times — check data pipeline for missing article ingestion`,
+          message: `"no_sources" skip occurred ${noSourcesCount} times -- check data pipeline for missing article ingestion`,
           sectionRef: "why-skip-reason",
         });
       }
@@ -359,7 +444,7 @@ export function createContentGenerationInsightsProvider(
 
       const sections: InsightSection[] = [];
 
-      // What — outcome breakdown
+      // What -- outcome breakdown
       if (totalRuns > 0) {
         const outcomeSlices = [
           {
@@ -391,7 +476,7 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // What — stage funnel (runs reaching each stage)
+      // What -- stage funnel (runs reaching each stage)
       const stageDropCounts = new Map<string, number>();
       for (const run of runs) {
         if (run.stage) {
@@ -428,7 +513,7 @@ export function createContentGenerationInsightsProvider(
         },
       });
 
-      // When — runs per day
+      // When -- runs per day
       const runsDailyBuckets = buildWindowDates(windowStart, now);
       for (const run of runs) {
         const dayKey = run.createdAt.toISOString().slice(0, 10);
@@ -450,7 +535,7 @@ export function createContentGenerationInsightsProvider(
         },
       });
 
-      // When — tokens per day (from newsletters only — failed/skipped runs produce no tokens)
+      // When -- tokens per day (from newsletters only -- failed/skipped runs produce no tokens)
       if (newsletters.length > 0) {
         const tokensDailyBuckets = buildWindowDates(windowStart, now);
         for (const newsletter of newsletters) {
@@ -468,7 +553,7 @@ export function createContentGenerationInsightsProvider(
           category: "when",
           title: "Tokens over time",
           insight:
-            "Daily token usage reflects successfully generated newsletters only — failed and skipped runs do not consume tokens.",
+            "Daily token usage reflects successfully generated newsletters only -- failed and skipped runs do not consume tokens.",
           widget: {
             kind: "timeSeries",
             points: Array.from(tokensDailyBuckets.entries()).map(
@@ -482,7 +567,7 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // Where — newsletters by ticker (top-N)
+      // Where -- newsletters by ticker (top-N)
       const tickerNewsletterCounts = new Map<string, number>();
       for (const newsletter of newsletters) {
         const label = newsletter.ticker?.symbol ?? newsletter.tickerId;
@@ -509,35 +594,112 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // Who — model mix from Newsletter.model
+      // Who -- model mix, config version, and prompt hash from Newsletter
       const modelMix = new Map<string, number>();
+      const configVersionMix = new Map<string, number>();
+      const promptHashMix = new Map<string, number>();
       for (const newsletter of newsletters) {
         const model = newsletter.model ?? "unknown";
         modelMix.set(model, (modelMix.get(model) ?? 0) + 1);
+
+        const configVersion = newsletter.configVersion ?? "unknown";
+        configVersionMix.set(
+          configVersion,
+          (configVersionMix.get(configVersion) ?? 0) + 1,
+        );
+
+        const promptHash = newsletter.promptHash ?? "unknown";
+        promptHashMix.set(promptHash, (promptHashMix.get(promptHash) ?? 0) + 1);
       }
       if (modelMix.size > 0) {
         const modelTotal = Array.from(modelMix.values()).reduce(
           (sum, v) => sum + v,
           0,
         );
+        const configVersionTotal = Array.from(configVersionMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+        const promptHashTotal = Array.from(promptHashMix.values()).reduce(
+          (sum, v) => sum + v,
+          0,
+        );
+
         sections.push({
           id: "who-model-mix",
           category: "who",
-          title: "Model mix",
+          title: "Model, config, and prompt distribution",
           insight:
-            "Model distribution reflects successfully generated newsletters only.",
+            "Distribution of model, configVersion, and promptHash across successfully generated newsletters.",
           widget: {
-            kind: "breakdown",
-            slices: Array.from(modelMix.entries()).map(([label, value]) => ({
-              label,
-              value,
-              fraction: modelTotal > 0 ? value / modelTotal : 0,
-            })),
+            kind: "table",
+            columns: ["dimension", "value", "count", "share"],
+            rows: [
+              ...Array.from(modelMix.entries()).map(
+                ([label, value]) =>
+                  [
+                    "model",
+                    label,
+                    value,
+                    modelTotal > 0
+                      ? Math.round((value / modelTotal) * 100) / 100
+                      : 0,
+                  ] as (string | number | null)[],
+              ),
+              ...Array.from(configVersionMix.entries()).map(
+                ([label, value]) =>
+                  [
+                    "configVersion",
+                    label,
+                    value,
+                    configVersionTotal > 0
+                      ? Math.round((value / configVersionTotal) * 100) / 100
+                      : 0,
+                  ] as (string | number | null)[],
+              ),
+              ...Array.from(promptHashMix.entries()).map(
+                ([label, value]) =>
+                  [
+                    "promptHash",
+                    label,
+                    value,
+                    promptHashTotal > 0
+                      ? Math.round((value / promptHashTotal) * 100) / 100
+                      : 0,
+                  ] as (string | number | null)[],
+              ),
+            ],
           },
         });
+
+        // Config drift alerts
+        const distinctConfigVersions = new Set(
+          newsletters.map((n) => n.configVersion ?? "unknown"),
+        );
+        const distinctPromptHashes = new Set(
+          newsletters.map((n) => n.promptHash ?? "unknown"),
+        );
+
+        if (distinctConfigVersions.size > 1) {
+          alerts.push({
+            id: "config-version-drift",
+            severity: "warning",
+            message: `${distinctConfigVersions.size} distinct configVersions active in this window -- newsletters may have been generated with inconsistent configurations`,
+            sectionRef: "who-model-mix",
+          });
+        }
+
+        if (distinctPromptHashes.size > 1) {
+          alerts.push({
+            id: "prompt-hash-drift",
+            severity: "warning",
+            message: `${distinctPromptHashes.size} distinct promptHashes active in this window -- prompt definition changed mid-window`,
+            sectionRef: "who-model-mix",
+          });
+        }
       }
 
-      // Why — failures by stage (only failed runs)
+      // Why -- failures by stage (only failed runs)
       if (failedRuns.length > 0) {
         const failureStages = new Map<string, number>();
         for (const run of failedRuns) {
@@ -562,7 +724,7 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // Why — error category breakdown (only failed runs)
+      // Why -- error category breakdown (only failed runs)
       if (failedRuns.length > 0) {
         const errorCategories = new Map<string, number>();
         for (const run of failedRuns) {
@@ -590,7 +752,7 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // Why — skip reason breakdown (only skipped runs)
+      // Why -- skip reason breakdown (only skipped runs)
       if (skippedRuns.length > 0) {
         const skipReasons = new Map<string, number>();
         for (const run of skippedRuns) {
@@ -613,7 +775,7 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // How — duration histogram (only non-null durationMs)
+      // How -- duration histogram (only non-null durationMs)
       if (durations.length > 0) {
         const durationBuckets = new Map([
           ["< 5s", 0],
@@ -661,36 +823,46 @@ export function createContentGenerationInsightsProvider(
         });
       }
 
-      // How — median duration stat
-      if (medianDuration !== null) {
-        sections.push({
-          id: "how-median-duration",
-          category: "how",
-          title: "Median run duration",
-          widget: {
-            kind: "stat",
-            value: medianDuration,
-            unit: "ms",
-          },
-        });
-      }
-
-      // How — section-fill coverage (cited bullets per section, summed across successful runs)
+      // How -- section-fill coverage (cited bullets per section, averaged across successful runs)
+      // Also track sectionsRemoved per section across successful runs
       const sectionFillTotals = new Map<string, number>();
+      const sectionFillRunCounts = new Map<string, number>();
+      const sectionRemovedCounts = new Map<string, number>();
+      let successRunsWithDetails = 0;
+
       for (const run of successRuns) {
         const bySection = extractCgFillBySection(run.details);
-        if (bySection === null) {
-          continue;
+        const sectionsRemoved = extractCgSectionsRemoved(run.details);
+
+        if (bySection !== null || sectionsRemoved !== null) {
+          successRunsWithDetails += 1;
         }
-        for (const [sectionId, data] of Object.entries(bySection)) {
-          if (typeof data.citedBullets === "number") {
-            sectionFillTotals.set(
+
+        if (bySection !== null) {
+          for (const [sectionId, data] of Object.entries(bySection)) {
+            if (typeof data.citedBullets === "number") {
+              sectionFillTotals.set(
+                sectionId,
+                (sectionFillTotals.get(sectionId) ?? 0) + data.citedBullets,
+              );
+              sectionFillRunCounts.set(
+                sectionId,
+                (sectionFillRunCounts.get(sectionId) ?? 0) + 1,
+              );
+            }
+          }
+        }
+
+        if (sectionsRemoved !== null) {
+          for (const sectionId of sectionsRemoved) {
+            sectionRemovedCounts.set(
               sectionId,
-              (sectionFillTotals.get(sectionId) ?? 0) + data.citedBullets,
+              (sectionRemovedCounts.get(sectionId) ?? 0) + 1,
             );
           }
         }
       }
+
       if (sectionFillTotals.size > 0) {
         sections.push({
           id: "how-section-fill",
@@ -708,6 +880,113 @@ export function createContentGenerationInsightsProvider(
               TOP_N,
             ),
             unit: "cited bullets",
+          },
+        });
+      }
+
+      // What -- section coverage: avg cited bullets and removal share per section
+      const allKnownSections = new Set<string>([
+        ...NEWSLETTER_SECTION_IDS,
+        ...sectionFillTotals.keys(),
+        ...sectionRemovedCounts.keys(),
+      ]);
+
+      if (
+        successRunsWithDetails > 0 &&
+        (sectionFillTotals.size > 0 || sectionRemovedCounts.size > 0)
+      ) {
+        const coverageRows: (string | number | null)[][] = [];
+        for (const sectionId of allKnownSections) {
+          const totalBullets = sectionFillTotals.get(sectionId) ?? 0;
+          const runCount = sectionFillRunCounts.get(sectionId) ?? 0;
+          const avgBullets =
+            runCount > 0 ? Math.round((totalBullets / runCount) * 10) / 10 : 0;
+          const removedCount = sectionRemovedCounts.get(sectionId) ?? 0;
+          const removedShare =
+            successRunsWithDetails > 0
+              ? Math.round((removedCount / successRunsWithDetails) * 100) / 100
+              : 0;
+          coverageRows.push([
+            sectionId,
+            avgBullets,
+            removedCount,
+            removedShare,
+          ]);
+        }
+
+        sections.push({
+          id: "what-section-coverage",
+          category: "what",
+          title: "Section coverage",
+          insight:
+            "Average cited bullets per section and how often each section was removed across successful runs.",
+          widget: {
+            kind: "table",
+            columns: [
+              "section",
+              "avg_cited_bullets",
+              "removed_count",
+              "removed_share",
+            ],
+            rows: coverageRows,
+          },
+        });
+
+        // Alert when a section is dropped in >20% of successful runs
+        for (const [sectionId, removedCount] of sectionRemovedCounts) {
+          const dropRate = removedCount / successRunsWithDetails;
+          if (dropRate > SECTION_DROP_RATE_THRESHOLD) {
+            alerts.push({
+              id: `section-drop-${sectionId}`,
+              severity: "warning",
+              message: `Section "${sectionId}" was removed in ${Math.round(dropRate * 100)}% of successful runs -- content coverage may be degraded`,
+              sectionRef: "what-section-coverage",
+            });
+          }
+        }
+      }
+
+      // How -- prompt vs completion token breakdown
+      const newslettersWithTokenBreakdown = newsletters.filter(
+        (n) => n.promptTokens !== null && n.completionTokens !== null,
+      );
+      if (newslettersWithTokenBreakdown.length > 0) {
+        const totalPromptTokens = newslettersWithTokenBreakdown.reduce(
+          (sum, n) => sum + (n.promptTokens ?? 0),
+          0,
+        );
+        const totalCompletionTokens = newslettersWithTokenBreakdown.reduce(
+          (sum, n) => sum + (n.completionTokens ?? 0),
+          0,
+        );
+        const promptPlusCompletion = totalPromptTokens + totalCompletionTokens;
+
+        sections.push({
+          id: "how-prompt-vs-completion-tokens",
+          category: "how",
+          title: "Prompt vs completion token split",
+          insight:
+            "Breakdown of prompt and completion tokens across newsletters that have both values. Prompt + completion should reconcile to total when both are present.",
+          widget: {
+            kind: "breakdown",
+            slices: [
+              {
+                label: "Prompt",
+                value: totalPromptTokens,
+                fraction:
+                  promptPlusCompletion > 0
+                    ? totalPromptTokens / promptPlusCompletion
+                    : 0,
+              },
+              {
+                label: "Completion",
+                value: totalCompletionTokens,
+                fraction:
+                  promptPlusCompletion > 0
+                    ? totalCompletionTokens / promptPlusCompletion
+                    : 0,
+              },
+            ],
           },
         });
       }


### PR DESCRIPTION
## Summary

The content-generation provider already had the richest data of any agent, but still showed median duration twice, had no KPI tones, and ignored three ready-to-use signals: section drops, the prompt/completion token split, and config/prompt change tracking. This resolves the duplicate, adds tones, and brings in the three missing views.

## Related issues

Closes #768

## Important changes

- `how-median-duration` stat section is removed. The `median_duration_ms` KPI and `how-duration-histogram` remain.
- `success_rate` carries `critical` when <60% and `warning` when <80% (reconciled with `FAILURE_RATE_THRESHOLD`). `median_duration_ms` carries `warning` above 120 seconds. Thresholds are named constants.
- New `what-section-coverage` table shows per-section average cited-bullet fill and the count/share of successful runs where each section appeared in `sectionsRemoved`. Section labels use `NEWSLETTER_SECTION_IDS`. `section-drop-<sectionId>` alerts fire when a section's drop rate exceeds 20%.
- New `avg_tokens_per_newsletter` KPI and `how-prompt-vs-completion-tokens` breakdown section from `promptTokens`/`completionTokens`. Null-token newsletters are skipped; the section is omitted when no newsletters have both fields.
- `who-model-mix` section is replaced with a richer config-drift table keyed by `model`, `configVersion`, and `promptHash`. `config-version-drift` and `prompt-hash-drift` alerts fire when more than one distinct value is active in the window.

## Other changes

- `NewsletterRow` type widened to include `promptTokens`, `completionTokens`, `configVersion`, `promptHash`.
- `extractCgSectionsRemoved()` helper added alongside the existing `extractCgFillBySection()`.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.ts` — all changes.
- `apps/mediapulse/agent-data-api/src/services/insights/content-generation-insights-provider.test.ts` — updated and new test cases.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` — 279 tests pass.
2. Manual (read-only DB, 7d window): confirm no `how-median-duration` section, toned `success_rate`, a `what-section-coverage` table, a token split breakdown, and a config-drift table.
3. Confirm `section-drop-*` alert fires for any section dropped in >20% of runs in the window.
