### PR TITLE
Use {{OPENAI_API_KEY}} and {{OPENAI_MODEL}} as credentials defaults in article-analysis

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.test.ts
@@ -92,7 +92,7 @@ describe("articleAnalysisConfigSchema", () => {
     expect(config.dynamics.runDeadlineMs).toBeUndefined();
     expect(config.quality.groundingPolicy).toBe("off");
     expect(config.quality.groundingMinTitleHits).toBe(0);
-    expect(config.credentials.openaiModel).toBe("gpt-4o-mini");
+    expect(config.credentials.openaiModel).toBe("{{OPENAI_MODEL}}");
   });
 
   it("preserves Hermes dynamics and batch overrides", () => {

--- a/apps/mediapulse/agents/article-analysis/src/config-schema.ts
+++ b/apps/mediapulse/agents/article-analysis/src/config-schema.ts
@@ -15,14 +15,20 @@ const credentialsSchema = z
     openaiApiKey: z
       .string()
       .min(1)
-      .describe("OpenAI-compatible API key for structured extraction."),
+      .default("{{OPENAI_API_KEY}}")
+      .describe(
+        "OpenAI API key or a Hermes variable placeholder such as {{OPENAI_API_KEY}}.",
+      ),
     openaiModel: z
       .string()
       .min(1)
-      .default("gpt-4o-mini")
-      .describe("Chat model id (e.g. gpt-4o-mini)."),
+      .default("{{OPENAI_MODEL}}")
+      .describe(
+        "Chat model id (e.g. gpt-4o-mini) or a Hermes variable placeholder such as {{OPENAI_MODEL}}.",
+      ),
   })
-  .describe("OpenAI credentials for structured extraction.");
+  .default({})
+  .describe("OpenAI credentials resolved from Hermes Variables.");
 
 const extractionSchema = z
   .object({


### PR DESCRIPTION
## Summary

Follows the same pattern as query-analysis and content-generation: `openaiApiKey` defaults to `{{OPENAI_API_KEY}}`, `openaiModel` defaults to `{{OPENAI_MODEL}}`, and the `credentials` group gets `.default({})` so Hermes resolves both from Variables without requiring them in agent config JSON.

## Related issues

Refs #780

## Important changes

- `credentials.openaiApiKey` default changed from required to `{{OPENAI_API_KEY}}`.
- `credentials.openaiModel` default changed from `gpt-4o-mini` to `{{OPENAI_MODEL}}`.
- `credentialsSchema` now has `.default({})`, making the entire group optional when Hermes Variables cover both fields.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/config-schema.ts` - credentials schema changes.
- `apps/mediapulse/agents/article-analysis/src/config-schema.test.ts` - updated default assertion.

## How to test

1. `pnpm --filter @mediapulse/article-analysis type:check` — exits 0.
2. `pnpm --filter @mediapulse/article-analysis test` — all 263 tests pass.
