### PR TITLE
Fix query-analysis LLM returning only two queries

### DIFF
--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -54,7 +54,7 @@ const GOLDEN_PROMPT_FINGERPRINT_FIXTURE = {
     headlineSamples: [] as [],
     kgNeighborhood: [] as [],
   },
-  fingerprint: "730d66ed9cd31a1d",
+  fingerprint: "091297a760adf9a3",
 } as const;
 
 const emptyEnrichedContext = {
@@ -150,6 +150,43 @@ describe("buildQueryAnalysisSystemContent", () => {
     expect(text).toContain("supply_chain: suppliers, logistics");
     expect(text).toContain("esg: environmental, social, governance");
     expect(text).not.toContain("{{");
+  });
+
+  it("states the explicit total query count and does not embed a bare '2 queries' cap", () => {
+    const text = buildQueryAnalysisSystemContent({
+      queryCount: 10,
+      language: "en",
+      minDeterministicCount: 4,
+      intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+    });
+
+    expect(text).toContain("approximately 10 queries in total");
+    expect(text).not.toContain("at most 2 queries");
+  });
+
+  it("uses unambiguous words-per-query phrasing for the default queryMaxWords", () => {
+    const text = buildQueryAnalysisSystemContent({
+      queryCount: 10,
+      language: "en",
+      minDeterministicCount: 4,
+      intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+    });
+
+    expect(text).toContain("Keep each query to about 2–5 words.");
+    expect(text).not.toContain("Prefer 2-word keyword phrases.");
+  });
+
+  it("uses unambiguous words-per-query phrasing when queryMaxWords is 2", () => {
+    const text = buildQueryAnalysisSystemContent({
+      queryCount: 10,
+      language: "en",
+      minDeterministicCount: 4,
+      intentWeights: DEFAULT_QUERY_ANALYSIS_INTENT_WEIGHTS,
+      queryMaxWords: 2,
+    });
+
+    expect(text).toContain("Keep each query to about 2 words.");
+    expect(text).not.toContain("Prefer 2-word keyword phrases.");
   });
 });
 

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -147,8 +147,8 @@ export const buildQueryAnalysisSystemContent = (
   const maxWords = strategy.queryMaxWords ?? 5;
   const phraseLengthHint =
     maxWords === 5
-      ? "Prefer 2–5 word keyword phrases."
-      : `Prefer ${String(maxWords)}-word keyword phrases.`;
+      ? "Keep each query to about 2–5 words."
+      : `Keep each query to about ${String(maxWords)} words.`;
 
   const sections: string[] = [
     "You generate short keyword search queries for news monitoring.",
@@ -156,10 +156,10 @@ export const buildQueryAnalysisSystemContent = (
     `${phraseLengthHint} Do not write full sentences, questions, or analyst-style commentary.`,
     `All queries must be in ${strategy.language} (BCP-47). Do not code-mix or translate ticker symbols and proper nouns.`,
     "Do not translate ticker symbols or proper nouns into other languages.",
-    "Include the company name or ticker symbol in at most 2 queries — the rest should be bare topic keywords, industry terms, or regulatory terms that stand alone without the company name.",
+    "Most queries should be bare topic keywords, industry terms, or regulatory terms that stand alone without the company name or ticker symbol. Only a small minority of your queries should name the company or ticker.",
     "Generate topic keywords across sectors, regulation, supply chain, ESG, and macro themes relevant to the company's operating environment.",
     [
-      "Target approximate intent counts (total queries should not exceed the remaining budget after the deterministic baseline):",
+      `Generate approximately ${String(strategy.queryCount)} queries in total, distributed across the intents below:`,
       intentTargetLines,
     ].join("\n"),
     `At least ${String(strategy.minDeterministicCount)} high-quality queries will be added deterministically by the system; your queries complement that set (avoid duplicating obvious symbol+news patterns).`,
@@ -576,12 +576,15 @@ export const resolveWildcardSystemContent = (
   queryMaxWords?: number,
 ): string => {
   const maxWords = queryMaxWords ?? 5;
-  const wordsHint = maxWords === 5 ? "2–5 words" : `${String(maxWords)} words`;
+  const wordsHint =
+    maxWords === 5
+      ? "2–5 words per query"
+      : `about ${String(maxWords)} words per query`;
   return [
     `Generate ${String(wildcardCount)} short search queries unlike anything an institutional analyst would typically search for.`,
     "Lateral, surprising, second-order, contrarian, or culturally-grounded angles welcome.",
     "Do not use the standard intent taxonomy — these queries are deliberately unconventional.",
-    `Keep queries short — ${wordsHint}. Prefer unusual keyword combinations over full questions or sentences.`,
+    `Keep each query to ${wordsHint}. Prefer unusual keyword combinations over full questions or sentences.`,
     'Return ONLY a JSON object: { "queries": [ { "text": string } ] }.',
     `Write in these languages when natural (BCP-47 codes): ${allowedLanguages.join(", ")}.`,
   ].join("\n\n");


### PR DESCRIPTION
## Summary

The query-analysis LLM was capping itself at two queries per pass because the system prompt never stated the intended total. The model latched onto "at most 2 queries" from the company-name constraint as a global result limit. A default `queryMaxWords` of 2 made things worse — the model saw two independent "2"s near query-related instructions and conflated words-per-phrase with result count.

This PR rewrites the three ambiguous lines so the model gets an unambiguous total and clear per-concept numbers.

## Related issues

Closes #772

## Important changes

- `buildQueryAnalysisSystemContent` now opens the intent-target block with "Generate approximately N queries in total, distributed across the intents below:" where N is `strategy.queryCount`
- Company-name constraint reworded from "at most 2 queries" to "only a small minority of your queries should name the company or ticker" — no bare count that the model can read as a global cap
- Phrase-length hint reworded from "Prefer 2-word keyword phrases" to "Keep each query to about N words" — unambiguously about words, not result count
- Same clarity fix for the wildcard path's `wordsHint`

## Other changes

- Golden prompt fingerprint updated to `091297a760adf9a3`
- New test assertions verify the explicit total-count line is present, "at most 2 queries" is absent, and the phrase-length wording is unambiguous for both the default and `queryMaxWords: 2` cases

## Key files to review

- [apps/mediapulse/agents/query-analysis/src/llm-queries.ts](apps/mediapulse/agents/query-analysis/src/llm-queries.ts) — three wording changes in `buildQueryAnalysisSystemContent` and one in `resolveWildcardSystemContent`
- [apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts](apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts) — updated fingerprint + new assertions

## How to test

1. Run `pnpm --filter @mediapulse/query-analysis test` — all 214 tests should pass
2. Optionally snapshot `buildQueryAnalysisSystemContent` output for a default config and confirm exactly one stated total, no bare "2 queries" cap, and the phrase-length line reads as words per query
