### PR TITLE
Group article-analysis config into named sub-schemas with inline defaults

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -2,7 +2,6 @@
 
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
 import { describe, expect, it } from "vitest";
-import { zodToJsonSchema } from "zod-to-json-schema";
 
 import {
   buildDraftRelevanceRow,
@@ -10,13 +9,11 @@ import {
 } from "./analysis-relevance-scoring.js";
 import {
   articleAnalysisConfigSchema,
-  articleAnalysisConfigDefaults,
-  resolveArticleAnalysisConfig,
   toRelevanceWeightMapV1,
 } from "./config-schema.js";
 
 const minimalConfig = {
-  openaiApiKey: "sk-test",
+  credentials: { openaiApiKey: "sk-test" },
 } satisfies Parameters<typeof articleAnalysisConfigSchema.parse>[0];
 
 const minimalSignals = {
@@ -32,7 +29,7 @@ const minimalSignals = {
 } satisfies PerSourceRelevanceSignals;
 
 describe("articleAnalysisConfigSchema", () => {
-  it("rejects prompts block under strict mode", () => {
+  it("rejects unknown keys under strict mode", () => {
     const result = articleAnalysisConfigSchema.safeParse({
       ...minimalConfig,
       prompts: {
@@ -46,21 +43,23 @@ describe("articleAnalysisConfigSchema", () => {
     }
   });
 
-  it("parses optional debounce and batch fields", () => {
-    // Act
+  it("parses optional dynamics and batch fields", () => {
     const parsed = articleAnalysisConfigSchema.parse({
       ...minimalConfig,
-      debounceMinUnanalyzedCount: 3,
-      debounceMinMinutesSinceLastScore: 15,
-      maxBatchSize: 20,
-      analysisGetDataSourceLimitMax: 8,
+      dynamics: {
+        debounceMinUnanalyzedCount: 3,
+        debounceMinMinutesSinceLastScore: 15,
+      },
+      batch: {
+        maxSources: 20,
+        getDataSourceLimitMax: 8,
+      },
     });
 
-    // Assert
-    expect(parsed.debounceMinUnanalyzedCount).toBe(3);
-    expect(parsed.debounceMinMinutesSinceLastScore).toBe(15);
-    expect(parsed.maxBatchSize).toBe(20);
-    expect(parsed.analysisGetDataSourceLimitMax).toBe(8);
+    expect(parsed.dynamics.debounceMinUnanalyzedCount).toBe(3);
+    expect(parsed.dynamics.debounceMinMinutesSinceLastScore).toBe(15);
+    expect(parsed.batch.maxSources).toBe(20);
+    expect(parsed.batch.getDataSourceLimitMax).toBe(8);
   });
 
   it("rejects legacy defaultMaxBatchSize key under strict mode", () => {
@@ -74,103 +73,79 @@ describe("articleAnalysisConfigSchema", () => {
       expect(result.error.issues[0]?.message).toMatch(/unrecognized/i);
     }
   });
-});
 
-describe("resolveArticleAnalysisConfig", () => {
-  it("fills debounce defaults of zero when Hermes omits them", () => {
-    // Act
-    const resolved = resolveArticleAnalysisConfig(
-      articleAnalysisConfigSchema.parse(minimalConfig),
-    );
+  it("fills schema defaults when Hermes omits optional groups", () => {
+    const config = articleAnalysisConfigSchema.parse(minimalConfig);
 
-    // Assert
-    expect(resolved.debounceMinUnanalyzedCount).toBe(0);
-    expect(resolved.debounceMinMinutesSinceLastScore).toBe(0);
-    expect(resolved.maxBatchSize).toBe(
-      articleAnalysisConfigDefaults.maxBatchSize,
+    expect(config.dynamics.debounceMinUnanalyzedCount).toBe(0);
+    expect(config.dynamics.debounceMinMinutesSinceLastScore).toBe(0);
+    expect(config.batch.maxSources).toBe(10);
+    expect(config.batch.getDataSourceLimitMax).toBe(
+      ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX,
     );
-    expect(resolved.analysisGetDataSourceLimitMax).toBe(
-      articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,
-    );
-    expect(resolved.useStructureAwareTruncation).toBe(false);
-    expect(resolved.truncationLeadParagraphsAlwaysKept).toBe(2);
-    expect(resolved.truncationFinancialKeywordsExtra).toEqual([]);
-    expect(resolved.fewShotExemplarCount).toBe(0);
-    expect(resolved.useBrainstormPass).toBe(false);
-    expect(resolved.brainstormModel).toBe(
-      articleAnalysisConfigDefaults.openaiModel,
-    );
-    expect(resolved.extractionConcurrency).toBe(1);
-    expect(resolved.runDeadlineMs).toBeUndefined();
-    expect(resolved.entityGroundingPolicy).toBe("off");
-    expect(resolved.entityGroundingMinTitleHits).toBe(0);
+    expect(config.extraction.useStructureAwareTruncation).toBe(false);
+    expect(config.extraction.truncationLeadParagraphsAlwaysKept).toBe(2);
+    expect(config.extraction.truncationFinancialKeywordsExtra).toEqual([]);
+    expect(config.extraction.fewShotExemplarCount).toBe(0);
+    expect(config.extraction.useBrainstormPass).toBe(false);
+    expect(config.extraction.concurrency).toBe(1);
+    expect(config.dynamics.runDeadlineMs).toBeUndefined();
+    expect(config.quality.groundingPolicy).toBe("off");
+    expect(config.quality.groundingMinTitleHits).toBe(0);
+    expect(config.credentials.openaiModel).toBe("gpt-4o-mini");
   });
 
-  it("preserves Hermes debounce and maxBatchSize overrides", () => {
-    // Act
-    const resolved = resolveArticleAnalysisConfig(
-      articleAnalysisConfigSchema.parse({
-        ...minimalConfig,
+  it("preserves Hermes dynamics and batch overrides", () => {
+    const config = articleAnalysisConfigSchema.parse({
+      ...minimalConfig,
+      dynamics: {
         debounceMinUnanalyzedCount: 5,
         debounceMinMinutesSinceLastScore: 30,
-        maxBatchSize: 12,
-      }),
-    );
+      },
+      batch: { maxSources: 12 },
+    });
 
-    // Assert
-    expect(resolved.debounceMinUnanalyzedCount).toBe(5);
-    expect(resolved.debounceMinMinutesSinceLastScore).toBe(30);
-    expect(resolved.maxBatchSize).toBe(12);
+    expect(config.dynamics.debounceMinUnanalyzedCount).toBe(5);
+    expect(config.dynamics.debounceMinMinutesSinceLastScore).toBe(30);
+    expect(config.batch.maxSources).toBe(12);
   });
 
-  it("preserves analysisGetDataSourceLimitMax override from Hermes", () => {
-    const resolved = resolveArticleAnalysisConfig(
-      articleAnalysisConfigSchema.parse({
-        ...minimalConfig,
-        analysisGetDataSourceLimitMax: 9,
-      }),
-    );
+  it("preserves batch.getDataSourceLimitMax override from Hermes", () => {
+    const config = articleAnalysisConfigSchema.parse({
+      ...minimalConfig,
+      batch: { getDataSourceLimitMax: 9 },
+    });
 
-    expect(resolved.analysisGetDataSourceLimitMax).toBe(9);
+    expect(config.batch.getDataSourceLimitMax).toBe(9);
   });
 
-  it("rejects analysisGetDataSourceLimitMax above API hard cap", () => {
+  it("rejects batch.getDataSourceLimitMax above API hard cap", () => {
     const result = articleAnalysisConfigSchema.safeParse({
       ...minimalConfig,
-      analysisGetDataSourceLimitMax: ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX + 1,
+      batch: { getDataSourceLimitMax: ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX + 1 },
     });
 
     expect(result.success).toBe(false);
   });
 
-  it("maps scoreBreakdownVersion to resolved config used for POST breakdown", () => {
-    // Act
-    const resolved = resolveArticleAnalysisConfig(
-      articleAnalysisConfigSchema.parse({
-        ...minimalConfig,
-        scoreBreakdownVersion: 7,
-      }),
-    );
+  it("maps scoring.breakdownVersion to the version stored in POST breakdown", () => {
+    const config = articleAnalysisConfigSchema.parse({
+      ...minimalConfig,
+      scoring: { breakdownVersion: 7 },
+    });
     const row = buildDraftRelevanceRow(
       minimalSignals,
-      resolved.scoreBreakdownVersion,
-      toRelevanceWeightMapV1(resolved),
+      config.scoring.breakdownVersion,
+      toRelevanceWeightMapV1(config),
     );
 
-    // Assert
-    expect(resolved.scoreBreakdownVersion).toBe(7);
+    expect(config.scoring.breakdownVersion).toBe(7);
     expect(row.scoreBreakdown._version).toBe(7);
   });
 
-  it("uses package default scoreBreakdownVersion when Hermes omits it", () => {
-    // Act
-    const resolved = resolveArticleAnalysisConfig(
-      articleAnalysisConfigSchema.parse(minimalConfig),
-    );
+  it("uses default breakdownVersion when Hermes omits scoring", () => {
+    const config = articleAnalysisConfigSchema.parse(minimalConfig);
 
-    // Assert
-    expect(resolved.scoreBreakdownVersion).toBe(
-      articleAnalysisConfigDefaults.scoreBreakdownVersion,
-    );
+    expect(config.scoring.breakdownVersion).toBe(1);
   });
 });

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -1,8 +1,7 @@
 import { ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX } from "@workspace/agent-data-api-contract";
-import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
-import type { ArticleAnalysisRunPolicy } from "./article-analysis-run-policy.js";
-import type { ExtractionExemplarArchetype } from "./exemplars/default-extraction-exemplars.js";
 import { z } from "zod";
+
+import type { RelevanceWeightMapV1 } from "./analysis-relevance-scoring.js";
 
 const extractionExemplarArchetypeSchema = z.enum([
   "earnings",
@@ -11,492 +10,502 @@ const extractionExemplarArchetypeSchema = z.enum([
   "product",
 ]);
 
-const articleAnalysisRunPolicySchema = z.object({
-  minSuccessfulSources: z.number().int().nonnegative().optional(),
-  failOnZeroSuccess: z.boolean().optional(),
-});
-
-/**
- * Hermes agent config for article-analysis (extraction, caps, chunking, relevance, debounce).
- * Operational defaults are filled by {@link resolveArticleAnalysisConfig}.
- */
-export const articleAnalysisConfigSchema = z
+const credentialsSchema = z
   .object({
-    verbose: z.boolean().optional(),
-    /** OpenAI-compatible API key for structured extraction. */
-    openaiApiKey: z.string().min(1),
-    /** Chat model id (e.g. `gpt-4o-mini`). */
-    openaiModel: z.string().min(1).optional(),
-    /** Truncate article text in the LLM user message (full text remains in DB). */
-    maxContentChars: z.number().int().positive().optional(),
-    /** When true, use structure-aware paragraph truncation instead of naive slice. */
-    useStructureAwareTruncation: z.boolean().optional(),
-    /** Lead paragraphs always kept before score-ranked allocation. */
+    openaiApiKey: z
+      .string()
+      .min(1)
+      .describe("OpenAI-compatible API key for structured extraction."),
+    openaiModel: z
+      .string()
+      .min(1)
+      .default("gpt-4o-mini")
+      .describe("Chat model id (e.g. gpt-4o-mini)."),
+  })
+  .describe("OpenAI credentials for structured extraction.");
+
+const extractionSchema = z
+  .object({
+    maxContentChars: z
+      .number()
+      .int()
+      .positive()
+      .default(12_000)
+      .describe(
+        "Truncate article text in the LLM user message (full text remains in DB).",
+      ),
+    useStructureAwareTruncation: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, use structure-aware paragraph truncation instead of naive slice.",
+      ),
     truncationLeadParagraphsAlwaysKept: z
       .number()
       .int()
       .min(0)
       .max(8)
-      .optional(),
-    /** Operator-extensible financial keywords for truncation scoring. */
-    truncationFinancialKeywordsExtra: z.array(z.string()).optional(),
-    /** Number of few-shot extraction exemplars to inject (0 disables). */
-    fewShotExemplarCount: z.number().int().min(0).max(4).optional(),
-    /** When set, only these archetypes are eligible for few-shot selection. */
+      .default(2)
+      .describe("Lead paragraphs always kept before score-ranked allocation."),
+    truncationFinancialKeywordsExtra: z
+      .array(z.string())
+      .default([])
+      .describe(
+        "Operator-extensible financial keywords for truncation scoring.",
+      ),
+    fewShotExemplarCount: z
+      .number()
+      .int()
+      .min(0)
+      .max(4)
+      .default(0)
+      .describe(
+        "Number of few-shot extraction exemplars to inject (0 disables).",
+      ),
     fewShotExemplarArchetypes: z
       .array(extractionExemplarArchetypeSchema)
-      .optional(),
-    /** When true, run a free-form brainstorm pass before structured extraction. */
-    useBrainstormPass: z.boolean().optional(),
-    /** Chat model for the brainstorm pass (defaults to `openaiModel`). */
-    brainstormModel: z.string().min(1).optional(),
-    /** Max concurrent per-source extractions (1 = sequential; opt-in parallelism). */
-    extractionConcurrency: z.number().int().min(1).max(16).optional(),
-    /** Wall-clock budget in ms from run start; skips undispatched sources and late brainstorm/critique. */
-    runDeadlineMs: z.number().int().positive().optional(),
-    /** When true, run a second LLM pass to critique and prune noisy relation triples. */
-    useRelationSelfCritique: z.boolean().optional(),
-    /** Max fraction of relations per source that critique may drop (hard cap). */
-    relationCritiqueDropFraction: z.number().min(0).max(0.5).optional(),
-    /** Skip critique when a source has fewer relations than this threshold. */
-    relationCritiqueMinRelationCount: z.number().int().nonnegative().optional(),
-    /** Chat model for relation critique (defaults to `openaiModel`). */
-    relationCritiqueModel: z.string().min(1).optional(),
-    /**
-     * How to handle vocabulary-invalid extraction rows.
-     * `strict` skips the whole source (legacy). `partition` drops bad rows. `repair` partitions then re-labels bad rows once.
-     */
-    vocabularyPolicy: z.enum(["strict", "partition", "repair"]).optional(),
-    /** Chat model for vocabulary repair (defaults to `openaiModel`). */
-    vocabularyRepairModel: z.string().min(1).optional(),
-    /** Skip repair when rejected row count exceeds this cap (likely systemic vocabulary drift). */
-    vocabularyRepairMaxItems: z.number().int().positive().optional(),
-    /** Post-extraction grounding policy for hallucinated entities. */
-    entityGroundingPolicy: z.enum(["drop", "flag", "off"]).optional(),
-    /** When greater than zero, entity must appear in the title to count as grounded. */
-    entityGroundingMinTitleHits: z.number().int().nonnegative().optional(),
-    maxEntitiesPerArticle: z.number().int().positive().optional(),
-    maxRelationsPerArticle: z.number().int().positive().optional(),
-    maxEntitiesPerRun: z.number().int().positive().optional(),
-    maxRelationsPerRun: z.number().int().positive().optional(),
-    /** Max relations per POST chunk (FR9); entity closure is added per chunk. */
-    postChunkRelationBatchSize: z.number().int().positive().optional(),
-    /** Max `articleEntities` rows per source after LLM extract (before run merge). */
-    maxArticleEntitiesPerArticle: z.number().int().positive().optional(),
-    /** Max `articleEntities` rows for the run after dedupe (before POST). */
-    maxArticleEntitiesPerRun: z.number().int().positive().optional(),
-    /** Max `articleEntities` rows per POST chunk. */
-    postChunkArticleEntityBatchSize: z.number().int().positive().optional(),
-    /** Stored in `scoreBreakdown._version` (must match Hermes when bumping breakdown schema). */
-    scoreBreakdownVersion: z.number().int().min(1).optional(),
-    relevanceWeightBreakingNews: z.number().nonnegative().optional(),
-    relevanceWeightKgRelation: z.number().nonnegative().optional(),
-    relevanceWeightFundamental: z.number().nonnegative().optional(),
-    relevanceWeightTickerSalience: z.number().nonnegative().optional(),
-    relevanceWeightSourceQuality: z.number().nonnegative().optional(),
-    /** When true, compute real `sourceQuality` from host tier, recency, and structural cues. */
-    useSourceQualityV2: z.boolean().optional(),
-    /** Recency half-life (hours) for source-quality exponential decay. */
-    sourceQualityRecencyHalfLifeHours: z.number().positive().optional(),
-    /** Replaces default tier-1 host suffix list when set. */
-    sourceQualityHostTier1: z.array(z.string()).optional(),
-    /** Replaces default tier-2 host suffix list when set. */
-    sourceQualityHostTier2: z.array(z.string()).optional(),
-    /** Replaces default tier-3 host suffix list when set. */
-    sourceQualityHostTier3: z.array(z.string()).optional(),
-    /** When true, diversify `selected` rows by entity/title event clusters. */
-    useSelectionDiversification: z.boolean().optional(),
-    /** Jaccard threshold for merging rows by shared entity names (default 0.5). */
-    selectionEntityOverlapThreshold: z.number().min(0).max(1).optional(),
-    /** Jaccard threshold for merging rows by title 4-gram overlap (default 0.4). */
-    selectionTitleSimilarityThreshold: z.number().min(0).max(1).optional(),
-    /** Minimum score to be eligible for `selected: true`. */
-    relevanceMinScore: z.number().min(0).max(1).optional(),
-    /** Cap on additional `selected` rows per UTC day (budget minus GET `selectedCountToday`). */
-    maxSelectedRelevancePerTickerPerDay: z
+      .optional()
+      .describe(
+        "When set, only these archetypes are eligible for few-shot selection.",
+      ),
+    useBrainstormPass: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, run a free-form brainstorm pass before structured extraction.",
+      ),
+    brainstormModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for the brainstorm pass. If omitted, uses credentials.openaiModel.",
+      ),
+    concurrency: z
+      .number()
+      .int()
+      .min(1)
+      .max(16)
+      .default(1)
+      .describe(
+        "Max concurrent per-source extractions (1 = sequential; opt-in parallelism).",
+      ),
+    transientRetries: z
+      .number()
+      .int()
+      .min(0)
+      .max(5)
+      .default(2)
+      .describe(
+        "Retries after the first LLM extraction attempt when a transient error is classified. 0 disables retries.",
+      ),
+    transientRetryBaseDelayMs: z
+      .number()
+      .int()
+      .positive()
+      .default(500)
+      .describe(
+        "Initial backoff in ms for extraction retries (full-jitter exponential).",
+      ),
+    transientRetryMaxDelayMs: z
+      .number()
+      .int()
+      .positive()
+      .default(8_000)
+      .describe("Cap on jittered backoff in ms for extraction retries."),
+    callTimeoutMs: z
+      .number()
+      .int()
+      .positive()
+      .default(60_000)
+      .describe(
+        "Per-call wall-clock timeout in ms applied to each generateObject/generateText attempt. A stuck call aborts after this interval and is retried.",
+      ),
+  })
+  .default({})
+  .describe("LLM extraction settings.");
+
+const qualitySchema = z
+  .object({
+    useRelationSelfCritique: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, run a second LLM pass to critique and prune noisy relation triples.",
+      ),
+    critiqueDropFraction: z
+      .number()
+      .min(0)
+      .max(0.5)
+      .default(0.25)
+      .describe(
+        "Max fraction of relations per source that critique may drop (hard cap).",
+      ),
+    critiqueMinRelationCount: z
       .number()
       .int()
       .nonnegative()
-      .optional(),
-    /** Max `articleRelevances` rows per POST chunk. */
-    postChunkArticleRelevanceBatchSize: z.number().int().positive().optional(),
-    /**
-     * When `failOnZeroSuccess` is true, require at least this many sources to complete extraction
-     * (LLM + vocabulary) before POST (MP-ART-ANALYSIS-007).
-     */
-    runPolicy: articleAnalysisRunPolicySchema.optional(),
-    /**
-     * Retries after the first attempt for `analysis.create` when the API returns 429 or 5xx.
-     */
-    postTransientRetries: z.number().int().nonnegative().optional(),
-    /** Initial backoff in ms; delay doubles each retry (`base * 2^attempt`). */
-    postTransientRetryBaseDelayMs: z.number().int().positive().optional(),
-    /**
-     * Retries after the first LLM extraction attempt when a transient error is classified
-     * (rate limit, empty completion, timeout, 5xx). 0 disables retries.
-     */
-    extractionTransientRetries: z.number().int().min(0).max(5).optional(),
-    /** Initial backoff in ms for extraction retries (full-jitter exponential). */
-    extractionTransientRetryBaseDelayMs: z.number().int().positive().optional(),
-    /** Cap on jittered backoff in ms for extraction retries. */
-    extractionTransientRetryMaxDelayMs: z.number().int().positive().optional(),
-    /**
-     * Per-call wall-clock timeout in ms applied to each `generateObject`/`generateText` attempt
-     * (extraction, brainstorm, critique, repair). A stuck call aborts after this interval and is
-     * retried by `executeLlmCallWithTransientRetries`. Default is generous — this is a hung-call
-     * backstop, not a latency SLA.
-     */
-    extractionCallTimeoutMs: z.number().int().positive().optional(),
-    /**
-     * Cap on data sources loaded and processed per run
-     * (also bounds `analysis.get` `limit` together with `analysisGetDataSourceLimitMax`).
-     * Override in Hermes agent config; package default applies when omitted.
-     */
-    maxBatchSize: z.number().int().positive().optional(),
-    /**
-     * Max `analysis.get` `limit` (must not exceed `ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX` from `@workspace/agent-data-api-contract`).
-     * Actual limit is `min(maxBatchSize, analysisGetDataSourceLimitMax)`. Set in Hermes agent config JSON.
-     */
-    analysisGetDataSourceLimitMax: z
+      .default(3)
+      .describe(
+        "Skip critique when a source has fewer relations than this threshold.",
+      ),
+    critiqueModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for relation critique. If omitted, uses credentials.openaiModel.",
+      ),
+    vocabularyPolicy: z
+      .enum(["strict", "partition", "repair"])
+      .default("strict")
+      .describe(
+        "How to handle vocabulary-invalid extraction rows. `strict` skips the whole source (legacy). `partition` drops bad rows. `repair` partitions then re-labels bad rows once.",
+      ),
+    repairModel: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for vocabulary repair. If omitted, uses credentials.openaiModel.",
+      ),
+    repairMaxItems: z
+      .number()
+      .int()
+      .positive()
+      .default(20)
+      .describe(
+        "Skip repair when rejected row count exceeds this cap (likely systemic vocabulary drift).",
+      ),
+    groundingPolicy: z
+      .enum(["drop", "flag", "off"])
+      .default("off")
+      .describe("Post-extraction grounding policy for hallucinated entities."),
+    groundingMinTitleHits: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(0)
+      .describe(
+        "When greater than zero, entity must appear in the title to count as grounded.",
+      ),
+  })
+  .default({})
+  .describe(
+    "Post-extraction quality passes: relation critique, vocabulary repair, and entity grounding.",
+  );
+
+const limitsSchema = z
+  .object({
+    entitiesPerArticle: z
+      .number()
+      .int()
+      .positive()
+      .default(20)
+      .describe("Max entities extracted per source."),
+    relationsPerArticle: z
+      .number()
+      .int()
+      .positive()
+      .default(20)
+      .describe("Max relations extracted per source."),
+    entitiesPerRun: z
+      .number()
+      .int()
+      .positive()
+      .default(200)
+      .describe("Max entities accumulated across the run."),
+    relationsPerRun: z
+      .number()
+      .int()
+      .positive()
+      .default(200)
+      .describe("Max relations accumulated across the run."),
+    articleEntitiesPerArticle: z
+      .number()
+      .int()
+      .positive()
+      .default(30)
+      .describe(
+        "Max articleEntities rows per source after LLM extract (before run merge).",
+      ),
+    articleEntitiesPerRun: z
+      .number()
+      .int()
+      .positive()
+      .default(500)
+      .describe(
+        "Max articleEntities rows for the run after dedupe (before POST).",
+      ),
+  })
+  .default({})
+  .describe("Entity and relation output caps per article and per run.");
+
+const postingSchema = z
+  .object({
+    chunkRelationBatchSize: z
+      .number()
+      .int()
+      .positive()
+      .default(25)
+      .describe(
+        "Max relations per POST chunk (FR9); entity closure is added per chunk.",
+      ),
+    chunkArticleEntityBatchSize: z
+      .number()
+      .int()
+      .positive()
+      .default(50)
+      .describe("Max articleEntities rows per POST chunk."),
+    chunkArticleRelevanceBatchSize: z
+      .number()
+      .int()
+      .positive()
+      .default(40)
+      .describe("Max articleRelevances rows per POST chunk."),
+    transientRetries: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(0)
+      .describe(
+        "Retries after the first attempt for analysis.create when the API returns 429 or 5xx.",
+      ),
+    transientRetryBaseDelayMs: z
+      .number()
+      .int()
+      .positive()
+      .default(500)
+      .describe(
+        "Initial backoff in ms; delay doubles each retry (base * 2^attempt).",
+      ),
+  })
+  .default({})
+  .describe("Chunked POST settings and retry policy.");
+
+const scoringSchema = z
+  .object({
+    breakdownVersion: z
+      .number()
+      .int()
+      .min(1)
+      .default(1)
+      .describe(
+        "Stored in scoreBreakdown._version (must match Hermes when bumping breakdown schema).",
+      ),
+    weightBreakingNews: z
+      .number()
+      .nonnegative()
+      .default(0.2)
+      .describe("Relevance weight for breaking-news signal."),
+    weightKgRelation: z
+      .number()
+      .nonnegative()
+      .default(0.3)
+      .describe("Relevance weight for KG relation signal."),
+    weightFundamental: z
+      .number()
+      .nonnegative()
+      .default(0.05)
+      .describe("Relevance weight for fundamental signal."),
+    weightTickerSalience: z
+      .number()
+      .nonnegative()
+      .default(0.2)
+      .describe("Relevance weight for ticker-salience signal."),
+    weightSourceQuality: z
+      .number()
+      .nonnegative()
+      .default(0.25)
+      .describe("Relevance weight for source-quality signal."),
+    useSourceQualityV2: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, compute real sourceQuality from host tier, recency, and structural cues.",
+      ),
+    sourceQualityRecencyHalfLifeHours: z
+      .number()
+      .positive()
+      .default(72)
+      .describe(
+        "Recency half-life (hours) for source-quality exponential decay.",
+      ),
+    hostTier1: z
+      .array(z.string())
+      .optional()
+      .describe("Replaces default tier-1 host suffix list when set."),
+    hostTier2: z
+      .array(z.string())
+      .optional()
+      .describe("Replaces default tier-2 host suffix list when set."),
+    hostTier3: z
+      .array(z.string())
+      .optional()
+      .describe("Replaces default tier-3 host suffix list when set."),
+  })
+  .default({})
+  .describe("Relevance scoring weights and source quality settings.");
+
+const selectionSchema = z
+  .object({
+    useDiversification: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, diversify selected rows by entity/title event clusters.",
+      ),
+    entityOverlapThreshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.5)
+      .describe(
+        "Jaccard threshold for merging rows by shared entity names (default 0.5).",
+      ),
+    titleSimilarityThreshold: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.4)
+      .describe(
+        "Jaccard threshold for merging rows by title 4-gram overlap (default 0.4).",
+      ),
+    minScore: z
+      .number()
+      .min(0)
+      .max(1)
+      .default(0.35)
+      .describe("Minimum score to be eligible for selected: true."),
+    maxPerTickerPerDay: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(10)
+      .describe(
+        "Cap on additional selected rows per UTC day (budget minus GET selectedCountToday).",
+      ),
+  })
+  .default({})
+  .describe("Article selection criteria for relevance scoring.");
+
+const batchSchema = z
+  .object({
+    maxSources: z
+      .number()
+      .int()
+      .positive()
+      .default(10)
+      .describe(
+        "Cap on data sources loaded and processed per run. Override in Hermes agent config.",
+      ),
+    getDataSourceLimitMax: z
       .number()
       .int()
       .positive()
       .max(ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX)
-      .optional(),
-    /**
-     * When greater than zero, skip the run (success no-op) if GET returns fewer unanalyzed sources than this threshold.
-     */
-    debounceMinUnanalyzedCount: z.number().int().nonnegative().optional(),
-    /**
-     * When greater than zero, skip the run (success no-op) if any relevance was scored for this ticker within the last N minutes (requires GET `lastRelevanceScoredAtIso`).
-     */
-    debounceMinMinutesSinceLastScore: z.number().int().nonnegative().optional(),
-    /**
-     * Operator-supplied yield P50 baselines for regression warnings (not auto-computed from history).
-     */
+      .default(ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX)
+      .describe(
+        "Max analysis.get limit. Actual limit is min(maxSources, getDataSourceLimitMax). Set in Hermes agent config JSON.",
+      ),
+  })
+  .default({})
+  .describe("Batch size controls.");
+
+const runPolicySchema = z
+  .object({
+    minSuccessfulSources: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(1)
+      .describe("Minimum sources to complete extraction before POST."),
+    failOnZeroSuccess: z
+      .boolean()
+      .default(true)
+      .describe(
+        "When true, require at least minSuccessfulSources to complete before POST (MP-ART-ANALYSIS-007).",
+      ),
+  })
+  .default({})
+  .describe("Run success criteria applied after extraction.");
+
+const dynamicsSchema = z
+  .object({
+    runDeadlineMs: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe(
+        "Wall-clock budget in ms from run start; skips undispatched sources and late brainstorm/critique.",
+      ),
+    debounceMinUnanalyzedCount: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(0)
+      .describe(
+        "When greater than zero, skip the run (success no-op) if GET returns fewer unanalyzed sources than this threshold.",
+      ),
+    debounceMinMinutesSinceLastScore: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(0)
+      .describe(
+        "When greater than zero, skip the run if any relevance was scored for this ticker within the last N minutes (requires GET lastRelevanceScoredAtIso).",
+      ),
+    runPolicy: runPolicySchema,
+  })
+  .default({})
+  .describe("Run timing, debounce, and success criteria.");
+
+/**
+ * Hermes agent config for article-analysis (extraction, caps, chunking, relevance, debounce).
+ * All defaults are applied inline; Zod output is the fully resolved config type.
+ */
+export const articleAnalysisConfigSchema = z
+  .object({
+    verbose: z.boolean().optional(),
+    credentials: credentialsSchema,
+    extraction: extractionSchema,
+    quality: qualitySchema,
+    limits: limitsSchema,
+    posting: postingSchema,
+    scoring: scoringSchema,
+    selection: selectionSchema,
+    batch: batchSchema,
+    dynamics: dynamicsSchema,
     yieldBaseline: z
       .object({
         extractionYieldP50: z.number().min(0).max(1).optional(),
         groundingYieldP50: z.number().min(0).max(1).optional(),
         vocabularyYieldP50: z.number().min(0).max(1).optional(),
       })
-      .optional(),
+      .optional()
+      .describe(
+        "Operator-supplied yield P50 baselines for regression warnings (not auto-computed from history).",
+      ),
   })
   .strict();
 
-export type ArticleAnalysisConfig = z.infer<typeof articleAnalysisConfigSchema>;
-
-/** Config with optional fields filled from {@link articleAnalysisConfigDefaults}. */
-export type ResolvedArticleAnalysisConfig = ArticleAnalysisConfig & {
-  openaiModel: string;
-  maxContentChars: number;
-  useStructureAwareTruncation: boolean;
-  truncationLeadParagraphsAlwaysKept: number;
-  truncationFinancialKeywordsExtra: string[];
-  fewShotExemplarCount: number;
-  fewShotExemplarArchetypes?: ExtractionExemplarArchetype[];
-  useBrainstormPass: boolean;
-  brainstormModel: string;
-  extractionConcurrency: number;
-  runDeadlineMs?: number;
-  useRelationSelfCritique: boolean;
-  relationCritiqueDropFraction: number;
-  relationCritiqueMinRelationCount: number;
-  relationCritiqueModel: string;
-  vocabularyPolicy: "strict" | "partition" | "repair";
-  vocabularyRepairModel: string;
-  vocabularyRepairMaxItems: number;
-  entityGroundingPolicy: "drop" | "flag" | "off";
-  entityGroundingMinTitleHits: number;
-  maxEntitiesPerArticle: number;
-  maxRelationsPerArticle: number;
-  maxEntitiesPerRun: number;
-  maxRelationsPerRun: number;
-  postChunkRelationBatchSize: number;
-  maxArticleEntitiesPerArticle: number;
-  maxArticleEntitiesPerRun: number;
-  postChunkArticleEntityBatchSize: number;
-  scoreBreakdownVersion: number;
-  relevanceWeightBreakingNews: number;
-  relevanceWeightKgRelation: number;
-  relevanceWeightFundamental: number;
-  relevanceWeightTickerSalience: number;
-  relevanceWeightSourceQuality: number;
-  useSourceQualityV2: boolean;
-  sourceQualityRecencyHalfLifeHours: number;
-  sourceQualityHostTier1?: string[];
-  sourceQualityHostTier2?: string[];
-  sourceQualityHostTier3?: string[];
-  useSelectionDiversification: boolean;
-  selectionEntityOverlapThreshold: number;
-  selectionTitleSimilarityThreshold: number;
-  relevanceMinScore: number;
-  maxSelectedRelevancePerTickerPerDay: number;
-  postChunkArticleRelevanceBatchSize: number;
-  runPolicy: ArticleAnalysisRunPolicy;
-  postTransientRetries: number;
-  postTransientRetryBaseDelayMs: number;
-  extractionTransientRetries: number;
-  extractionTransientRetryBaseDelayMs: number;
-  extractionTransientRetryMaxDelayMs: number;
-  extractionCallTimeoutMs: number;
-  debounceMinUnanalyzedCount: number;
-  debounceMinMinutesSinceLastScore: number;
-  /** Cap on sources per run (Hermes agent config). */
-  maxBatchSize: number;
-  /** Upper bound for `analysis.get` `limit` (see `analysisGetDataSourceLimitMax` on Hermes config). */
-  analysisGetDataSourceLimitMax: number;
-};
-
-/** Production-oriented defaults merged onto parsed Hermes config. */
-export const articleAnalysisConfigDefaults = {
-  openaiModel: "gpt-4o-mini",
-  maxContentChars: 12_000,
-  useStructureAwareTruncation: false,
-  truncationLeadParagraphsAlwaysKept: 2,
-  truncationFinancialKeywordsExtra: [],
-  fewShotExemplarCount: 0,
-  useBrainstormPass: false,
-  extractionConcurrency: 1,
-  useRelationSelfCritique: false,
-  relationCritiqueDropFraction: 0.25,
-  relationCritiqueMinRelationCount: 3,
-  vocabularyPolicy: "strict",
-  vocabularyRepairMaxItems: 20,
-  entityGroundingPolicy: "off",
-  entityGroundingMinTitleHits: 0,
-  maxEntitiesPerArticle: 20,
-  maxRelationsPerArticle: 20,
-  maxEntitiesPerRun: 200,
-  maxRelationsPerRun: 200,
-  postChunkRelationBatchSize: 25,
-  maxArticleEntitiesPerArticle: 30,
-  maxArticleEntitiesPerRun: 500,
-  postChunkArticleEntityBatchSize: 50,
-  scoreBreakdownVersion: 1,
-  relevanceWeightBreakingNews: 0.2,
-  relevanceWeightKgRelation: 0.3,
-  relevanceWeightFundamental: 0.05,
-  relevanceWeightTickerSalience: 0.2,
-  relevanceWeightSourceQuality: 0.25,
-  useSourceQualityV2: false,
-  sourceQualityRecencyHalfLifeHours: 72,
-  useSelectionDiversification: false,
-  selectionEntityOverlapThreshold: 0.5,
-  selectionTitleSimilarityThreshold: 0.4,
-  relevanceMinScore: 0.35,
-  maxSelectedRelevancePerTickerPerDay: 10,
-  postChunkArticleRelevanceBatchSize: 40,
-  runPolicy: {
-    minSuccessfulSources: 1,
-    failOnZeroSuccess: true,
-  },
-  postTransientRetries: 0,
-  postTransientRetryBaseDelayMs: 500,
-  extractionTransientRetries: 2,
-  extractionTransientRetryBaseDelayMs: 500,
-  extractionTransientRetryMaxDelayMs: 8000,
-  extractionCallTimeoutMs: 60_000,
-  debounceMinUnanalyzedCount: 0,
-  debounceMinMinutesSinceLastScore: 0,
-  maxBatchSize: 10,
-  analysisGetDataSourceLimitMax: ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX,
-} as const;
-
-/**
- * Returns effective config with defaults applied for optional numeric/string fields,
- * including debounce knobs, `maxBatchSize`, and `analysisGetDataSourceLimitMax`
- * (Hermes config overrides or package defaults).
- *
- * @param config - Parsed Hermes config.
- * @returns Config safe to use at runtime.
- */
-export const resolveArticleAnalysisConfig = (
-  config: ArticleAnalysisConfig,
-): ResolvedArticleAnalysisConfig => {
-  const openaiModel =
-    config.openaiModel ?? articleAnalysisConfigDefaults.openaiModel;
-
-  return {
-    ...config,
-    openaiModel,
-    maxContentChars:
-      config.maxContentChars ?? articleAnalysisConfigDefaults.maxContentChars,
-    useStructureAwareTruncation:
-      config.useStructureAwareTruncation ??
-      articleAnalysisConfigDefaults.useStructureAwareTruncation,
-    truncationLeadParagraphsAlwaysKept:
-      config.truncationLeadParagraphsAlwaysKept ??
-      articleAnalysisConfigDefaults.truncationLeadParagraphsAlwaysKept,
-    truncationFinancialKeywordsExtra:
-      config.truncationFinancialKeywordsExtra ?? [
-        ...articleAnalysisConfigDefaults.truncationFinancialKeywordsExtra,
-      ],
-    fewShotExemplarCount:
-      config.fewShotExemplarCount ??
-      articleAnalysisConfigDefaults.fewShotExemplarCount,
-    ...(config.fewShotExemplarArchetypes !== undefined
-      ? { fewShotExemplarArchetypes: config.fewShotExemplarArchetypes }
-      : {}),
-    useBrainstormPass:
-      config.useBrainstormPass ??
-      articleAnalysisConfigDefaults.useBrainstormPass,
-    brainstormModel: config.brainstormModel ?? openaiModel,
-    extractionConcurrency:
-      config.extractionConcurrency ??
-      articleAnalysisConfigDefaults.extractionConcurrency,
-    ...(config.runDeadlineMs !== undefined
-      ? { runDeadlineMs: config.runDeadlineMs }
-      : {}),
-    useRelationSelfCritique:
-      config.useRelationSelfCritique ??
-      articleAnalysisConfigDefaults.useRelationSelfCritique,
-    relationCritiqueDropFraction:
-      config.relationCritiqueDropFraction ??
-      articleAnalysisConfigDefaults.relationCritiqueDropFraction,
-    relationCritiqueMinRelationCount:
-      config.relationCritiqueMinRelationCount ??
-      articleAnalysisConfigDefaults.relationCritiqueMinRelationCount,
-    relationCritiqueModel: config.relationCritiqueModel ?? openaiModel,
-    vocabularyPolicy:
-      config.vocabularyPolicy ?? articleAnalysisConfigDefaults.vocabularyPolicy,
-    vocabularyRepairModel: config.vocabularyRepairModel ?? openaiModel,
-    vocabularyRepairMaxItems:
-      config.vocabularyRepairMaxItems ??
-      articleAnalysisConfigDefaults.vocabularyRepairMaxItems,
-    entityGroundingPolicy:
-      config.entityGroundingPolicy ??
-      articleAnalysisConfigDefaults.entityGroundingPolicy,
-    entityGroundingMinTitleHits:
-      config.entityGroundingMinTitleHits ??
-      articleAnalysisConfigDefaults.entityGroundingMinTitleHits,
-    maxEntitiesPerArticle:
-      config.maxEntitiesPerArticle ??
-      articleAnalysisConfigDefaults.maxEntitiesPerArticle,
-    maxRelationsPerArticle:
-      config.maxRelationsPerArticle ??
-      articleAnalysisConfigDefaults.maxRelationsPerArticle,
-    maxEntitiesPerRun:
-      config.maxEntitiesPerRun ??
-      articleAnalysisConfigDefaults.maxEntitiesPerRun,
-    maxRelationsPerRun:
-      config.maxRelationsPerRun ??
-      articleAnalysisConfigDefaults.maxRelationsPerRun,
-    postChunkRelationBatchSize:
-      config.postChunkRelationBatchSize ??
-      articleAnalysisConfigDefaults.postChunkRelationBatchSize,
-    maxArticleEntitiesPerArticle:
-      config.maxArticleEntitiesPerArticle ??
-      articleAnalysisConfigDefaults.maxArticleEntitiesPerArticle,
-    maxArticleEntitiesPerRun:
-      config.maxArticleEntitiesPerRun ??
-      articleAnalysisConfigDefaults.maxArticleEntitiesPerRun,
-    postChunkArticleEntityBatchSize:
-      config.postChunkArticleEntityBatchSize ??
-      articleAnalysisConfigDefaults.postChunkArticleEntityBatchSize,
-    scoreBreakdownVersion:
-      config.scoreBreakdownVersion ??
-      articleAnalysisConfigDefaults.scoreBreakdownVersion,
-    relevanceWeightBreakingNews:
-      config.relevanceWeightBreakingNews ??
-      articleAnalysisConfigDefaults.relevanceWeightBreakingNews,
-    relevanceWeightKgRelation:
-      config.relevanceWeightKgRelation ??
-      articleAnalysisConfigDefaults.relevanceWeightKgRelation,
-    relevanceWeightFundamental:
-      config.relevanceWeightFundamental ??
-      articleAnalysisConfigDefaults.relevanceWeightFundamental,
-    relevanceWeightTickerSalience:
-      config.relevanceWeightTickerSalience ??
-      articleAnalysisConfigDefaults.relevanceWeightTickerSalience,
-    relevanceWeightSourceQuality:
-      config.relevanceWeightSourceQuality ??
-      articleAnalysisConfigDefaults.relevanceWeightSourceQuality,
-    useSourceQualityV2:
-      config.useSourceQualityV2 ??
-      articleAnalysisConfigDefaults.useSourceQualityV2,
-    sourceQualityRecencyHalfLifeHours:
-      config.sourceQualityRecencyHalfLifeHours ??
-      articleAnalysisConfigDefaults.sourceQualityRecencyHalfLifeHours,
-    ...(config.sourceQualityHostTier1 !== undefined
-      ? { sourceQualityHostTier1: config.sourceQualityHostTier1 }
-      : {}),
-    ...(config.sourceQualityHostTier2 !== undefined
-      ? { sourceQualityHostTier2: config.sourceQualityHostTier2 }
-      : {}),
-    ...(config.sourceQualityHostTier3 !== undefined
-      ? { sourceQualityHostTier3: config.sourceQualityHostTier3 }
-      : {}),
-    useSelectionDiversification:
-      config.useSelectionDiversification ??
-      articleAnalysisConfigDefaults.useSelectionDiversification,
-    selectionEntityOverlapThreshold:
-      config.selectionEntityOverlapThreshold ??
-      articleAnalysisConfigDefaults.selectionEntityOverlapThreshold,
-    selectionTitleSimilarityThreshold:
-      config.selectionTitleSimilarityThreshold ??
-      articleAnalysisConfigDefaults.selectionTitleSimilarityThreshold,
-    relevanceMinScore:
-      config.relevanceMinScore ??
-      articleAnalysisConfigDefaults.relevanceMinScore,
-    maxSelectedRelevancePerTickerPerDay:
-      config.maxSelectedRelevancePerTickerPerDay ??
-      articleAnalysisConfigDefaults.maxSelectedRelevancePerTickerPerDay,
-    postChunkArticleRelevanceBatchSize:
-      config.postChunkArticleRelevanceBatchSize ??
-      articleAnalysisConfigDefaults.postChunkArticleRelevanceBatchSize,
-    runPolicy: {
-      minSuccessfulSources:
-        config.runPolicy?.minSuccessfulSources ??
-        articleAnalysisConfigDefaults.runPolicy.minSuccessfulSources,
-      failOnZeroSuccess:
-        config.runPolicy?.failOnZeroSuccess ??
-        articleAnalysisConfigDefaults.runPolicy.failOnZeroSuccess,
-    },
-    postTransientRetries:
-      config.postTransientRetries ??
-      articleAnalysisConfigDefaults.postTransientRetries,
-    postTransientRetryBaseDelayMs:
-      config.postTransientRetryBaseDelayMs ??
-      articleAnalysisConfigDefaults.postTransientRetryBaseDelayMs,
-    extractionTransientRetries:
-      config.extractionTransientRetries ??
-      articleAnalysisConfigDefaults.extractionTransientRetries,
-    extractionTransientRetryBaseDelayMs:
-      config.extractionTransientRetryBaseDelayMs ??
-      articleAnalysisConfigDefaults.extractionTransientRetryBaseDelayMs,
-    extractionTransientRetryMaxDelayMs:
-      config.extractionTransientRetryMaxDelayMs ??
-      articleAnalysisConfigDefaults.extractionTransientRetryMaxDelayMs,
-    extractionCallTimeoutMs:
-      config.extractionCallTimeoutMs ??
-      articleAnalysisConfigDefaults.extractionCallTimeoutMs,
-    debounceMinUnanalyzedCount:
-      config.debounceMinUnanalyzedCount ??
-      articleAnalysisConfigDefaults.debounceMinUnanalyzedCount,
-    debounceMinMinutesSinceLastScore:
-      config.debounceMinMinutesSinceLastScore ??
-      articleAnalysisConfigDefaults.debounceMinMinutesSinceLastScore,
-    maxBatchSize:
-      config.maxBatchSize ?? articleAnalysisConfigDefaults.maxBatchSize,
-    analysisGetDataSourceLimitMax:
-      config.analysisGetDataSourceLimitMax ??
-      articleAnalysisConfigDefaults.analysisGetDataSourceLimitMax,
-  };
-};
+export type ArticleAnalysisConfig = z.output<
+  typeof articleAnalysisConfigSchema
+>;
 
 /**
  * Maps resolved Hermes relevance weights into the v1 weight map used by scoring.
  *
- * @param cfg - Fully resolved article-analysis config.
+ * @param cfg - Parsed article-analysis config.
  * @returns Weights for canonical breakdown keys.
  */
 export const toRelevanceWeightMapV1 = (
-  cfg: ResolvedArticleAnalysisConfig,
+  cfg: ArticleAnalysisConfig,
 ): RelevanceWeightMapV1 => ({
-  breakingNews: cfg.relevanceWeightBreakingNews,
-  kgRelation: cfg.relevanceWeightKgRelation,
-  fundamental: cfg.relevanceWeightFundamental,
-  tickerSalience: cfg.relevanceWeightTickerSalience,
-  sourceQuality: cfg.relevanceWeightSourceQuality,
+  breakingNews: cfg.scoring.weightBreakingNews,
+  kgRelation: cfg.scoring.weightKgRelation,
+  fundamental: cfg.scoring.weightFundamental,
+  tickerSalience: cfg.scoring.weightTickerSalience,
+  sourceQuality: cfg.scoring.weightSourceQuality,
 });

--- a/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts
@@ -29,7 +29,7 @@ import type {
   ArticleAnalysisExtractionFailureRecord,
   ExtractionLlmFailureReason,
 } from "./article-analysis-run-policy.js";
-import type { ResolvedArticleAnalysisConfig } from "./config-schema.js";
+import type { ArticleAnalysisConfig } from "./config-schema.js";
 import {
   buildArticleAnalysisExtractionUserContent,
   buildBrainstormSystemContent,
@@ -168,7 +168,7 @@ export const createEmptySourceProcessingOutcome =
   });
 
 export type ProcessOneSourceDeps = {
-  cfg: ResolvedArticleAnalysisConfig;
+  cfg: ArticleAnalysisConfig;
   ctx: AnalysisContext;
   tickerId: string;
   systemContent: string;
@@ -273,20 +273,22 @@ export const createProcessOneSource =
       return outcome;
     }
 
-    const truncated = cfg.useStructureAwareTruncation
+    const truncated = cfg.extraction.useStructureAwareTruncation
       ? (() => {
           const result = truncateArticleForExtraction(source.content, {
-            maxChars: cfg.maxContentChars,
+            maxChars: cfg.extraction.maxContentChars,
             tickerSymbols: truncationTickerContext.tickerSymbols,
             companyAliases: truncationTickerContext.companyAliases,
-            leadParagraphsAlwaysKept: cfg.truncationLeadParagraphsAlwaysKept,
-            financialKeywordsExtra: cfg.truncationFinancialKeywordsExtra,
+            leadParagraphsAlwaysKept:
+              cfg.extraction.truncationLeadParagraphsAlwaysKept,
+            financialKeywordsExtra:
+              cfg.extraction.truncationFinancialKeywordsExtra,
           });
           outcome.truncationMeta = result.meta;
           return result.content;
         })()
-      : source.content.length > cfg.maxContentChars
-        ? source.content.slice(0, cfg.maxContentChars)
+      : source.content.length > cfg.extraction.maxContentChars
+        ? source.content.slice(0, cfg.extraction.maxContentChars)
         : source.content;
 
     try {
@@ -305,7 +307,7 @@ export const createProcessOneSource =
 
       let brainstormText: string | undefined;
       const shouldRunBrainstorm =
-        cfg.useBrainstormPass && !isRunDeadlineElapsed();
+        cfg.extraction.useBrainstormPass && !isRunDeadlineElapsed();
 
       if (shouldRunBrainstorm) {
         try {
@@ -313,9 +315,10 @@ export const createProcessOneSource =
           const brainstormResult = await executeLlmCallWithTransientRetries(
             () =>
               fetchArticleBrainstorm({
-                apiKey: cfg.openaiApiKey,
-                model: cfg.brainstormModel,
-                timeoutMs: cfg.extractionCallTimeoutMs,
+                apiKey: cfg.credentials.openaiApiKey,
+                model:
+                  cfg.extraction.brainstormModel ?? cfg.credentials.openaiModel,
+                timeoutMs: cfg.extraction.callTimeoutMs,
                 messages: [
                   {
                     role: "system",
@@ -334,9 +337,9 @@ export const createProcessOneSource =
                 ],
               }),
             {
-              maxRetries: cfg.extractionTransientRetries,
-              baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
-              maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+              maxRetries: cfg.extraction.transientRetries,
+              baseDelayMs: cfg.extraction.transientRetryBaseDelayMs,
+              maxDelayMs: cfg.extraction.transientRetryMaxDelayMs,
               sleep,
               classify: classifyLlmExtractionError,
               shouldAbort: isRunDeadlineElapsed,
@@ -363,12 +366,12 @@ export const createProcessOneSource =
             "article-analysis brainstorm pass failed; falling back to single-pass extraction",
           );
         }
-      } else if (cfg.useBrainstormPass && isRunDeadlineElapsed()) {
+      } else if (cfg.extraction.useBrainstormPass && isRunDeadlineElapsed()) {
         log.warn(
           {
             dataSourceId: source.id,
             runElapsedMs: Date.now() - deps.runStart,
-            runDeadlineMs: cfg.runDeadlineMs,
+            runDeadlineMs: cfg.dynamics.runDeadlineMs,
           },
           "article-analysis skipping brainstorm pass due to run deadline",
         );
@@ -378,9 +381,9 @@ export const createProcessOneSource =
       const extractedResult = await executeLlmCallWithTransientRetries(
         () =>
           extractEntitiesAndRelationsForSource({
-            apiKey: cfg.openaiApiKey,
-            model: cfg.openaiModel,
-            timeoutMs: cfg.extractionCallTimeoutMs,
+            apiKey: cfg.credentials.openaiApiKey,
+            model: cfg.credentials.openaiModel,
+            timeoutMs: cfg.extraction.callTimeoutMs,
             messages: [
               { role: "system", content: systemContent },
               {
@@ -394,9 +397,9 @@ export const createProcessOneSource =
             ...(brainstormText !== undefined ? { brainstormText } : {}),
           }),
         {
-          maxRetries: cfg.extractionTransientRetries,
-          baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
-          maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+          maxRetries: cfg.extraction.transientRetries,
+          baseDelayMs: cfg.extraction.transientRetryBaseDelayMs,
+          maxDelayMs: cfg.extraction.transientRetryMaxDelayMs,
           sleep,
           classify: classifyLlmExtractionError,
           shouldAbort: isRunDeadlineElapsed,
@@ -429,7 +432,7 @@ export const createProcessOneSource =
       let entitiesForPipeline: EntityProposal[] = [...extracted.entities];
       let relationsForPipeline: RelationProposal[] = [...extracted.relations];
 
-      if (cfg.vocabularyPolicy === "strict") {
+      if (cfg.quality.vocabularyPolicy === "strict") {
         const vocab = validateExtractionVocabulary(
           entitiesForPipeline,
           relationsForPipeline,
@@ -466,16 +469,16 @@ export const createProcessOneSource =
           partitioned.badEntities.length + partitioned.badRelations.length;
 
         if (
-          cfg.vocabularyPolicy === "repair" &&
+          cfg.quality.vocabularyPolicy === "repair" &&
           rejectedCount > 0 &&
-          rejectedCount <= cfg.vocabularyRepairMaxItems
+          rejectedCount <= cfg.quality.repairMaxItems
         ) {
           outcome.vocabularyRepairCallsAttempted = 1;
           try {
             const repairResult = await repairExtractionVocabulary({
-              apiKey: cfg.openaiApiKey,
-              model: cfg.vocabularyRepairModel,
-              timeoutMs: cfg.extractionCallTimeoutMs,
+              apiKey: cfg.credentials.openaiApiKey,
+              model: cfg.quality.repairModel ?? cfg.credentials.openaiModel,
+              timeoutMs: cfg.extraction.callTimeoutMs,
               ctx,
               badEntities: partitioned.badEntities,
               badRelations: partitioned.badRelations,
@@ -515,14 +518,14 @@ export const createProcessOneSource =
             );
           }
         } else if (
-          cfg.vocabularyPolicy === "repair" &&
-          rejectedCount > cfg.vocabularyRepairMaxItems
+          cfg.quality.vocabularyPolicy === "repair" &&
+          rejectedCount > cfg.quality.repairMaxItems
         ) {
           log.warn(
             {
               dataSourceId: source.id,
               rejectedCount,
-              vocabularyRepairMaxItems: cfg.vocabularyRepairMaxItems,
+              vocabularyRepairMaxItems: cfg.quality.repairMaxItems,
             },
             "article-analysis skipping vocabulary repair due to rejected row cap",
           );
@@ -536,7 +539,7 @@ export const createProcessOneSource =
             {
               dataSourceId: source.id,
               stage: "vocabulary",
-              vocabularyPolicy: cfg.vocabularyPolicy,
+              vocabularyPolicy: cfg.quality.vocabularyPolicy,
             },
             "article-analysis no vocabulary-valid rows remain for source; skipping",
           );
@@ -550,11 +553,11 @@ export const createProcessOneSource =
         mentions: extracted.articleMentions,
         articleText: source.content,
         title: source.title,
-        policy: cfg.entityGroundingPolicy,
-        entityGroundingMinTitleHits: cfg.entityGroundingMinTitleHits,
+        policy: cfg.quality.groundingPolicy,
+        entityGroundingMinTitleHits: cfg.quality.groundingMinTitleHits,
       });
       outcome.groundingCounters = groundedExtraction.counters;
-      if (cfg.verbose && cfg.entityGroundingPolicy !== "off") {
+      if (cfg.verbose && cfg.quality.groundingPolicy !== "off") {
         log.info(
           {
             dataSourceId: source.id,
@@ -579,8 +582,8 @@ export const createProcessOneSource =
       let relationsAfterCritique = resolved.relations;
       let relationEvidenceByKey: ReadonlyMap<string, string> | undefined;
       const critiqueEligible =
-        cfg.useRelationSelfCritique &&
-        resolved.relations.length >= cfg.relationCritiqueMinRelationCount;
+        cfg.quality.useRelationSelfCritique &&
+        resolved.relations.length >= cfg.quality.critiqueMinRelationCount;
 
       if (critiqueEligible && isRunDeadlineElapsed()) {
         outcome.relationsCritiqueSkippedDueToDeadline = 1;
@@ -588,7 +591,7 @@ export const createProcessOneSource =
           {
             dataSourceId: source.id,
             runElapsedMs: Date.now() - deps.runStart,
-            runDeadlineMs: cfg.runDeadlineMs,
+            runDeadlineMs: cfg.dynamics.runDeadlineMs,
             relationCount: resolved.relations.length,
           },
           "article-analysis skipping relation critique due to run deadline",
@@ -599,9 +602,9 @@ export const createProcessOneSource =
           const critiqueResult = await executeLlmCallWithTransientRetries(
             () =>
               critiqueExtractedRelations({
-                apiKey: cfg.openaiApiKey,
-                model: cfg.relationCritiqueModel,
-                timeoutMs: cfg.extractionCallTimeoutMs,
+                apiKey: cfg.credentials.openaiApiKey,
+                model: cfg.quality.critiqueModel ?? cfg.credentials.openaiModel,
+                timeoutMs: cfg.extraction.callTimeoutMs,
                 messages: buildRelationCritiqueModelMessages(ctx, {
                   articleTitle: source.title,
                   articleBody: source.content,
@@ -609,9 +612,9 @@ export const createProcessOneSource =
                 }),
               }),
             {
-              maxRetries: cfg.extractionTransientRetries,
-              baseDelayMs: cfg.extractionTransientRetryBaseDelayMs,
-              maxDelayMs: cfg.extractionTransientRetryMaxDelayMs,
+              maxRetries: cfg.extraction.transientRetries,
+              baseDelayMs: cfg.extraction.transientRetryBaseDelayMs,
+              maxDelayMs: cfg.extraction.transientRetryMaxDelayMs,
               sleep,
               classify: classifyLlmExtractionError,
               shouldAbort: isRunDeadlineElapsed,
@@ -629,7 +632,7 @@ export const createProcessOneSource =
           const critiqueApplied = applyRelationCritiqueDrops(
             resolved.relations,
             critiqueResult.ratings,
-            cfg.relationCritiqueDropFraction,
+            cfg.quality.critiqueDropFraction,
           );
           outcome.relationsDroppedByCritique = critiqueApplied.droppedCount;
           relationsAfterCritique = critiqueApplied.relations;
@@ -666,8 +669,8 @@ export const createProcessOneSource =
       const capped = applyPerArticleExtractionCaps(
         resolved.entities,
         relationsAfterCritique,
-        cfg.maxEntitiesPerArticle,
-        cfg.maxRelationsPerArticle,
+        cfg.limits.entitiesPerArticle,
+        cfg.limits.relationsPerArticle,
       );
       outcome.mergedEntities = capped.entities;
       outcome.mergedRelations = capped.relations;
@@ -681,7 +684,7 @@ export const createProcessOneSource =
       );
       const mentionCapped = applyPerArticleArticleMentionCap(
         mentionFiltered,
-        cfg.maxArticleEntitiesPerArticle,
+        cfg.limits.articleEntitiesPerArticle,
       );
       outcome.mergedArticleEntityRows = toArticleEntityRowsForSource(
         source.id,
@@ -704,7 +707,7 @@ export const createProcessOneSource =
           : mentionCapped.reduce((s, m) => s + m.confidence, 0) /
             mentionCapped.length;
 
-      if (cfg.useSourceQualityV2) {
+      if (cfg.scoring.useSourceQualityV2) {
         const qualityMeta = computeSourceQualityWithMeta(
           {
             url: source.url,
@@ -715,7 +718,7 @@ export const createProcessOneSource =
           },
           {
             now: new Date(),
-            recencyHalfLifeHours: cfg.sourceQualityRecencyHalfLifeHours,
+            recencyHalfLifeHours: cfg.scoring.sourceQualityRecencyHalfLifeHours,
             hostTiers: sourceQualityHostTiers,
           },
         );

--- a/apps/mediapulse/agents/article-analysis/src/run.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.test.ts
@@ -10,7 +10,10 @@ import * as RelevancePostChunks from "./analysis-relevance-post-chunks.js";
 import * as Llm from "./llm-extract-entities.js";
 import * as RelevanceScoring from "./analysis-relevance-scoring.js";
 import * as RelevanceSelection from "./analysis-relevance-selection.js";
-import { type ArticleAnalysisConfig } from "./config-schema.js";
+import {
+  articleAnalysisConfigSchema,
+  type ArticleAnalysisConfig,
+} from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
 import { run } from "./run.js";
 
@@ -187,18 +190,74 @@ const analysisGetOk = <
       : null,
 });
 
-const baseConfig: ArticleAnalysisConfig = {
-  openaiApiKey: "sk-test",
+/** Config overrides accepted by `runContext`; `credentials` is optional since the base key is always injected. */
+type RunContextConfigOverride = Omit<
+  ReturnType<typeof articleAnalysisConfigSchema.parse>,
+  | "credentials"
+  | "extraction"
+  | "quality"
+  | "limits"
+  | "posting"
+  | "scoring"
+  | "selection"
+  | "batch"
+  | "dynamics"
+  | "yieldBaseline"
+  | "verbose"
+> & {
+  credentials?: { openaiApiKey?: string; openaiModel?: string };
+  extraction?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["extraction"]
+  >;
+  quality?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["quality"]
+  >;
+  limits?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["limits"]
+  >;
+  posting?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["posting"]
+  >;
+  scoring?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["scoring"]
+  >;
+  selection?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["selection"]
+  >;
+  batch?: Partial<
+    ReturnType<typeof articleAnalysisConfigSchema.parse>["batch"]
+  >;
+  dynamics?: {
+    runDeadlineMs?: number;
+    debounceMinUnanalyzedCount?: number;
+    debounceMinMinutesSinceLastScore?: number;
+    runPolicy?: Partial<
+      ReturnType<
+        typeof articleAnalysisConfigSchema.parse
+      >["dynamics"]["runPolicy"]
+    >;
+  };
+  yieldBaseline?: ReturnType<
+    typeof articleAnalysisConfigSchema.parse
+  >["yieldBaseline"];
+  verbose?: boolean;
 };
 
 function runContext(overrides: {
   input: ArticleAnalysisInput;
-  config?: Partial<ArticleAnalysisConfig>;
+  config?: RunContextConfigOverride;
   token?: string;
 }): AgentRunContext<ArticleAnalysisInput, ArticleAnalysisConfig> {
+  const configOverride = overrides.config ?? {};
   return {
     input: overrides.input,
-    config: { ...baseConfig, ...overrides.config },
+    config: articleAnalysisConfigSchema.parse({
+      ...configOverride,
+      credentials: {
+        openaiApiKey: "sk-test",
+        ...(configOverride.credentials ?? {}),
+      },
+    }),
     token: overrides.token ?? "Bearer test",
   };
 }
@@ -262,7 +321,7 @@ describe("run", () => {
         input: {
           tickerId: "ticker-cap",
         },
-        config: { maxBatchSize: 10, analysisGetDataSourceLimitMax: 4 },
+        config: { batch: { maxSources: 10, getDataSourceLimitMax: 4 } },
       }),
     );
 
@@ -287,7 +346,7 @@ describe("run", () => {
     await run(
       runContext({
         input: { tickerId: "ticker-limit" },
-        config: { maxBatchSize: 3 },
+        config: { batch: { maxSources: 3 } },
       }),
     );
 
@@ -466,7 +525,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { postChunkRelationBatchSize: 1 },
+        config: { posting: { chunkRelationBatchSize: 1 } },
       }),
     );
 
@@ -679,12 +738,24 @@ describe("run", () => {
       articlesSelected: 0,
     });
 
-    const result = await run(
-      runContext({
-        input: { tickerId: "ticker-1" },
-        config: { scoreBreakdownVersion: 1.5 },
+    // Use a manually constructed config so we can inject a non-integer breakdownVersion
+    // that bypasses Zod's .int() constraint, exercising the runtime relevance-row validator.
+    const invalidBreakdownConfig: ArticleAnalysisConfig = {
+      ...articleAnalysisConfigSchema.parse({
+        credentials: { openaiApiKey: "sk-test" },
       }),
-    );
+      scoring: {
+        ...articleAnalysisConfigSchema.parse({
+          credentials: { openaiApiKey: "sk-test" },
+        }).scoring,
+        breakdownVersion: 1.5 as unknown as 1,
+      },
+    };
+    const result = await run({
+      input: { tickerId: "ticker-1" },
+      config: invalidBreakdownConfig,
+      token: "Bearer test",
+    });
 
     expect(result.success).toBe(false);
     expect(result.message).toContain("validation failed before selection");
@@ -1010,7 +1081,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { postChunkRelationBatchSize: 1 },
+        config: { posting: { chunkRelationBatchSize: 1 } },
       }),
     );
 
@@ -1181,7 +1252,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { postChunkArticleEntityBatchSize: 1 },
+        config: { posting: { chunkArticleEntityBatchSize: 1 } },
       }),
     );
 
@@ -1429,8 +1500,10 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          useStructureAwareTruncation: true,
-          maxContentChars: 260,
+          extraction: {
+            useStructureAwareTruncation: true,
+            maxContentChars: 260,
+          },
         },
       }),
     );
@@ -1447,8 +1520,10 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          useStructureAwareTruncation: false,
-          maxContentChars: 260,
+          extraction: {
+            useStructureAwareTruncation: false,
+            maxContentChars: 260,
+          },
         },
       }),
     );
@@ -1548,7 +1623,7 @@ describe("run", () => {
     await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { openaiApiKey: apiKey },
+        config: { credentials: { openaiApiKey: apiKey } },
         token: bearer,
       }),
     );
@@ -1645,7 +1720,7 @@ describe("run", () => {
     await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { maxBatchSize: 1 },
+        config: { batch: { maxSources: 1 } },
       }),
     );
 
@@ -1684,7 +1759,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { debounceMinUnanalyzedCount: 5 },
+        config: { dynamics: { debounceMinUnanalyzedCount: 5 } },
       }),
     );
 
@@ -1727,7 +1802,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { debounceMinMinutesSinceLastScore: 60 },
+        config: { dynamics: { debounceMinMinutesSinceLastScore: 60 } },
       }),
     );
 
@@ -1790,7 +1865,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { useBrainstormPass: true },
+        config: { extraction: { useBrainstormPass: true } },
       }),
     );
 
@@ -1897,7 +1972,7 @@ describe("run", () => {
     const withBrainstorm = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { useBrainstormPass: true },
+        config: { extraction: { useBrainstormPass: true } },
       }),
     );
 
@@ -1909,7 +1984,7 @@ describe("run", () => {
     const withoutBrainstorm = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { useBrainstormPass: false },
+        config: { extraction: { useBrainstormPass: false } },
       }),
     );
 
@@ -1977,7 +2052,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { entityGroundingPolicy: "drop" },
+        config: { quality: { groundingPolicy: "drop" } },
       }),
     );
 
@@ -2069,7 +2144,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { entityGroundingPolicy: "flag" },
+        config: { quality: { groundingPolicy: "flag" } },
       }),
     );
 
