### PR TITLE
Stream each collected URL to the Agent Data API as its fetch resolves

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -130,7 +130,20 @@ describe("data-collection agent (HTTP)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     performWebSearchMock.mockResolvedValue(defaultSearchSuccess);
-    performWebFetchMock.mockResolvedValue(defaultFetchSuccess);
+    // performWebFetch now streams each outcome through the onOutcome hook (so
+    // run.ts persists per URL); mirror that contract instead of just resolving.
+    performWebFetchMock.mockImplementation(
+      async (
+        _searchResults: unknown,
+        deps: { onOutcome?: (outcome: unknown) => unknown },
+      ) => {
+        for (const outcome of defaultFetchSuccess) {
+          await deps?.onOutcome?.(outcome);
+        }
+
+        return defaultFetchSuccess;
+      },
+    );
     existingUrlsCreateMock.mockResolvedValue({
       existingUrls: [],
       hostCounts: {},

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -10,8 +10,10 @@ import {
 } from "./utilities/config-schema";
 import type {
   FetchedWebSearchResult,
+  WebFetchDeps,
   WebFetchFailure,
   WebFetchOutcome,
+  WebSearchResult,
 } from "@workspace/agent-ingestion";
 
 const TICKER_ID = "11111111-1111-4111-a111-111111111111";
@@ -151,6 +153,26 @@ const mockFetchFailure = (
   failures: [{ provider: "jina", ...failure }],
 });
 
+/**
+ * Mirrors the real performWebFetch streaming contract in tests: invokes the
+ * `onOutcome` hook for each outcome (so per-URL persistence runs in run.ts)
+ * before resolving with the full outcome list.
+ *
+ * @param outcomes - Fetch outcomes the mocked call should stream and return.
+ */
+const fetchYielding =
+  (outcomes: WebFetchOutcome[]) =>
+  async (
+    _searchResults: WebSearchResult[],
+    deps: WebFetchDeps,
+  ): Promise<WebFetchOutcome[]> => {
+    for (const outcome of outcomes) {
+      await deps.onOutcome?.(outcome);
+    }
+
+    return outcomes;
+  };
+
 vi.mock("@mediapulse/env/agents-data-collection", () => ({
   env: {
     AGENT_DATA_API_URL: "http://agent-data-api",
@@ -251,12 +273,14 @@ describe("runDataCollection", () => {
         data: searchSuccessPage,
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValue([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        content: validArticleContent,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementation(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          content: validArticleContent,
+        }),
+      ]),
+    );
     getMock.mockResolvedValue({
       data: [{ id: "sq-1", text: "test query", tickerId: TICKER_ID }],
     });
@@ -356,7 +380,7 @@ describe("runDataCollection", () => {
       existingUrls: ["http://example.com"],
       hostCounts: {},
     });
-    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+    vi.mocked(performWebFetch).mockImplementationOnce(fetchYielding([]));
 
     const result = await runDataCollection(
       createContext({
@@ -390,7 +414,7 @@ describe("runDataCollection", () => {
     deadUrlsLookupMock.mockResolvedValueOnce({
       deadUrls: ["http://example.com/page-0", "http://example.com/page-1"],
     });
-    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+    vi.mocked(performWebFetch).mockImplementationOnce(fetchYielding([]));
 
     const result = await runDataCollection(
       createContext({
@@ -425,17 +449,19 @@ describe("runDataCollection", () => {
   });
 
   it("records 404 fetch failures to the dead-url cache", async () => {
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchFailure({
-        url: "http://failed.com",
-        queryId: "sq-1",
-        tickerId: TICKER_ID,
-        errorCategory: "provider_http_error",
-        message: "404 Not Found",
-        retryable: false,
-        httpStatus: 404,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchFailure({
+          url: "http://failed.com",
+          queryId: "sq-1",
+          tickerId: TICKER_ID,
+          errorCategory: "provider_http_error",
+          message: "404 Not Found",
+          retryable: false,
+          httpStatus: 404,
+        }),
+      ]),
+    );
 
     await runDataCollection(
       createContext({
@@ -488,31 +514,33 @@ describe("runDataCollection", () => {
         },
       ]);
 
-      vi.mocked(performWebFetch).mockResolvedValueOnce([
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          url: "http://example.com/fresh",
-          content: validArticleContent,
-          fetchMetadata: { publishedTime: isoDaysAgo(2) },
-        }),
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          url: "http://example.com/stale",
-          content: validArticleContent,
-          fetchMetadata: { publishedTime: isoDaysAgo(30) },
-        }),
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          url: "http://example.com/unknown",
-          content: validArticleContent,
-        }),
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          url: "http://example.com/future",
-          content: validArticleContent,
-          fetchMetadata: { publishedTime: isoDaysAhead(5) },
-        }),
-      ]);
+      vi.mocked(performWebFetch).mockImplementationOnce(
+        fetchYielding([
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            url: "http://example.com/fresh",
+            content: validArticleContent,
+            fetchMetadata: { publishedTime: isoDaysAgo(2) },
+          }),
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            url: "http://example.com/stale",
+            content: validArticleContent,
+            fetchMetadata: { publishedTime: isoDaysAgo(30) },
+          }),
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            url: "http://example.com/unknown",
+            content: validArticleContent,
+          }),
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            url: "http://example.com/future",
+            content: validArticleContent,
+            fetchMetadata: { publishedTime: isoDaysAhead(5) },
+          }),
+        ]),
+      );
 
       const result = await runDataCollection(
         createContext({
@@ -548,7 +576,7 @@ describe("runDataCollection", () => {
 
   it("does not call dataCollection.create when there are no fetch successes", async () => {
     // Setup
-    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+    vi.mocked(performWebFetch).mockImplementationOnce(fetchYielding([]));
 
     // Act
     await runDataCollection(
@@ -571,17 +599,19 @@ describe("runDataCollection", () => {
 
   it("records partial_success and persists fetch failures", async () => {
     // Setup
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchFailure({
-        url: "http://failed.com",
-        queryId: "sq-1",
-        tickerId: TICKER_ID,
-        errorCategory: "provider_http_error",
-        message: "404 Not Found",
-        retryable: false,
-        httpStatus: 404,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchFailure({
+          url: "http://failed.com",
+          queryId: "sq-1",
+          tickerId: TICKER_ID,
+          errorCategory: "provider_http_error",
+          message: "404 Not Found",
+          retryable: false,
+          httpStatus: 404,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(
@@ -621,7 +651,7 @@ describe("runDataCollection", () => {
   it("returns semantic failure when run policy requires successes but none were collected", async () => {
     // Setup
     vi.mocked(performWebSearch).mockResolvedValueOnce([]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+    vi.mocked(performWebFetch).mockImplementationOnce(fetchYielding([]));
 
     // Act
     const result = await runDataCollection(createContext());
@@ -661,12 +691,14 @@ describe("runDataCollection", () => {
         data: searchSuccessPage,
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        content: validArticleContent,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          content: validArticleContent,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(
@@ -713,7 +745,7 @@ describe("runDataCollection", () => {
         },
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([]);
+    vi.mocked(performWebFetch).mockImplementationOnce(fetchYielding([]));
 
     // Act
     const result = await runDataCollection(createContext());
@@ -755,26 +787,28 @@ describe("runDataCollection", () => {
         },
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/clean",
-        title: validArticleTitle,
-        content: validArticleContent,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/off-topic",
-        title: "Microsoft earnings headline here",
-        content: offTopicContent,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/paywall",
-        title: "Premium article headline here",
-        content: paywallContent,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/clean",
+          title: validArticleTitle,
+          content: validArticleContent,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/off-topic",
+          title: "Microsoft earnings headline here",
+          content: offTopicContent,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/paywall",
+          title: "Premium article headline here",
+          content: paywallContent,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(
@@ -850,32 +884,34 @@ describe("runDataCollection", () => {
         },
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/clean",
-        title: validArticleTitle,
-        content: validArticleContent,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/paywall",
-        title: "Premium article headline here",
-        content: paywallContent,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/soft-404",
-        title: "Missing article headline here",
-        content: soft404Content,
-      }),
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        url: "https://example.com/short",
-        title: "Valid headline for short body",
-        content: shortContent,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/clean",
+          title: validArticleTitle,
+          content: validArticleContent,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/paywall",
+          title: "Premium article headline here",
+          content: paywallContent,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/soft-404",
+          title: "Missing article headline here",
+          content: soft404Content,
+        }),
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          url: "https://example.com/short",
+          title: "Valid headline for short body",
+          content: shortContent,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(
@@ -923,14 +959,16 @@ describe("runDataCollection", () => {
         },
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValueOnce([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        title: "Company profile and key statistics",
-        url: "https://example.com/stocks",
-        content: `Financial summary and key statistics with market cap details. ${Array.from({ length: 120 }, (_, index) => `Detail paragraph ${index} covers regional lending trends.`).join(" ")}`,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementationOnce(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          title: "Company profile and key statistics",
+          url: "https://example.com/stocks",
+          content: `Financial summary and key statistics with market cap details. ${Array.from({ length: 120 }, (_, index) => `Detail paragraph ${index} covers regional lending trends.`).join(" ")}`,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(createContext());
@@ -989,18 +1027,22 @@ describe("runDataCollection", () => {
         },
       ]);
     vi.mocked(performWebFetch)
-      .mockResolvedValueOnce([
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          content: validArticleContent,
-        }),
-      ])
-      .mockResolvedValueOnce([
-        mockFetchSuccess({
-          ...searchSuccessPage,
-          content: validArticleContent,
-        }),
-      ]);
+      .mockImplementationOnce(
+        fetchYielding([
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            content: validArticleContent,
+          }),
+        ]),
+      )
+      .mockImplementationOnce(
+        fetchYielding([
+          mockFetchSuccess({
+            ...searchSuccessPage,
+            content: validArticleContent,
+          }),
+        ]),
+      );
 
     // Act
     const result = await runDataCollection(
@@ -1027,7 +1069,7 @@ describe("runDataCollection", () => {
   it("stops refill when no progress is made in a round", async () => {
     // Setup
     vi.mocked(performWebSearch).mockResolvedValue([]);
-    vi.mocked(performWebFetch).mockResolvedValue([]);
+    vi.mocked(performWebFetch).mockImplementation(fetchYielding([]));
 
     // Act
     const result = await runDataCollection(
@@ -1056,12 +1098,14 @@ describe("runDataCollection", () => {
         data: searchSuccessPage,
       },
     ]);
-    vi.mocked(performWebFetch).mockResolvedValue([
-      mockFetchSuccess({
-        ...searchSuccessPage,
-        content: validArticleContent,
-      }),
-    ]);
+    vi.mocked(performWebFetch).mockImplementation(
+      fetchYielding([
+        mockFetchSuccess({
+          ...searchSuccessPage,
+          content: validArticleContent,
+        }),
+      ]),
+    );
 
     // Act
     const result = await runDataCollection(
@@ -1103,14 +1147,16 @@ describe("runDataCollection", () => {
     );
 
     vi.mocked(performWebSearch).mockResolvedValueOnce(searchHits);
-    vi.mocked(performWebFetch).mockImplementation(async (results) =>
-      results.map((page) =>
+    vi.mocked(performWebFetch).mockImplementation((results, deps) => {
+      const outcomes = results.map((page) =>
         mockFetchSuccess({
           ...page,
           content: validArticleContent,
         }),
-      ),
-    );
+      );
+
+      return fetchYielding(outcomes)(results, deps);
+    });
 
     // Act
     await runDataCollection(

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -27,6 +27,7 @@ import {
   HostErrorTracker,
   hostFromUrl,
   type QualityDropForDeadUrl,
+  type FetchedWebSearchResult,
   buildTickerAliases,
   buildIndustryAliases,
   isRelevant,
@@ -393,38 +394,20 @@ export async function runDataCollection(
         ...narrativeFetchStart(subject, searchSuccessesAfterHostBreaker.length),
       );
 
-      const fetchThrottleStats = { throttleEvents: 0 };
-      const fetchAttemptResults = await performWebFetch(
-        searchSuccessesAfterHostBreaker,
-        {
-          config: webFetchConfig,
-          logger: log,
-          throttleStats: fetchThrottleStats,
-          hostErrorTracker,
-        },
-      );
-      throttleEvents += fetchThrottleStats.throttleEvents;
-      const roundFetchSuccesses = fetchAttemptResults
-        .filter((outcome) => outcome.success !== null)
-        .map((outcome) => outcome.success!);
-      const roundFetchFailures = fetchAttemptResults.flatMap(
-        (outcome) => outcome.failures,
-      );
-      const roundFailedUrlCount = fetchAttemptResults.filter(
-        (outcome) => outcome.success === null,
-      ).length;
-      fetchedCount += roundFetchSuccesses.length;
-      fetchFailedCount += roundFailedUrlCount;
-      fetchFailures.push(...roundFetchFailures);
-
       let persistedThisRoundCount = 0;
       const roundQualityDrops: QualityDropForDeadUrl[] = [];
-      report(...narrativeSavingSources(subject, roundFetchSuccesses.length));
-      for (const page of roundFetchSuccesses) {
+
+      // Persist a single fetched page as soon as its fetch resolves, so each
+      // source reaches the Agent Data API immediately instead of waiting for the
+      // whole round's fetch batch to finish. Invoked per URL from performWebFetch
+      // via the onOutcome hook below.
+      const persistFetchedPage = async (
+        page: FetchedWebSearchResult,
+      ): Promise<void> => {
         const urlDecision = classifyNoisyUrl(page.url);
         if (urlDecision.blocked) {
           droppedByUrlReason[urlDecision.reason] += 1;
-          continue;
+          return;
         }
 
         const contentDecision = runQualityGate(
@@ -438,7 +421,7 @@ export async function runDataCollection(
             url: urlDecision.canonicalUrl,
             reason: contentDecision.reason,
           });
-          continue;
+          return;
         }
 
         if (relevanceGateConfig.enabled) {
@@ -464,7 +447,7 @@ export async function runDataCollection(
               },
               "dropped page that did not mention the target ticker or industry",
             );
-            continue;
+            return;
           }
         }
 
@@ -490,7 +473,7 @@ export async function runDataCollection(
               },
               "dropped page outside freshness window",
             );
-            continue;
+            return;
           }
         }
 
@@ -510,7 +493,43 @@ export async function runDataCollection(
         persistedThisRunCount += 1;
         persistedThisRoundCount += 1;
         fetchSuccessCount += 1;
-      }
+      };
+
+      report(
+        ...narrativeSavingSources(
+          subject,
+          searchSuccessesAfterHostBreaker.length,
+        ),
+      );
+
+      const fetchThrottleStats = { throttleEvents: 0 };
+      const fetchAttemptResults = await performWebFetch(
+        searchSuccessesAfterHostBreaker,
+        {
+          config: webFetchConfig,
+          logger: log,
+          throttleStats: fetchThrottleStats,
+          hostErrorTracker,
+          onOutcome: async (outcome) => {
+            if (outcome.success !== null) {
+              await persistFetchedPage(outcome.success);
+            }
+          },
+        },
+      );
+      throttleEvents += fetchThrottleStats.throttleEvents;
+      const roundFetchSuccesses = fetchAttemptResults
+        .filter((outcome) => outcome.success !== null)
+        .map((outcome) => outcome.success!);
+      const roundFetchFailures = fetchAttemptResults.flatMap(
+        (outcome) => outcome.failures,
+      );
+      const roundFailedUrlCount = fetchAttemptResults.filter(
+        (outcome) => outcome.success === null,
+      ).length;
+      fetchedCount += roundFetchSuccesses.length;
+      fetchFailedCount += roundFailedUrlCount;
+      fetchFailures.push(...roundFetchFailures);
 
       log.info(
         {

--- a/packages/shared/agent-ingestion/src/web-fetch.test.ts
+++ b/packages/shared/agent-ingestion/src/web-fetch.test.ts
@@ -10,7 +10,7 @@ vi.mock("@workspace/logger", () => ({
   },
 }));
 
-import type { WebSearchResult } from "./web-fetch";
+import type { WebFetchOutcome, WebSearchResult } from "./web-fetch";
 import { performWebFetch } from "./web-fetch";
 
 const jinaProviderConfig = {
@@ -299,6 +299,43 @@ describe("performWebFetch", () => {
     // Assert — both providers were invoked once per URL through their own limiters
     expect(acquireCounts.jina).toBe(2);
     expect(acquireCounts.firecrawl).toBe(2);
+  });
+
+  it("streams each fetch outcome through onOutcome as it resolves", async () => {
+    // Setup
+    const postMock = vi.fn().mockReturnValue(
+      mockGotPostResponse({
+        data: {
+          url: "http://example.com",
+          title: "Title",
+          content: "Full content",
+        },
+      }),
+    );
+    const fakeGot = { post: postMock } as unknown as typeof got;
+    const streamed: WebFetchOutcome[] = [];
+
+    // Act
+    const result = await performWebFetch(
+      [
+        { ...baseSearchResult, searchQueryId: "q1" },
+        { ...baseSearchResult, searchQueryId: "q2" },
+      ],
+      {
+        config: { providers: [jinaProviderConfig] },
+        gotClient: fakeGot,
+        onOutcome: (outcome) => {
+          streamed.push(outcome);
+        },
+      },
+    );
+
+    // Assert — the hook fires once per URL with each resolved outcome
+    expect(streamed).toHaveLength(2);
+    expect(
+      streamed.map((outcome) => outcome.success?.searchQueryId).sort(),
+    ).toEqual(["q1", "q2"]);
+    expect(result).toHaveLength(2);
   });
 
   it("logs a warning with a truncated URL when fetch fails and the URL is very long", async () => {

--- a/packages/shared/agent-ingestion/src/web-fetch.ts
+++ b/packages/shared/agent-ingestion/src/web-fetch.ts
@@ -69,6 +69,14 @@ export interface WebFetchDeps {
   throttleStats?: StageThrottleStats;
   /** Optional per-run host error tracker updated on every fetch attempt. */
   hostErrorTracker?: HostErrorTracker;
+  /**
+   * Optional hook invoked with each fetch outcome the moment it resolves, before the
+   * rest of the batch finishes. Lets callers stream per-URL side effects (for example,
+   * persisting a successful page immediately) instead of waiting for every fetch in the
+   * batch to complete. Awaited within the fetch concurrency slot, so a rejecting hook
+   * aborts the batch the same way a failing fetch would.
+   */
+  onOutcome?: (outcome: WebFetchOutcome) => void | Promise<void>;
 }
 
 type ProviderChainEntry = {
@@ -257,7 +265,13 @@ export async function performWebFetch(
   searchResults: WebSearchResult[],
   deps: WebFetchDeps,
 ): Promise<WebFetchOutcome[]> {
-  const { config, gotClient = got, logger: logOpt, throttleStats } = deps;
+  const {
+    config,
+    gotClient = got,
+    logger: logOpt,
+    throttleStats,
+    onOutcome,
+  } = deps;
   const log = logOpt ?? defaultLogger;
   const providerConfigs = config.providers;
 
@@ -279,7 +293,13 @@ export async function performWebFetch(
 
   const results = await pMap(
     searchResults,
-    (result) => fetchOneResult(result, chain, sharedDeps),
+    async (result) => {
+      const outcome = await fetchOneResult(result, chain, sharedDeps);
+      if (onOutcome) {
+        await onOutcome(outcome);
+      }
+      return outcome;
+    },
     { concurrency },
   );
 


### PR DESCRIPTION
## Summary

Data-collection was persisting collected URLs in a burst at the end of each fetch round rather than as each URL finished. Every URL in the round had to complete fetching before any of them were written to the Agent Data API — so on rounds with many candidates, the first successful articles sat idle waiting for the slowest fetch. This PR makes each URL stream to the data API the moment its own fetch and quality gates pass.

## Related issues

Closes #787

## Important changes

- **`WebFetchDeps.onOutcome`** — new optional hook in `performWebFetch` that fires inside `pMap` per resolved fetch outcome, before the rest of the batch finishes. Backward-compatible: callers that don't pass it see no change in behavior.
- **`runDataCollection` persist loop** — the post-fetch quality-gate and `dataCollection.create` logic is now a `persistFetchedPage` function invoked via `onOutcome` inside `performWebFetch`, rather than a separate loop that ran after the full batch returned. Each URL hits the data API as soon as it passes relevance, freshness, and content quality checks.

## Other changes

- `run.ts`: the "Saving sources" agent-activity report now fires just before the fetch+save stage starts (matching how "Fetching articles" announces before fetch begins), since with streaming there is no longer a discrete "batch fetch done, now saving" transition.
- `run.test.ts` / `index.test.ts`: all `mockResolvedValue(Once)` calls on `performWebFetch` replaced with `mockImplementation(fetchYielding(...))`, a new test helper that calls `deps.onOutcome` per outcome before resolving — mirrors the real streaming contract so per-URL persistence fires in tests.
- `web-fetch.test.ts`: new test verifying the `onOutcome` hook fires once per URL with each resolved outcome.

## Key files to review

- `packages/shared/agent-ingestion/src/web-fetch.ts` — `onOutcome` hook added to `WebFetchDeps`; invoked inside the `pMap` mapper after each `fetchOneResult` resolves.
- `apps/mediapulse/agents/data-collection/src/run.ts` — `persistFetchedPage` function extracted from what was the post-fetch loop; wired into `onOutcome`.
- `apps/mediapulse/agents/data-collection/src/run.test.ts` — `fetchYielding` helper and updated mocks.

## How to test

1. Run scoped tests: `pnpm --filter @mediapulse/data-collection --filter @workspace/agent-ingestion run test` — all 194 tests should pass.
2. Run a data-collection job against a real ticker and observe logs: "persisting collected source to Agent Data API" log lines should appear interleaved with the web fetch stage, not only after "web fetch stage finished".
3. Confirm run-level counters (`fetchSuccess`, `persisted`, etc.) and dead-URL recording in the "web fetch stage finished" log line are unchanged.
