### PR TITLE
Fix 500: add missing Prisma migration for SearchQueryIntent deals value

### DIFF
--- a/packages/mediapulse/database/prisma/migrations/20260612000000_add_search_query_intent_deals/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260612000000_add_search_query_intent_deals/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "SearchQueryIntent" ADD VALUE 'deals';


### PR DESCRIPTION
## Summary

The query-analysis pipeline can classify queries with the intent `"deals"`, but a Prisma migration to add that value to the `SearchQueryIntent` database enum was never written. Every `searchQuerySet.create()` call carrying `intent: "deals"` hit a 500 in production. This PR adds the missing migration.

## Related issues

Closes #783

## Important changes

- New migration `20260612000000_add_search_query_intent_deals` runs `ALTER TYPE "SearchQueryIntent" ADD VALUE 'deals'` — the sole missing piece between the schema and the live database.

## Other changes

None. The Prisma schema, generated client, and TypeScript contract already included `deals`; only the migration file was absent.

## Key files to review

- `packages/mediapulse/database/prisma/migrations/20260612000000_add_search_query_intent_deals/migration.sql` — the single `ALTER TYPE` statement; matches the three prior enum-extension migrations exactly.

## How to test

1. On a fresh database, run `prisma migrate deploy` — the migration applies cleanly.
2. On production (already ahead): `prisma migrate deploy` detects the migration as already applied and skips it with no changes.
3. Trigger a query-analysis run that produces a `"deals"` intent — confirm the `searchQuerySet.create()` call succeeds and returns HTTP 200 instead of 500.
