### PR TITLE
Show collection source as Collected by tag on data sources and selected newsletter sources

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/data-sources/collection-source.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/collection-source.test.ts
@@ -1,0 +1,45 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+import {
+  classifyCollectionSource,
+  COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL,
+  COLLECTION_SOURCE_LABEL,
+} from "./collection-source";
+
+describe("classifyCollectionSource", () => {
+  it("maps curated to page-collection", () => {
+    expect(classifyCollectionSource("curated")).toBe("page-collection");
+  });
+
+  it("maps deterministic to data-collection", () => {
+    expect(classifyCollectionSource("deterministic")).toBe("data-collection");
+  });
+
+  it("maps llm to data-collection", () => {
+    expect(classifyCollectionSource("llm")).toBe("data-collection");
+  });
+});
+
+describe("COLLECTION_SOURCE_LABEL", () => {
+  it("labels page-collection as Page Collection", () => {
+    expect(COLLECTION_SOURCE_LABEL["page-collection"]).toBe("Page Collection");
+  });
+
+  it("labels data-collection as Data Collection", () => {
+    expect(COLLECTION_SOURCE_LABEL["data-collection"]).toBe("Data Collection");
+  });
+});
+
+describe("COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL", () => {
+  it("assigns success variant to Page Collection", () => {
+    expect(COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL["Page Collection"]).toBe(
+      "success",
+    );
+  });
+
+  it("assigns outline variant to Data Collection", () => {
+    expect(COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL["Data Collection"]).toBe(
+      "outline",
+    );
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/data-sources/collection-source.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/collection-source.ts
@@ -1,0 +1,29 @@
+import type { DetailBlockBadgeVariant } from "@hermes/domain-contract";
+import type { SearchQuerySource } from "@mediapulse/database";
+
+export type CollectionSource = "page-collection" | "data-collection";
+
+export const classifyCollectionSource = (
+  source: SearchQuerySource,
+): CollectionSource => {
+  switch (source) {
+    case "curated":
+      return "page-collection";
+    case "deterministic":
+    case "llm":
+      return "data-collection";
+  }
+};
+
+export const COLLECTION_SOURCE_LABEL: Record<CollectionSource, string> = {
+  "page-collection": "Page Collection",
+  "data-collection": "Data Collection",
+};
+
+export const COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL: Record<
+  string,
+  DetailBlockBadgeVariant
+> = {
+  "Page Collection": "success",
+  "Data Collection": "outline",
+};

--- a/apps/mediapulse/domain-api/src/resources/data-sources/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/dashboard-page.ts
@@ -29,6 +29,7 @@ export const dataSourcesDashboardPage = {
     { key: "title", label: "Title", type: "text" },
     { key: "url", label: "URL", type: "text" },
     { key: "searchQueryText", label: "Search query", type: "text" },
+    { key: "collectionSourceLabel", label: "Collected by", type: "text" },
     { key: "contentPreview", label: "Preview", type: "text" },
     { key: "contentLength", label: "Chars", type: "text" },
     { key: "createdAt", label: "Created", type: "date-time" },
@@ -39,6 +40,7 @@ export const dataSourcesDashboardPage = {
     "tickerSymbol",
     "tickerName",
     "searchQueryText",
+    "collectionSourceLabel",
   ]),
   sortableFields: rowFieldKeysFor<ListItem>()([
     "createdAt",

--- a/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.test.ts
@@ -20,7 +20,7 @@ describe("truncateContentPreview", () => {
 });
 
 describe("mapRowToListItem", () => {
-  it("flattens relations and previews content", () => {
+  it("flattens relations, previews content, and emits collection source for curated", () => {
     const createdAt = new Date("2024-07-01T00:00:00.000Z");
     const updatedAt = new Date("2024-07-02T00:00:00.000Z");
     const content = "x".repeat(DATA_SOURCE_CONTENT_PREVIEW_MAX + 10);
@@ -37,7 +37,11 @@ describe("mapRowToListItem", () => {
       createdAt,
       updatedAt,
       ticker: { symbol: "ACME", name: "Acme Inc" },
-      searchQuery: { id: "sq-1", text: "earnings news" },
+      searchQuery: {
+        id: "sq-1",
+        text: "earnings news",
+        source: "curated" as const,
+      },
     } satisfies ListRow;
 
     const item = mapRowToListItem(row);
@@ -50,11 +54,42 @@ describe("mapRowToListItem", () => {
     expect(item.contentPreview.length).toBe(
       DATA_SOURCE_CONTENT_PREVIEW_MAX + 1,
     );
+    expect(item.collectionSource).toBe("page-collection");
+    expect(item.collectionSourceLabel).toBe("Page Collection");
+  });
+
+  it("emits data-collection for deterministic source", () => {
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const updatedAt = new Date("2024-07-02T00:00:00.000Z");
+    const row = {
+      id: "ds-2",
+      url: "https://example.com/b",
+      canonicalUrl: "https://example.com/b",
+      title: "Article 2",
+      content: "short",
+      metadata: null,
+      publishedAt: null,
+      tickerId: "t-1",
+      searchQueryId: "sq-2",
+      createdAt,
+      updatedAt,
+      ticker: { symbol: "ACME", name: "Acme Inc" },
+      searchQuery: {
+        id: "sq-2",
+        text: "news",
+        source: "deterministic" as const,
+      },
+    } satisfies ListRow;
+
+    const item = mapRowToListItem(row);
+
+    expect(item.collectionSource).toBe("data-collection");
+    expect(item.collectionSourceLabel).toBe("Data Collection");
   });
 });
 
 describe("mapRowToDetailItem", () => {
-  it("includes full content and metadata", () => {
+  it("includes full content, metadata, and collection source for curated", () => {
     const createdAt = new Date("2024-07-01T00:00:00.000Z");
     const updatedAt = new Date("2024-07-02T00:00:00.000Z");
     const row = {
@@ -70,12 +105,39 @@ describe("mapRowToDetailItem", () => {
       createdAt,
       updatedAt,
       ticker: { symbol: "ACME", name: "Acme Inc" },
-      searchQuery: { id: "sq-1", text: "q" },
+      searchQuery: { id: "sq-1", text: "q", source: "curated" as const },
     } satisfies ListRow;
 
     const detail = mapRowToDetailItem(row);
 
     expect(detail.content).toBe("body text");
     expect(detail.metadata).toEqual({ key: "v" });
+    expect(detail.collectionSource).toBe("page-collection");
+    expect(detail.collectionSourceLabel).toBe("Page Collection");
+  });
+
+  it("emits data-collection for llm source", () => {
+    const createdAt = new Date("2024-07-01T00:00:00.000Z");
+    const updatedAt = new Date("2024-07-02T00:00:00.000Z");
+    const row = {
+      id: "ds-3",
+      url: "https://example.com/c",
+      canonicalUrl: "https://example.com/c",
+      title: "LLM",
+      content: "body text",
+      metadata: null,
+      publishedAt: null,
+      tickerId: "t-1",
+      searchQueryId: "sq-3",
+      createdAt,
+      updatedAt,
+      ticker: { symbol: "ACME", name: "Acme Inc" },
+      searchQuery: { id: "sq-3", text: "q", source: "llm" as const },
+    } satisfies ListRow;
+
+    const detail = mapRowToDetailItem(row);
+
+    expect(detail.collectionSource).toBe("data-collection");
+    expect(detail.collectionSourceLabel).toBe("Data Collection");
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.ts
@@ -3,6 +3,10 @@
  */
 
 import type { Prisma } from "@mediapulse/database";
+import {
+  classifyCollectionSource,
+  COLLECTION_SOURCE_LABEL,
+} from "./collection-source";
 
 /** Max characters of `content` included in list rows (full body is only on GET by id). */
 export const DATA_SOURCE_CONTENT_PREVIEW_MAX = 200;
@@ -21,6 +25,7 @@ export const listInclude = {
     select: {
       id: true,
       text: true,
+      source: true,
     },
   },
 } satisfies Prisma.DataSourceInclude;
@@ -55,21 +60,27 @@ export const truncateContentPreview = (
  * @param row - Row from `prisma.dataSource.findMany` using {@link listInclude}.
  * @returns Serializable list row for the domain API.
  */
-export const mapRowToListItem = (row: ListRow) => ({
-  id: row.id,
-  url: row.url,
-  title: row.title,
-  tickerSymbol: row.ticker.symbol,
-  tickerName: row.ticker.name,
-  searchQueryText: row.searchQuery.text,
-  contentPreview: truncateContentPreview(
-    row.content,
-    DATA_SOURCE_CONTENT_PREVIEW_MAX,
-  ),
-  contentLength: row.content.length,
-  createdAt: row.createdAt.toISOString(),
-  updatedAt: row.updatedAt.toISOString(),
-});
+export const mapRowToListItem = (row: ListRow) => {
+  const collectionSource = classifyCollectionSource(row.searchQuery.source);
+
+  return {
+    id: row.id,
+    url: row.url,
+    title: row.title,
+    tickerSymbol: row.ticker.symbol,
+    tickerName: row.ticker.name,
+    searchQueryText: row.searchQuery.text,
+    collectionSource,
+    collectionSourceLabel: COLLECTION_SOURCE_LABEL[collectionSource],
+    contentPreview: truncateContentPreview(
+      row.content,
+      DATA_SOURCE_CONTENT_PREVIEW_MAX,
+    ),
+    contentLength: row.content.length,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+};
 
 /** JSON list item type; derived from {@link mapRowToListItem}. */
 export type ListItem = ReturnType<typeof mapRowToListItem>;
@@ -80,20 +91,26 @@ export type ListItem = ReturnType<typeof mapRowToListItem>;
  * @param row - Row from `prisma.dataSource.findUnique` using {@link listInclude}.
  * @returns Serializable detail record for the Hermes read-only detail page.
  */
-export const mapRowToDetailItem = (row: ListRow) => ({
-  id: row.id,
-  url: row.url,
-  title: row.title,
-  content: row.content,
-  metadata: row.metadata,
-  tickerId: row.tickerId,
-  searchQueryId: row.searchQueryId,
-  tickerSymbol: row.ticker.symbol,
-  tickerName: row.ticker.name,
-  searchQueryText: row.searchQuery.text,
-  createdAt: row.createdAt.toISOString(),
-  updatedAt: row.updatedAt.toISOString(),
-});
+export const mapRowToDetailItem = (row: ListRow) => {
+  const collectionSource = classifyCollectionSource(row.searchQuery.source);
+
+  return {
+    id: row.id,
+    url: row.url,
+    title: row.title,
+    content: row.content,
+    metadata: row.metadata,
+    tickerId: row.tickerId,
+    searchQueryId: row.searchQueryId,
+    tickerSymbol: row.ticker.symbol,
+    tickerName: row.ticker.name,
+    searchQueryText: row.searchQuery.text,
+    collectionSource,
+    collectionSourceLabel: COLLECTION_SOURCE_LABEL[collectionSource],
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+};
 
 /** JSON detail item type; derived from {@link mapRowToDetailItem}. */
 export type DetailItem = ReturnType<typeof mapRowToDetailItem>;

--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.test.ts
@@ -36,6 +36,7 @@ describe("buildSelectedSources", () => {
         title: "Low",
         searchQueryId: "sq",
         createdAt: new Date("2026-05-14T01:00:00.000Z"),
+        searchQuery: { source: "deterministic" },
         articleRelevances: [
           { score: 0.2, scoredAt: new Date("2026-05-14T01:00:00.000Z") },
         ],
@@ -46,6 +47,7 @@ describe("buildSelectedSources", () => {
         title: "Mid 1",
         searchQueryId: "sq",
         createdAt: new Date("2026-05-14T01:00:00.000Z"),
+        searchQuery: { source: "deterministic" },
         articleRelevances: [
           { score: 0.7, scoredAt: new Date("2026-05-14T03:00:00.000Z") },
         ],
@@ -56,6 +58,7 @@ describe("buildSelectedSources", () => {
         title: "Mid 2",
         searchQueryId: "sq",
         createdAt: new Date("2026-05-14T01:00:00.000Z"),
+        searchQuery: { source: "deterministic" },
         articleRelevances: [
           { score: 0.7, scoredAt: new Date("2026-05-14T05:00:00.000Z") },
         ],
@@ -84,6 +87,7 @@ describe("buildSelectedSources", () => {
         title: "X",
         searchQueryId: "sq",
         createdAt: new Date("2026-05-14T02:00:00.000Z"),
+        searchQuery: { source: "llm" },
         articleRelevances: [],
       },
     ]);
@@ -100,5 +104,47 @@ describe("buildSelectedSources", () => {
       score: 0,
       scoredAt: "2026-05-14T02:00:00.000Z",
     });
+  });
+
+  it("emits collectionSource and label for curated and deterministic rows", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "src-curated",
+        url: "https://example.com/curated",
+        title: "Curated",
+        searchQueryId: "sq-c",
+        createdAt: new Date("2026-05-14T01:00:00.000Z"),
+        searchQuery: { source: "curated" },
+        articleRelevances: [
+          { score: 0.9, scoredAt: new Date("2026-05-14T01:00:00.000Z") },
+        ],
+      },
+      {
+        id: "src-det",
+        url: "https://example.com/det",
+        title: "Deterministic",
+        searchQueryId: "sq-d",
+        createdAt: new Date("2026-05-14T01:00:00.000Z"),
+        searchQuery: { source: "deterministic" },
+        articleRelevances: [
+          { score: 0.5, scoredAt: new Date("2026-05-14T01:00:00.000Z") },
+        ],
+      },
+    ]);
+
+    const result = await buildSelectedSources(
+      "nl-1",
+      "tk-1",
+      new Date("2026-05-14T13:00:00.000Z"),
+      { dataSource: { findMany } },
+    );
+
+    const curated = result.sources.find((s) => s.id === "src-curated");
+    const deterministic = result.sources.find((s) => s.id === "src-det");
+
+    expect(curated?.collectionSource).toBe("page-collection");
+    expect(curated?.collectionSourceLabel).toBe("Page Collection");
+    expect(deterministic?.collectionSource).toBe("data-collection");
+    expect(deterministic?.collectionSourceLabel).toBe("Data Collection");
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.ts
@@ -1,5 +1,10 @@
 import type { Prisma, prisma } from "@mediapulse/database";
 
+import {
+  classifyCollectionSource,
+  COLLECTION_SOURCE_LABEL,
+  type CollectionSource,
+} from "../data-sources/collection-source";
 import { buildSelectedSourcesWindow } from "./selected-sources-window";
 
 /** Shape of one selected-source entry in the detail payload. */
@@ -10,6 +15,8 @@ export type SelectedSourcePayload = {
   score: number;
   scoredAt: string;
   searchQueryId: string;
+  collectionSource: CollectionSource;
+  collectionSourceLabel: string;
 };
 
 /** Output of {@link buildSelectedSources}. */
@@ -68,6 +75,9 @@ export const buildSelectedSources = async (
         },
         select: { score: true, scoredAt: true },
       },
+      searchQuery: {
+        select: { source: true },
+      },
     },
   } satisfies Prisma.DataSourceFindManyArgs;
 
@@ -76,11 +86,14 @@ export const buildSelectedSources = async (
   type RowWithScore = Prisma.DataSourceGetPayload<{
     include: {
       articleRelevances: { select: { score: true; scoredAt: true } };
+      searchQuery: { select: { source: true } };
     };
   }>;
 
   const mapped = (rows as RowWithScore[]).map((row) => {
     const relevance = row.articleRelevances[0];
+    const collectionSource = classifyCollectionSource(row.searchQuery.source);
+
     return {
       id: row.id,
       url: row.url,
@@ -88,6 +101,8 @@ export const buildSelectedSources = async (
       score: relevance?.score ?? 0,
       scoredAt: (relevance?.scoredAt ?? row.createdAt).toISOString(),
       searchQueryId: row.searchQueryId,
+      collectionSource,
+      collectionSourceLabel: COLLECTION_SOURCE_LABEL[collectionSource],
     } satisfies SelectedSourcePayload;
   });
 

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.test.ts
@@ -53,6 +53,21 @@ describe("newslettersDashboardPage section rules", () => {
     expect(evaluateDetailBlockRule(ast, { selectedSources: [{}] })).toBe(false);
   });
 
+  it("selected-sources block has a badge Collected by column with correct variants", () => {
+    const sources = findBlock("Selected sources");
+    expect(sources.type).toBe("subTable");
+    if (sources.type !== "subTable") return;
+
+    const column = sources.columns.find((col) => col.label === "Collected by");
+    expect(column).toBeDefined();
+    expect(column?.type).toBe("badge");
+    expect(column?.field).toBe("collectionSourceLabel");
+    expect(column?.badgeVariants).toMatchObject({
+      "Page Collection": "success",
+      "Data Collection": "outline",
+    });
+  });
+
   it("declares a search-queries rule that uses hoursBetween > 24", () => {
     const queries = findBlock("Search queries");
     expect(queries.sectionRule).toMatchObject({

--- a/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts
@@ -4,8 +4,9 @@ import {
   columnsFor,
   rowFieldKeysFor,
 } from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
-import type { ListItem } from "./list-mapper";
+import { COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL } from "../data-sources/collection-source";
 import { newslettersCustomActionsForManifest } from "./custom-actions";
+import type { ListItem } from "./list-mapper";
 
 /** URL path segment for this resource under `/v1/hermes-dashboard/`. */
 export const newslettersHermesPathSegment = "newsletters" as const;
@@ -182,6 +183,12 @@ const newslettersSelectedSourcesBlock = {
     { field: "domain", label: "Domain", type: "text" },
     { field: "score", label: "Score", type: "number" },
     { field: "scoredAt", label: "Scored at", type: "date-time" },
+    {
+      field: "collectionSourceLabel",
+      label: "Collected by",
+      type: "badge",
+      badgeVariants: COLLECTION_SOURCE_BADGE_VARIANTS_BY_LABEL,
+    },
   ],
 } satisfies DetailBlock;
 


### PR DESCRIPTION
## Summary

Collected sources had no indicator of which pipeline produced them. This wires `SearchQuery.source` through to both places sources are listed in the Hermes dashboard — the Data Sources table and the Newsletter detail "Selected sources" sub-table — so operators can see at a glance whether a source came from the page-collection agent or the data-collection agent.

## Related issues

Closes #791

## Important changes

- New `collection-source.ts` classifier: `classifyCollectionSource` maps `curated` → `"page-collection"` and `deterministic`/`llm` → `"data-collection"`, with display label and badge-variant maps shared by both consumers.
- Data-sources list and detail mappers now include `searchQuery.source` via `listInclude` and emit `collectionSource` + `collectionSourceLabel` on every row.
- Newsletter `build-selected-sources` joins `searchQuery.source` and extends `SelectedSourcePayload` with the same two fields.

## Other changes

- Data Sources manifest gains a "Collected by" text column (list columns are text/date-time only) after "Search query", added to `searchableFields`.
- Newsletter detail "Selected sources" sub-table gains a badge "Collected by" column with `success` for Page Collection and `outline` for Data Collection.
- All affected tests updated; new `collection-source.test.ts` covers all three enum values and both maps.

## Key files to review

- [collection-source.ts](apps/mediapulse/domain-api/src/resources/data-sources/collection-source.ts) — classifier, label map, badge-variant map.
- [list-mapper.ts](apps/mediapulse/domain-api/src/resources/data-sources/list-mapper.ts) — `listInclude` gains `source: true`; both mappers emit new fields.
- [build-selected-sources.ts](apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.ts) — `searchQuery` added to include; `RowWithScore` and `SelectedSourcePayload` extended.
- [newsletters/dashboard-page.ts](apps/mediapulse/domain-api/src/resources/newsletters/dashboard-page.ts) — badge column added to `newslettersSelectedSourcesBlock`.

## How to test

1. Run `pnpm --filter @mediapulse/domain-api test` — all 274 tests should pass.
2. In the Hermes dashboard, open the Data Sources list and confirm a "Collected by" column showing "Page Collection" (for rows whose search query has `source: curated`) or "Data Collection" (for `deterministic`/`llm`).
3. Open a Newsletter detail page, scroll to "Selected sources", and confirm a colored "Collected by" badge on each row.
