### PR TITLE
Remove LLM output-token caps and reasoning-effort plumbing

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -100,7 +100,6 @@ describe("resolveArticleAnalysisConfig", () => {
     expect(resolved.brainstormModel).toBe(
       articleAnalysisConfigDefaults.openaiModel,
     );
-    expect(resolved.brainstormMaxOutputTokens).toBe(800);
     expect(resolved.extractionConcurrency).toBe(1);
     expect(resolved.runDeadlineMs).toBeUndefined();
     expect(resolved.entityGroundingPolicy).toBe("off");

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -33,17 +33,8 @@ export const articleAnalysisConfigSchema = z
      * Leave unset for non-reasoning models like gpt-4o-mini.
      */
     reasoningEffort: reasoningEffortSchema.optional(),
-    /** Max output tokens for `generateObject`. */
-    maxOutputTokens: z.number().int().positive().optional(),
-    /**
-     * Max output tokens for the extraction pass only. Covers reasoning tokens + JSON for reasoning
-     * models. Falls back to `maxOutputTokens` when unset.
-     */
-    extractionMaxOutputTokens: z.number().int().positive().optional(),
     /**
      * Reasoning effort for the extraction pass only. Falls back to `reasoningEffort` when unset.
-     * Tune together with `extractionMaxOutputTokens` — lowering effort saves budget but reduces
-     * extraction quality when brainstorm is disabled.
      */
     extractionReasoningEffort: reasoningEffortSchema.optional(),
     /** Truncate article text in the LLM user message (full text remains in DB). */
@@ -71,8 +62,6 @@ export const articleAnalysisConfigSchema = z
     brainstormModel: z.string().min(1).optional(),
     /** Overrides `reasoningEffort` for the brainstorm pass. */
     brainstormReasoningEffort: reasoningEffortSchema.optional(),
-    /** Max output tokens for the brainstorm `generateText` call. */
-    brainstormMaxOutputTokens: z.number().int().positive().optional(),
     /** Max concurrent per-source extractions (1 = sequential; opt-in parallelism). */
     extractionConcurrency: z.number().int().min(1).max(16).optional(),
     /** Wall-clock budget in ms from run start; skips undispatched sources and late brainstorm/critique. */
@@ -216,7 +205,6 @@ export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
 /** Config with optional fields filled from {@link articleAnalysisConfigDefaults}. */
 export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   openaiModel: string;
-  maxOutputTokens: number;
   maxContentChars: number;
   useStructureAwareTruncation: boolean;
   truncationLeadParagraphsAlwaysKept: number;
@@ -225,9 +213,6 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
   fewShotExemplarArchetypes?: ExtractionExemplarArchetype[];
   useBrainstormPass: boolean;
   brainstormModel: string;
-  brainstormMaxOutputTokens: number;
-  /** Max output tokens for the extraction pass (falls back to `maxOutputTokens`). */
-  extractionMaxOutputTokens: number;
   /** Resolved reasoning effort for the extraction pass (falls back to `reasoningEffort`). */
   extractionReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
   /** Resolved reasoning effort for the brainstorm pass. */
@@ -290,14 +275,12 @@ export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
 /** Production-oriented defaults merged onto parsed Hermes config. */
 export const articleAnalysisConfigDefaults = {
   openaiModel: "gpt-4o-mini",
-  maxOutputTokens: 24576,
   maxContentChars: 12_000,
   useStructureAwareTruncation: false,
   truncationLeadParagraphsAlwaysKept: 2,
   truncationFinancialKeywordsExtra: [],
   fewShotExemplarCount: 0,
   useBrainstormPass: false,
-  brainstormMaxOutputTokens: 800,
   extractionConcurrency: 1,
   useRelationSelfCritique: false,
   relationCritiqueDropFraction: 0.25,
@@ -362,12 +345,6 @@ export const resolveArticleAnalysisConfig = (
   return {
     ...config,
     openaiModel,
-    maxOutputTokens:
-      config.maxOutputTokens ?? articleAnalysisConfigDefaults.maxOutputTokens,
-    extractionMaxOutputTokens:
-      config.extractionMaxOutputTokens ??
-      config.maxOutputTokens ??
-      articleAnalysisConfigDefaults.maxOutputTokens,
     maxContentChars:
       config.maxContentChars ?? articleAnalysisConfigDefaults.maxContentChars,
     useStructureAwareTruncation:
@@ -390,9 +367,6 @@ export const resolveArticleAnalysisConfig = (
       config.useBrainstormPass ??
       articleAnalysisConfigDefaults.useBrainstormPass,
     brainstormModel: config.brainstormModel ?? openaiModel,
-    brainstormMaxOutputTokens:
-      config.brainstormMaxOutputTokens ??
-      articleAnalysisConfigDefaults.brainstormMaxOutputTokens,
     extractionConcurrency:
       config.extractionConcurrency ??
       articleAnalysisConfigDefaults.extractionConcurrency,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.test.ts
@@ -203,7 +203,6 @@ describe("extractEntitiesAndRelationsForSource", () => {
       {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
-        maxOutputTokens: 100,
         messages: [
           { role: "system", content: "system prompt" },
           { role: "user", content: "real user prompt" },
@@ -242,7 +241,6 @@ describe("extractEntitiesAndRelationsForSource", () => {
       {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
-        maxOutputTokens: 100,
         messages,
       },
       { generateObjectForExtraction },
@@ -276,7 +274,6 @@ describe("extractEntitiesAndRelationsForSource", () => {
       {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
-        maxOutputTokens: 100,
         messages,
         brainstormText,
       },
@@ -359,7 +356,6 @@ describe("fetchArticleBrainstorm", () => {
       {
         apiKey: "sk-test",
         model: "gpt-4o-mini",
-        maxOutputTokens: 800,
         messages: [{ role: "user", content: "article" }],
       },
       { generateTextForBrainstorm },
@@ -538,7 +534,6 @@ describe("repairExtractionVocabulary", () => {
       {
         apiKey: "sk-test",
         model: "gpt-test",
-        maxOutputTokens: 512,
         ctx: {
           entityTypes: [{ id: TID, name: "Company", description: null }],
           relationTypes: [{ id: RID, name: "PART_OF", description: null }],
@@ -594,7 +589,6 @@ describe("vocabulary repair with partition (repair policy flow)", () => {
       {
         apiKey: "sk-test",
         model: "gpt-test",
-        maxOutputTokens: 512,
         ctx,
         badEntities: partitioned.badEntities,
         badRelations: partitioned.badRelations,
@@ -653,7 +647,6 @@ describe("vocabulary repair with partition (repair policy flow)", () => {
         {
           apiKey: "sk-test",
           model: "gpt-test",
-          maxOutputTokens: 512,
           ctx,
           badEntities: partitioned.badEntities,
           badRelations: partitioned.badRelations,

--- a/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts
@@ -6,10 +6,6 @@ import {
   NoObjectGeneratedError,
   type ModelMessage,
 } from "ai";
-import {
-  buildOpenAiReasoningProviderOptions,
-  type OpenAiReasoningProviderOptions,
-} from "@workspace/agent-runtime";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
@@ -105,9 +101,7 @@ export type ArticleBrainstormCallResult = {
 
 export type GenerateTextForBrainstorm = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
-  maxOutputTokens: number;
   messages: ModelMessage[];
-  providerOptions?: OpenAiReasoningProviderOptions;
   timeoutMs?: number;
 }) => Promise<ArticleBrainstormCallResult>;
 
@@ -333,9 +327,7 @@ export type LlmRelationCritiqueCallResult = {
 export type GenerateObjectForRelationCritique = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmRelationCritiqueSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
-  providerOptions?: OpenAiReasoningProviderOptions;
   timeoutMs?: number;
 }) => Promise<{
   object: LlmRelationCritiqueWireOutput;
@@ -345,9 +337,7 @@ export type GenerateObjectForRelationCritique = (args: {
 export type GenerateObjectForExtraction = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmExtractionOpenAiWireSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
-  providerOptions?: OpenAiReasoningProviderOptions;
   timeoutMs?: number;
 }) => Promise<{
   object: LlmExtractionWireOutput;
@@ -386,9 +376,7 @@ export type LlmVocabularyRepairCallResult = {
 export type GenerateObjectForVocabularyRepair = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmVocabularyRepairWireSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
-  providerOptions?: OpenAiReasoningProviderOptions;
   timeoutMs?: number;
 }) => Promise<{
   object: LlmVocabularyRepairWireOutput;
@@ -424,14 +412,13 @@ export const normalizeLlmUsageFromSdk = (usage: {
 const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
   args,
 ) => {
-  const { providerOptions, timeoutMs, ...rest } = args;
+  const { timeoutMs, ...rest } = args;
   const result = await generateObject({
     ...rest,
     maxRetries: 0,
     ...(timeoutMs !== undefined
       ? { abortSignal: AbortSignal.timeout(timeoutMs) }
       : {}),
-    ...(providerOptions !== undefined ? { providerOptions } : {}),
   });
   return {
     object: result.object,
@@ -442,14 +429,13 @@ const defaultGenerateObjectForExtraction: GenerateObjectForExtraction = async (
 const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
   args,
 ) => {
-  const { providerOptions, timeoutMs, ...rest } = args;
+  const { timeoutMs, ...rest } = args;
   const result = await generateText({
     ...rest,
     maxRetries: 0,
     ...(timeoutMs !== undefined
       ? { abortSignal: AbortSignal.timeout(timeoutMs) }
       : {}),
-    ...(providerOptions !== undefined ? { providerOptions } : {}),
   });
   return {
     text: result.text,
@@ -459,14 +445,13 @@ const defaultGenerateTextForBrainstorm: GenerateTextForBrainstorm = async (
 
 const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritique =
   async (args) => {
-    const { providerOptions, timeoutMs, ...rest } = args;
+    const { timeoutMs, ...rest } = args;
     const result = await generateObject({
       ...rest,
       maxRetries: 0,
       ...(timeoutMs !== undefined
         ? { abortSignal: AbortSignal.timeout(timeoutMs) }
         : {}),
-      ...(providerOptions !== undefined ? { providerOptions } : {}),
     });
     return {
       object: result.object,
@@ -476,14 +461,13 @@ const defaultGenerateObjectForRelationCritique: GenerateObjectForRelationCritiqu
 
 const defaultGenerateObjectForVocabularyRepair: GenerateObjectForVocabularyRepair =
   async (args) => {
-    const { providerOptions, timeoutMs, ...rest } = args;
+    const { timeoutMs, ...rest } = args;
     const result = await generateObject({
       ...rest,
       maxRetries: 0,
       ...(timeoutMs !== undefined
         ? { abortSignal: AbortSignal.timeout(timeoutMs) }
         : {}),
-      ...(providerOptions !== undefined ? { providerOptions } : {}),
     });
     return {
       object: result.object,
@@ -655,9 +639,7 @@ export const fetchArticleBrainstorm = async (
   params: {
     apiKey: string;
     model: string;
-    maxOutputTokens: number;
     messages: ModelMessage[];
-    providerOptions?: OpenAiReasoningProviderOptions;
     timeoutMs?: number;
   },
   deps: { generateTextForBrainstorm: GenerateTextForBrainstorm } = {
@@ -667,11 +649,7 @@ export const fetchArticleBrainstorm = async (
   const openai = createOpenAI({ apiKey: params.apiKey });
   return deps.generateTextForBrainstorm({
     model: openai(params.model),
-    maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
-    ...(params.providerOptions !== undefined
-      ? { providerOptions: params.providerOptions }
-      : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
 };
@@ -734,11 +712,9 @@ export const extractEntitiesAndRelationsForSource = async (
   params: {
     apiKey: string;
     model: string;
-    maxOutputTokens: number;
     messages: ModelMessage[];
     exemplars?: readonly ResolvedExemplar[];
     brainstormText?: string;
-    providerOptions?: OpenAiReasoningProviderOptions;
     timeoutMs?: number;
   },
   deps: { generateObjectForExtraction: GenerateObjectForExtraction } = {
@@ -765,11 +741,7 @@ export const extractEntitiesAndRelationsForSource = async (
   const raw = await deps.generateObjectForExtraction({
     model: openai(params.model),
     schema: llmExtractionOpenAiWireSchema,
-    maxOutputTokens: params.maxOutputTokens,
     messages,
-    ...(params.providerOptions !== undefined
-      ? { providerOptions: params.providerOptions }
-      : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
   return {
@@ -938,9 +910,7 @@ export const critiqueExtractedRelations = async (
   params: {
     apiKey: string;
     model: string;
-    maxOutputTokens: number;
     messages: ModelMessage[];
-    providerOptions?: OpenAiReasoningProviderOptions;
     timeoutMs?: number;
   },
   deps: {
@@ -953,11 +923,7 @@ export const critiqueExtractedRelations = async (
   const raw = await deps.generateObjectForRelationCritique({
     model: openai(params.model),
     schema: llmRelationCritiqueSchema,
-    maxOutputTokens: params.maxOutputTokens,
     messages: params.messages,
-    ...(params.providerOptions !== undefined
-      ? { providerOptions: params.providerOptions }
-      : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
   return {
@@ -1103,11 +1069,9 @@ export const repairExtractionVocabulary = async (
   params: {
     apiKey: string;
     model: string;
-    maxOutputTokens: number;
     ctx: Pick<GetAnalysisResponse, "entityTypes" | "relationTypes">;
     badEntities: readonly BadEntityRecord[];
     badRelations: readonly BadRelationRecord[];
-    providerOptions?: OpenAiReasoningProviderOptions;
     timeoutMs?: number;
   },
   deps: {
@@ -1120,15 +1084,11 @@ export const repairExtractionVocabulary = async (
   const raw = await deps.generateObjectForVocabularyRepair({
     model: openai(params.model),
     schema: llmVocabularyRepairWireSchema,
-    maxOutputTokens: params.maxOutputTokens,
     messages: buildVocabularyRepairModelMessages(
       params.ctx,
       params.badEntities,
       params.badRelations,
     ),
-    ...(params.providerOptions !== undefined
-      ? { providerOptions: params.providerOptions }
-      : {}),
     ...(params.timeoutMs !== undefined ? { timeoutMs: params.timeoutMs } : {}),
   });
 

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -1,7 +1,6 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { GetAnalysisResponse } from "@workspace/agent-data-api-contract";
 import { computeLlmPromptFingerprint } from "@workspace/agent-llm-prompt-template";
-import { buildOpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 import { NoObjectGeneratedError } from "ai";
 
 import { applyPerArticleExtractionCaps } from "./analysis-caps-dedupe.js";
@@ -290,8 +289,6 @@ export const createProcessOneSource =
         ? source.content.slice(0, cfg.maxContentChars)
         : source.content;
 
-    let currentExtractionMaxOutputTokens = cfg.extractionMaxOutputTokens;
-
     try {
       const t0 = Date.now();
       const extractionUserContent = buildArticleAnalysisExtractionUserContent({
@@ -313,15 +310,11 @@ export const createProcessOneSource =
       if (shouldRunBrainstorm) {
         try {
           const brainstormStartedAt = Date.now();
-          const brainstormProviderOptions = buildOpenAiReasoningProviderOptions(
-            cfg.brainstormReasoningEffort,
-          );
           const brainstormResult = await executeLlmCallWithTransientRetries(
             () =>
               fetchArticleBrainstorm({
                 apiKey: cfg.openaiApiKey,
                 model: cfg.brainstormModel,
-                maxOutputTokens: cfg.brainstormMaxOutputTokens,
                 timeoutMs: cfg.extractionCallTimeoutMs,
                 messages: [
                   {
@@ -339,9 +332,6 @@ export const createProcessOneSource =
                     }),
                   },
                 ],
-                ...(brainstormProviderOptions !== undefined
-                  ? { providerOptions: brainstormProviderOptions }
-                  : {}),
               }),
             {
               maxRetries: cfg.extractionTransientRetries,
@@ -384,17 +374,12 @@ export const createProcessOneSource =
         );
       }
 
-      const extractionProviderOptions = buildOpenAiReasoningProviderOptions(
-        cfg.extractionReasoningEffort,
-      );
       let extractionRetryAttempts = 0;
-      const extractionBudgetCap = cfg.extractionMaxOutputTokens * 4;
       const extractedResult = await executeLlmCallWithTransientRetries(
         () =>
           extractEntitiesAndRelationsForSource({
             apiKey: cfg.openaiApiKey,
             model: cfg.openaiModel,
-            maxOutputTokens: currentExtractionMaxOutputTokens,
             timeoutMs: cfg.extractionCallTimeoutMs,
             messages: [
               { role: "system", content: systemContent },
@@ -407,9 +392,6 @@ export const createProcessOneSource =
               ? { exemplars: resolvedExemplars }
               : {}),
             ...(brainstormText !== undefined ? { brainstormText } : {}),
-            ...(extractionProviderOptions !== undefined
-              ? { providerOptions: extractionProviderOptions }
-              : {}),
           }),
         {
           maxRetries: cfg.extractionTransientRetries,
@@ -424,19 +406,12 @@ export const createProcessOneSource =
               outcome.extractionCallTimeouts += 1;
             }
             const noResponseSubtype = classifyNoResponseSubtype(error);
-            if (noResponseSubtype === "length_truncation") {
-              currentExtractionMaxOutputTokens = Math.min(
-                extractionBudgetCap,
-                Math.ceil(currentExtractionMaxOutputTokens * 1.5),
-              );
-            }
             log.warn(
               {
                 dataSourceId: source.id,
                 stage: "extraction",
                 retryAttempt: attempt,
                 noResponseSubtype,
-                currentExtractionMaxOutputTokens,
                 err: toSafeLogError(error),
               },
               "article-analysis LLM extraction transient failure; retrying",
@@ -497,20 +472,13 @@ export const createProcessOneSource =
         ) {
           outcome.vocabularyRepairCallsAttempted = 1;
           try {
-            const repairProviderOptions = buildOpenAiReasoningProviderOptions(
-              cfg.vocabularyRepairReasoningEffort,
-            );
             const repairResult = await repairExtractionVocabulary({
               apiKey: cfg.openaiApiKey,
               model: cfg.vocabularyRepairModel,
-              maxOutputTokens: cfg.maxOutputTokens,
               timeoutMs: cfg.extractionCallTimeoutMs,
               ctx,
               badEntities: partitioned.badEntities,
               badRelations: partitioned.badRelations,
-              ...(repairProviderOptions !== undefined
-                ? { providerOptions: repairProviderOptions }
-                : {}),
             });
             outcome.repairUsage = repairResult.usage;
 
@@ -628,24 +596,17 @@ export const createProcessOneSource =
       } else if (critiqueEligible) {
         try {
           const critiqueStartedAt = Date.now();
-          const critiqueProviderOptions = buildOpenAiReasoningProviderOptions(
-            cfg.relationCritiqueReasoningEffort,
-          );
           const critiqueResult = await executeLlmCallWithTransientRetries(
             () =>
               critiqueExtractedRelations({
                 apiKey: cfg.openaiApiKey,
                 model: cfg.relationCritiqueModel,
-                maxOutputTokens: cfg.maxOutputTokens,
                 timeoutMs: cfg.extractionCallTimeoutMs,
                 messages: buildRelationCritiqueModelMessages(ctx, {
                   articleTitle: source.title,
                   articleBody: source.content,
                   candidates: resolved.relations,
                 }),
-                ...(critiqueProviderOptions !== undefined
-                  ? { providerOptions: critiqueProviderOptions }
-                  : {}),
               }),
             {
               maxRetries: cfg.extractionTransientRetries,
@@ -818,7 +779,6 @@ export const createProcessOneSource =
         if (outputTokens !== undefined) {
           failureRecord.outputTokens = outputTokens;
         }
-        failureRecord.maxOutputTokens = currentExtractionMaxOutputTokens;
       }
       outcome.extractionFailures.push(failureRecord);
       log.warn(
@@ -830,7 +790,6 @@ export const createProcessOneSource =
             ? {
                 finishReason: err.finishReason,
                 outputTokens: err.usage?.outputTokens,
-                maxOutputTokens: currentExtractionMaxOutputTokens,
                 responseTextLength: err.text?.length,
               }
             : {}),

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -3037,7 +3037,7 @@ describe("run", () => {
     ).toBe(0);
   });
 
-  it("recovers from length-truncation via budget escalation and reports recoveredByRetry", async () => {
+  it("recovers from length-truncation on retry and reports recoveredByRetry", async () => {
     // Setup
     const { NoObjectGeneratedError } = await import("ai");
     const lengthTruncationError = new NoObjectGeneratedError({
@@ -3083,11 +3083,11 @@ describe("run", () => {
         lastRelevanceScoredAtIso: null,
       }),
     );
-    const capturedMaxOutputTokens: number[] = [];
+    let extractionCallCount = 0;
     vi.spyOn(Llm, "extractEntitiesAndRelationsForSource").mockImplementation(
-      async (params) => {
-        capturedMaxOutputTokens.push(params.maxOutputTokens);
-        if (capturedMaxOutputTokens.length === 1) {
+      async () => {
+        extractionCallCount++;
+        if (extractionCallCount === 1) {
           throw lengthTruncationError;
         }
 
@@ -3107,7 +3107,6 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionMaxOutputTokens: 8192,
           extractionTransientRetries: 2,
           extractionTransientRetryBaseDelayMs: 1,
           extractionTransientRetryMaxDelayMs: 1,
@@ -3118,10 +3117,7 @@ describe("run", () => {
     // Assert
     expect(result.success).toBe(true);
     expect(result.details?.extractionFailures).toHaveLength(0);
-    expect(capturedMaxOutputTokens).toHaveLength(2);
-    expect(capturedMaxOutputTokens[1]).toBeGreaterThan(
-      capturedMaxOutputTokens[0]!,
-    );
+    expect(extractionCallCount).toBe(2);
 
     const summaryCall = mockLog.info.mock.calls.find(
       (call) =>

--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -43,7 +43,6 @@ describe("ContentGenerationConfigSchema", () => {
     expect(parsed.inputs.fewShot.maxExemplars).toBe(1);
     expect(parsed.inputs.fewShot.sectorTag).toBeUndefined();
     expect(parsed.creativity.brainstorm.enabled).toBe(true);
-    expect(parsed.creativity.brainstorm.maxOutputTokens).toBe(700);
     expect(parsed.creativity.brainstorm.model).toBeUndefined();
     expect(parsed.quality.citationGrounding.enabled).toBe(true);
     expect(parsed.quality.citationGrounding.policy).toBe("unlink");
@@ -300,18 +299,6 @@ describe("ContentGenerationConfigSchema", () => {
     expect(schemaStr).not.toContain('"openai"');
   });
 
-  it("JSON schema exposes credentials.reasoningEffort as a four-value enum for Hermes dropdown", () => {
-    const jsonSchema = zodToJsonSchema(ContentGenerationConfigSchema, {
-      $refStrategy: "none",
-    });
-    const schemaStr = JSON.stringify(jsonSchema);
-    expect(schemaStr).toContain("reasoningEffort");
-    expect(schemaStr).toContain('"minimal"');
-    expect(schemaStr).toContain('"low"');
-    expect(schemaStr).toContain('"medium"');
-    expect(schemaStr).toContain('"high"');
-  });
-
   it("parses reliability.llmRetry with all fields provided", () => {
     const parsed = ContentGenerationConfigSchema.parse({
       ...testCredentials,
@@ -520,45 +507,5 @@ describe("resolveContentGenerationConfig", () => {
 
     expect(resolved.critiqueModel).toBe("gpt-4o");
     expect(resolved.subjectLineModel).toBe("gpt-4o");
-  });
-
-  it("resolves all per-pass reasoningEffort to undefined when unset", () => {
-    const resolved = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({ ...testCredentials }),
-    );
-
-    expect(resolved.structuredReasoningEffort).toBeUndefined();
-    expect(resolved.brainstormReasoningEffort).toBeUndefined();
-    expect(resolved.critiqueReasoningEffort).toBeUndefined();
-    expect(resolved.subjectLineReasoningEffort).toBeUndefined();
-  });
-
-  it("resolves per-pass reasoningEffort to credentials default when no overrides", () => {
-    const resolved = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
-      }),
-    );
-
-    expect(resolved.structuredReasoningEffort).toBe("high");
-    expect(resolved.brainstormReasoningEffort).toBe("high");
-    expect(resolved.critiqueReasoningEffort).toBe("high");
-    expect(resolved.subjectLineReasoningEffort).toBe("high");
-  });
-
-  it("per-pass override wins over credentials default", () => {
-    const resolved = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
-        creativity: { brainstorm: { reasoningEffort: "low" } },
-        quality: { selfCritique: { reasoningEffort: "medium" } },
-        delivery: { subjectLine: { reasoningEffort: "low" } },
-      }),
-    );
-
-    expect(resolved.structuredReasoningEffort).toBe("high");
-    expect(resolved.brainstormReasoningEffort).toBe("low");
-    expect(resolved.critiqueReasoningEffort).toBe("medium");
-    expect(resolved.subjectLineReasoningEffort).toBe("low");
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
 import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
-import { reasoningEffortSchema } from "@workspace/agent-runtime";
 import { NEWSLETTER_SECTION_IDS } from "@workspace/agent-data-api-contract";
 import type { NewsletterSectionId } from "@workspace/agent-data-api-contract";
 
@@ -190,17 +189,6 @@ const brainstormSchema = z
       .describe(
         "Chat model for the brainstorm pass. If omitted, uses credentials.chatModel.",
       ),
-    reasoningEffort: reasoningEffortSchema
-      .optional()
-      .describe(
-        "Overrides credentials.reasoningEffort for the brainstorm pass.",
-      ),
-    maxOutputTokens: z
-      .number()
-      .int()
-      .positive()
-      .default(700)
-      .describe("Max output tokens for the brainstorm generateText call."),
   })
   .default({})
   .describe("Two-pass generation: free-form memo before structured JSON.");
@@ -243,17 +231,6 @@ const selfCritiqueSchema = z
       .describe(
         "Chat model for the critique pass. If omitted, uses credentials.chatModel.",
       ),
-    reasoningEffort: reasoningEffortSchema
-      .optional()
-      .describe(
-        "Overrides credentials.reasoningEffort for the self-critique pass.",
-      ),
-    critiqueMaxOutputTokens: z
-      .number()
-      .int()
-      .positive()
-      .default(1500)
-      .describe("Max output tokens for the critique generateObject call."),
     preferRewriteOverDrop: z
       .boolean()
       .default(true)
@@ -471,11 +448,6 @@ const subjectLineSchema = z
       .describe(
         "Chat model for subject candidates. If omitted, uses credentials.chatModel.",
       ),
-    reasoningEffort: reasoningEffortSchema
-      .optional()
-      .describe(
-        "Overrides credentials.reasoningEffort for the subject-line pass.",
-      ),
     weights: z
       .object({
         lengthFit: z
@@ -554,11 +526,6 @@ const credentialsSchema = z
       .positive()
       .optional()
       .describe("Maximum tokens to generate per LLM call."),
-    reasoningEffort: reasoningEffortSchema
-      .optional()
-      .describe(
-        "Reasoning effort for LLM passes when the model supports it (gpt-5/o-series). Leave unset for non-reasoning models like gpt-4o-mini.",
-      ),
     timeoutMs: z
       .number()
       .int()
@@ -766,21 +733,13 @@ export type ResolvedPersistRetryConfig =
   ContentGenerationConfig["reliability"]["persistRetry"];
 
 /**
- * Content-generation config with per-pass model ids and reasoning effort levels
- * resolved. Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
- *
- * Per-pass reasoning effort falls back to `credentials.reasoningEffort` when the
- * pass-level override is unset. All values may be `undefined` when the operator has
- * not set reasoning effort — this is safe for non-reasoning models.
+ * Content-generation config with per-pass model ids resolved.
+ * Use {@link resolveContentGenerationConfig} to obtain this from a parsed config.
  */
 export type ResolvedContentGenerationConfig = ContentGenerationConfig & {
   brainstormModel: string;
   critiqueModel: string;
   subjectLineModel: string;
-  structuredReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
-  brainstormReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
-  critiqueReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
-  subjectLineReasoningEffort?: import("@workspace/agent-runtime").OpenAiReasoningEffort;
 };
 
 type RetryFields = {
@@ -830,36 +789,11 @@ export function resolveContentGenerationConfig(
 ): ResolvedContentGenerationConfig {
   const parsed = ContentGenerationConfigSchema.parse(config);
   const chatModel = parsed.credentials.chatModel;
-  const defaultEffort = parsed.credentials.reasoningEffort;
 
   return {
     ...parsed,
     brainstormModel: parsed.creativity.brainstorm.model ?? chatModel,
     critiqueModel: parsed.quality.selfCritique.critiqueModel ?? chatModel,
     subjectLineModel: parsed.delivery.subjectLine.model ?? chatModel,
-    ...(defaultEffort !== undefined
-      ? { structuredReasoningEffort: defaultEffort }
-      : {}),
-    ...(parsed.creativity.brainstorm.reasoningEffort !== undefined
-      ? {
-          brainstormReasoningEffort:
-            parsed.creativity.brainstorm.reasoningEffort,
-        }
-      : defaultEffort !== undefined
-        ? { brainstormReasoningEffort: defaultEffort }
-        : {}),
-    ...(parsed.quality.selfCritique.reasoningEffort !== undefined
-      ? { critiqueReasoningEffort: parsed.quality.selfCritique.reasoningEffort }
-      : defaultEffort !== undefined
-        ? { critiqueReasoningEffort: defaultEffort }
-        : {}),
-    ...(parsed.delivery.subjectLine.reasoningEffort !== undefined
-      ? {
-          subjectLineReasoningEffort:
-            parsed.delivery.subjectLine.reasoningEffort,
-        }
-      : defaultEffort !== undefined
-        ? { subjectLineReasoningEffort: defaultEffort }
-        : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/newsletter-self-critique.ts
@@ -241,7 +241,6 @@ export type GenerateObjectForNewsletterCritiqueArgs = {
   schema: typeof newsletterCritiqueLlmSchema;
   system: string;
   prompt: string;
-  maxOutputTokens: number;
   maxRetries: number;
   timeout?: number;
   /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
@@ -264,7 +263,6 @@ const defaultGenerateObjectForNewsletterCritique: GenerateObjectForNewsletterCri
       system: args.system,
       prompt: args.prompt,
       maxRetries: args.maxRetries,
-      maxOutputTokens: args.maxOutputTokens,
       ...(args.timeout !== undefined ? { timeout: args.timeout } : {}),
       ...(args.providerOptions !== undefined
         ? { providerOptions: args.providerOptions }
@@ -290,7 +288,6 @@ export const critiqueNewsletter = async (
     apiKey: string;
     baseUrl?: string;
     model: string;
-    maxOutputTokens: number;
     system: string;
     prompt: string;
     timeout?: number;
@@ -315,7 +312,6 @@ export const critiqueNewsletter = async (
     schema: newsletterCritiqueLlmSchema,
     system: params.system,
     prompt: params.prompt,
-    maxOutputTokens: params.maxOutputTokens,
     maxRetries: 0,
     ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
     ...(params.providerOptions !== undefined

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -1,7 +1,6 @@
 import { APICallError, NoObjectGeneratedError, TypeValidationError } from "ai";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { OpenAiReasoningProviderOptions } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 
 import { parseIndustryNewsletterWire } from "@workspace/email-templates/parse-industry-newsletter-wire";
@@ -1626,35 +1625,6 @@ describe("generateNewsletterWithLlm — self-critique", () => {
       expect.any(String),
     );
   });
-
-  it("scales critique maxOutputTokens above the configured floor with candidate count", async () => {
-    // Setup
-    const generateObjectFn = makeSuccessfulGenerateFn();
-    const critiqueGenerateObjectFn = vi.fn().mockResolvedValue({
-      object: { ratings: [] },
-      usage: { promptTokens: 50, completionTokens: 25 },
-    });
-
-    // Act
-    await generateNewsletterWithLlm(
-      testSources,
-      critiqueEnabledConfig,
-      { ...testContext, runStartedAt: 0 },
-      {
-        generateObjectFn,
-        critiqueGenerateObjectFn,
-        sleepFn: noopSleepFn,
-        nowFn: () => 100,
-      },
-    );
-
-    // Assert — nine eligible bullets must push the budget past the 1500 default
-    expect(critiqueGenerateObjectFn).toHaveBeenCalledOnce();
-    const callArgs = critiqueGenerateObjectFn.mock.calls[0]?.[0] as {
-      maxOutputTokens: number;
-    };
-    expect(callArgs.maxOutputTokens).toBeGreaterThan(1500);
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -2329,110 +2299,6 @@ describe("generateNewsletterWithLlm — competitor prompt injection", () => {
 
     expect(capturedPrompt).not.toContain("Do NOT make these bullets about");
     expect(capturedPrompt).not.toContain("{{");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// Reasoning effort wiring
-// ---------------------------------------------------------------------------
-
-describe("generateNewsletterWithLlm — reasoning effort", () => {
-  it("does not pass providerOptions to the structured generateFn when reasoningEffort is unset", async () => {
-    let capturedArgs: GenerateNewsletterObjectArgs | undefined;
-    const generateObjectFn: GenerateNewsletterObjectFn = vi
-      .fn()
-      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
-        capturedArgs = args;
-        return { object: minimalIndustryBrief() };
-      });
-
-    await generateNewsletterWithLlm(testSources, baseConfig, testContext, {
-      generateObjectFn,
-      sleepFn: noopSleepFn,
-    });
-
-    expect(capturedArgs?.providerOptions).toBeUndefined();
-  });
-
-  it("passes providerOptions with reasoningEffort to the structured generateFn when set", async () => {
-    let capturedArgs: GenerateNewsletterObjectArgs | undefined;
-    const generateObjectFn: GenerateNewsletterObjectFn = vi
-      .fn()
-      .mockImplementation(async (args: GenerateNewsletterObjectArgs) => {
-        capturedArgs = args;
-        return { object: minimalIndustryBrief() };
-      });
-
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        ...conservativeTestConfigInput,
-        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
-      }),
-    );
-
-    await generateNewsletterWithLlm(testSources, config, testContext, {
-      generateObjectFn,
-      sleepFn: noopSleepFn,
-    });
-
-    expect(capturedArgs?.providerOptions).toEqual({
-      openai: { reasoningEffort: "high" },
-    });
-  });
-
-  it("per-pass subject-line override is independent of structured-pass effort", async () => {
-    const generateObjectFn = makeSuccessfulGenerateFn();
-
-    let capturedSubjectArgs:
-      | { providerOptions?: OpenAiReasoningProviderOptions }
-      | undefined;
-    const subjectGenerateObjectFn = vi
-      .fn()
-      .mockImplementation(
-        async (args: { providerOptions?: OpenAiReasoningProviderOptions }) => {
-          capturedSubjectArgs = args;
-          return {
-            object: {
-              candidates: [
-                {
-                  subject: "Top Story Today",
-                  style: "declarative",
-                  preheader: "Industry news",
-                },
-                {
-                  subject: "Markets Move Fast",
-                  style: "numeric",
-                  preheader: "Key figures",
-                },
-                {
-                  subject: "What Changed?",
-                  style: "question",
-                  preheader: "Sector update",
-                },
-              ],
-            },
-            usage: { promptTokens: 10, completionTokens: 5 },
-          };
-        },
-      );
-
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        ...conservativeTestConfigInput,
-        credentials: { openaiApiKey: "sk-test", reasoningEffort: "high" },
-        delivery: { subjectLine: { enabled: true, reasoningEffort: "low" } },
-      }),
-    );
-
-    await generateNewsletterWithLlm(testSources, config, testContext, {
-      generateObjectFn,
-      sleepFn: noopSleepFn,
-      subjectGenerateObjectFn,
-    });
-
-    expect(capturedSubjectArgs?.providerOptions).toEqual({
-      openai: { reasoningEffort: "low" },
-    });
   });
 });
 

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -6,11 +6,7 @@ import {
   NEWSLETTER_SECTION_IDS,
   type NewsletterSectionId,
 } from "@workspace/agent-data-api-contract";
-import {
-  applyContractBrief,
-  buildOpenAiReasoningProviderOptions,
-  type OpenAiReasoningProviderOptions,
-} from "@workspace/agent-runtime";
+import { applyContractBrief } from "@workspace/agent-runtime";
 import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
@@ -246,8 +242,6 @@ export type GenerateNewsletterObjectArgs = {
   timeout?: number;
   /** Maximum tokens to generate (passed to `generateObject`). */
   maxTokens?: number;
-  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
-  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Token usage extracted from a single `generateObject` response. */
@@ -276,10 +270,8 @@ export type GenerateNewsletterObjectFn = (
 const defaultGenerateNewsletterObject: GenerateNewsletterObjectFn = async (
   args,
 ) => {
-  const { providerOptions, ...rest } = args;
   const result = await generateObject({
-    ...rest,
-    ...(providerOptions !== undefined ? { providerOptions } : {}),
+    ...args,
   });
   // AI SDK v6 uses inputTokens/outputTokens (not promptTokens/completionTokens).
   // We map to the contract names (promptTokens/completionTokens/totalTokens) here
@@ -307,13 +299,10 @@ export type GenerateTextForNewsletterBrainstormArgs = {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   system: string;
   prompt: string;
-  maxOutputTokens: number;
   /** Should always be 0 — retries are managed at the orchestration layer. */
   maxRetries: number;
   /** Per-request timeout in milliseconds (passed to the AI SDK). */
   timeout?: number;
-  /** Provider-specific options (e.g. `{ openai: { reasoningEffort } }`). Omit for non-reasoning models. */
-  providerOptions?: OpenAiReasoningProviderOptions;
 };
 
 /** Token usage from a brainstorm `generateText` response. */
@@ -335,10 +324,8 @@ export type GenerateTextForNewsletterBrainstorm = (
 
 const defaultGenerateTextForNewsletterBrainstorm: GenerateTextForNewsletterBrainstorm =
   async (args) => {
-    const { providerOptions, ...rest } = args;
     const result = await generateText({
-      ...rest,
-      ...(providerOptions !== undefined ? { providerOptions } : {}),
+      ...args,
     });
     const usage =
       result.usage !== undefined
@@ -349,11 +336,6 @@ const defaultGenerateTextForNewsletterBrainstorm: GenerateTextForNewsletterBrain
         : null;
     return { text: result.text, usage };
   };
-
-/** Fixed JSON overhead (wrapper object, schema scaffolding) for the critique pass. */
-const CRITIQUE_TOKENS_BASE_OVERHEAD = 256;
-/** Output-token allowance per critique rating row (scores + rationale + optional rewrite). */
-const CRITIQUE_TOKENS_PER_CANDIDATE = 180;
 
 const BRAINSTORM_SYSTEM_PROMPT = [
   "You are an editorial planner for a daily industry briefing.",
@@ -526,11 +508,9 @@ export const fetchNewsletterBrainstorm = async (
     apiKey: string;
     baseUrl?: string;
     model: string;
-    maxOutputTokens: number;
     system: string;
     prompt: string;
     timeout?: number;
-    providerOptions?: OpenAiReasoningProviderOptions;
   },
   deps: {
     generateTextFn?: GenerateTextForNewsletterBrainstorm;
@@ -547,12 +527,8 @@ export const fetchNewsletterBrainstorm = async (
     model: openai(params.model),
     system: params.system,
     prompt: params.prompt,
-    maxOutputTokens: params.maxOutputTokens,
     maxRetries: 0,
     ...(params.timeout !== undefined ? { timeout: params.timeout } : {}),
-    ...(params.providerOptions !== undefined
-      ? { providerOptions: params.providerOptions }
-      : {}),
   });
 };
 
@@ -886,9 +862,6 @@ export async function generateNewsletterWithLlm(
 
     try {
       const brainstormStartedAt = nowFn();
-      const brainstormProviderOptions = buildOpenAiReasoningProviderOptions(
-        config.brainstormReasoningEffort,
-      );
       const brainstormResult = await fetchNewsletterBrainstorm(
         {
           apiKey: config.credentials.openaiApiKey,
@@ -896,13 +869,9 @@ export async function generateNewsletterWithLlm(
             ? { baseUrl: config.credentials.baseUrl }
             : {}),
           model: config.brainstormModel,
-          maxOutputTokens: config.creativity.brainstorm.maxOutputTokens,
           system: brainstormSystemPrompt,
           prompt: brainstormUserPrompt,
           ...(timeout !== undefined ? { timeout } : {}),
-          ...(brainstormProviderOptions !== undefined
-            ? { providerOptions: brainstormProviderOptions }
-            : {}),
         },
         { generateTextFn: deps.generateTextFn },
       );
@@ -1019,25 +988,6 @@ export async function generateNewsletterWithLlm(
       ? Math.max(1, timeout - (nowFn() - generationStartedAt))
       : timeout;
 
-  // Reasoning tokens are consumed from the output budget. When using a
-  // reasoning model, ensure credentials.maxTokens is large enough to
-  // accommodate both reasoning tokens and the structured JSON output.
-  // See the config reference for recommended pairings.
-  const structuredProviderOptions = buildOpenAiReasoningProviderOptions(
-    config.structuredReasoningEffort,
-  );
-
-  logger.info(
-    {
-      tickerId: context.tickerId,
-      structuredReasoningEffort: config.structuredReasoningEffort,
-      brainstormReasoningEffort: config.brainstormReasoningEffort,
-      critiqueReasoningEffort: config.critiqueReasoningEffort,
-      subjectLineReasoningEffort: config.subjectLineReasoningEffort,
-    },
-    "LLM passes: effective reasoning effort per pass",
-  );
-
   const result = await retryWithBackoff(
     async () => {
       return generateFn({
@@ -1050,9 +1000,6 @@ export async function generateNewsletterWithLlm(
           ? { timeout: structuredTimeout }
           : {}),
         ...(maxTokens !== undefined ? { maxTokens } : {}),
-        ...(structuredProviderOptions !== undefined
-          ? { providerOptions: structuredProviderOptions }
-          : {}),
       });
     },
     config.reliability.llmRetry,
@@ -1170,19 +1117,6 @@ export async function generateNewsletterWithLlm(
             ? Math.max(1, timeout - (nowFn() - generationStartedAt))
             : undefined;
 
-        // The critic emits one JSON row per candidate, so a fixed token cap
-        // truncates (and fails to parse) on larger briefings. Scale the budget
-        // with candidate count while honoring the configured value as a floor.
-        const critiqueMaxOutputTokens = Math.max(
-          selfCritique.critiqueMaxOutputTokens,
-          CRITIQUE_TOKENS_BASE_OVERHEAD +
-            candidates.length * CRITIQUE_TOKENS_PER_CANDIDATE,
-        );
-
-        const critiqueProviderOptions = buildOpenAiReasoningProviderOptions(
-          config.critiqueReasoningEffort,
-        );
-
         try {
           const critiqueResult = await critiqueNewsletter(
             {
@@ -1191,14 +1125,10 @@ export async function generateNewsletterWithLlm(
                 ? { baseUrl: config.credentials.baseUrl }
                 : {}),
               model: config.critiqueModel,
-              maxOutputTokens: critiqueMaxOutputTokens,
               system: critiqueSystem,
               prompt: critiquePrompt,
               ...(critiqueTimeout !== undefined
                 ? { timeout: critiqueTimeout }
-                : {}),
-              ...(critiqueProviderOptions !== undefined
-                ? { providerOptions: critiqueProviderOptions }
                 : {}),
             },
             { generateObjectFn: deps.critiqueGenerateObjectFn },
@@ -1407,10 +1337,6 @@ export async function generateNewsletterWithLlm(
           ? Math.max(1, timeout - (nowFn() - generationStartedAt))
           : undefined;
 
-      const subjectProviderOptions = buildOpenAiReasoningProviderOptions(
-        config.subjectLineReasoningEffort,
-      );
-
       const subjectResult = await fetchSubjectCandidates(
         {
           apiKey: config.credentials.openaiApiKey,
@@ -1422,9 +1348,6 @@ export async function generateNewsletterWithLlm(
           system: subjectSystem,
           prompt: subjectPrompt,
           ...(subjectTimeout !== undefined ? { timeout: subjectTimeout } : {}),
-          ...(subjectProviderOptions !== undefined
-            ? { providerOptions: subjectProviderOptions }
-            : {}),
         },
         { generateObjectFn: deps.subjectGenerateObjectFn },
       );

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -608,27 +608,6 @@ export async function run({
     success: true,
     details: {
       promptHash,
-      ...(resolvedConfig.structuredReasoningEffort !== undefined ||
-      resolvedConfig.brainstormReasoningEffort !== undefined ||
-      resolvedConfig.critiqueReasoningEffort !== undefined ||
-      resolvedConfig.subjectLineReasoningEffort !== undefined
-        ? {
-            reasoningEffort: {
-              ...(resolvedConfig.structuredReasoningEffort !== undefined
-                ? { structured: resolvedConfig.structuredReasoningEffort }
-                : {}),
-              ...(resolvedConfig.brainstormReasoningEffort !== undefined
-                ? { brainstorm: resolvedConfig.brainstormReasoningEffort }
-                : {}),
-              ...(resolvedConfig.critiqueReasoningEffort !== undefined
-                ? { critique: resolvedConfig.critiqueReasoningEffort }
-                : {}),
-              ...(resolvedConfig.subjectLineReasoningEffort !== undefined
-                ? { subjectLine: resolvedConfig.subjectLineReasoningEffort }
-                : {}),
-            },
-          }
-        : {}),
       ...(generated.structuredReasoningTokens !== undefined
         ? { reasoningTokens: generated.structuredReasoningTokens }
         : {}),

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.test.ts
@@ -649,7 +649,7 @@ describe("fetchLlmQueryCandidates", () => {
     expect(generateObjectForQueries).toHaveBeenCalledTimes(1);
   });
 
-  it("forwards the fixed output-token budget to generateObject", async () => {
+  it("does not pass seed or providerOptions to generateObject", async () => {
     // Setup
     const generateObjectForQueries = vi.fn().mockResolvedValue({
       object: { queries: [] },

--- a/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
+++ b/apps/mediapulse/agents/query-analysis/src/llm-queries.ts
@@ -21,9 +21,6 @@ import type { LlmCandidate } from "./merge-query-candidates";
 import { normalizeQueryKey } from "./merge-query-candidates";
 import { resolveEntityDisplayName } from "./i18n/entity-aliases";
 
-/** Fixed LLM output token budget for all query-analysis structured calls. */
-export const QUERY_ANALYSIS_MAX_OUTPUT_TOKENS = 800;
-
 /** Zod schema for structured LLM output (validated by AI SDK). */
 export const llmQueriesOutputSchema = z.object({
   queries: z.array(
@@ -340,21 +337,18 @@ export const buildStructuredQueryMessages = (options: {
 export type GenerateObjectForWildcards = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmWildcardOutputSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
 }) => Promise<{ object: z.infer<typeof llmWildcardOutputSchema> }>;
 
 export type GenerateObjectForQueries = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmQueriesOutputSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
 }) => Promise<{ object: z.infer<typeof llmQueriesOutputSchema> }>;
 
 export type GenerateObjectForCritique = (args: {
   model: ReturnType<ReturnType<typeof createOpenAI>>;
   schema: typeof llmCritiqueOutputSchema;
-  maxOutputTokens: number;
   messages: ModelMessage[];
 }) => Promise<{ object: z.infer<typeof llmCritiqueOutputSchema> }>;
 
@@ -380,7 +374,6 @@ export const fetchLlmQueryCandidates = async (
   const { object } = await deps.generateObjectForQueries({
     model: openai(params.model),
     schema: llmQueriesOutputSchema,
-    maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
     messages: params.messages,
   });
   return (object.queries ?? [])
@@ -484,7 +477,6 @@ export const fetchWildcardCandidates = async (
   const { object } = await deps.generateObjectForWildcards({
     model: openai(params.model),
     schema: llmWildcardOutputSchema,
-    maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
     messages: [
       { role: "system", content: systemContent },
       { role: "user", content: userContent },
@@ -698,7 +690,6 @@ export const critiqueQueryCandidates = async (
   const { object } = await deps.generateObjectForCritique({
     model: openai(params.model),
     schema: llmCritiqueOutputSchema,
-    maxOutputTokens: QUERY_ANALYSIS_MAX_OUTPUT_TOKENS,
     messages: [
       {
         role: "system",


### PR DESCRIPTION
## Summary

Removes `maxOutputTokens` from all LLM calls across article-analysis, content-generation, and query-analysis. With no cap sent, the AI SDK omits `max_tokens`/`max_completion_tokens` and completions run to the model's own output maximum. Also removes all reasoning-effort config knobs and `buildOpenAiReasoningProviderOptions`/`providerOptions` plumbing from article-analysis and content-generation.

The direct bug fix: the article-analysis brainstorm prompt asks for four sections of 4-7 bullets each (roughly 1,678 output tokens against an 800-token cap), so it was silently truncating with `finishReason: "length"` and getting classified as the model not answering.

## Related issues

Closes #776

## Important changes

- **article-analysis:** `maxOutputTokens` (24576), `extractionMaxOutputTokens`, and `brainstormMaxOutputTokens` (800) removed from config and resolution. `maxOutputTokens` and `providerOptions` stripped from all `llm-extract-entities` call-arg types and SDK calls. All `buildOpenAiReasoningProviderOptions` calls removed from `run-process-one-source`.
- **content-generation:** `brainstorm.maxOutputTokens` (700) and all per-pass `reasoningEffort` config fields removed. `maxOutputTokens` and `providerOptions` stripped from `llm-generate-newsletter` calls. `reasoningEffort` snapshot block removed from `run.ts`.
- **query-analysis:** `QUERY_ANALYSIS_MAX_OUTPUT_TOKENS` (800) deleted; `maxOutputTokens` removed from four `generateObject` call sites and three call-arg types. (Reasoning effort was already removed by the plan 136 merge.)

`@workspace/agent-runtime` reasoning exports are left in place.

## Other changes

- Removed `CRITIQUE_TOKENS_BASE_OVERHEAD`/`CRITIQUE_TOKENS_PER_CANDIDATE` constants from content-generation that only fed the removed critique token cap
- Removed `critiqueMaxOutputTokens` config field from `selfCritiqueSchema`

## Key files to review

- [apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts](apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts) — `buildOpenAiReasoningProviderOptions` calls gone
- [apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts](apps/mediapulse/agents/article-analysis/src/llm-extract-entities.ts) — `maxOutputTokens` + `providerOptions` stripped from types and calls
- [apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts](apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts) — output caps and providerOptions removed

## How to test

1. `pnpm --filter @mediapulse/article-analysis test` — 267 tests pass
2. `pnpm --filter @mediapulse/content-generation test` — 435 tests pass
3. `pnpm --filter @mediapulse/query-analysis test` — 165 tests pass
4. `pnpm code-quality` — clean