@@ -2143,8 +2218,10 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          useRelationSelfCritique: true,
-          relationCritiqueMinRelationCount: 3,
+          quality: {
+            useRelationSelfCritique: true,
+            critiqueMinRelationCount: 3,
+          },
         },
       }),
     );
@@ -2225,15 +2302,24 @@ describe("run", () => {
       articlesSelected: 1,
     });
 
-    const result = await run(
-      runContext({
-        input: { tickerId: "ticker-1" },
-        config: {
-          useRelationSelfCritique: true,
-          runDeadlineMs: 0,
-        },
-      }),
-    );
+    // Use a manually constructed config so we can inject runDeadlineMs: 0,
+    // which bypasses Zod's .positive() constraint and simulates an already-elapsed deadline.
+    const baseResolved = articleAnalysisConfigSchema.parse({
+      credentials: { openaiApiKey: "sk-test" },
+      quality: { useRelationSelfCritique: true },
+    });
+    const zeroDeadlineConfig: ArticleAnalysisConfig = {
+      ...baseResolved,
+      dynamics: {
+        ...baseResolved.dynamics,
+        runDeadlineMs: 0 as unknown as number,
+      },
+    };
+    const result = await run({
+      input: { tickerId: "ticker-1" },
+      config: zeroDeadlineConfig,
+      token: "Bearer test",
+    });
 
     expect(result.success).toBe(true);
     expect(critiqueSpy).not.toHaveBeenCalled();
