### PR TITLE
Format newsletter email subjects with TICKER Pulse prefix

### DIFF
--- a/apps/mediapulse/agents/content-generation/src/lib/subject-line.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/subject-line.test.ts
@@ -18,13 +18,13 @@ const scoringCtx = {
 };
 
 describe("scoreLengthFit", () => {
-  it("returns 0 at 8 and 70 characters and peaks at 42", () => {
+  it("returns 0 at 8 and 58 characters and peaks at 34", () => {
     // Assert
     expect(scoreLengthFit("x".repeat(8))).toBe(0);
-    expect(scoreLengthFit("x".repeat(70))).toBe(0);
-    expect(scoreLengthFit("x".repeat(42))).toBe(1);
-    expect(scoreLengthFit("x".repeat(25))).toBeCloseTo(17 / 34, 5);
-    expect(scoreLengthFit("x".repeat(56))).toBeCloseTo(14 / 28, 5);
+    expect(scoreLengthFit("x".repeat(58))).toBe(0);
+    expect(scoreLengthFit("x".repeat(34))).toBe(1);
+    expect(scoreLengthFit("x".repeat(25))).toBeCloseTo(17 / 26, 5);
+    expect(scoreLengthFit("x".repeat(56))).toBeCloseTo(2 / 24, 5);
   });
 });
 

--- a/apps/mediapulse/agents/content-generation/src/lib/subject-line.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/subject-line.ts
@@ -83,7 +83,7 @@ export const subjectCandidateStyleSchema = z.enum([
 ]);
 
 export const subjectCandidateSchema = z.object({
-  subject: z.string().min(1).max(60),
+  subject: z.string().min(1).max(48),
   style: subjectCandidateStyleSchema,
   preheader: z.string().min(1).max(110),
 });
@@ -100,9 +100,9 @@ const CLICKBAIT_PATTERN = /\b(shocking|unbelievable|mind-blowing)\b/i;
 const GENERIC_TICKER_REFERENCE_PATTERN =
   /\b(the bank|the conglomerate|the group|the company|perusahaan|grup|bank tersebut)\b/i;
 
-const LENGTH_PEAK = 42;
+const LENGTH_PEAK = 34;
 const LENGTH_MIN = 8;
-const LENGTH_MAX = 70;
+const LENGTH_MAX = 58;
 
 const NOVELTY_FLOOR = 0.6;
 
@@ -365,11 +365,12 @@ export const buildSubjectCandidateSystemPrompt = (
 ): string =>
   [
     "You write email subject lines for an industry briefing.",
-    `Produce exactly ${String(candidateCount)} candidate subjects, each at most 60 characters,`,
+    `Produce exactly ${String(candidateCount)} candidate subject titles, each at most 48 characters,`,
     "plus a 50–110 character preheader (preview line shown after the subject in most inboxes).",
+    "The delivery system adds a SYMBOL Pulse: prefix automatically — do not include that prefix in subject titles.",
     "Avoid clickbait, exclamation marks, ALL-CAPS, and emoji.",
     "Style mix: at least one declarative, one with a number, one curiosity-gap, one with a contrast.",
-    "Cite the ticker name or symbol naturally when it fits — never twice in one subject.",
+    "Avoid repeating the ticker symbol in the title when the prefix already identifies it.",
     'Return JSON: { "candidates": [ { "subject", "style", "preheader" }, ... ] }.',
     "style must be one of: declarative, question, curiosity, numeric, contrast.",
   ].join(" ");

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -125,6 +125,7 @@ const testSources = [
 const testContext = {
   tickerId: "ticker-123",
   date: "2026-04-21",
+  tickerSymbol: "BBCA",
 };
 
 // ---------------------------------------------------------------------------
@@ -148,7 +149,7 @@ describe("generateNewsletterWithLlm — happy path", () => {
     );
 
     // Assert
-    expect(result.subject).toBe("Market Rally Continues");
+    expect(result.subject).toBe("BBCA Pulse: Market Rally Continues");
     expect(result.content).toContain("MP_NEWSLETTER");
     expect(result.content).toContain("Stocks rose for the third day.");
     expect(result.content).toContain("BEGIN quick-hits");
@@ -173,7 +174,7 @@ describe("generateNewsletterWithLlm — happy path", () => {
     );
 
     // Assert
-    expect(result.subject).toBe("Your daily briefing");
+    expect(result.subject).toBe("BBCA Pulse: Your daily briefing");
   });
 
   it("slices sources to output.topNewsCount when building the user prompt", async () => {
@@ -561,7 +562,7 @@ describe("generateNewsletterWithLlm — retryable errors", () => {
     );
 
     // Assert
-    expect(result.subject).toBe("Recovery");
+    expect(result.subject).toBe("BBCA Pulse: Recovery");
     expect(generateObjectFn).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -7,6 +7,7 @@ import {
   type NewsletterSectionId,
 } from "@workspace/agent-data-api-contract";
 import { applyContractBrief } from "@workspace/agent-runtime";
+import { formatNewsletterEmailSubject } from "@workspace/email-templates";
 import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";
@@ -551,7 +552,7 @@ Focus on what is happening outside the company — macro forces, regulatory shif
 You receive exactly {{topNewsCount}} numbered articles (Article 1 … Article {{topNewsCount}}). Ground claims in those articles. When a bullet or quick hit should link to a source in the final email, set "articleIndex" to the 1-based article number from that list. Never output URLs in JSON; the system injects them. Never write "(Article N)" or bare article numbers inside any "text" or "prose" field; citations are expressed only via "articleIndex", and the system renders the visible link.
 
 Return JSON matching this shape (camelCase keys):
-- "subject": short email subject (under ~60 chars), sector-relevant, may mention {{tickerName}} or {{tickerSymbol}} once if natural.
+- "subject": short email subject title only (under ~48 chars), sector-relevant headline text. Do not include a "SYMBOL Pulse:" prefix — the system adds that automatically. Avoid repeating {{tickerSymbol}} in the title when the prefix already identifies the ticker.
 - "industryPulse": { "displayHeading", "prose", "articleIndex" } — short lead framing the industry story (no bullet characters in prose). Set "articleIndex" to the single most representative article the lead summarizes; use null when the lead does not lean on a specific article.
 - "competitiveLandscape": { "displayHeading", "bullets" } — 2–3 bullets about {{tickerName}}'s COMPETITORS, not {{tickerName}} itself — peer positioning, rival launches, share shifts, competitive threats. Each bullet should name a competitor. Each bullet { "title", "text", "articleIndex" } where "title" is a short headline (under 60 chars) naming the story, "text" is the full bullet sentence, and articleIndex is a 1-based article number or null when uncited.
 - "dealsAndMovements": { "displayHeading", "bullets" } — 1–3 bullets; each bullet { "title", "text", "articleIndex" } with the same title and articleIndex rules.
@@ -1512,12 +1513,18 @@ export async function generateNewsletterWithLlm(
 
   const content = formatIndustryNewsletterWire(resolved);
 
+  const rawTitle =
+    finalStructure.subject !== undefined &&
+    finalStructure.subject.trim().length > 0
+      ? finalStructure.subject.trim()
+      : "Your daily briefing";
+  const subject = formatNewsletterEmailSubject(
+    context.tickerSymbol ?? "",
+    rawTitle,
+  );
+
   return {
-    subject:
-      finalStructure.subject !== undefined &&
-      finalStructure.subject.trim().length > 0
-        ? finalStructure.subject.trim()
-        : "Your daily briefing",
+    subject,
     content,
     // Reads the pre-prune finalStructure, so this is safe even when the resolved
     // lead was later removed by the require-citation pass.

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -7,7 +7,7 @@ import {
   type NewsletterSectionId,
 } from "@workspace/agent-data-api-contract";
 import { applyContractBrief } from "@workspace/agent-runtime";
-import { formatNewsletterEmailSubject } from "@workspace/email-templates";
+import { formatNewsletterEmailSubject } from "@workspace/email-templates/newsletter-email-subject";
 import { logger } from "@workspace/logger";
 
 import type { ResolvedContentGenerationConfig } from "./config-schema.js";

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -1,7 +1,7 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-content-generation";
-import { parseNewsletterEmailSubject } from "@workspace/email-templates";
+import { parseNewsletterEmailSubject } from "@workspace/email-templates/newsletter-email-subject";
 import { logger } from "@workspace/logger";
 
 import { AGENT_VERSION } from "./agent-version.js";

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -1,6 +1,7 @@
 import { createAgentDataApiClient } from "@workspace/agent-data-api-client";
 import type { AgentRunContext, AgentRunResult } from "@workspace/agent-runtime";
 import { env } from "@mediapulse/env/agents-content-generation";
+import { parseNewsletterEmailSubject } from "@workspace/email-templates";
 import { logger } from "@workspace/logger";
 
 import { AGENT_VERSION } from "./agent-version.js";
@@ -388,7 +389,9 @@ export async function run({
           days: 7,
         },
       );
-      recentSubjects = recent.items.map((item) => item.subject);
+      recentSubjects = recent.items.map(
+        (item) => parseNewsletterEmailSubject(item.subject).title,
+      );
     } catch (recentErr) {
       logger.warn(
         {

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -36,7 +36,7 @@ vi.mock("@workspace/email-templates", async () => {
 
 const newsletter = {
   id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
-  subject: "Subject",
+  subject: "AAPL Pulse: Subject",
   content: "Body",
   symbol: "AAPL",
 } as const;
@@ -81,7 +81,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const renderCall = vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0];
     expect(renderCall).toMatchObject({
-      title: newsletter.subject,
+      title: "Subject",
       bodyText: newsletter.content,
       variant: "default",
       unsubscribeUrl: expect.stringContaining(

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 
-import { renderNewsletterEmail } from "@workspace/email-templates";
+import {
+  parseNewsletterEmailSubject,
+  renderNewsletterEmail,
+} from "@workspace/email-templates";
 import type { LoggerLike } from "@workspace/agent-runtime";
 import { createUnsubscribeToken, formatResendSender } from "@workspace/utils";
 import { Resend } from "resend";
@@ -135,8 +138,9 @@ export async function deliverNewsletterToSubscribers(
     const unsubscribeUrl = `${config.unsubscribe.baseUrl}/api/unsubscribe?token=${unsubscribeToken}`;
 
     const renderStart = Date.now();
+    const emailTitle = parseNewsletterEmailSubject(newsletter.subject).title;
     const { html, text } = await renderNewsletterEmail({
-      title: newsletter.subject,
+      title: emailTitle,
       bodyText: newsletter.content,
       variant: config.template.newsletterVariant,
       unsubscribeUrl,

--- a/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.test.ts
@@ -28,6 +28,29 @@ describe("renderEmailPreview", () => {
     });
   });
 
+  it("strips the Pulse prefix from the stored subject for the email body title", async () => {
+    const renderHtml = vi
+      .fn()
+      .mockResolvedValue({ html: "<html><body>Preview</body></html>" });
+
+    await renderEmailPreview(
+      {
+        newsletterId: "nl-1",
+        subject: "AAPL Pulse: Apple weekly digest",
+        bodyText: "Hello",
+        tickerSymbol: "AAPL",
+      },
+      { renderHtml },
+    );
+
+    expect(renderHtml).toHaveBeenCalledWith({
+      title: "Apple weekly digest",
+      bodyText: "Hello",
+      tickerSymbol: "AAPL",
+      unsubscribeUrl: "https://example.com/preview/unsubscribe",
+    });
+  });
+
   it("returns a safe placeholder on render error and logs a warning", async () => {
     const renderHtml = vi
       .fn()

--- a/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
@@ -1,7 +1,5 @@
-import {
-  parseNewsletterEmailSubject,
-  renderNewsletterEmail,
-} from "@workspace/email-templates";
+import { parseNewsletterEmailSubject } from "@workspace/email-templates/newsletter-email-subject";
+import { renderNewsletterEmail } from "@workspace/email-templates";
 
 import type { Logger } from "@workspace/logger";
 

--- a/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts
@@ -1,4 +1,7 @@
-import { renderNewsletterEmail } from "@workspace/email-templates";
+import {
+  parseNewsletterEmailSubject,
+  renderNewsletterEmail,
+} from "@workspace/email-templates";
 
 import type { Logger } from "@workspace/logger";
 
@@ -69,8 +72,9 @@ export const renderEmailPreview = async (
     });
 
   try {
+    const emailTitle = parseNewsletterEmailSubject(input.subject).title;
     const { html } = await renderHtml({
-      title: input.subject,
+      title: emailTitle,
       bodyText: input.bodyText,
       tickerSymbol: input.tickerSymbol,
       unsubscribeUrl: PREVIEW_UNSUBSCRIBE_URL,

--- a/packages/shared/email-templates/package.json
+++ b/packages/shared/email-templates/package.json
@@ -19,6 +19,10 @@
     "./parse-industry-newsletter-wire": {
       "types": "./src/newsletter/parse-industry-newsletter-wire.ts",
       "default": "./src/newsletter/parse-industry-newsletter-wire.ts"
+    },
+    "./newsletter-email-subject": {
+      "types": "./src/newsletter/newsletter-email-subject.ts",
+      "default": "./src/newsletter/newsletter-email-subject.ts"
     }
   },
   "scripts": {

--- a/packages/shared/email-templates/src/index.ts
+++ b/packages/shared/email-templates/src/index.ts
@@ -5,6 +5,11 @@ export {
   DEFAULT_HYPERJUMP_SITE_URL,
 } from "./newsletter/default-newsletter.js";
 export {
+  formatNewsletterEmailSubject,
+  parseNewsletterEmailSubject,
+  type ParsedNewsletterEmailSubject,
+} from "./newsletter/newsletter-email-subject.js";
+export {
   parseNewsletterBody,
   type LegacyParsedNewsletterBody,
   type ParsedNewsletterBody,

--- a/packages/shared/email-templates/src/newsletter/newsletter-email-subject.test.ts
+++ b/packages/shared/email-templates/src/newsletter/newsletter-email-subject.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  formatNewsletterEmailSubject,
+  parseNewsletterEmailSubject,
+} from "./newsletter-email-subject.js";
+
+describe("formatNewsletterEmailSubject", () => {
+  it("prefixes a plain title with the uppercased ticker symbol", () => {
+    // Act
+    const subject = formatNewsletterEmailSubject(
+      "ihsg",
+      "Market cap up Rp 717 trillion as IHSG hits 6,008",
+    );
+
+    // Assert
+    expect(subject).toBe(
+      "IHSG Pulse: Market cap up Rp 717 trillion as IHSG hits 6,008",
+    );
+  });
+
+  it("returns the title unchanged when already formatted", () => {
+    // Setup
+    const formatted = "BBCA Pulse: Banking rally lifts sector sentiment";
+
+    // Act
+    const subject = formatNewsletterEmailSubject("BBCA", formatted);
+
+    // Assert
+    expect(subject).toBe(formatted);
+  });
+
+  it("normalizes legacy bracket subjects to the unbracketed format", () => {
+    // Act
+    const subject = formatNewsletterEmailSubject(
+      "BBCA",
+      "[BBCA] Pulse: Banking rally lifts sector sentiment",
+    );
+
+    // Assert
+    expect(subject).toBe("BBCA Pulse: Banking rally lifts sector sentiment");
+  });
+
+  it("returns the trimmed title when ticker symbol is empty", () => {
+    // Act
+    const subject = formatNewsletterEmailSubject("", "  Plain headline  ");
+
+    // Assert
+    expect(subject).toBe("Plain headline");
+  });
+
+  it("uses a default title when title is empty but symbol is present", () => {
+    // Act
+    const subject = formatNewsletterEmailSubject("BBCA", "   ");
+
+    // Assert
+    expect(subject).toBe("BBCA Pulse: Your daily briefing");
+  });
+});
+
+describe("parseNewsletterEmailSubject", () => {
+  it("extracts ticker symbol and plain title from a formatted subject", () => {
+    // Act
+    const parsed = parseNewsletterEmailSubject(
+      "IHSG Pulse: Market cap up Rp 717 trillion as IHSG hits 6,008",
+    );
+
+    // Assert
+    expect(parsed).toEqual({
+      tickerSymbol: "IHSG",
+      title: "Market cap up Rp 717 trillion as IHSG hits 6,008",
+    });
+  });
+
+  it("parses legacy bracket subjects for backward compatibility", () => {
+    // Act
+    const parsed = parseNewsletterEmailSubject(
+      "[IHSG] Pulse: Market cap up Rp 717 trillion as IHSG hits 6,008",
+    );
+
+    // Assert
+    expect(parsed).toEqual({
+      tickerSymbol: "IHSG",
+      title: "Market cap up Rp 717 trillion as IHSG hits 6,008",
+    });
+  });
+
+  it("returns legacy subjects unchanged with null ticker symbol", () => {
+    // Act
+    const parsed = parseNewsletterEmailSubject(
+      "Market cap up Rp 717 trillion as IHSG hits 6,008",
+    );
+
+    // Assert
+    expect(parsed).toEqual({
+      tickerSymbol: null,
+      title: "Market cap up Rp 717 trillion as IHSG hits 6,008",
+    });
+  });
+
+  it("round-trips with formatNewsletterEmailSubject", () => {
+    // Setup
+    const title = "Energy stocks rally on policy shift";
+
+    // Act
+    const formatted = formatNewsletterEmailSubject("enrg", title);
+    const parsed = parseNewsletterEmailSubject(formatted);
+
+    // Assert
+    expect(parsed).toEqual({ tickerSymbol: "ENRG", title });
+  });
+});

--- a/packages/shared/email-templates/src/newsletter/newsletter-email-subject.ts
+++ b/packages/shared/email-templates/src/newsletter/newsletter-email-subject.ts
@@ -1,0 +1,69 @@
+/** Parsed newsletter email subject: ticker prefix and plain headline. */
+export type ParsedNewsletterEmailSubject = {
+  tickerSymbol: string | null;
+  title: string;
+};
+
+const NEWSLETTER_EMAIL_SUBJECT_PATTERN = /^([A-Za-z0-9]+)\s+Pulse:\s+(.+)$/;
+
+const LEGACY_BRACKET_NEWSLETTER_EMAIL_SUBJECT_PATTERN =
+  /^\[([^\]]+)\]\s+Pulse:\s+(.+)$/;
+
+/**
+ * Formats a newsletter inbox subject as `TICKER Pulse: title`.
+ * Idempotent when the subject is already formatted (including legacy bracket form).
+ *
+ * @param tickerSymbol - Exchange symbol (uppercased in output).
+ * @param title - Plain headline without the Pulse prefix.
+ * @returns Formatted subject, or trimmed title when symbol is missing.
+ */
+export const formatNewsletterEmailSubject = (
+  tickerSymbol: string,
+  title: string,
+): string => {
+  const trimmedTitle = title.trim();
+  const symbol = tickerSymbol.trim().toUpperCase();
+
+  if (trimmedTitle.length === 0) {
+    return symbol.length > 0
+      ? `${symbol} Pulse: Your daily briefing`
+      : "Your daily briefing";
+  }
+
+  const parsed = parseNewsletterEmailSubject(trimmedTitle);
+  if (parsed.tickerSymbol !== null) {
+    return `${parsed.tickerSymbol} Pulse: ${parsed.title}`;
+  }
+
+  if (symbol.length === 0) {
+    return trimmedTitle;
+  }
+
+  return `${symbol} Pulse: ${trimmedTitle}`;
+};
+
+/**
+ * Parses a stored newsletter subject into ticker symbol and plain title.
+ * Supports `TICKER Pulse: title` and legacy `[TICKER] Pulse: title` rows.
+ * Plain legacy subjects without the Pulse prefix return `tickerSymbol: null`.
+ *
+ * @param subject - Stored or rendered newsletter subject line.
+ * @returns Ticker symbol (when prefixed) and plain headline title.
+ */
+export const parseNewsletterEmailSubject = (
+  subject: string,
+): ParsedNewsletterEmailSubject => {
+  const trimmed = subject.trim();
+  const match =
+    NEWSLETTER_EMAIL_SUBJECT_PATTERN.exec(trimmed) ??
+    LEGACY_BRACKET_NEWSLETTER_EMAIL_SUBJECT_PATTERN.exec(trimmed);
+
+  if (match === null) {
+    return { tickerSymbol: null, title: trimmed };
+  }
+
+  return {
+    tickerSymbol: match[1]!.trim().toUpperCase(),
+    title: match[2]!.trim(),
+  };
+};


### PR DESCRIPTION
## Summary

Newsletter inbox subjects now follow **`TICKER Pulse: title`** (e.g. `IHSG Pulse: Market cap up Rp 717 trillion as IHSG hits 6,008`). The headline inside the email body stays the plain title so the message does not repeat the prefix.

## Related issues

Closes #801

## Important changes

- Added shared `formatNewsletterEmailSubject` / `parseNewsletterEmailSubject` helpers in `@workspace/email-templates`
- Content-generation applies the prefix after subject-line selection; LLM prompts generate plain titles only
- Delivery sends the formatted subject but renders the email body with the parsed plain title
- Domain-api newsletter preview uses the same split
- Parse accepts legacy plain subjects and legacy `[TICKER] Pulse:` rows

## Other changes

- Tightened subject candidate max length (48 chars) and length scoring to leave room for the prefix
- Recent-subject novelty scoring strips the prefix before comparison

## Key files to review

- `packages/shared/email-templates/src/newsletter/newsletter-email-subject.ts` — format/parse contract and legacy bracket support
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` — prefix applied at generation time
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` — subject vs body title split at send time
- `apps/mediapulse/domain-api/src/resources/newsletters/render-email-preview.ts` — preview matches delivery behavior

## How to test

1. Run `pnpm --filter @workspace/email-templates test`
2. Run `pnpm --filter @mediapulse/content-generation test`
3. Run `pnpm --filter @mediapulse/delivery test`
4. Run `pnpm --filter @mediapulse/domain-api exec vitest run src/resources/newsletters/render-email-preview.test.ts`
5. Confirm `pnpm format:check` passes
6. After deploy, trigger a content-generation run and verify inbox subject is `TICKER Pulse: …` while the email heading is the plain title
