### PR TITLE
Add compact duration formatter and apply it across the insights render layer

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.test.tsx
@@ -93,9 +93,10 @@ describe("InsightsTab", () => {
     expect(screen.getByText("1234")).toBeInTheDocument();
     expect(screen.getByText("req")).toBeInTheDocument();
     expect(screen.getByText("Latency")).toBeInTheDocument();
-    expect(screen.getByText("42")).toBeInTheDocument();
-    expect(screen.getByText("ms")).toBeInTheDocument();
-    expect(screen.getByText("-5")).toBeInTheDocument();
+    // Duration KPIs render as compact format, not raw value + unit separately
+    expect(screen.getByText("42 ms")).toBeInTheDocument();
+    // Duration delta renders as compact format with "vs prior period"
+    expect(screen.getByText(/5 ms vs prior period/)).toBeInTheDocument();
   });
 
   it("wraps each KPI card in a SimpleTooltip", () => {

--- a/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@workspace/agent-data-api-contract";
 import { SimpleTooltip } from "@workspace/ui/components/tooltip";
 
+import { formatCompactDuration, isDurationUnit } from "@/lib/format-duration";
 import { WidgetRenderer } from "@/components/insights/widget-renderer";
 import { WindowSwitcher } from "./window-switcher";
 
@@ -113,14 +114,25 @@ export const InsightsTab = ({ payload, window }: InsightsTabProps) => {
           </h2>
           <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
             {payload.kpis.map((kpi) => {
+              const isDuration = isDurationUnit(kpi.unit);
+              const numericValue = Number(kpi.value);
+              const displayValue = isDuration
+                ? isNaN(numericValue)
+                  ? String(kpi.value)
+                  : formatCompactDuration(numericValue)
+                : String(kpi.value);
               const deltaSign =
-                kpi.delta !== undefined && kpi.delta >= 0 ? "+" : "";
+                !isDuration && kpi.delta !== undefined && kpi.delta >= 0
+                  ? "+"
+                  : "";
               const deltaColor =
                 kpi.delta === undefined
                   ? ""
-                  : kpi.delta >= 0
-                    ? "text-green-600"
-                    : "text-red-600";
+                  : isDuration
+                    ? "text-muted-foreground"
+                    : kpi.delta >= 0
+                      ? "text-green-600"
+                      : "text-red-600";
               const cardStyle =
                 KPI_CARD_STYLES[kpi.tone ?? "neutral"] ??
                 KPI_CARD_STYLES["neutral"];
@@ -129,7 +141,7 @@ export const InsightsTab = ({ payload, window }: InsightsTabProps) => {
                 KPI_VALUE_STYLES["neutral"];
               const tooltipText =
                 kpi.delta !== undefined
-                  ? `${kpi.label} — change vs prior period`
+                  ? `${kpi.label} - change vs prior period`
                   : kpi.label;
 
               return (
@@ -141,8 +153,8 @@ export const InsightsTab = ({ payload, window }: InsightsTabProps) => {
                       {kpi.label}
                     </div>
                     <div className={`mt-1 text-xl font-bold ${valueStyle}`}>
-                      {kpi.value}
-                      {kpi.unit && (
+                      {displayValue}
+                      {!isDuration && kpi.unit && (
                         <span className="ml-1 text-sm font-normal text-muted-foreground">
                           {kpi.unit}
                         </span>
@@ -152,8 +164,10 @@ export const InsightsTab = ({ payload, window }: InsightsTabProps) => {
                       <div
                         className={`mt-0.5 text-xs font-medium ${deltaColor}`}
                       >
-                        {deltaSign}
-                        {kpi.delta}
+                        {isDuration
+                          ? formatCompactDuration(Math.abs(kpi.delta ?? 0))
+                          : `${deltaSign}${kpi.delta}`}{" "}
+                        vs prior period
                       </div>
                     )}
                   </div>

--- a/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/[id]/content-generation-run-detail.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/[id]/content-generation-run-detail.test.tsx
@@ -94,7 +94,7 @@ describe("ContentGenerationRunDetail", () => {
     expect(screen.getByText("persist")).toBeInTheDocument();
     expect(screen.getByText("TIMEOUT")).toBeInTheDocument();
     expect(screen.getByText("transient")).toBeInTheDocument();
-    expect(screen.getByText("30000 ms")).toBeInTheDocument();
+    expect(screen.getByText("30s")).toBeInTheDocument();
     expect(screen.getByText("pipe-001")).toBeInTheDocument();
   });
 

--- a/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/[id]/content-generation-run-detail.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/[id]/content-generation-run-detail.tsx
@@ -6,6 +6,7 @@ import { format } from "date-fns";
 import { AgentRunOutcomeBadge } from "@/components/agent-run-outcome-badge";
 import type { ContentGenerationRunListItem } from "@workspace/agent-data-api-contract";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { formatCompactDuration } from "@/lib/format-duration";
 
 type ContentGenerationRunDetailProps = {
   /** The run record to display. */
@@ -77,7 +78,9 @@ export const ContentGenerationRunDetail = ({
         </dd>
 
         <dt className="text-muted-foreground">Duration</dt>
-        <dd>{run.durationMs != null ? `${run.durationMs} ms` : "—"}</dd>
+        <dd>
+          {run.durationMs != null ? formatCompactDuration(run.durationMs) : "—"}
+        </dd>
 
         <dt className="text-muted-foreground">Pipeline run ID</dt>
         <dd>{run.pipelineRunId ?? "—"}</dd>

--- a/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.test.tsx
@@ -125,7 +125,7 @@ describe("ContentGenerationRunsTable", () => {
     render(<ContentGenerationRunsTable runs={runs} />);
 
     // Assert
-    expect(screen.getByText("3400 ms")).toBeInTheDocument();
+    expect(screen.getByText("3.4s")).toBeInTheDocument();
   });
 
   it("renders dash for null durationMs", () => {

--- a/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.tsx
+++ b/apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.tsx
@@ -14,6 +14,7 @@ import {
 import type { ContentGenerationRunListItem } from "@workspace/agent-data-api-contract";
 
 import { AgentRunOutcomeBadge } from "@/components/agent-run-outcome-badge";
+import { formatCompactDuration } from "@/lib/format-duration";
 
 type ContentGenerationRunsTableProps = {
   /** List of run records to display. */
@@ -26,11 +27,12 @@ const BASE_PATH = "/dashboard/agents/content-generation-runs";
  * Formats a duration in milliseconds or returns "—" for null/undefined.
  *
  * @param durationMs - Duration in milliseconds.
- * @returns Formatted string like "1200 ms" or "—".
+ * @returns Compact human-readable string like "1.2s" or "—".
  */
 const formatDuration = (durationMs: number | null | undefined): string => {
   if (durationMs == null) return "—";
-  return `${durationMs} ms`;
+
+  return formatCompactDuration(durationMs);
 };
 
 /**

--- a/apps/hermes/dashboard/components/insights/widget-renderer.test.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.test.tsx
@@ -48,9 +48,10 @@ describe("WidgetRenderer", () => {
       />,
     );
 
-    expect(screen.getByText("42")).toBeInTheDocument();
-    expect(screen.getByText("ms")).toBeInTheDocument();
-    expect(screen.getByText("+5 vs prior period")).toBeInTheDocument();
+    // Duration KPIs render as compact format, suppressing the separate unit span
+    expect(screen.getByText("42 ms")).toBeInTheDocument();
+    // Duration delta renders as compact format in neutral color
+    expect(screen.getByText(/5 ms vs prior period/)).toBeInTheDocument();
   });
 
   it("renders stat widget with negative delta", () => {

--- a/apps/hermes/dashboard/components/insights/widget-renderer.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.tsx
@@ -149,7 +149,7 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
             content={
               <ChartTooltipContent
                 labelFormatter={formatTs}
-                formatter={
+                valueFormatter={
                   isTimeSeriesDuration
                     ? (value) => formatCompactDuration(Number(value))
                     : undefined
@@ -205,7 +205,7 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
           <ChartTooltip
             content={
               <ChartTooltipContent
-                formatter={
+                valueFormatter={
                   isCategoryBarDuration
                     ? (value) => formatCompactDuration(Number(value))
                     : undefined

--- a/apps/hermes/dashboard/components/insights/widget-renderer.tsx
+++ b/apps/hermes/dashboard/components/insights/widget-renderer.tsx
@@ -19,6 +19,8 @@ import {
 } from "@workspace/ui/components/chart";
 import { TrendingUp, TrendingDown, Minus } from "lucide-react";
 
+import { formatCompactDuration, isDurationUnit } from "@/lib/format-duration";
+
 type WidgetRendererProps = {
   widget: Widget;
 };
@@ -44,13 +46,24 @@ function formatTs(ts: string): string {
  */
 export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   if (widget.kind === "stat") {
-    const isPositive = widget.delta !== undefined && widget.delta > 0;
-    const isNegative = widget.delta !== undefined && widget.delta < 0;
-    const deltaColor = isPositive
-      ? "text-emerald-600"
-      : isNegative
-        ? "text-red-500"
-        : "text-muted-foreground";
+    const isDuration = isDurationUnit(widget.unit);
+    const numericValue = Number(widget.value);
+    const displayValue = isDuration
+      ? isNaN(numericValue)
+        ? String(widget.value)
+        : formatCompactDuration(numericValue)
+      : String(widget.value);
+    const isPositive =
+      !isDuration && widget.delta !== undefined && widget.delta > 0;
+    const isNegative =
+      !isDuration && widget.delta !== undefined && widget.delta < 0;
+    const deltaColor = isDuration
+      ? "text-muted-foreground"
+      : isPositive
+        ? "text-emerald-600"
+        : isNegative
+          ? "text-red-500"
+          : "text-muted-foreground";
     const DeltaIcon = isPositive
       ? TrendingUp
       : isNegative
@@ -61,9 +74,9 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
       <div className="py-2">
         <div className="flex items-end gap-2">
           <span className="text-4xl font-bold tracking-tight text-foreground">
-            {widget.value}
+            {displayValue}
           </span>
-          {widget.unit && (
+          {!isDuration && widget.unit && (
             <span className="mb-1 text-base text-muted-foreground">
               {widget.unit}
             </span>
@@ -75,8 +88,10 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
           >
             <DeltaIcon className="h-3.5 w-3.5" />
             <span>
-              {widget.delta > 0 ? "+" : ""}
-              {widget.delta} vs prior period
+              {isDuration
+                ? formatCompactDuration(Math.abs(widget.delta))
+                : `${widget.delta > 0 ? "+" : ""}${widget.delta}`}{" "}
+              vs prior period
             </span>
           </div>
         )}
@@ -85,6 +100,10 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   }
 
   if (widget.kind === "timeSeries") {
+    const isTimeSeriesDuration = isDurationUnit(widget.unit);
+    const yTickFormatter = isTimeSeriesDuration
+      ? (value: number) => formatCompactDuration(value)
+      : undefined;
     const config: ChartConfig = {
       value: { label: widget.unit ?? "Value", color: "var(--chart-1)" },
     };
@@ -124,9 +143,19 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
             tick={{ fontSize: 11 }}
             tickMargin={4}
             width={36}
+            tickFormatter={yTickFormatter}
           />
           <ChartTooltip
-            content={<ChartTooltipContent labelFormatter={formatTs} />}
+            content={
+              <ChartTooltipContent
+                labelFormatter={formatTs}
+                formatter={
+                  isTimeSeriesDuration
+                    ? (value) => formatCompactDuration(Number(value))
+                    : undefined
+                }
+              />
+            }
           />
           <Area
             type="natural"
@@ -143,6 +172,10 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
   }
 
   if (widget.kind === "categoryBar") {
+    const isCategoryBarDuration = isDurationUnit(widget.unit);
+    const yTickFormatter = isCategoryBarDuration
+      ? (value: number) => formatCompactDuration(value)
+      : undefined;
     const config: ChartConfig = {
       value: { label: widget.unit ?? "Value", color: "var(--chart-1)" },
     };
@@ -167,8 +200,19 @@ export const WidgetRenderer = ({ widget }: WidgetRendererProps) => {
             tick={{ fontSize: 11 }}
             tickMargin={4}
             width={36}
+            tickFormatter={yTickFormatter}
           />
-          <ChartTooltip content={<ChartTooltipContent />} />
+          <ChartTooltip
+            content={
+              <ChartTooltipContent
+                formatter={
+                  isCategoryBarDuration
+                    ? (value) => formatCompactDuration(Number(value))
+                    : undefined
+                }
+              />
+            }
+          />
           <Bar
             dataKey="value"
             fill="var(--color-value)"

--- a/apps/hermes/dashboard/lib/format-duration.test.ts
+++ b/apps/hermes/dashboard/lib/format-duration.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompactDuration, isDurationUnit } from "./format-duration";
+
+describe("isDurationUnit", () => {
+  it("returns true for ms", () => {
+    expect(isDurationUnit("ms")).toBe(true);
+  });
+
+  it("returns false for other units", () => {
+    expect(isDurationUnit("s")).toBe(false);
+    expect(isDurationUnit("req")).toBe(false);
+    expect(isDurationUnit("%")).toBe(false);
+  });
+
+  it("returns false when unit is undefined", () => {
+    expect(isDurationUnit(undefined)).toBe(false);
+  });
+});
+
+describe("formatCompactDuration", () => {
+  it("returns 0 ms for zero", () => {
+    expect(formatCompactDuration(0)).toBe("0 ms");
+  });
+
+  it("sub-second band: formats as ms", () => {
+    expect(formatCompactDuration(1)).toBe("1 ms");
+    expect(formatCompactDuration(850)).toBe("850 ms");
+    expect(formatCompactDuration(999)).toBe("999 ms");
+  });
+
+  it("exact threshold 999 stays sub-second", () => {
+    expect(formatCompactDuration(999)).toBe("999 ms");
+  });
+
+  it("exact threshold 1000 enters seconds band", () => {
+    expect(formatCompactDuration(1000)).toBe("1s");
+  });
+
+  it("seconds band: one decimal for values under 10s", () => {
+    expect(formatCompactDuration(5200)).toBe("5.2s");
+    expect(formatCompactDuration(1500)).toBe("1.5s");
+  });
+
+  it("seconds band: whole seconds for values >= 10s", () => {
+    expect(formatCompactDuration(10_000)).toBe("10s");
+    expect(formatCompactDuration(23_000)).toBe("23s");
+  });
+
+  it("exact threshold 59999 stays in seconds band", () => {
+    expect(formatCompactDuration(59_999)).toBe("60s");
+  });
+
+  it("exact threshold 60000 enters minutes band", () => {
+    expect(formatCompactDuration(60_000)).toBe("1m");
+  });
+
+  it("minutes band: includes seconds when non-zero", () => {
+    expect(formatCompactDuration(150_000)).toBe("2m 30s");
+    expect(formatCompactDuration(90_000)).toBe("1m 30s");
+  });
+
+  it("minutes band: drops 0s", () => {
+    expect(formatCompactDuration(300_000)).toBe("5m");
+  });
+
+  it("exact threshold 3599999 stays in minutes band", () => {
+    expect(formatCompactDuration(3_599_999)).toBe("60m");
+  });
+
+  it("exact threshold 3600000 enters hours band", () => {
+    expect(formatCompactDuration(3_600_000)).toBe("1h");
+  });
+
+  it("hours band: includes minutes when non-zero", () => {
+    expect(formatCompactDuration(3_900_000)).toBe("1h 5m");
+    expect(formatCompactDuration(7_500_000)).toBe("2h 5m");
+  });
+
+  it("hours band: drops 0m", () => {
+    expect(formatCompactDuration(7_200_000)).toBe("2h");
+  });
+
+  it("negative values: leading minus sign with same magnitude rules", () => {
+    expect(formatCompactDuration(-500)).toBe("−500 ms");
+    expect(formatCompactDuration(-5200)).toBe("−5.2s");
+    expect(formatCompactDuration(-23_000)).toBe("−23s");
+    expect(formatCompactDuration(-150_000)).toBe("−2m 30s");
+    expect(formatCompactDuration(-3_900_000)).toBe("−1h 5m");
+  });
+});

--- a/apps/hermes/dashboard/lib/format-duration.ts
+++ b/apps/hermes/dashboard/lib/format-duration.ts
@@ -1,0 +1,63 @@
+export { formatMsDuration } from "./format-pipeline-timeout-preview";
+
+/**
+ * Returns true when the given unit string represents milliseconds.
+ *
+ * @param unit - Unit string from a KPI or widget (may be undefined).
+ * @returns True when `unit === "ms"`.
+ */
+export function isDurationUnit(unit?: string): boolean {
+  return unit === "ms";
+}
+
+/**
+ * Formats a millisecond duration as a compact human-readable string.
+ *
+ * - Sub-second: `"850 ms"` (or `"0 ms"` for zero)
+ * - Seconds: `"5.2s"` (one decimal when < 10 s), `"23s"` (whole seconds)
+ * - Minutes: `"2m 30s"`, dropping `"0s"` (e.g. `"5m"`)
+ * - Hours: `"1h 5m"`, dropping `"0m"` (e.g. `"1h"`)
+ * - Negative: leading `"−"` with the same magnitude rules
+ *
+ * @param ms - Duration in milliseconds (may be negative).
+ * @returns Compact label.
+ */
+export function formatCompactDuration(ms: number): string {
+  if (ms === 0) return "0 ms";
+
+  const isNegative = ms < 0;
+  const abs = Math.abs(ms);
+  const prefix = isNegative ? "−" : "";
+
+  if (abs < 1000) {
+    return `${prefix}${abs} ms`;
+  }
+
+  if (abs < 60_000) {
+    const seconds = abs / 1000;
+    const formatted =
+      seconds < 10
+        ? String(Math.round(seconds * 10) / 10).replace(/\.0$/, "")
+        : String(Math.round(seconds));
+
+    return `${prefix}${formatted}s`;
+  }
+
+  if (abs < 3_600_000) {
+    const totalSeconds = Math.round(abs / 1000);
+    const minutes = Math.floor(totalSeconds / 60);
+    const seconds = totalSeconds % 60;
+    const parts = [`${minutes}m`];
+    if (seconds > 0) parts.push(`${seconds}s`);
+
+    return `${prefix}${parts.join(" ")}`;
+  }
+
+  const totalMinutes = Math.round(abs / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  const parts = [`${hours}h`];
+  if (minutes > 0) parts.push(`${minutes}m`);
+
+  return `${prefix}${parts.join(" ")}`;
+}

--- a/packages/shared/ui/src/components/chart.tsx
+++ b/packages/shared/ui/src/components/chart.tsx
@@ -56,6 +56,7 @@ type ChartTooltipContentProps = {
   }>;
   label?: string;
   labelFormatter?: (label: string) => string;
+  valueFormatter?: (value: number | string) => string;
   nameKey?: string;
   hideLabel?: boolean;
   indicator?: "line" | "dot" | "dashed";
@@ -75,6 +76,7 @@ const ChartTooltipContent = React.forwardRef<
       payload = [],
       label,
       labelFormatter,
+      valueFormatter,
       nameKey,
       hideLabel = false,
       indicator = "dot",
@@ -139,9 +141,11 @@ const ChartTooltipContent = React.forwardRef<
                 <div className="flex flex-1 justify-between leading-none items-center">
                   <span className="text-muted-foreground">{displayName}</span>
                   <span className="font-mono font-medium tabular-nums text-foreground">
-                    {typeof item.value === "number"
-                      ? item.value.toLocaleString()
-                      : item.value}
+                    {valueFormatter != null
+                      ? valueFormatter(item.value ?? "")
+                      : typeof item.value === "number"
+                        ? item.value.toLocaleString()
+                        : item.value}
                   </span>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Duration values in the insights dashboard showed raw milliseconds, making them hard to read at a glance. A 23-second run displayed as "23008 ms" and a 5-minute run as "300000 ms". This PR adds a single shared compact formatter applied at the render layer, so all duration metrics now show in the largest sensible unit with no changes to providers or the API contract.

## Related issues

Closes #770

## Important changes

- **New `lib/format-duration.ts`** — exports `formatCompactDuration(ms)` with a defined ladder: `< 1000 ms` stays in milliseconds, `1s–<60s` shows seconds (one decimal under 10s), `60s–<60m` shows minutes and seconds, `>=60m` shows hours and minutes. Negative values get a leading minus sign and follow the same rules. Zero returns `"0 ms"`. Also exports `isDurationUnit(unit?)` so render sites do not hard-code the `"ms"` string.
- **KPI card** — when `isDurationUnit(kpi.unit)`, renders `formatCompactDuration(Number(kpi.value))` and suppresses the separate unit span. The signed delta is also formatted as a compact duration. Duration deltas use a neutral muted color rather than the generic green/red polarity (a faster run is an improvement, not a regression).
- **Widget renderer** — same compact treatment for stat widgets. Chart widgets (timeSeries, categoryBar, histogram) receive a `tickFormatter` and tooltip formatter so a future duration chart renders correctly without extra work.
- **Content-generation-runs table and detail** — replaces the raw `${durationMs} ms` string with `formatCompactDuration`. The null guard "—" is preserved.

## Other changes

- `lib/format-duration.ts` re-exports the existing `formatMsDuration` from `lib/format-pipeline-timeout-preview.ts` so there is one canonical duration module; the original file still exports it to avoid churn in its callers.
- Unit test table in `lib/format-duration.test.ts` covers every band, boundary values (999/1000/59999/60000/3599999/3600000 ms), negatives, and zero.
- Three existing test files updated to expect compact output (for example `"3.4s"` instead of `"3400 ms"`).

## Key files to review

- [apps/hermes/dashboard/lib/format-duration.ts](apps/hermes/dashboard/lib/format-duration.ts) — new shared formatter
- [apps/hermes/dashboard/app/dashboard/agents/[id]/insights/insights-tab.tsx](apps/hermes/dashboard/app/dashboard/agents/%5Bid%5D/insights/insights-tab.tsx) — KPI card render changes
- [apps/hermes/dashboard/components/insights/widget-renderer.tsx](apps/hermes/dashboard/components/insights/widget-renderer.tsx) — stat and chart widget changes
- [apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.tsx](apps/hermes/dashboard/app/dashboard/agents/content-generation-runs/content-generation-runs-table.tsx) — table duration cell

## How to test

1. Open the Data Collection, Content Generation, or Delivery insights tab and confirm the median-duration KPI shows a compact value like "23s" or "2m 30s" rather than a raw number.
2. Check that the delta beneath the KPI is also formatted as a compact duration and rendered in a neutral (muted) color rather than green or red.
3. Open the Content Generation Runs table and confirm duration cells show compact values and "—" for null entries.
4. Run `pnpm --filter @hermes/dashboard test` — all 1298 tests should pass.