@@ -2288,7 +2374,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { vocabularyPolicy: "strict" },
+        config: { quality: { vocabularyPolicy: "strict" } },
       }),
     );
 
@@ -2336,7 +2422,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { vocabularyPolicy: "partition" },
+        config: { quality: { vocabularyPolicy: "partition" } },
       }),
     );
 
@@ -2416,7 +2502,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { vocabularyPolicy: "repair" },
+        config: { quality: { vocabularyPolicy: "repair" } },
       }),
     );
 
@@ -2485,7 +2571,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { vocabularyPolicy: "repair" },
+        config: { quality: { vocabularyPolicy: "repair" } },
       }),
     );
 
@@ -2577,7 +2663,7 @@ describe("run", () => {
     const result = await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { useSourceQualityV2: true },
+        config: { scoring: { useSourceQualityV2: true } },
       }),
     );
 
@@ -2655,7 +2741,7 @@ describe("run", () => {
     await run(
       runContext({
         input: { tickerId: "ticker-1" },
-        config: { useSelectionDiversification: false },
+        config: { selection: { useDiversification: false } },
       }),
     );
 
@@ -2745,7 +2831,10 @@ describe("run", () => {
       const result = await run(
         runContext({
           input: { tickerId: "ticker-1" },
-          config: { extractionConcurrency: concurrency, maxBatchSize: 5 },
+          config: {
+            extraction: { concurrency: concurrency },
+            batch: { maxSources: 5 },
+          },
         }),
       );
 
@@ -2798,9 +2887,9 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionConcurrency: 1,
-          runDeadlineMs: 200,
-          maxBatchSize: 10,
+          extraction: { concurrency: 1 },
+          dynamics: { runDeadlineMs: 200 },
+          batch: { maxSources: 10 },
         },
       }),
     );
