### PR TITLE
Add processed-URLs view per schedule execution

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/page.tsx
@@ -171,6 +171,15 @@ export default async function ScheduleExecutionDetailPage({
         </div>
       </section>
 
+      <div>
+        <Link
+          href={`/dashboard/schedules/${scheduleId}/executions/${executionId}/processed-urls`}
+          className="text-sm underline-offset-4 hover:underline"
+        >
+          View Processed URLs →
+        </Link>
+      </div>
+
       <section>
         <h2 className="mb-2 text-lg font-medium">Invocations</h2>
         <ScheduleExecutionInvocationsTable

--- a/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/processed-urls/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/processed-urls/page.tsx
@@ -1,0 +1,242 @@
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@workspace/ui/components/table";
+import { Badge } from "@workspace/ui/components/badge";
+
+import { fetchProcessedUrlsForExecution } from "@/lib/domain-dashboard";
+
+type PageProps = {
+  params: Promise<{ id: string; executionId: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+const PAGE_SIZE = 50;
+
+const STATUS_BADGE: Record<string, "success" | "destructive" | "outline"> = {
+  collected: "success",
+  failed: "destructive",
+  dropped: "outline",
+};
+
+function first(value: string | string[] | undefined): string | undefined {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+/**
+ * Processed-URLs sub-page for a schedule execution: shows every URL processed
+ * by data-collection and page-collection agents, with status and drop reason.
+ */
+export default async function ProcessedUrlsPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { id: scheduleId, executionId } = await params;
+  const resolvedSearchParams = await searchParams;
+
+  const page = Math.max(
+    1,
+    Number.parseInt(first(resolvedSearchParams.page) ?? "1", 10) || 1,
+  );
+  const tickerId = first(resolvedSearchParams.tickerId);
+  const agent = first(resolvedSearchParams.agent);
+  const status = first(resolvedSearchParams.status);
+
+  let data: Awaited<ReturnType<typeof fetchProcessedUrlsForExecution>> | null =
+    null;
+  let fetchError: string | null = null;
+
+  try {
+    data = await fetchProcessedUrlsForExecution({
+      scheduleExecutionId: executionId,
+      page,
+      pageSize: PAGE_SIZE,
+      tickerId,
+      agent,
+      status,
+    });
+  } catch (error) {
+    fetchError =
+      error instanceof Error ? error.message : "Failed to load processed URLs";
+  }
+
+  const backHref = `/dashboard/schedules/${scheduleId}/executions/${executionId}`;
+
+  const buildFilterHref = (updates: Record<string, string | undefined>) => {
+    const next = new URLSearchParams();
+    const merged = { tickerId, agent, status, page: "1", ...updates };
+    for (const [key, value] of Object.entries(merged)) {
+      if (value) next.set(key, value);
+    }
+    const qs = next.toString();
+
+    return qs
+      ? `/dashboard/schedules/${scheduleId}/executions/${executionId}/processed-urls?${qs}`
+      : `/dashboard/schedules/${scheduleId}/executions/${executionId}/processed-urls`;
+  };
+
+  const buildPageHref = (targetPage: number) => {
+    const next = new URLSearchParams();
+    if (tickerId) next.set("tickerId", tickerId);
+    if (agent) next.set("agent", agent);
+    if (status) next.set("status", status);
+    next.set("page", String(targetPage));
+
+    return `/dashboard/schedules/${scheduleId}/executions/${executionId}/processed-urls?${next.toString()}`;
+  };
+
+  const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 1;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <Link
+          href={backHref}
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          Back to execution
+        </Link>
+      </div>
+
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">
+          Processed URLs
+        </h1>
+        <p className="text-muted-foreground text-sm">
+          Every URL seen by data-collection and page-collection agents in this
+          execution.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-sm">
+        <span className="text-muted-foreground">Agent:</span>
+        {["", "data-collection", "page-collection"].map((value) => (
+          <Link
+            key={value || "all"}
+            href={buildFilterHref({ agent: value || undefined })}
+            className={`rounded px-2 py-0.5 ${
+              (agent ?? "") === value
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {value || "All"}
+          </Link>
+        ))}
+        <span className="ml-4 text-muted-foreground">Status:</span>
+        {["", "collected", "dropped", "failed"].map((value) => (
+          <Link
+            key={value || "all"}
+            href={buildFilterHref({ status: value || undefined })}
+            className={`rounded px-2 py-0.5 ${
+              (status ?? "") === value
+                ? "bg-foreground text-background"
+                : "bg-muted text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {value || "All"}
+          </Link>
+        ))}
+      </div>
+
+      {fetchError ? (
+        <p className="text-sm text-destructive">{fetchError}</p>
+      ) : data && data.total === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No processed URL outcomes for this execution. Outcomes are recorded
+          from agent runs triggered after this feature was deployed.
+        </p>
+      ) : (
+        <>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Ticker</TableHead>
+                  <TableHead>Agent</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>URL</TableHead>
+                  <TableHead>Source</TableHead>
+                  <TableHead>Time</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.items.map((item) => (
+                  <TableRow key={item.id}>
+                    <TableCell className="font-mono text-xs">
+                      {item.tickerSymbol}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground">
+                      {item.agent}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={STATUS_BADGE[item.status] ?? "outline"}>
+                        {item.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-xs text-xs text-muted-foreground">
+                      {item.reasonDetail ?? item.reason ?? "—"}
+                    </TableCell>
+                    <TableCell className="max-w-sm break-all text-xs">
+                      <a
+                        href={item.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline-offset-4 hover:underline"
+                      >
+                        {item.url.length > 80
+                          ? `${item.url.slice(0, 80)}…`
+                          : item.url}
+                      </a>
+                    </TableCell>
+                    <TableCell className="max-w-xs break-all text-xs text-muted-foreground">
+                      {item.source ?? "—"}
+                    </TableCell>
+                    <TableCell className="text-xs text-muted-foreground whitespace-nowrap">
+                      {new Date(item.createdAt).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {data && (
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>
+                {data.total} total · page {page} of {totalPages}
+              </span>
+              <div className="flex gap-2">
+                {page > 1 && (
+                  <Link
+                    href={buildPageHref(page - 1)}
+                    className="rounded border px-3 py-1 hover:bg-muted"
+                  >
+                    Previous
+                  </Link>
+                )}
+                {page < totalPages && (
+                  <Link
+                    href={buildPageHref(page + 1)}
+                    className="rounded border px-3 py-1 hover:bg-muted"
+                  >
+                    Next
+                  </Link>
+                )}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/hermes/dashboard/lib/domain-dashboard.ts
+++ b/apps/hermes/dashboard/lib/domain-dashboard.ts
@@ -740,3 +740,94 @@ export const deleteDomainTableItem = async (
     domainIntegrationId,
   );
 };
+
+/** Mediapulse integration id used for processed-URL lookups. */
+const MEDIAPULSE_INTEGRATION_ID = "mediapulse";
+
+/** Domain-api path for the processed-urls endpoint (relative to `/v1`). */
+const PROCESSED_URLS_PATH = "/hermes-dashboard/processed-urls";
+
+/** Response item shape returned by the processed-urls domain-api endpoint. */
+export type ProcessedUrlItem = {
+  id: string;
+  tickerSymbol: string;
+  agent: string;
+  url: string;
+  status: string;
+  reason: string | null;
+  reasonDetail: string | null;
+  source: string | null;
+  createdAt: string;
+};
+
+/** Paginated response from the processed-urls domain-api endpoint. */
+export type ProcessedUrlsListResponse = {
+  items: ProcessedUrlItem[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+const processedUrlsListResponseSchema = (
+  value: unknown,
+): ProcessedUrlsListResponse => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !Array.isArray((value as { items?: unknown }).items) ||
+    typeof (value as { total?: unknown }).total !== "number" ||
+    typeof (value as { page?: unknown }).page !== "number" ||
+    typeof (value as { pageSize?: unknown }).pageSize !== "number"
+  ) {
+    throw new Error("Invalid processed-urls response shape");
+  }
+  return value as ProcessedUrlsListResponse;
+};
+
+/** Query params for {@link fetchProcessedUrlsForExecution}. */
+export type FetchProcessedUrlsParams = {
+  scheduleExecutionId: string;
+  page?: number;
+  pageSize?: number;
+  tickerId?: string;
+  agent?: string;
+  status?: string;
+};
+
+/**
+ * Fetches paginated processed-URL outcomes for a given schedule execution from the mediapulse domain-api.
+ *
+ * @param params - Required `scheduleExecutionId` plus optional filters and pagination.
+ * @returns Paginated list of processed-URL outcome items.
+ */
+export const fetchProcessedUrlsForExecution = async (
+  params: FetchProcessedUrlsParams,
+): Promise<ProcessedUrlsListResponse> => {
+  const integration = await getDomainIntegrationByIntegrationId(
+    MEDIAPULSE_INTEGRATION_ID,
+  );
+  if (!integration) {
+    throw new Error(
+      "Mediapulse domain integration is not active or not registered",
+    );
+  }
+
+  const baseUrl = integration.baseUrl.replace(/\/$/, "");
+  const domainIntegrationId = integration.id;
+
+  const search = new URLSearchParams();
+  search.set("scheduleExecutionId", params.scheduleExecutionId);
+  if (params.page !== undefined) search.set("page", String(params.page));
+  if (params.pageSize !== undefined)
+    search.set("pageSize", String(params.pageSize));
+  if (params.tickerId) search.set("tickerId", params.tickerId);
+  if (params.agent) search.set("agent", params.agent);
+  if (params.status) search.set("status", params.status);
+
+  return callDomain(
+    `${baseUrl}/v1${PROCESSED_URLS_PATH}?${search.toString()}`,
+    processedUrlsListResponseSchema,
+    undefined,
+    domainIntegrationId,
+  );
+};

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -68,6 +68,7 @@ import {
 } from "./routes/content-generation-run.js";
 import { getSectionCoverageRollupHandler } from "./routes/section-coverage-rollup.js";
 import { getAgentInsights } from "./routes/agent-insights.js";
+import { postCollectionUrlOutcome } from "./routes/collection-url-outcome.js";
 import { createPageCollectionInsightsProvider } from "./services/insights/page-collection-insights-provider.js";
 import { createContentGenerationInsightsProvider } from "./services/insights/content-generation-insights-provider.js";
 import { createUserRegistrationInsightsProvider } from "./services/insights/user-registration-insights-provider.js";
@@ -199,6 +200,9 @@ const routeHandlers = {
   },
   agentInsights: {
     get: getAgentInsights,
+  },
+  collectionUrlOutcome: {
+    post: postCollectionUrlOutcome,
   },
 } satisfies AgentDataApiHandlers;
 

--- a/apps/mediapulse/agent-data-api/src/routes/collection-url-outcome.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/collection-url-outcome.ts
@@ -1,0 +1,39 @@
+import { Context } from "hono";
+
+import { postCollectionUrlOutcomeBodySchema } from "@workspace/agent-data-api-contract";
+import { internalError } from "@workspace/api-utils";
+import { prisma } from "@mediapulse/database";
+
+export async function postCollectionUrlOutcome(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const dataList = await postCollectionUrlOutcomeBodySchema.parseAsync(body);
+
+    await prisma.collectionUrlOutcome.createMany({
+      data: dataList.map((item) => ({
+        id: item.id,
+        scheduleExecutionId: item.scheduleExecutionId ?? null,
+        runId: item.runId,
+        tickerId: item.tickerId,
+        agent:
+          item.agent === "data-collection"
+            ? "data_collection"
+            : "page_collection",
+        status: item.status,
+        url: item.url,
+        reason: item.reason ?? null,
+        reasonDetail: item.reasonDetail ?? null,
+        source: item.source ?? null,
+        searchQueryId: item.searchQueryId ?? null,
+        createdAt: new Date(item.createdAt),
+      })),
+      skipDuplicates: true,
+    });
+
+    return context.json({ message: "Success" }, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection-run.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection-run.ts
@@ -54,6 +54,7 @@ export async function postDataCollectionRun(
       data: {
         id: data.id,
         tickerId: data.tickerId,
+        scheduleExecutionId: data.scheduleExecutionId ?? null,
         startedAt: new Date(data.startedAt),
         completedAt: data.completedAt ? new Date(data.completedAt) : null,
         status: data.status,

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -35,6 +35,11 @@ import {
   type RunCounters,
   extractPublishedDate,
   isFresh,
+  makeDroppedOutcome,
+  makeCollectedOutcome,
+  makeFailedOutcome,
+  postOutcomesInChunks,
+  type CollectionUrlOutcomeInput,
 } from "@workspace/agent-ingestion";
 import {
   performWebSearch,
@@ -58,6 +63,9 @@ export async function runDataCollection(
   const { input, config, token, hermesCorrelation } = context;
   const startedAt = new Date();
   const runId = crypto.randomUUID();
+  const scheduleExecutionId =
+    hermesCorrelation?.scheduleExecutionId ?? undefined;
+  const outcomes: CollectionUrlOutcomeInput[] = [];
 
   const hermes = hermesCorrelation;
   const log = logger.child({
@@ -291,11 +299,43 @@ export async function runDataCollection(
         const decision = classifyNoisyUrl(hit.url);
         if (decision.blocked) {
           droppedByUrlReason[decision.reason] += 1;
+          outcomes.push(
+            makeDroppedOutcome(
+              {
+                id: crypto.randomUUID(),
+                scheduleExecutionId,
+                runId,
+                tickerId: input.tickerId,
+                agent: "data-collection",
+                url: hit.url,
+                source: hit.searchQueryText,
+                searchQueryId: hit.searchQueryId,
+                createdAt: new Date().toISOString(),
+              },
+              { reason: `url_noise_${decision.reason}`, detail: hit.url },
+            ),
+          );
           continue;
         }
 
         if (canonicalUniqueHits.has(decision.canonicalUrl)) {
           droppedByDuplicateCanonicalUrl += 1;
+          outcomes.push(
+            makeDroppedOutcome(
+              {
+                id: crypto.randomUUID(),
+                scheduleExecutionId,
+                runId,
+                tickerId: input.tickerId,
+                agent: "data-collection",
+                url: decision.canonicalUrl,
+                source: hit.searchQueryText,
+                searchQueryId: hit.searchQueryId,
+                createdAt: new Date().toISOString(),
+              },
+              { reason: "duplicate_canonical_url" },
+            ),
+          );
           continue;
         }
 
@@ -313,9 +353,28 @@ export async function runDataCollection(
           candidateUrls,
           (body) => dataApiClient.dataCollectionExistingUrls.create(body),
         );
-      const searchSuccessesForFetch = filteredSearchSuccesses.filter(
-        (hit) => !existingUrlSet.has(hit.url),
-      );
+      const searchSuccessesForFetch = filteredSearchSuccesses.filter((hit) => {
+        if (existingUrlSet.has(hit.url)) {
+          outcomes.push(
+            makeDroppedOutcome(
+              {
+                id: crypto.randomUUID(),
+                scheduleExecutionId,
+                runId,
+                tickerId: input.tickerId,
+                agent: "data-collection",
+                url: hit.url,
+                source: hit.searchQueryText,
+                searchQueryId: hit.searchQueryId,
+                createdAt: new Date().toISOString(),
+              },
+              { reason: "existing_canonical_url" },
+            ),
+          );
+          return false;
+        }
+        return true;
+      });
       const skippedExistingUrlCount =
         filteredSearchSuccesses.length - searchSuccessesForFetch.length;
       droppedByExistingCanonicalUrl += skippedExistingUrlCount;
@@ -339,12 +398,33 @@ export async function runDataCollection(
           deadUrlCacheConfig.skipLookupBatchSize,
         );
         if (deadUrlSet.size > 0) {
-          const beforeCount = searchSuccessesAfterDeadUrl.length;
+          const beforeDeadUrlCount = searchSuccessesAfterDeadUrl.length;
           searchSuccessesAfterDeadUrl = searchSuccessesAfterDeadUrl.filter(
-            (hit) => !deadUrlSet.has(hit.url),
+            (hit) => {
+              if (deadUrlSet.has(hit.url)) {
+                outcomes.push(
+                  makeDroppedOutcome(
+                    {
+                      id: crypto.randomUUID(),
+                      scheduleExecutionId,
+                      runId,
+                      tickerId: input.tickerId,
+                      agent: "data-collection",
+                      url: hit.url,
+                      source: hit.searchQueryText,
+                      searchQueryId: hit.searchQueryId,
+                      createdAt: new Date().toISOString(),
+                    },
+                    { reason: "dead_url_cache" },
+                  ),
+                );
+                return false;
+              }
+              return true;
+            },
           );
           const skippedDeadUrlCount =
-            beforeCount - searchSuccessesAfterDeadUrl.length;
+            beforeDeadUrlCount - searchSuccessesAfterDeadUrl.length;
           droppedByDeadUrlCache += skippedDeadUrlCount;
           log.info(
             {
@@ -362,6 +442,22 @@ export async function runDataCollection(
           const host = hostFromUrl(hit.url);
           if (hostErrorTracker.isSkipped(host)) {
             droppedByHostErrorRate += 1;
+            outcomes.push(
+              makeDroppedOutcome(
+                {
+                  id: crypto.randomUUID(),
+                  scheduleExecutionId,
+                  runId,
+                  tickerId: input.tickerId,
+                  agent: "data-collection",
+                  url: hit.url,
+                  source: hit.searchQueryText,
+                  searchQueryId: hit.searchQueryId,
+                  createdAt: new Date().toISOString(),
+                },
+                { reason: "host_error_rate", host },
+              ),
+            );
             return false;
           }
           return true;
@@ -404,9 +500,27 @@ export async function runDataCollection(
       const persistFetchedPage = async (
         page: FetchedWebSearchResult,
       ): Promise<void> => {
+        const outcomeBase = {
+          id: crypto.randomUUID(),
+          scheduleExecutionId,
+          runId,
+          tickerId: input.tickerId,
+          agent: "data-collection" as const,
+          url: page.url,
+          source: page.searchQueryText,
+          searchQueryId: page.searchQueryId,
+          createdAt: new Date().toISOString(),
+        };
+
         const urlDecision = classifyNoisyUrl(page.url);
         if (urlDecision.blocked) {
           droppedByUrlReason[urlDecision.reason] += 1;
+          outcomes.push(
+            makeDroppedOutcome(outcomeBase, {
+              reason: `url_noise_${urlDecision.reason}`,
+              detail: page.url,
+            }),
+          );
           return;
         }
 
@@ -421,6 +535,17 @@ export async function runDataCollection(
             url: urlDecision.canonicalUrl,
             reason: contentDecision.reason,
           });
+          outcomes.push(
+            makeDroppedOutcome(
+              { ...outcomeBase, url: urlDecision.canonicalUrl },
+              contentDecision.reason === "content_too_short"
+                ? {
+                    reason: contentDecision.reason,
+                    charCount: page.content.length,
+                  }
+                : { reason: contentDecision.reason },
+            ),
+          );
           return;
         }
 
@@ -439,6 +564,16 @@ export async function runDataCollection(
           );
           if (!relevanceDecision.relevant) {
             droppedByRelevance += 1;
+            outcomes.push(
+              makeDroppedOutcome(
+                { ...outcomeBase, url: urlDecision.canonicalUrl },
+                {
+                  reason: "relevance_no_match",
+                  tickerSymbol: subject.symbol,
+                  headChars: relevanceGateConfig.headChars ?? 4000,
+                },
+              ),
+            );
             log.info(
               {
                 round,
@@ -464,6 +599,22 @@ export async function runDataCollection(
           if (!freshnessDecision.fresh) {
             droppedByFreshnessReason[freshnessDecision.reason] =
               (droppedByFreshnessReason[freshnessDecision.reason] ?? 0) + 1;
+            const freshnessContext =
+              freshnessDecision.reason === "too_old" && publishedAt
+                ? {
+                    reason: "freshness_too_old" as const,
+                    publishedAt,
+                    maxAgeDays: freshnessGateConfig.maxAgeDays ?? 14,
+                  }
+                : freshnessDecision.reason === "future_dated" && publishedAt
+                  ? { reason: "freshness_future_dated" as const, publishedAt }
+                  : { reason: "freshness_unknown_date" as const };
+            outcomes.push(
+              makeDroppedOutcome(
+                { ...outcomeBase, url: urlDecision.canonicalUrl },
+                freshnessContext,
+              ),
+            );
             log.info(
               {
                 round,
@@ -490,6 +641,12 @@ export async function runDataCollection(
           "persisting collected source to Agent Data API",
         );
         await dataApiClient.dataCollection.create([source]);
+        outcomes.push(
+          makeCollectedOutcome({
+            ...outcomeBase,
+            url: urlDecision.canonicalUrl,
+          }),
+        );
         persistedThisRunCount += 1;
         persistedThisRoundCount += 1;
         fetchSuccessCount += 1;
@@ -677,6 +834,7 @@ export async function runDataCollection(
   const runPayload = {
     id: runId,
     tickerId: input.tickerId,
+    scheduleExecutionId,
     startedAt: startedAt.toISOString(),
     completedAt: new Date().toISOString(),
     status,
@@ -695,6 +853,45 @@ export async function runDataCollection(
       "recording run failures to Agent Data API",
     );
     await dataApiClient.dataCollectionFailure.create(failuresPayload);
+  }
+
+  for (const failure of fetchFailures) {
+    if (failure.url) {
+      outcomes.push(
+        makeFailedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "data-collection",
+            url: failure.url,
+            source: undefined,
+            searchQueryId: failure.queryId,
+            createdAt: new Date().toISOString(),
+          },
+          failure.errorCategory,
+          failure.httpStatus,
+        ),
+      );
+    }
+  }
+
+  if (outcomes.length > 0) {
+    try {
+      await postOutcomesInChunks(outcomes, (batch) =>
+        dataApiClient.collectionUrlOutcome.create(batch),
+      );
+      log.info(
+        { outcomeCount: outcomes.length },
+        "posted per-URL collection outcomes",
+      );
+    } catch (outcomeError) {
+      log.warn(
+        { err: outcomeError },
+        "failed to post collection URL outcomes; continuing",
+      );
+    }
   }
 
   const summary = {

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -30,6 +30,11 @@ import {
   type DiscoveryCache,
   type DiscoverySource,
   type WebSearchResult,
+  makeDroppedOutcome,
+  makeCollectedOutcome,
+  makeFailedOutcome,
+  postOutcomesInChunks,
+  type CollectionUrlOutcomeInput,
 } from "@workspace/agent-ingestion";
 import { classifyNoisyUrl, type UrlNoiseReason } from "@workspace/utils";
 import { prefilterByAliases } from "./utilities/prefilter-by-aliases";
@@ -48,6 +53,9 @@ export async function runPageCollection(
   const { input, config, token, hermesCorrelation } = context;
   const startedAt = new Date();
   const runId = crypto.randomUUID();
+  const scheduleExecutionId =
+    hermesCorrelation?.scheduleExecutionId ?? undefined;
+  const outcomes: CollectionUrlOutcomeInput[] = [];
 
   const hermes = hermesCorrelation;
   const log = logger.child({
@@ -211,18 +219,56 @@ export async function runPageCollection(
       { droppedByRunItemCap, maxDiscoveredItemsPerRun: maxDiscoveredItems },
       "discovered items truncated by per-run cap",
     );
+    for (const item of discoveredItems.slice(maxDiscoveredItems)) {
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url: item.url,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: "dropped_by_run_item_cap" },
+        ),
+      );
+    }
   }
 
-  const prefilterDropCount =
-    cappedDiscoveredItems.length -
-    prefilterByAliases(cappedDiscoveredItems, {
-      tickerAliases,
-      industryAliases,
-    }).length;
   const filteredItems = prefilterByAliases(cappedDiscoveredItems, {
     tickerAliases,
     industryAliases,
   });
+  const prefilterDropCount =
+    cappedDiscoveredItems.length - filteredItems.length;
+
+  if (prefilterDropCount > 0) {
+    const filteredItemUrls = new Set(filteredItems.map((item) => item.url));
+    for (const item of cappedDiscoveredItems) {
+      if (!filteredItemUrls.has(item.url)) {
+        outcomes.push(
+          makeDroppedOutcome(
+            {
+              id: crypto.randomUUID(),
+              scheduleExecutionId,
+              runId,
+              tickerId: input.tickerId,
+              agent: "page-collection",
+              url: item.url,
+              source: undefined,
+              searchQueryId,
+              createdAt: new Date().toISOString(),
+            },
+            { reason: "prefilter_alias_mismatch" },
+          ),
+        );
+      }
+    }
+  }
 
   log.info(
     {
@@ -261,11 +307,43 @@ export async function runPageCollection(
     const decision = classifyNoisyUrl(item.url);
     if (decision.blocked) {
       droppedByUrlReason[decision.reason] += 1;
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url: item.url,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: `url_noise_${decision.reason}`, detail: item.url },
+        ),
+      );
       continue;
     }
 
     if (canonicalItemMap.has(decision.canonicalUrl)) {
       droppedByDuplicateCanonicalUrl += 1;
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url: decision.canonicalUrl,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: "duplicate_canonical_url" },
+        ),
+      );
       continue;
     }
 
@@ -301,6 +379,26 @@ export async function runPageCollection(
       { droppedByExistingCanonicalUrl },
       "skipped fetch for URLs already stored as data sources",
     );
+    for (const url of candidateUrls) {
+      if (existingUrlSet.has(url)) {
+        outcomes.push(
+          makeDroppedOutcome(
+            {
+              id: crypto.randomUUID(),
+              scheduleExecutionId,
+              runId,
+              tickerId: input.tickerId,
+              agent: "page-collection",
+              url,
+              source: undefined,
+              searchQueryId,
+              createdAt: new Date().toISOString(),
+            },
+            { reason: "existing_canonical_url" },
+          ),
+        );
+      }
+    }
   }
 
   let candidatesAfterDeadUrl = candidatesAfterExisting;
@@ -321,6 +419,26 @@ export async function runPageCollection(
         { droppedByDeadUrlCache },
         "skipped fetch for URLs in dead-url negative cache",
       );
+      for (const url of candidatesAfterExisting) {
+        if (deadUrlSet.has(url)) {
+          outcomes.push(
+            makeDroppedOutcome(
+              {
+                id: crypto.randomUUID(),
+                scheduleExecutionId,
+                runId,
+                tickerId: input.tickerId,
+                agent: "page-collection",
+                url,
+                source: undefined,
+                searchQueryId,
+                createdAt: new Date().toISOString(),
+              },
+              { reason: "dead_url_cache" },
+            ),
+          );
+        }
+      }
     }
   }
 
@@ -328,6 +446,22 @@ export async function runPageCollection(
     const host = hostFromUrl(url);
     if (hostErrorTracker.isSkipped(host)) {
       droppedByHostErrorRate += 1;
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: "host_error_rate", host },
+        ),
+      );
       return false;
     }
     return true;
@@ -354,6 +488,24 @@ export async function runPageCollection(
       { droppedByFetchBudget, perRunFetchBudget },
       "fetch candidates truncated by per-run fetch budget",
     );
+    for (const url of candidatesAfterHostBreaker.slice(perRunFetchBudget)) {
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: "dropped_by_fetch_budget" },
+        ),
+      );
+    }
   }
 
   report(
@@ -408,6 +560,22 @@ export async function runPageCollection(
     const urlDecision = classifyNoisyUrl(page.url);
     if (urlDecision.blocked) {
       droppedByUrlReason[urlDecision.reason] += 1;
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url: page.url,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: `url_noise_${urlDecision.reason}`, detail: page.url },
+        ),
+      );
       continue;
     }
 
@@ -418,6 +586,22 @@ export async function runPageCollection(
         url: urlDecision.canonicalUrl,
         reason: contentDecision.reason,
       });
+      outcomes.push(
+        makeDroppedOutcome(
+          {
+            id: crypto.randomUUID(),
+            scheduleExecutionId,
+            runId,
+            tickerId: input.tickerId,
+            agent: "page-collection",
+            url: urlDecision.canonicalUrl,
+            source: undefined,
+            searchQueryId,
+            createdAt: new Date().toISOString(),
+          },
+          { reason: contentDecision.reason },
+        ),
+      );
       continue;
     }
 
@@ -442,6 +626,26 @@ export async function runPageCollection(
             reason: relevanceDecision.reason,
           },
           "dropped page that did not mention the target ticker or industry",
+        );
+        outcomes.push(
+          makeDroppedOutcome(
+            {
+              id: crypto.randomUUID(),
+              scheduleExecutionId,
+              runId,
+              tickerId: input.tickerId,
+              agent: "page-collection",
+              url: urlDecision.canonicalUrl,
+              source: undefined,
+              searchQueryId,
+              createdAt: new Date().toISOString(),
+            },
+            {
+              reason: "relevance_no_match",
+              tickerSymbol: tickerRecord.symbol,
+              headChars: relevanceGateConfig.headChars,
+            },
+          ),
         );
         continue;
       }
@@ -472,6 +676,31 @@ export async function runPageCollection(
           },
           "dropped page outside freshness window",
         );
+        outcomes.push(
+          makeDroppedOutcome(
+            {
+              id: crypto.randomUUID(),
+              scheduleExecutionId,
+              runId,
+              tickerId: input.tickerId,
+              agent: "page-collection",
+              url: urlDecision.canonicalUrl,
+              source: undefined,
+              searchQueryId,
+              createdAt: new Date().toISOString(),
+            },
+            freshnessDecision.reason === "too_old" && publishedAt !== null
+              ? {
+                  reason: "freshness_too_old",
+                  publishedAt,
+                  maxAgeDays: freshnessGateConfig.maxAgeDays,
+                }
+              : freshnessDecision.reason === "future_dated" &&
+                  publishedAt !== null
+                ? { reason: "freshness_future_dated", publishedAt }
+                : { reason: "freshness_unknown_date" },
+          ),
+        );
         continue;
       }
     }
@@ -486,6 +715,19 @@ export async function runPageCollection(
       metadata: { provider: page.provider },
     });
     fetchSuccessCount += 1;
+    outcomes.push(
+      makeCollectedOutcome({
+        id: crypto.randomUUID(),
+        scheduleExecutionId,
+        runId,
+        tickerId: input.tickerId,
+        agent: "page-collection",
+        url: urlDecision.canonicalUrl,
+        source: undefined,
+        searchQueryId,
+        createdAt: new Date().toISOString(),
+      }),
+    );
   }
 
   if (sourcesToPersist.length > 0) {
@@ -636,6 +878,7 @@ export async function runPageCollection(
   const runPayload = {
     id: runId,
     tickerId: input.tickerId,
+    scheduleExecutionId,
     startedAt: startedAt.toISOString(),
     completedAt: new Date().toISOString(),
     status,
@@ -650,6 +893,44 @@ export async function runPageCollection(
       "recording run failures to Agent Data API",
     );
     await dataApiClient.dataCollectionFailure.create(failuresPayload);
+    for (const failure of failuresPayload) {
+      if (failure.url) {
+        outcomes.push(
+          makeFailedOutcome(
+            {
+              id: crypto.randomUUID(),
+              scheduleExecutionId,
+              runId,
+              tickerId: input.tickerId,
+              agent: "page-collection",
+              url: failure.url,
+              source: undefined,
+              searchQueryId,
+              createdAt: failure.createdAt,
+            },
+            failure.errorCategory,
+            failure.httpStatus ?? undefined,
+          ),
+        );
+      }
+    }
+  }
+
+  if (outcomes.length > 0) {
+    try {
+      await postOutcomesInChunks(outcomes, (batch) =>
+        dataApiClient.collectionUrlOutcome.create(batch),
+      );
+      log.info(
+        { outcomeCount: outcomes.length },
+        "posted collection URL outcomes",
+      );
+    } catch (outcomeError) {
+      log.warn(
+        { outcomeCount: outcomes.length, err: outcomeError },
+        "failed to post collection URL outcomes; continuing",
+      );
+    }
   }
 
   const summary = {

--- a/apps/mediapulse/domain-api/src/http/create-hono-app.ts
+++ b/apps/mediapulse/domain-api/src/http/create-hono-app.ts
@@ -11,6 +11,7 @@ import { hermesDashboardManifestRoutes } from "./routes/hermes-dashboard-manifes
 import { stepInputExpansionRoutes } from "./routes/step-input-expansion-routes";
 import { unsubscribeRoutes } from "./routes/unsubscribe-routes";
 import { verifyInvocationJwtFromHeader } from "./verify-invocation-jwt-middleware";
+import { processedUrlsRoutes } from "../resources/processed-urls/routes";
 
 /**
  * Builds the Mediapulse domain API Hono application (middleware, versioned routes).
@@ -56,6 +57,7 @@ export const createDomainApiServer = (): {
     api.route(hermesDashboardTableMountPath(segment), subApp);
   }
 
+  api.route("/hermes-dashboard/processed-urls", processedUrlsRoutes);
   api.route(HERMES_DASHBOARD_V1_MOUNT_PATH, hermesDashboardManifestRoutes);
   api.route("/", stepInputExpansionRoutes);
 

--- a/apps/mediapulse/domain-api/src/resources/processed-urls/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/processed-urls/list-mapper.ts
@@ -1,0 +1,35 @@
+import type { Prisma } from "@mediapulse/database";
+
+/** Prisma include for collection-url-outcome rows (ticker symbol for display). */
+export const listInclude = {
+  ticker: {
+    select: { symbol: true },
+  },
+} satisfies Prisma.CollectionUrlOutcomeInclude;
+
+/** Prisma row shape for `collectionUrlOutcome.findMany` when loading the list view. */
+export type ListRow = Prisma.CollectionUrlOutcomeGetPayload<{
+  include: typeof listInclude;
+}>;
+
+/**
+ * Maps a `CollectionUrlOutcome` row to the JSON list item served to the Hermes dashboard.
+ *
+ * @param row - Row from `prisma.collectionUrlOutcome.findMany` using {@link listInclude}.
+ * @returns Serializable list item for the processed-URLs table.
+ */
+export const mapRowToListItem = (row: ListRow) => ({
+  id: row.id,
+  tickerSymbol: row.ticker.symbol,
+  agent:
+    row.agent === "data_collection" ? "data-collection" : "page-collection",
+  url: row.url,
+  status: row.status,
+  reason: row.reason ?? null,
+  reasonDetail: row.reasonDetail ?? null,
+  source: row.source ?? null,
+  createdAt: row.createdAt.toISOString(),
+});
+
+/** JSON list item type; derived from {@link mapRowToListItem}. */
+export type ListItem = ReturnType<typeof mapRowToListItem>;

--- a/apps/mediapulse/domain-api/src/resources/processed-urls/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/processed-urls/routes.ts
@@ -1,0 +1,81 @@
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import { prisma, Prisma, type CollectionAgent } from "@mediapulse/database";
+import { Hono } from "hono";
+import { z } from "zod";
+
+import { parsePagination } from "../../lib/list-pagination";
+import { listInclude, mapRowToListItem } from "./list-mapper";
+
+const agentFilterSchema = z.enum(["data-collection", "page-collection"]);
+const statusFilterSchema = z.enum(["collected", "dropped", "failed"]);
+
+/**
+ * Hermes dashboard API for per-execution processed-URL outcomes (read-only paginated list).
+ *
+ * Required query param: `scheduleExecutionId` (UUID).
+ * Optional filters: `tickerId`, `agent`, `status`.
+ */
+export const processedUrlsRoutes = new Hono();
+
+processedUrlsRoutes.get("/", async (c) => {
+  const scheduleExecutionIdResult = z
+    .string()
+    .uuid()
+    .safeParse(c.req.query("scheduleExecutionId")?.trim() ?? "");
+
+  if (!scheduleExecutionIdResult.success) {
+    return c.json({ message: "scheduleExecutionId must be a valid UUID" }, 400);
+  }
+
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const skip = (page - 1) * pageSize;
+
+  const tickerFilter = z
+    .string()
+    .uuid()
+    .safeParse(c.req.query("tickerId")?.trim() ?? "");
+  const agentFilter = agentFilterSchema.safeParse(
+    c.req.query("agent")?.trim() ?? "",
+  );
+  const statusFilter = statusFilterSchema.safeParse(
+    c.req.query("status")?.trim() ?? "",
+  );
+
+  const agentDbValue: CollectionAgent | undefined = agentFilter.success
+    ? agentFilter.data === "data-collection"
+      ? "data_collection"
+      : "page_collection"
+    : undefined;
+
+  const where = {
+    scheduleExecutionId: scheduleExecutionIdResult.data,
+    ...(tickerFilter.success ? { tickerId: tickerFilter.data } : {}),
+    ...(agentDbValue !== undefined ? { agent: agentDbValue } : {}),
+    ...(statusFilter.success ? { status: statusFilter.data } : {}),
+  } satisfies Prisma.CollectionUrlOutcomeWhereInput;
+
+  const findManyArgs = {
+    where,
+    include: listInclude,
+    skip,
+    take: pageSize,
+    orderBy: { createdAt: "asc" as const },
+  } satisfies Prisma.CollectionUrlOutcomeFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.collectionUrlOutcome.findMany(findManyArgs),
+    prisma.collectionUrlOutcome.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -380,10 +380,11 @@ model Ticker {
   articleRelevances      ArticleRelevance[]
   entityEvidence         EntityEvidence[]
   entityRelationEvidence EntityRelationEvidence[]
-  dataCollectionRuns     DataCollectionRun[]
-  dataCollectionFailures DataCollectionFailure[]
-  deliveryRuns           DeliveryRun[]
-  contentGenerationRuns  ContentGenerationRun[]
+  dataCollectionRuns      DataCollectionRun[]
+  dataCollectionFailures  DataCollectionFailure[]
+  collectionUrlOutcomes   CollectionUrlOutcome[]
+  deliveryRuns            DeliveryRun[]
+  contentGenerationRuns   ContentGenerationRun[]
 
   @@map("ticker")
 }
@@ -535,11 +536,12 @@ enum DataCollectionErrorCategory {
 }
 
 model DataCollectionRun {
-  id          String                  @id @default(uuid())
-  tickerId    String                  @map("ticker_id")
-  startedAt   DateTime                @map("started_at")
-  completedAt DateTime?               @map("completed_at")
-  status      DataCollectionRunStatus
+  id                  String                  @id @default(uuid())
+  tickerId            String                  @map("ticker_id")
+  scheduleExecutionId String?                 @map("schedule_execution_id")
+  startedAt           DateTime                @map("started_at")
+  completedAt         DateTime?               @map("completed_at")
+  status              DataCollectionRunStatus
 
   queriesTotal  Int @default(0) @map("queries_total")
   urlsTotal     Int @default(0) @map("urls_total")
@@ -553,7 +555,9 @@ model DataCollectionRun {
 
   ticker   Ticker                  @relation(fields: [tickerId], references: [id])
   failures DataCollectionFailure[]
+  outcomes CollectionUrlOutcome[]
 
+  @@index([scheduleExecutionId])
   @@map("data_collection_run")
 }
 
@@ -578,6 +582,46 @@ model DataCollectionFailure {
   searchQuery SearchQuery?      @relation(fields: [searchQueryId], references: [id])
 
   @@map("data_collection_failure")
+}
+
+enum CollectionAgent {
+  data_collection @map("data-collection")
+  page_collection @map("page-collection")
+}
+
+enum CollectionUrlStatus {
+  collected
+  dropped
+  failed
+}
+
+/// Per-URL outcome record for a single collection agent run, linked to a ScheduleExecution.
+model CollectionUrlOutcome {
+  id                  String              @id @default(uuid())
+  scheduleExecutionId String?             @map("schedule_execution_id")
+  runId               String              @map("run_id")
+  tickerId            String              @map("ticker_id")
+  agent               CollectionAgent
+  status              CollectionUrlStatus
+
+  url           String
+  /// Stable machine token (e.g. "relevance_no_match", "freshness_too_old"). Null when collected.
+  reason        String?
+  /// Human-readable sentence built at the drop moment (e.g. "Published 2019-03-12, older than the 30-day window"). Null when collected.
+  reasonDetail  String?  @map("reason_detail")
+  /// Discovery listing/RSS URL (page-collection) or search query text (data-collection).
+  source        String?
+  searchQueryId String?  @map("search_query_id")
+
+  createdAt DateTime @default(now()) @map("created_at")
+
+  run    DataCollectionRun @relation(fields: [runId], references: [id], onDelete: Cascade)
+  ticker Ticker            @relation(fields: [tickerId], references: [id])
+
+  @@index([scheduleExecutionId])
+  @@index([runId, status])
+  @@index([tickerId, createdAt])
+  @@map("collection_url_outcome")
 }
 
 enum ContentGenerationRunOutcome {

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -109,6 +109,10 @@ import {
   getAgentInsightsQuerySchema,
   getAgentInsightsResponseSchema,
 } from "./agent-insights.js";
+import {
+  postCollectionUrlOutcomeBodySchema,
+  postCollectionUrlOutcomeResponseSchema,
+} from "./collection-url-outcome.js";
 
 type AgentDataApiMethodSchema =
   | {
@@ -655,6 +659,20 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       get: {
         query: getAgentInsightsQuerySchema,
         response: getAgentInsightsResponseSchema,
+      },
+    },
+  },
+  collectionUrlOutcome: {
+    v1: {
+      post: {
+        body: postCollectionUrlOutcomeBodySchema,
+        response: postCollectionUrlOutcomeResponseSchema,
+      },
+    },
+    v2: {
+      post: {
+        body: postCollectionUrlOutcomeBodySchema,
+        response: postCollectionUrlOutcomeResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/collection-url-outcome.ts
+++ b/packages/shared/agent-data-api-contract/src/collection-url-outcome.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+export const collectionAgentSchema = z.enum([
+  "data-collection",
+  "page-collection",
+]);
+
+export const collectionUrlStatusSchema = z.enum([
+  "collected",
+  "dropped",
+  "failed",
+]);
+
+export const collectionUrlOutcomeInputSchema = z.object({
+  id: z.string().uuid(),
+  scheduleExecutionId: z.string().uuid().optional(),
+  runId: z.string().uuid(),
+  tickerId: z.string().trim().min(1),
+  agent: collectionAgentSchema,
+  status: collectionUrlStatusSchema,
+  url: z.string().url(),
+  reason: z.string().optional(),
+  reasonDetail: z.string().optional(),
+  source: z.string().optional(),
+  searchQueryId: z.string().uuid().optional(),
+  createdAt: z.string().datetime(),
+});
+
+export const postCollectionUrlOutcomeBodySchema = z.array(
+  collectionUrlOutcomeInputSchema,
+);
+
+export const postCollectionUrlOutcomeResponseSchema = z.object({
+  message: z.string(),
+});
+
+export type CollectionAgent = z.infer<typeof collectionAgentSchema>;
+export type CollectionUrlStatus = z.infer<typeof collectionUrlStatusSchema>;
+export type CollectionUrlOutcomeInput = z.infer<
+  typeof collectionUrlOutcomeInputSchema
+>;
+export type PostCollectionUrlOutcomeBody = z.infer<
+  typeof postCollectionUrlOutcomeBodySchema
+>;
+export type PostCollectionUrlOutcomeResponse = z.infer<
+  typeof postCollectionUrlOutcomeResponseSchema
+>;

--- a/packages/shared/agent-data-api-contract/src/data-collection-run.ts
+++ b/packages/shared/agent-data-api-contract/src/data-collection-run.ts
@@ -9,6 +9,7 @@ export const dataCollectionRunStatusSchema = z.enum([
 export const dataCollectionRunInputSchema = z.object({
   id: z.string().uuid(),
   tickerId: z.string().trim().min(1),
+  scheduleExecutionId: z.string().uuid().optional(),
   startedAt: z.string().datetime(),
   completedAt: z.string().datetime(),
   status: dataCollectionRunStatusSchema,

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -253,6 +253,18 @@ export {
   type Widget,
 } from "./agent-insights.js";
 export {
+  collectionAgentSchema,
+  collectionUrlOutcomeInputSchema,
+  collectionUrlStatusSchema,
+  postCollectionUrlOutcomeBodySchema,
+  postCollectionUrlOutcomeResponseSchema,
+  type CollectionAgent,
+  type CollectionUrlOutcomeInput,
+  type CollectionUrlStatus,
+  type PostCollectionUrlOutcomeBody,
+  type PostCollectionUrlOutcomeResponse,
+} from "./collection-url-outcome.js";
+export {
   classifyQueryToSection,
   MEDIAPULSE_NEWSLETTER_SECTIONS,
   NEWSLETTER_SECTION_IDS,

--- a/packages/shared/agent-ingestion/src/collection-url-outcome.ts
+++ b/packages/shared/agent-ingestion/src/collection-url-outcome.ts
@@ -1,0 +1,278 @@
+import type { CollectionUrlOutcomeInput } from "@workspace/agent-data-api-contract";
+import type { QualityDropReason } from "./content-quality-gate";
+import type { FreshnessDropReason } from "./freshness-gate";
+import type { UrlNoiseReason } from "@workspace/utils";
+
+export type { CollectionUrlOutcomeInput };
+
+/** Stable machine tokens for per-URL outcomes. Used for filtering and counter reconciliation. */
+export type CollectionUrlOutcomeReason =
+  | `url_noise_${UrlNoiseReason}`
+  | QualityDropReason
+  | `relevance_no_match`
+  | `freshness_${FreshnessDropReason}`
+  | "duplicate_canonical_url"
+  | "existing_canonical_url"
+  | "dead_url_cache"
+  | "host_error_rate"
+  | "fetch_failed"
+  | "prefilter_alias_mismatch"
+  | "dropped_by_fetch_budget"
+  | "dropped_by_run_item_cap";
+
+/**
+ * Human-readable fallback labels for each reason token, used when `reasonDetail` is absent.
+ */
+export const REASON_LABELS: Record<string, string> = {
+  url_noise_blocked_host: "Blocked host",
+  url_noise_blocked_host_path: "Blocked host path",
+  url_noise_blocked_path: "Blocked path",
+  url_noise_blocked_extension: "Blocked file extension",
+  content_no_title: "Missing or blocked title",
+  content_soft_404: "Page not found",
+  content_access_gated: "Access gated (paywall or login required)",
+  content_too_short: "Content too short",
+  content_repetitive: "Content is repetitive",
+  content_link_farm: "Link farm — too many links",
+  content_index_like: "Index-like or non-article content",
+  relevance_no_match: "Not relevant to ticker",
+  freshness_too_old: "Published date too old",
+  freshness_future_dated: "Publish date is in the future",
+  freshness_unknown_date: "No detectable publish date",
+  duplicate_canonical_url: "Duplicate URL in this run",
+  existing_canonical_url: "Already collected in a previous run",
+  dead_url_cache: "Previously recorded as a dead URL",
+  host_error_rate: "Host exceeded error-rate threshold",
+  fetch_failed: "Fetch failed",
+  prefilter_alias_mismatch: "Pre-filter: no ticker/industry mention",
+  dropped_by_fetch_budget: "Fetch budget exhausted for this run",
+  dropped_by_run_item_cap: "Run item cap reached",
+};
+
+type DropOutcomeContext =
+  | { reason: `url_noise_${UrlNoiseReason}`; detail: string }
+  | { reason: QualityDropReason; charCount?: number; minChars?: number }
+  | { reason: "relevance_no_match"; tickerSymbol: string; headChars: number }
+  | { reason: "freshness_too_old"; publishedAt: Date; maxAgeDays: number }
+  | { reason: "freshness_future_dated"; publishedAt: Date }
+  | { reason: "freshness_unknown_date" }
+  | { reason: "duplicate_canonical_url" }
+  | { reason: "existing_canonical_url" }
+  | { reason: "dead_url_cache" }
+  | { reason: "host_error_rate"; host: string }
+  | { reason: "fetch_failed"; errorCategory: string; httpStatus?: number }
+  | { reason: "prefilter_alias_mismatch" }
+  | { reason: "dropped_by_fetch_budget" }
+  | { reason: "dropped_by_run_item_cap" };
+
+/**
+ * Builds both the stable machine reason token and a human-readable detail sentence
+ * from the context available at the drop site.
+ *
+ * @param context - Drop reason and in-scope diagnostic values.
+ * @returns Object with `reason` (stable token) and `reasonDetail` (display sentence).
+ */
+export const describeOutcomeReason = (
+  context: DropOutcomeContext,
+): { reason: string; reasonDetail: string } => {
+  switch (context.reason) {
+    case "url_noise_blocked_host":
+    case "url_noise_blocked_host_path":
+    case "url_noise_blocked_path":
+    case "url_noise_blocked_extension": {
+      const label = REASON_LABELS[context.reason] ?? context.reason;
+      return {
+        reason: context.reason,
+        reasonDetail: `${label}: ${context.detail}`,
+      };
+    }
+
+    case "content_no_title":
+    case "content_soft_404":
+    case "content_access_gated":
+    case "content_repetitive":
+    case "content_link_farm":
+    case "content_index_like":
+      return {
+        reason: context.reason,
+        reasonDetail: REASON_LABELS[context.reason] ?? context.reason,
+      };
+
+    case "content_too_short": {
+      const charCount = context.charCount;
+      const minChars = context.minChars;
+      return {
+        reason: context.reason,
+        reasonDetail:
+          charCount !== undefined && minChars !== undefined
+            ? `Content too short: ${charCount} chars (min ${minChars})`
+            : "Content too short",
+      };
+    }
+
+    case "relevance_no_match":
+      return {
+        reason: context.reason,
+        reasonDetail: `No mention of ${context.tickerSymbol} or its industry in the first ${context.headChars} chars`,
+      };
+
+    case "freshness_too_old": {
+      const dateStr = context.publishedAt.toISOString().slice(0, 10);
+      return {
+        reason: context.reason,
+        reasonDetail: `Published ${dateStr}, older than the ${context.maxAgeDays}-day freshness window`,
+      };
+    }
+
+    case "freshness_future_dated": {
+      const dateStr = context.publishedAt.toISOString().slice(0, 10);
+      return {
+        reason: context.reason,
+        reasonDetail: `Publish date ${dateStr} is in the future`,
+      };
+    }
+
+    case "freshness_unknown_date":
+      return {
+        reason: context.reason,
+        reasonDetail: "No detectable publish date",
+      };
+
+    case "duplicate_canonical_url":
+      return {
+        reason: context.reason,
+        reasonDetail: "Duplicate of another URL already seen in this run",
+      };
+
+    case "existing_canonical_url":
+      return {
+        reason: context.reason,
+        reasonDetail: "Already stored from an earlier run",
+      };
+
+    case "dead_url_cache":
+      return {
+        reason: context.reason,
+        reasonDetail: "Skipped: previously recorded as a dead URL",
+      };
+
+    case "host_error_rate":
+      return {
+        reason: context.reason,
+        reasonDetail: `Skipped: ${context.host} exceeded the error-rate threshold this run`,
+      };
+
+    case "fetch_failed": {
+      const status = context.httpStatus ? `, HTTP ${context.httpStatus}` : "";
+      return {
+        reason: context.reason,
+        reasonDetail: `Fetch failed: ${context.errorCategory}${status}`,
+      };
+    }
+
+    case "prefilter_alias_mismatch":
+      return {
+        reason: context.reason,
+        reasonDetail: "Pre-filter: no ticker or industry mention detected",
+      };
+
+    case "dropped_by_fetch_budget":
+      return {
+        reason: context.reason,
+        reasonDetail: "Fetch budget exhausted for this run",
+      };
+
+    case "dropped_by_run_item_cap":
+      return {
+        reason: context.reason,
+        reasonDetail: "Run item cap reached",
+      };
+  }
+};
+
+/** Builds a `CollectionUrlOutcomeInput` for a dropped URL. */
+export const makeDroppedOutcome = (
+  fields: Pick<
+    CollectionUrlOutcomeInput,
+    | "id"
+    | "scheduleExecutionId"
+    | "runId"
+    | "tickerId"
+    | "agent"
+    | "url"
+    | "source"
+    | "searchQueryId"
+    | "createdAt"
+  >,
+  dropContext: DropOutcomeContext,
+): CollectionUrlOutcomeInput => {
+  const { reason, reasonDetail } = describeOutcomeReason(dropContext);
+  return {
+    ...fields,
+    status: "dropped",
+    reason,
+    reasonDetail,
+  };
+};
+
+/** Builds a `CollectionUrlOutcomeInput` for a successfully collected URL. */
+export const makeCollectedOutcome = (
+  fields: Pick<
+    CollectionUrlOutcomeInput,
+    | "id"
+    | "scheduleExecutionId"
+    | "runId"
+    | "tickerId"
+    | "agent"
+    | "url"
+    | "source"
+    | "searchQueryId"
+    | "createdAt"
+  >,
+): CollectionUrlOutcomeInput => ({
+  ...fields,
+  status: "collected",
+  reason: undefined,
+  reasonDetail: undefined,
+});
+
+/** Builds a `CollectionUrlOutcomeInput` for a fetch-failed URL. */
+export const makeFailedOutcome = (
+  fields: Pick<
+    CollectionUrlOutcomeInput,
+    | "id"
+    | "scheduleExecutionId"
+    | "runId"
+    | "tickerId"
+    | "agent"
+    | "url"
+    | "source"
+    | "searchQueryId"
+    | "createdAt"
+  >,
+  errorCategory: string,
+  httpStatus?: number,
+): CollectionUrlOutcomeInput => {
+  const { reason, reasonDetail } = describeOutcomeReason({
+    reason: "fetch_failed",
+    errorCategory,
+    httpStatus,
+  });
+  return {
+    ...fields,
+    status: "failed",
+    reason,
+    reasonDetail,
+  };
+};
+
+/** Posts outcomes in chunks to avoid request size limits. */
+export const postOutcomesInChunks = async (
+  outcomes: CollectionUrlOutcomeInput[],
+  post: (batch: CollectionUrlOutcomeInput[]) => Promise<unknown>,
+  chunkSize = 200,
+): Promise<void> => {
+  for (let i = 0; i < outcomes.length; i += chunkSize) {
+    await post(outcomes.slice(i, i + chunkSize));
+  }
+};

--- a/packages/shared/agent-ingestion/src/index.ts
+++ b/packages/shared/agent-ingestion/src/index.ts
@@ -115,3 +115,14 @@ export {
   type DiscoveryDeps,
   type DiscoveryLogger,
 } from "./discovery/types";
+
+export {
+  describeOutcomeReason,
+  makeCollectedOutcome,
+  makeDroppedOutcome,
+  makeFailedOutcome,
+  postOutcomesInChunks,
+  REASON_LABELS,
+  type CollectionUrlOutcomeInput,
+  type CollectionUrlOutcomeReason,
+} from "./collection-url-outcome";


### PR DESCRIPTION
## Summary

Adds a "Processed URLs" sub-page under each schedule execution so operators can see every URL the data-collection and page-collection agents touched, why each one was dropped, and which ones made it through. The reason column shows full context sentences rather than raw tokens, so "Published 2019-03-12, older than the 30-day freshness window" appears instead of `freshness_too_old`.

## Related issues

Closes #799

## Important changes

- **New Prisma model** — `CollectionUrlOutcome` stores one row per URL per run, linked to `ScheduleExecution` and `DataCollectionRun`. `DataCollectionRun` gains a `scheduleExecutionId` column too. Migration is required before outcomes flow in.
- **Agent wiring** — both `data-collection` and `page-collection` accumulate outcomes at every gate (url-noise, duplicate, existing, dead-url, host-error-rate, fetch-budget, quality, relevance, freshness, collected, fetch-failed) and POST them in 200-item chunks after the run completes. Failures are non-blocking.
- **Context-rich reasons** — `describeOutcomeReason()` in `agent-ingestion` builds human-readable sentences from in-scope diagnostics at each drop site (e.g. "No mention of AAPL or its industry in the first 4000 chars", "Skipped: deadhost.io exceeded the error-rate threshold this run").
- **Domain-api endpoint** — `GET /v1/hermes-dashboard/processed-urls?scheduleExecutionId={uuid}` with optional `tickerId`, `agent`, and `status` filters. Mounted alongside existing hermes-dashboard routes but not registered in the manifest (execution-scoped, not a global nav page).
- **Dashboard page** — `/dashboard/schedules/{id}/executions/{executionId}/processed-urls` shows a paginated table with Ticker, Agent, Status badge, Reason, URL, Source, and Time. Agent and Status filter chips are inline URL-param links. A "View Processed URLs →" link is added to the execution detail page.

## Other changes

- `agent-data-api-contract` — new `collectionUrlOutcome` resource with POST body/response schemas, added to the manifest for v1 and v2.
- `agent-data-api` — new `POST /collection-url-outcome` handler using `createMany` + `skipDuplicates: true` for resume safety.
- `agent-ingestion` — exports `makeDroppedOutcome`, `makeCollectedOutcome`, `makeFailedOutcome`, `postOutcomesInChunks`, and `REASON_LABELS`.
- `domain-dashboard.ts` — `fetchProcessedUrlsForExecution` helper resolves the mediapulse integration base URL and calls the new endpoint.
- The `source` field is populated for data-collection (RSS URL or search query text) but left blank for page-collection — `runDiscovery` merges items from all listing sources and does not carry per-item listing attribution after the merge.

## Key files to review

- [`packages/mediapulse/database/prisma/schema.prisma`](packages/mediapulse/database/prisma/schema.prisma) — `CollectionUrlOutcome` model and new enums; run migration before deploying agents.
- [`packages/shared/agent-ingestion/src/collection-url-outcome.ts`](packages/shared/agent-ingestion/src/collection-url-outcome.ts) — `describeOutcomeReason` switch and all factory functions.
- [`apps/mediapulse/agents/data-collection/src/run.ts`](apps/mediapulse/agents/data-collection/src/run.ts) — full gate wiring with outcome pushes.
- [`apps/mediapulse/agents/page-collection/src/run.ts`](apps/mediapulse/agents/page-collection/src/run.ts) — same pattern for the page-collection pipeline.
- [`apps/mediapulse/domain-api/src/resources/processed-urls/routes.ts`](apps/mediapulse/domain-api/src/resources/processed-urls/routes.ts) — filtering and pagination logic.
- [`apps/hermes/dashboard/app/dashboard/schedules/[id]/executions/[executionId]/processed-urls/page.tsx`](apps/hermes/dashboard/app/dashboard/schedules/%5Bid%5D/executions/%5BexecutionId%5D/processed-urls/page.tsx) — dashboard page with filter chips and table.

## How to test

1. Start OrbStack and run `pnpm --filter @mediapulse/database db:migrate:dev` to apply the schema migration.
2. Trigger a schedule execution that runs data-collection or page-collection agents.
3. After the execution completes, open the execution detail page in Hermes and click **View Processed URLs →**.
4. Confirm the table shows rows for collected, dropped, and failed URLs with full reason sentences.
5. Use the Agent and Status filter chips to narrow results — the table should refresh without a full navigation.
6. For executions that pre-date this deploy, confirm the page shows the empty-state message.
