### PR TITLE
Remove prompts config group from content-generation agent

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -3,7 +3,6 @@ import { describe, expect, it } from "vitest";
 
 import {
   ContentGenerationConfigSchema,
-  CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH,
   CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING,
   resolveContentGenerationConfig,
 } from "./config-schema.js";
@@ -97,10 +96,6 @@ describe("ContentGenerationConfigSchema", () => {
         maxTokens: 1000,
         timeoutMs: 60_000,
       },
-      prompts: {
-        systemPrompt: "You are a bot",
-        userPromptTemplate: "Hello {{tickerId}}",
-      },
       output: {
         topNewsCount: 5,
       },
@@ -133,61 +128,7 @@ describe("ContentGenerationConfigSchema", () => {
     expect(parsed.credentials.baseUrl).toBe("https://example.com");
     expect(parsed.credentials.chatModel).toBe("gpt-4");
     expect(parsed.output.topNewsCount).toBe(5);
-    expect(parsed.prompts.userPromptTemplate).toBe("Hello {{tickerId}}");
     expect(parsed.freshness.timezone).toBe("America/New_York");
-  });
-
-  it("rejects unknown placeholder in prompts.systemPrompt", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      ...testCredentials,
-      prompts: {
-        systemPrompt: "{{tickerId}} {{notARealToken}}",
-      },
-    });
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      expect(
-        result.error.issues.some((i) =>
-          i.message.includes("{{notARealToken}}"),
-        ),
-      ).toBe(true);
-    }
-  });
-
-  it("rejects unknown placeholder in prompts.userPromptTemplate", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      ...testCredentials,
-      prompts: {
-        userPromptTemplate: "{{tickerId}} {{bogus}}",
-      },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("rejects prompts.systemPrompt longer than max", () => {
-    const result = ContentGenerationConfigSchema.safeParse({
-      ...testCredentials,
-      prompts: {
-        systemPrompt: "x".repeat(
-          CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH + 1,
-        ),
-      },
-    });
-    expect(result.success).toBe(false);
-  });
-
-  it("accepts systemPrompt at exactly max length", () => {
-    const parsed = ContentGenerationConfigSchema.parse({
-      ...testCredentials,
-      prompts: {
-        systemPrompt: "y".repeat(
-          CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH,
-        ),
-      },
-    });
-    expect(parsed.prompts.systemPrompt?.length).toBe(
-      CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH,
-    );
   });
 
   it("parses config with credentials.openaiApiKey only", () => {
@@ -291,8 +232,6 @@ describe("ContentGenerationConfigSchema", () => {
     expect(schemaStr).toContain("delivery");
     expect(schemaStr).toContain("reliability");
     expect(schemaStr).toContain("topNewsCount");
-    expect(schemaStr).toContain("systemPrompt");
-    expect(schemaStr).toContain("userPromptTemplate");
     expect(schemaStr).toContain("calendar_day");
     expect(schemaStr).toContain("maxCharsPerSource");
     expect(schemaStr).toContain("maxTotalContextChars");

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -1,30 +1,10 @@
 import { z } from "zod";
 
-import { findUnknownLlmPromptPlaceholderTokens } from "@workspace/agent-llm-prompt-template";
 import { NEWSLETTER_SECTION_IDS } from "@workspace/agent-data-api-contract";
 import type { NewsletterSectionId } from "@workspace/agent-data-api-contract";
 
-/** Maximum length for each optional `prompts.*` string (Hermes JSON config). */
-export const CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH = 50_000;
-
 /** Rejects runaway `maxAttempts` overrides that would hammer upstream APIs. */
 export const CONTENT_GENERATION_RETRY_MAX_ATTEMPTS_CEILING = 10;
-
-const contentGenerationSystemPromptPlaceholders = new Set([
-  "topNewsCount",
-  "tickerId",
-  "tickerName",
-  "tickerSymbol",
-]);
-
-const contentGenerationUserPromptPlaceholders = new Set([
-  "sourceSummaries",
-  "tickerId",
-  "tickerName",
-  "tickerSymbol",
-  "date",
-  "topNewsCount",
-]);
 
 const sourceRankingWeightsSchema = z
   .object({
@@ -548,30 +528,6 @@ const outputSchema = z
   .default({})
   .describe("Newsletter output sizing.");
 
-const promptsSchema = z
-  .object({
-    systemPrompt: z
-      .string()
-      .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
-        message: `prompts.systemPrompt must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-      })
-      .optional()
-      .describe(
-        "System prompt template. Placeholders: {{topNewsCount}}, {{tickerId}}, {{tickerName}}, {{tickerSymbol}}. Do not put secrets here.",
-      ),
-    userPromptTemplate: z
-      .string()
-      .max(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH, {
-        message: `prompts.userPromptTemplate must be at most ${String(CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH)} characters`,
-      })
-      .optional()
-      .describe(
-        "User prompt template. Placeholders: {{sourceSummaries}}, {{tickerId}}, {{tickerName}}, {{tickerSymbol}}, {{date}}, {{topNewsCount}}. Do not put secrets here.",
-      ),
-  })
-  .default({})
-  .describe("Optional LLM prompt template overrides.");
-
 const llmRetrySchema = z
   .object({
     maxAttempts: z
@@ -670,7 +626,6 @@ export const ContentGenerationConfigSchema = z
   .object({
     credentials: credentialsSchema,
     output: outputSchema,
-    prompts: promptsSchema,
     inputs: inputsSchema,
     creativity: creativitySchema,
     quality: qualitySchema,
@@ -681,32 +636,6 @@ export const ContentGenerationConfigSchema = z
   /** Reject unknown keys (e.g. legacy flat `openai`, `sourceRanking`) so configs fail fast. */
   .strict()
   .superRefine((data, ctx) => {
-    const prompts = data.prompts;
-    if (prompts.systemPrompt) {
-      for (const token of findUnknownLlmPromptPlaceholderTokens(
-        prompts.systemPrompt,
-        contentGenerationSystemPromptPlaceholders,
-      )) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Unknown placeholder {{${token}}} in prompts.systemPrompt`,
-          path: ["prompts", "systemPrompt"],
-        });
-      }
-    }
-    if (prompts.userPromptTemplate) {
-      for (const token of findUnknownLlmPromptPlaceholderTokens(
-        prompts.userPromptTemplate,
-        contentGenerationUserPromptPlaceholders,
-      )) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `Unknown placeholder {{${token}}} in prompts.userPromptTemplate`,
-          path: ["prompts", "userPromptTemplate"],
-        });
-      }
-    }
-
     refineRetryGroupValidity(
       data.reliability.llmRetry,
       ["reliability", "llmRetry"],

--- a/apps/mediapulse/agents/content-generation/src/index.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/index.test.ts
@@ -269,8 +269,6 @@ describe("GET /schemas", () => {
     expect(schemaStr).toContain("quality");
     expect(schemaStr).toContain("delivery");
     expect(schemaStr).toContain("reliability");
-    expect(schemaStr).toContain("systemPrompt");
-    expect(schemaStr).toContain("userPromptTemplate");
     expect(schemaStr).toContain("topNewsCount");
     expect(schemaStr).toContain("maxCharsPerSource");
     expect(schemaStr).toContain("maxTotalContextChars");

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -778,21 +778,14 @@ describe("generateNewsletterWithLlm — token usage and provenance", () => {
 // ---------------------------------------------------------------------------
 
 describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
-  it("uses systemPrompt from config when provided", async () => {
+  it("substitutes {{date}} and sources in the default user prompt template", async () => {
     // Setup
-    const customSystem = "You are a specialized financial analyst.";
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        ...conservativeTestConfigInput,
-        prompts: { systemPrompt: customSystem },
-      }),
-    );
     const generateObjectFn = makeSuccessfulGenerateFn();
 
     // Act
     const result = await generateNewsletterWithLlm(
       testSources,
-      config,
+      baseConfig,
       testContext,
       {
         generateObjectFn,
@@ -800,73 +793,12 @@ describe("generateNewsletterWithLlm — prompt wiring and substitution", () => {
       },
     );
 
-    // Assert
-    expect(result.systemPrompt).toBe(customSystem);
-    const callArgs = (generateObjectFn as ReturnType<typeof vi.fn>).mock
-      .calls[0]![0] as GenerateNewsletterObjectArgs;
-    expect(callArgs.system).toBe(customSystem);
-  });
-
-  it("substitutes {{tickerId}} and {{date}} in userPromptTemplate", async () => {
-    // Setup
-    const customTemplate =
-      "Analysis for {{tickerId}} on {{date}}.\n\n{{sourceSummaries}}";
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        ...conservativeTestConfigInput,
-        prompts: { userPromptTemplate: customTemplate },
-      }),
-    );
-    const generateObjectFn = makeSuccessfulGenerateFn();
-
-    // Act
-    const result = await generateNewsletterWithLlm(
-      testSources,
-      config,
-      testContext,
-      {
-        generateObjectFn,
-        sleepFn: noopSleepFn,
-      },
-    );
-
-    // Assert
-    expect(result.resolvedUserPrompt).toContain(
-      `Analysis for ${testContext.tickerId}`,
-    );
-    expect(result.resolvedUserPrompt).toContain(`on ${testContext.date}`);
+    // Assert — the default template substitutes {{date}} and embeds sources
+    expect(result.resolvedUserPrompt).toContain(testContext.date);
     expect(result.resolvedUserPrompt).toContain("Story A");
     const callArgs = (generateObjectFn as ReturnType<typeof vi.fn>).mock
       .calls[0]![0] as GenerateNewsletterObjectArgs;
     expect(callArgs.prompt).toBe(result.resolvedUserPrompt);
-  });
-
-  it("handles multiple occurrences of the same placeholder", async () => {
-    // Setup
-    const customTemplate = "{{tickerId}} report: {{tickerId}}.";
-    const config = resolveContentGenerationConfig(
-      ContentGenerationConfigSchema.parse({
-        ...conservativeTestConfigInput,
-        prompts: { userPromptTemplate: customTemplate },
-      }),
-    );
-    const generateObjectFn = makeSuccessfulGenerateFn();
-
-    // Act
-    const result = await generateNewsletterWithLlm(
-      testSources,
-      config,
-      testContext,
-      {
-        generateObjectFn,
-        sleepFn: noopSleepFn,
-      },
-    );
-
-    // Assert
-    expect(result.resolvedUserPrompt).toBe(
-      `${testContext.tickerId} report: ${testContext.tickerId}.`,
-    );
   });
 
   it("formats source summaries as numbered articles in the default template", async () => {

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -919,7 +919,7 @@ export async function generateNewsletterWithLlm(
 
   // Apply placeholder substitution to the system prompt so {{topNewsCount}},
   // {{tickerName}}, and {{tickerSymbol}} are resolved before the LLM call.
-  const rawSystemPrompt = config.prompts?.systemPrompt || SYSTEM_PROMPT;
+  const rawSystemPrompt = SYSTEM_PROMPT;
   const substitutedSystemPrompt = rawSystemPrompt
     .replaceAll("{{topNewsCount}}", String(effectiveTopNewsCount))
     .replaceAll("{{tickerId}}", context.tickerId)
@@ -962,8 +962,7 @@ export async function generateNewsletterWithLlm(
     context.tickerName ?? context.tickerId,
   );
 
-  const userTemplate =
-    config.prompts?.userPromptTemplate || DEFAULT_USER_PROMPT_TEMPLATE;
+  const userTemplate = DEFAULT_USER_PROMPT_TEMPLATE;
   const prompt = buildUserPrompt(
     promptSources,
     userTemplate,


### PR DESCRIPTION
## Summary

Removes the `prompts` config group from the content-generation agent. The `systemPrompt` and `userPromptTemplate` Hermes overrides are no longer needed — the agent now always runs with the built-in prompt constants.

## Related issues

Closes #789

## Important changes

- `ContentGenerationConfigSchema` no longer has a `prompts` field — passing `prompts` in Hermes config will now fail schema validation (`.strict()`), making misconfigured runs fail fast instead of silently ignoring the override
- `llm-generate-newsletter.ts` reads `SYSTEM_PROMPT` and `DEFAULT_USER_PROMPT_TEMPLATE` directly; the `config.prompts?.systemPrompt` and `config.prompts?.userPromptTemplate` fallback paths are gone

## Other changes

- Removed `CONTENT_GENERATION_LLM_PROMPT_FIELD_MAX_LENGTH` export and the `findUnknownLlmPromptPlaceholderTokens` import from `config-schema.ts`
- Removed the `superRefine` block that validated prompt placeholder tokens
- Updated `config-schema.test.ts`, `index.test.ts`, and `llm-generate-newsletter.test.ts` to drop all prompts-config coverage (61 lines removed from tests)

## Key files to review

- [config-schema.ts](apps/mediapulse/agents/content-generation/src/config-schema.ts) — schema changes; `prompts` group and related exports gone
- [llm-generate-newsletter.ts](apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts) — lines 922 and 966; now use constants directly

## How to test

1. Run `pnpm --filter @mediapulse/content-generation test` — all tests should pass
2. Run `pnpm --filter @mediapulse/content-generation type:check` — no type errors
3. Confirm that passing `{ prompts: { systemPrompt: "..." } }` to `ContentGenerationConfigSchema.parse()` throws a ZodError (strict mode rejects unknown keys)