@@ -2875,9 +2964,9 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          maxBatchSize: 2,
-          entityGroundingPolicy: "drop",
-          useSelectionDiversification: true,
+          batch: { maxSources: 2 },
+          quality: { groundingPolicy: "drop" },
+          selection: { useDiversification: true },
         },
       }),
     );
@@ -3008,9 +3097,11 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionTransientRetries: 2,
-          extractionTransientRetryBaseDelayMs: 1,
-          extractionTransientRetryMaxDelayMs: 1,
+          extraction: {
+            transientRetries: 2,
+            transientRetryBaseDelayMs: 1,
+            transientRetryMaxDelayMs: 1,
+          },
         },
       }),
     );
@@ -3107,9 +3198,11 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionTransientRetries: 2,
-          extractionTransientRetryBaseDelayMs: 1,
-          extractionTransientRetryMaxDelayMs: 1,
+          extraction: {
+            transientRetries: 2,
+            transientRetryBaseDelayMs: 1,
+            transientRetryMaxDelayMs: 1,
+          },
         },
       }),
     );
@@ -3184,9 +3277,11 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionTransientRetries: 2,
-          extractionTransientRetryBaseDelayMs: 1,
-          extractionTransientRetryMaxDelayMs: 1,
+          extraction: {
+            transientRetries: 2,
+            transientRetryBaseDelayMs: 1,
+            transientRetryMaxDelayMs: 1,
+          },
         },
       }),
     );
@@ -3239,10 +3334,14 @@ describe("run", () => {
       runContext({
         input: { tickerId: "ticker-1" },
         config: {
-          extractionTransientRetries: 1,
-          extractionTransientRetryBaseDelayMs: 1,
-          extractionTransientRetryMaxDelayMs: 1,
-          runPolicy: { minSuccessfulSources: 0 },
+          extraction: {
+            transientRetries: 1,
+            transientRetryBaseDelayMs: 1,
+            transientRetryMaxDelayMs: 1,
+          },
+          dynamics: {
+            runPolicy: { minSuccessfulSources: 0 },
+          },
         },
       }),
     );

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -72,7 +72,6 @@ import {
 } from "./article-analysis-run-policy.js";
 import { buildAnalysisPostChunks } from "./build-analysis-post-chunks.js";
 import {
-  resolveArticleAnalysisConfig,
   toRelevanceWeightMapV1,
   type ArticleAnalysisConfig,
 } from "./config-schema.js";
@@ -252,7 +251,7 @@ export const run = async ({
   ArticleAnalysisInput,
   ArticleAnalysisConfig
 >): Promise<AgentRunResult> => {
-  const cfg = resolveArticleAnalysisConfig(config);
+  const cfg = config;
   const runId = crypto.randomUUID();
   const runStart = Date.now();
 
@@ -372,11 +371,11 @@ export const run = async ({
         : undefined),
     parallelism:
       summary.parallelism ??
-      (cfg.extractionConcurrency > 1 ||
+      (cfg.extraction.concurrency > 1 ||
       extractionSkippedDueToDeadline > 0 ||
       parallelPeakInFlight > 0
         ? {
-            concurrency: cfg.extractionConcurrency,
+            concurrency: cfg.extraction.concurrency,
             peakInFlight: parallelPeakInFlight,
             extractionSkippedDueToDeadline,
             ...(parallelDeadlineFiredAtMs !== undefined
@@ -437,14 +436,14 @@ export const run = async ({
   };
 
   const sourceQualityHostTiers: SourceQualityComputeCtx["hostTiers"] = {
-    ...(cfg.sourceQualityHostTier1 !== undefined
-      ? { tier1: cfg.sourceQualityHostTier1 }
+    ...(cfg.scoring.hostTier1 !== undefined
+      ? { tier1: cfg.scoring.hostTier1 }
       : {}),
-    ...(cfg.sourceQualityHostTier2 !== undefined
-      ? { tier2: cfg.sourceQualityHostTier2 }
+    ...(cfg.scoring.hostTier2 !== undefined
+      ? { tier2: cfg.scoring.hostTier2 }
       : {}),
-    ...(cfg.sourceQualityHostTier3 !== undefined
-      ? { tier3: cfg.sourceQualityHostTier3 }
+    ...(cfg.scoring.hostTier3 !== undefined
+      ? { tier3: cfg.scoring.hostTier3 }
       : {}),
   };
 
@@ -463,8 +462,8 @@ export const run = async ({
   if (cfg.verbose) {
     log.info(
       {
-        openaiModel: cfg.openaiModel,
-        maxContentChars: cfg.maxContentChars,
+        openaiModel: cfg.credentials.openaiModel,
+        maxContentChars: cfg.extraction.maxContentChars,
       },
       "article-analysis run started",
     );
@@ -594,10 +593,10 @@ export const run = async ({
   };
 
   try {
-    const effectiveMaxBatchSize = cfg.maxBatchSize;
+    const effectiveMaxBatchSize = cfg.batch.maxSources;
     const analysisGetLimit = Math.min(
       effectiveMaxBatchSize,
-      cfg.analysisGetDataSourceLimitMax,
+      cfg.batch.getDataSourceLimitMax,
     );
     const query = buildAnalysisGetQuery(input.tickerId, {
       limit: analysisGetLimit,
@@ -607,8 +606,8 @@ export const run = async ({
     const unanalyzedBacklogTotal = ctx.dataSourceTotalCount;
     if (
       unanalyzedBacklogTotal > 0 &&
-      cfg.debounceMinUnanalyzedCount > 0 &&
-      unanalyzedBacklogTotal < cfg.debounceMinUnanalyzedCount
+      cfg.dynamics.debounceMinUnanalyzedCount > 0 &&
+      unanalyzedBacklogTotal < cfg.dynamics.debounceMinUnanalyzedCount
     ) {
       const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
@@ -632,12 +631,12 @@ export const run = async ({
       });
       report(
         "Run debounced",
-        `${unanalyzedBacklogTotal} articles below min ${cfg.debounceMinUnanalyzedCount}`,
+        `${unanalyzedBacklogTotal} articles below min ${cfg.dynamics.debounceMinUnanalyzedCount}`,
         "completed",
       );
       return {
         success: true,
-        message: `debounce: ${unanalyzedBacklogTotal} unanalyzed source(s) below min ${cfg.debounceMinUnanalyzedCount}; skipping run`,
+        message: `debounce: ${unanalyzedBacklogTotal} unanalyzed source(s) below min ${cfg.dynamics.debounceMinUnanalyzedCount}; skipping run`,
         details: {
           yieldSnapshot,
           dataSourcesReturned: unanalyzedBacklogTotal,
@@ -661,10 +660,10 @@ export const run = async ({
 
     if (
       unanalyzedBacklogTotal > 0 &&
-      cfg.debounceMinMinutesSinceLastScore > 0 &&
+      cfg.dynamics.debounceMinMinutesSinceLastScore > 0 &&
       ctx.lastRelevanceScoredAtIso !== null &&
       minutesSinceUtcIso(ctx.lastRelevanceScoredAtIso) <
-        cfg.debounceMinMinutesSinceLastScore
+        cfg.dynamics.debounceMinMinutesSinceLastScore
     ) {
       const yieldSnapshot = emitRunSummaryAndYield({
         outcome: "success",
@@ -688,12 +687,12 @@ export const run = async ({
       });
       report(
         "Run debounced",
-        `last scored within ${cfg.debounceMinMinutesSinceLastScore}min`,
+        `last scored within ${cfg.dynamics.debounceMinMinutesSinceLastScore}min`,
         "completed",
       );
       return {
         success: true,
-        message: `debounce: last relevance scored at ${ctx.lastRelevanceScoredAtIso} is within ${cfg.debounceMinMinutesSinceLastScore} minute(s); skipping run`,
+        message: `debounce: last relevance scored at ${ctx.lastRelevanceScoredAtIso} is within ${cfg.dynamics.debounceMinMinutesSinceLastScore} minute(s); skipping run`,
         details: {
           yieldSnapshot,
           dataSourcesReturned: unanalyzedBacklogTotal,
@@ -818,11 +817,11 @@ export const run = async ({
     const resolvedExemplars = resolveExemplarsForContext(
       DEFAULT_EXTRACTION_EXEMPLARS,
       ctx,
-      cfg.fewShotExemplarCount,
-      cfg.fewShotExemplarArchetypes,
+      cfg.extraction.fewShotExemplarCount,
+      cfg.extraction.fewShotExemplarArchetypes,
     );
     exemplarsObservability = {
-      requestedCount: cfg.fewShotExemplarCount,
+      requestedCount: cfg.extraction.fewShotExemplarCount,
       resolvedCount: resolvedExemplars.length,
       appliedArchetypes: resolvedExemplars.map(
         (exemplar) => exemplar.archetype,
@@ -843,8 +842,8 @@ export const run = async ({
       ctx.existingEntities,
     );
     const isRunDeadlineElapsed = (): boolean =>
-      cfg.runDeadlineMs !== undefined &&
-      Date.now() - runStart >= cfg.runDeadlineMs;
+      cfg.dynamics.runDeadlineMs !== undefined &&
+      Date.now() - runStart >= cfg.dynamics.runDeadlineMs;
 
     const applySourceProcessingOutcome = (
       outcome: SourceProcessingOutcome,
@@ -955,8 +954,8 @@ export const run = async ({
     });
 
     const extractionDeadlineAtMs =
-      cfg.runDeadlineMs !== undefined && cfg.runDeadlineMs > 0
-        ? runStart + cfg.runDeadlineMs
+      cfg.dynamics.runDeadlineMs !== undefined && cfg.dynamics.runDeadlineMs > 0
+        ? runStart + cfg.dynamics.runDeadlineMs
         : undefined;
 
     report(
@@ -965,13 +964,13 @@ export const run = async ({
     );
 
     const walkResult = await runExtractionsInParallel(batch, processOneSource, {
-      concurrency: cfg.extractionConcurrency,
+      concurrency: cfg.extraction.concurrency,
       deadlineAtMs: extractionDeadlineAtMs,
       onDeadlineSkip: (source) => {
         log.warn(
           {
             dataSourceId: source.id,
-            runDeadlineMs: cfg.runDeadlineMs,
+            runDeadlineMs: cfg.dynamics.runDeadlineMs,
           },
           "article-analysis skipped source extraction due to run deadline",
         );
@@ -1014,7 +1013,7 @@ export const run = async ({
     if (
       isArticleAnalysisExtractionPolicyFailure(
         extractionSuccessCount,
-        cfg.runPolicy,
+        cfg.dynamics.runPolicy,
       )
     ) {
       const yieldSnapshot = emitRunSummaryAndYield({
@@ -1046,12 +1045,12 @@ export const run = async ({
       );
       return {
         success: false,
-        message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.runPolicy.minSuccessfulSources}.`,
+        message: `Article analysis run failed: only ${extractionSuccessCount} source(s) extracted successfully, but run policy requires at least ${cfg.dynamics.runPolicy.minSuccessfulSources}.`,
         details: {
           yieldSnapshot,
           extractionFailures,
           extractionSuccessCount,
-          runPolicy: cfg.runPolicy,
+          runPolicy: cfg.dynamics.runPolicy,
           articlesScored: 0,
           articlesSelected: 0,
           relevancePostChunks: 0,
@@ -1067,8 +1066,8 @@ export const run = async ({
     const runCapped = applyPerRunCaps(
       entities,
       relations,
-      cfg.maxEntitiesPerRun,
-      cfg.maxRelationsPerRun,
+      cfg.limits.entitiesPerRun,
+      cfg.limits.relationsPerRun,
     );
     entities = runCapped.entities;
     relations = runCapped.relations;
@@ -1173,7 +1172,7 @@ export const run = async ({
     );
     articleEntitiesForPost = applyPerRunArticleEntityCap(
       articleEntitiesForPost,
-      cfg.maxArticleEntitiesPerRun,
+      cfg.limits.articleEntitiesPerRun,
     );
 
     const {
@@ -1248,7 +1247,7 @@ export const run = async ({
       input.tickerId,
       entities,
       relations,
-      cfg.postChunkRelationBatchSize,
+      cfg.posting.chunkRelationBatchSize,
       entityEvidenceForPost,
       relationEvidenceForPost,
     );
@@ -1325,7 +1324,7 @@ export const run = async ({
           chunkIndex: i,
           chunkEntities: chunk.entities.length,
           chunkRelations: chunk.relations.length,
-          model: cfg.openaiModel,
+          model: cfg.credentials.openaiModel,
         },
         "article-analysis posting chunk",
       );
@@ -1333,8 +1332,8 @@ export const run = async ({
         const res = await executeAnalysisCreateWithTransientRetries(
           () => dataApiClient.analysis.create(chunk),
           {
-            maxRetries: cfg.postTransientRetries,
-            baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+            maxRetries: cfg.posting.transientRetries,
+            baseDelayMs: cfg.posting.transientRetryBaseDelayMs,
             sleep: sleepMs,
           },
         );
@@ -1373,7 +1372,7 @@ export const run = async ({
         buildArticleEntityPostChunks(
           input.tickerId,
           articleEntitiesForPost,
-          cfg.postChunkArticleEntityBatchSize,
+          cfg.posting.chunkArticleEntityBatchSize,
         );
       articleEntityParseErrors = parseErrors;
       chunkParseCounts.articleEntityChunkParseErrors =
@@ -1395,7 +1394,7 @@ export const run = async ({
             chunkKind: "article_entities",
             chunkIndex: j,
             chunkArticleEntities: mentionChunk.articleEntities.length,
-            model: cfg.openaiModel,
+            model: cfg.credentials.openaiModel,
           },
           "article-analysis posting chunk",
         );
@@ -1403,8 +1402,8 @@ export const run = async ({
           await executeAnalysisCreateWithTransientRetries(
             () => dataApiClient.analysis.create(mentionChunk),
             {
-              maxRetries: cfg.postTransientRetries,
-              baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+              maxRetries: cfg.posting.transientRetries,
+              baseDelayMs: cfg.posting.transientRetryBaseDelayMs,
               sleep: sleepMs,
             },
           );
@@ -1438,7 +1437,7 @@ export const run = async ({
       );
       const weightMap = toRelevanceWeightMapV1(cfg);
       const relevanceDrafts = perSourceSignals.map((sig) =>
-        buildDraftRelevanceRow(sig, cfg.scoreBreakdownVersion, weightMap),
+        buildDraftRelevanceRow(sig, cfg.scoring.breakdownVersion, weightMap),
       );
       const relevanceValidationErrors: string[] = [];
       for (const row of relevanceDrafts) {
@@ -1495,19 +1494,20 @@ export const run = async ({
       }));
       const remainingBudget = Math.max(
         0,
-        cfg.maxSelectedRelevancePerTickerPerDay -
+        cfg.selection.maxPerTickerPerDay -
           ctx.relevanceSelectionState.selectedCountToday,
       );
-      const relevanceRows = cfg.useSelectionDiversification
+      const relevanceRows = cfg.selection.useDiversification
         ? (() => {
             const diversified = applyRelevanceSelectionDiversified(
               selectionInput,
               perSourceSignals,
               {
-                minScore: cfg.relevanceMinScore,
+                minScore: cfg.selection.minScore,
                 remainingBudget,
-                entityOverlapThreshold: cfg.selectionEntityOverlapThreshold,
-                titleSimilarityThreshold: cfg.selectionTitleSimilarityThreshold,
+                entityOverlapThreshold: cfg.selection.entityOverlapThreshold,
+                titleSimilarityThreshold:
+                  cfg.selection.titleSimilarityThreshold,
               },
             );
             selectionEligibleRows = diversified.stats.eligibleRows;
@@ -1521,7 +1521,7 @@ export const run = async ({
           })()
         : applyRelevanceSelection(
             selectionInput,
-            cfg.relevanceMinScore,
+            cfg.selection.minScore,
             remainingBudget,
           );
       relevanceRowsForObservability = relevanceRows;
@@ -1530,7 +1530,7 @@ export const run = async ({
         buildArticleRelevancePostChunks(
           input.tickerId,
           relevanceRows,
-          cfg.postChunkArticleRelevanceBatchSize,
+          cfg.posting.chunkArticleRelevanceBatchSize,
         );
       chunkParseCounts.articleRelevanceChunkParseErrors =
         relevanceParseErrors.length;
@@ -1584,7 +1584,7 @@ export const run = async ({
             chunkKind: "article_relevances",
             chunkIndex: k,
             chunkArticleRelevances: relChunk.articleRelevances.length,
-            model: cfg.openaiModel,
+            model: cfg.credentials.openaiModel,
           },
           "article-analysis posting chunk",
         );
@@ -1592,8 +1592,8 @@ export const run = async ({
           const relRes = await executeAnalysisCreateWithTransientRetries(
             () => dataApiClient.analysis.create(relChunk),
             {
-              maxRetries: cfg.postTransientRetries,
-              baseDelayMs: cfg.postTransientRetryBaseDelayMs,
+              maxRetries: cfg.posting.transientRetries,
+              baseDelayMs: cfg.posting.transientRetryBaseDelayMs,
               sleep: sleepMs,
             },
           );
@@ -1682,7 +1682,7 @@ export const run = async ({
         relevancePostChunks: relevancePostChunksCompleted,
         relevanceSelectionBudgetRemaining: Math.max(
           0,
-          cfg.maxSelectedRelevancePerTickerPerDay -
+          cfg.selection.maxPerTickerPerDay -
             ctx.relevanceSelectionState.selectedCountToday,
         ),
         droppedRelations,


### PR DESCRIPTION
## Summary

The article-analysis config was a flat object with 40+ keys and a separate `resolveArticleAnalysisConfig` function to apply defaults at runtime. This PR reorganises it into 10 named sub-schemas (credentials, extraction, quality, limits, posting, scoring, selection, batch, dynamics, yieldBaseline), each with inline defaults via Zod's `.default()`. The result: `ArticleAnalysisConfig` is just `z.output<typeof articleAnalysisConfigSchema>`, the resolver function disappears, and the config shape in Hermes reads like a structured document rather than a flat key dump.

## Related issues

Closes #780

## Important changes

- `articleAnalysisConfigSchema` is now `.strict()` with 10 named groups; all fields carry inline defaults so no post-parse resolution step is needed.
- `resolveArticleAnalysisConfig`, `articleAnalysisConfigDefaults`, and `ResolvedArticleAnalysisConfig` are deleted.
- `ArticleAnalysisConfig = z.output<typeof articleAnalysisConfigSchema>` is both the parsed and fully-resolved type.
- Hermes agent config JSON shape changes from flat (`extractionConcurrency: 2`) to nested (`extraction: { concurrency: 2 }`). Existing Hermes configs need updating.
- Cross-field model fallbacks (`brainstormModel`, `critiqueModel`, `repairModel`) are handled at call sites with `?? cfg.credentials.openaiModel` rather than in the schema.

## Other changes

- `run.ts` and `run-process-one-source.ts` updated to use grouped paths (`cfg.extraction.*`, `cfg.quality.*`, etc.).
- All 263 tests in `run.test.ts` and `config-schema.test.ts` updated to the new grouped structure.
- Test helpers use `articleAnalysisConfigSchema.parse({ credentials: { openaiApiKey: "sk-test" } })` instead of a handwritten base config.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` - new grouped schema; all defaults live here.
- `apps/mediapulse/agents/article-analysis/src/run.ts` - main orchestration; check grouped cfg paths.
- `apps/mediapulse/agents/article-analysis/src/run-process-one-source.ts` - per-source extraction; check model fallback lines.

## How to test

1. `pnpm --filter @mediapulse/article-analysis type:check` - should exit 0.
2. `pnpm --filter @mediapulse/article-analysis test` - all 263 tests should pass.
3. `pnpm code-quality` from repo root - should exit 0 (100/100 tasks).
4. In a Hermes test environment, update an article-analysis agent config from flat to nested and confirm the agent starts correctly.
