### PR TITLE
Add curated source linkType for page vs listing URLs

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/page-collection.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/page-collection.test.ts
@@ -1,0 +1,68 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@mediapulse/database", () => ({
+  prisma: {},
+}));
+
+import { resolveCuratedSourcesByListingUrls } from "./page-collection";
+
+describe("resolveCuratedSourcesByListingUrls", () => {
+  it("returns linkType with resolved curated sources", async () => {
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "11111111-1111-4111-a111-111111111111",
+        listingUrl: "https://example.com/news",
+        linkType: "listing",
+        maxItems: 10,
+      },
+      {
+        id: "22222222-2222-4222-a222-222222222222",
+        listingUrl: "https://example.com/article/one",
+        linkType: "page",
+        maxItems: null,
+      },
+    ]);
+
+    const result = await resolveCuratedSourcesByListingUrls(
+      {
+        listingUrls: [
+          "https://example.com/news",
+          "https://example.com/article/one",
+        ],
+      },
+      { db: { findMany } },
+    );
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: {
+        listingUrl: {
+          in: ["https://example.com/news", "https://example.com/article/one"],
+        },
+        enabled: true,
+      },
+      select: {
+        id: true,
+        listingUrl: true,
+        linkType: true,
+        maxItems: true,
+      },
+    });
+    expect(result).toEqual({
+      sources: [
+        {
+          listingUrl: "https://example.com/news",
+          curatedSourceId: "11111111-1111-4111-a111-111111111111",
+          linkType: "listing",
+          maxItems: 10,
+        },
+        {
+          listingUrl: "https://example.com/article/one",
+          curatedSourceId: "22222222-2222-4222-a222-222222222222",
+          linkType: "page",
+          maxItems: null,
+        },
+      ],
+    });
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/page-collection.ts
+++ b/apps/mediapulse/agent-data-api/src/services/page-collection.ts
@@ -124,19 +124,24 @@ export const resolveCuratedSourcesByListingUrls = async (
   deps: { db?: Pick<typeof prisma.curatedSource, "findMany"> } = {},
 ) => {
   const curatedSource = deps.db ?? prisma.curatedSource;
-  const rows = await curatedSource.findMany({
+  const findManyArgs = {
     where: { listingUrl: { in: body.listingUrls }, enabled: true },
-    select: { id: true, listingUrl: true, maxItems: true },
-  } satisfies Prisma.CuratedSourceFindManyArgs);
+    select: { id: true, listingUrl: true, linkType: true, maxItems: true },
+  } satisfies Prisma.CuratedSourceFindManyArgs;
+
+  const rows = await curatedSource.findMany(findManyArgs);
+
+  type ResolvedCuratedSourceRow = Prisma.CuratedSourceGetPayload<{
+    select: typeof findManyArgs.select;
+  }>;
 
   return {
-    sources: rows.map(
-      (row: { listingUrl: string; id: string; maxItems: number | null }) => ({
-        listingUrl: row.listingUrl,
-        curatedSourceId: row.id,
-        maxItems: row.maxItems,
-      }),
-    ),
+    sources: rows.map((row: ResolvedCuratedSourceRow) => ({
+      listingUrl: row.listingUrl,
+      curatedSourceId: row.id,
+      linkType: row.linkType,
+      maxItems: row.maxItems,
+    })),
   };
 };
 

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -127,6 +127,7 @@ describe("runPageCollection", () => {
         {
           listingUrl: SOURCE_URL,
           curatedSourceId: "33333333-3333-4333-a333-333333333333",
+          linkType: "page",
           maxItems: null,
         },
       ],

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -122,6 +122,7 @@ export async function runPageCollection(
     const meta = sourceMetaByUrl.get(sourceUrl);
     const expanded = await expandSourceUrl(sourceUrl, discoveryDeps, {
       maxItems: meta?.maxItems ?? undefined,
+      linkType: meta?.linkType,
     });
     for (const item of expanded) {
       allCandidates.push({

--- a/apps/mediapulse/agents/page-collection/src/utilities/expand-source-urls.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/expand-source-urls.test.ts
@@ -1,10 +1,35 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const discoverMock = vi.fn();
+
+vi.mock("@workspace/agent-ingestion", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@workspace/agent-ingestion")>();
+  return {
+    ...actual,
+    createListingDiscoveryStrategy: vi.fn(() => ({
+      discover: discoverMock,
+    })),
+  };
+});
+
+import { createListingDiscoveryStrategy } from "@workspace/agent-ingestion";
 
 import {
   expandSourceUrl,
   looksLikeFeedUrl,
   looksLikeSitemapUrl,
 } from "./expand-source-urls";
+
+const discoveryDeps = {
+  gotClient: {
+    get: async () => ({ body: "", statusCode: 200 }),
+  } as never,
+  rateLimiter: { acquire: async () => {} } as never,
+  logger: { info: () => {}, warn: () => {}, error: () => {} } as never,
+  timeoutMs: 5000,
+  concurrency: 1,
+};
 
 describe("looksLikeSitemapUrl", () => {
   it("detects sitemap URLs", () => {
@@ -21,18 +46,58 @@ describe("looksLikeFeedUrl", () => {
 });
 
 describe("expandSourceUrl", () => {
-  it("returns the URL itself for a regular web page", async () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    discoverMock.mockResolvedValue([]);
+  });
+
+  it("returns the URL itself for a page-type source", async () => {
     const url = "https://example.com/article/one";
-    const items = await expandSourceUrl(url, {
-      gotClient: {
-        get: async () => ({ body: "", statusCode: 200 }),
-      } as never,
-      rateLimiter: { acquire: async () => {} } as never,
-      logger: { info: () => {}, warn: () => {}, error: () => {} } as never,
-      timeoutMs: 5000,
-      concurrency: 1,
+    const items = await expandSourceUrl(url, discoveryDeps, {
+      linkType: "page",
     });
 
     expect(items).toEqual([{ url }]);
+    expect(createListingDiscoveryStrategy).not.toHaveBeenCalled();
+  });
+
+  it("returns the URL itself for a regular web page without linkType", async () => {
+    const url = "https://example.com/article/one";
+    const items = await expandSourceUrl(url, discoveryDeps);
+
+    expect(items).toEqual([{ url }]);
+    expect(createListingDiscoveryStrategy).not.toHaveBeenCalled();
+  });
+
+  it("uses generic-links for listing-type HTML pages", async () => {
+    discoverMock.mockResolvedValue([
+      { url: "https://example.com/news/a" },
+      { url: "https://example.com/news/b" },
+    ]);
+
+    const listingUrl = "https://example.com/news";
+    const items = await expandSourceUrl(listingUrl, discoveryDeps, {
+      linkType: "listing",
+    });
+
+    expect(createListingDiscoveryStrategy).toHaveBeenCalledWith(
+      "generic-links",
+    );
+    expect(items).toEqual([
+      { url: "https://example.com/news/a" },
+      { url: "https://example.com/news/b" },
+    ]);
+  });
+
+  it("prefers RSS discovery for listing-type feed URLs", async () => {
+    discoverMock.mockResolvedValue([{ url: "https://example.com/post-1" }]);
+
+    const feedUrl = "https://example.com/feed";
+    const items = await expandSourceUrl(feedUrl, discoveryDeps, {
+      linkType: "listing",
+    });
+
+    expect(createListingDiscoveryStrategy).toHaveBeenCalledWith("rss");
+    expect(items).toEqual([{ url: "https://example.com/post-1" }]);
   });
 });

--- a/apps/mediapulse/agents/page-collection/src/utilities/expand-source-urls.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/expand-source-urls.ts
@@ -1,8 +1,11 @@
 import type { DiscoveredItem, DiscoveryDeps } from "@workspace/agent-ingestion";
 import { createListingDiscoveryStrategy } from "@workspace/agent-ingestion";
 
+export type CuratedSourceLinkType = "page" | "listing";
+
 export type ExpandSourceUrlOptions = {
   maxItems?: number;
+  linkType?: CuratedSourceLinkType;
 };
 
 /**
@@ -36,12 +39,51 @@ export const looksLikeFeedUrl = (url: string): boolean => {
 };
 
 /**
+ * Attempts sitemap or RSS discovery when URL heuristics match.
+ *
+ * @param sourceUrl - Curated listing URL.
+ * @param deps - Shared discovery HTTP dependencies.
+ * @returns Discovered items, or `null` when no feed/sitemap strategy applies.
+ */
+const discoverSitemapOrFeed = async (
+  sourceUrl: string,
+  deps: DiscoveryDeps,
+): Promise<DiscoveredItem[] | null> => {
+  if (looksLikeSitemapUrl(sourceUrl)) {
+    try {
+      const strategy = createListingDiscoveryStrategy("sitemap");
+      const items = await strategy.discover(sourceUrl, deps);
+      if (items.length > 0) {
+        return items;
+      }
+    } catch {
+      // fall through to RSS or generic listing handling
+    }
+  }
+
+  if (looksLikeFeedUrl(sourceUrl)) {
+    try {
+      const strategy = createListingDiscoveryStrategy("rss");
+      const items = await strategy.discover(sourceUrl, deps);
+      if (items.length > 0) {
+        return items;
+      }
+    } catch {
+      // fall through to generic listing handling
+    }
+  }
+
+  return null;
+};
+
+/**
  * Expands a curated source URL into candidate article URLs.
- * Sitemap and RSS feeds are parsed; all other URLs are treated as single articles.
+ * Page sources return a single URL; listing sources use feed/sitemap heuristics
+ * and HTML link extraction.
  *
  * @param sourceUrl - Curated listing URL from run input.
  * @param deps - Shared discovery HTTP dependencies.
- * @param options - Optional per-source cap.
+ * @param options - Optional per-source cap and stored link type.
  */
 export const expandSourceUrl = async (
   sourceUrl: string,
@@ -51,9 +93,18 @@ export const expandSourceUrl = async (
   const cap = (items: DiscoveredItem[]) =>
     options.maxItems !== undefined ? items.slice(0, options.maxItems) : items;
 
-  if (looksLikeSitemapUrl(sourceUrl)) {
+  if (options.linkType === "page") {
+    return cap([{ url: sourceUrl }]);
+  }
+
+  const feedOrSitemapItems = await discoverSitemapOrFeed(sourceUrl, deps);
+  if (feedOrSitemapItems) {
+    return cap(feedOrSitemapItems);
+  }
+
+  if (options.linkType === "listing") {
     try {
-      const strategy = createListingDiscoveryStrategy("sitemap");
+      const strategy = createListingDiscoveryStrategy("generic-links");
       const items = await strategy.discover(sourceUrl, deps);
       if (items.length > 0) {
         return cap(items);
@@ -63,17 +114,5 @@ export const expandSourceUrl = async (
     }
   }
 
-  if (looksLikeFeedUrl(sourceUrl)) {
-    try {
-      const strategy = createListingDiscoveryStrategy("rss");
-      const items = await strategy.discover(sourceUrl, deps);
-      if (items.length > 0) {
-        return cap(items);
-      }
-    } catch {
-      // fall through to single-article mode
-    }
-  }
-
-  return [{ url: sourceUrl }];
+  return cap([{ url: sourceUrl }]);
 };

--- a/apps/mediapulse/domain-api/src/generated/prisma-write-field-metadata.ts
+++ b/apps/mediapulse/domain-api/src/generated/prisma-write-field-metadata.ts
@@ -43,6 +43,12 @@ export const prismaWriteFieldMetadata = {
       isRequired: true,
       isList: false,
     },
+    linkType: {
+      kind: "enum",
+      enumName: "CuratedSourceLinkType",
+      isRequired: true,
+      isList: false,
+    },
     enabled: {
       kind: "scalar",
       type: "Boolean",

--- a/apps/mediapulse/domain-api/src/lib/prisma-write-schema/default-prisma-enum-zod.test.ts
+++ b/apps/mediapulse/domain-api/src/lib/prisma-write-schema/default-prisma-enum-zod.test.ts
@@ -14,6 +14,15 @@ describe("getPrismaEnumZodSchema", () => {
     expect(s!.safeParse("NOPE").success).toBe(false);
   });
 
+  it("returns nativeEnum for CuratedSourceLinkType", () => {
+    const s = getPrismaEnumZodSchema("CuratedSourceLinkType");
+
+    expect(s).toBeDefined();
+    expect(s!.safeParse("page").success).toBe(true);
+    expect(s!.safeParse("listing").success).toBe(true);
+    expect(s!.safeParse("rss").success).toBe(false);
+  });
+
   it("returns undefined for unknown enum names", () => {
     // Act
     const s = getPrismaEnumZodSchema("NoSuchEnum");

--- a/apps/mediapulse/domain-api/src/lib/prisma-write-schema/default-prisma-enum-zod.ts
+++ b/apps/mediapulse/domain-api/src/lib/prisma-write-schema/default-prisma-enum-zod.ts
@@ -2,10 +2,15 @@
  * Maps Prisma enum names from DMMF to `z.nativeEnum` schemas for write-body validation.
  */
 
-import { Sentiment, TickerEntitySource } from "@mediapulse/database";
+import {
+  CuratedSourceLinkType,
+  Sentiment,
+  TickerEntitySource,
+} from "@mediapulse/database";
 import { z } from "zod";
 
 const prismaEnumZodByName: Record<string, z.ZodTypeAny> = {
+  CuratedSourceLinkType: z.nativeEnum(CuratedSourceLinkType),
   Sentiment: z.nativeEnum(Sentiment),
   TickerEntitySource: z.nativeEnum(TickerEntitySource),
 };

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/dashboard-page.ts
@@ -33,6 +33,7 @@ const curatedSourcesMetadataBlock = {
       linkTemplate: "{listingUrl}",
       copyAction: true,
     },
+    { field: "linkType", label: "Link type", format: "text" },
     { field: "enabled", label: "Enabled", format: "text" },
     { field: "maxItems", label: "Max items", format: "text" },
     { field: "createdAt", label: "Created", format: "date-time" },
@@ -45,7 +46,7 @@ export const curatedSourcesDashboardPage = {
   id: curatedSourcesHermesPathSegment,
   label: "Curated Sources",
   description:
-    "Operator-managed listing URLs for page-collection (RSS feeds, sitemaps, or single article pages).",
+    "Operator-managed URLs for page-collection. Choose Page for a single article URL or Listing for RSS, sitemap, or HTML listing pages.",
   pathSegment: curatedSourcesHermesPathSegment,
   kind: "resource-table" as const,
   placement: "sidebar" as const,
@@ -54,6 +55,7 @@ export const curatedSourcesDashboardPage = {
   columns: columnsFor<ListItem>()([
     { key: "name", label: "Name", type: "text" },
     { key: "listingUrl", label: "Listing URL", type: "text" },
+    { key: "linkType", label: "Link type", type: "text" },
     { key: "enabled", label: "Enabled", type: "text" },
     { key: "maxItems", label: "Max items", type: "text" },
     { key: "createdAt", label: "Created", type: "date-time" },
@@ -62,6 +64,7 @@ export const curatedSourcesDashboardPage = {
   sortableFields: rowFieldKeysFor<ListItem>()([
     "name",
     "listingUrl",
+    "linkType",
     "enabled",
     "maxItems",
     "createdAt",

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/detail-mapper.ts
@@ -14,6 +14,7 @@ export const mapRowToDetailItem = (row: CuratedSource) => ({
   id: row.id,
   name: row.name ?? "",
   listingUrl: row.listingUrl,
+  linkType: row.linkType,
   enabled: row.enabled,
   maxItems: row.maxItems,
   createdAt: row.createdAt.toISOString(),

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/list-filters.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/list-filters.ts
@@ -22,6 +22,7 @@ export type CuratedSourceListSortDir = "asc" | "desc";
 export type CuratedSourceListSortField =
   | "name"
   | "listingUrl"
+  | "linkType"
   | "enabled"
   | "maxItems"
   | "createdAt";
@@ -85,6 +86,8 @@ export const buildCuratedSourceListOrderBy = (
       return { name: dir };
     case "listingUrl":
       return { listingUrl: dir };
+    case "linkType":
+      return { linkType: dir };
     case "enabled":
       return { enabled: dir };
     case "maxItems":

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/list-mapper.ts
@@ -14,6 +14,7 @@ export const mapRowToListItem = (row: CuratedSource) => ({
   id: row.id,
   name: row.name ?? "",
   listingUrl: row.listingUrl,
+  linkType: row.linkType === "page" ? "Page" : "Listing",
   enabled: row.enabled ? "Yes" : "No",
   maxItems: row.maxItems == null ? "" : String(row.maxItems),
   createdAt: row.createdAt.toISOString(),

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/routes.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/routes.test.ts
@@ -48,6 +48,7 @@ describe("curatedSourcesRoutes", () => {
         id: "source-1",
         name: "Example feed",
         listingUrl: "https://example.com/feed.xml",
+        linkType: "listing",
         enabled: true,
         maxItems: 25,
         createdAt: new Date("2026-06-17T10:00:00.000Z"),
@@ -109,6 +110,7 @@ describe("curatedSourcesRoutes", () => {
       id: "source-new",
       name: null,
       listingUrl: "https://example.com/rss",
+      linkType: "listing",
       enabled: true,
       maxItems: null,
       createdAt: new Date("2026-06-17T10:00:00.000Z"),
@@ -120,11 +122,55 @@ describe("curatedSourcesRoutes", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         listingUrl: "https://example.com/rss",
+        linkType: "listing",
         enabled: true,
       }),
     });
 
     expect(res.status).toBe(201);
     expect(await res.json()).toEqual({ id: "source-new" });
+    expect(prisma.curatedSource.create).toHaveBeenCalledWith({
+      data: {
+        name: null,
+        listingUrl: "https://example.com/rss",
+        linkType: "listing",
+        enabled: true,
+        maxItems: null,
+      },
+    });
+  });
+
+  it("creates a page-type curated source", async () => {
+    vi.mocked(prisma.curatedSource.create).mockResolvedValue({
+      id: "source-page",
+      name: "Single article",
+      listingUrl: "https://example.com/article/one",
+      linkType: "page",
+      enabled: true,
+      maxItems: null,
+      createdAt: new Date("2026-06-17T10:00:00.000Z"),
+      updatedAt: new Date("2026-06-17T10:00:00.000Z"),
+    } as never);
+
+    const res = await curatedSourcesRoutes.request("http://localhost/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        listingUrl: "https://example.com/article/one",
+        linkType: "page",
+        enabled: true,
+      }),
+    });
+
+    expect(res.status).toBe(201);
+    expect(prisma.curatedSource.create).toHaveBeenCalledWith({
+      data: {
+        name: null,
+        listingUrl: "https://example.com/article/one",
+        linkType: "page",
+        enabled: true,
+        maxItems: null,
+      },
+    });
   });
 });

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/routes.ts
@@ -34,6 +34,7 @@ const parseSortBy = (
 ): CuratedSourceListSortField | undefined => {
   if (raw === "name") return "name";
   if (raw === "listingUrl") return "listingUrl";
+  if (raw === "linkType") return "linkType";
   if (raw === "enabled") return "enabled";
   if (raw === "maxItems") return "maxItems";
   if (raw === "createdAt") return "createdAt";
@@ -64,6 +65,7 @@ const toCuratedSourceWriteData = (
 ) => ({
   name: nullableText(body.name),
   listingUrl: body.listingUrl.trim(),
+  linkType: body.linkType,
   enabled: body.enabled,
   maxItems: body.maxItems ?? null,
 });

--- a/apps/mediapulse/domain-api/src/resources/curated-sources/write-body-schemas.ts
+++ b/apps/mediapulse/domain-api/src/resources/curated-sources/write-body-schemas.ts
@@ -12,6 +12,7 @@ import { buildWriteBodySchema } from "../../lib/prisma-write-schema/build-write-
 const curatedSourceWriteFields = [
   "name",
   "listingUrl",
+  "linkType",
   "enabled",
   "maxItems",
 ] as const;

--- a/apps/mediapulse/scripts/migrate-curated-sources-from-agent-config.ts
+++ b/apps/mediapulse/scripts/migrate-curated-sources-from-agent-config.ts
@@ -73,6 +73,7 @@ async function main() {
         where: { listingUrl: source.listingUrl },
         create: {
           listingUrl: source.listingUrl,
+          linkType: "listing",
           enabled: source.enabled ?? true,
           maxItems: source.maxItems ?? null,
         },

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -48,7 +48,7 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | POST   | `/api/v1/user-registration-unsubscribe`         | Apply one-click unsubscribe from the user-registration app                 |
 | GET    | `/api/v1/query-analysis`                        | Get query-analysis context by ticker                                       |
 | POST   | `/api/v1/query-analysis`                        | Store and activate a versioned query set                                   |
-| GET    | `/api/v1/section-coverage-rollup`               | Per-section average query coverage and newsletter fill by contract version   |
+| GET    | `/api/v1/section-coverage-rollup`               | Per-section average query coverage and newsletter fill by contract version |
 
 ### Content generation (`/api/v1/content-generation`)
 
@@ -298,6 +298,15 @@ const rollup = await dataApiClient.sectionCoverageRollup.get({
 - **Config (`configSchema`):** required **`resendApiKey`** and **`resend.from`** (no env fallback); optional `resend.replyTo` / **`resend.tags`**, **`send.includeHtml` / `send.includeText`** (defaults `true`; at least one required), `rateLimit.minIntervalMs` + `maxSendsPerMinute`, `retry` (`maxAttempts`, `baseDelayMs`, `maxDelayMs`, `jitter`), `template.newsletterVariant` (`default` only in v1), optional **`template.preferencesUrl`** (absolute URL; when set, the default newsletter template shows a “Manage preferences” link).
 - **Pipeline HTTP outcome:** Partial delivery still returns **invoke envelope `status: success`** with `details.outcome: "partial_success"`; full diagnostics live in **delivery runs** (DB + Hermes Mediapulse **Delivery runs** table). All recipients failing returns `status: failure` on the agent response.
 - **PII:** Logs use hashed `userTickerId` fragments; persisted diagnostics store `userTickerId` and sanitized error text (not raw emails in optional summary fields).
+
+### Page collection (`/api/v1/page-collection-*`)
+
+Implemented in `apps/mediapulse/agent-data-api/src/routes/page-collection.ts`. Schemas live in `@workspace/agent-data-api-contract` (`page-collection.ts`).
+
+- **POST `/api/v1/page-collection-resolve-sources`** — Body: `listingUrls` (array of URLs). Response: `sources[]` with `listingUrl`, `curatedSourceId`, **`linkType`** (`page` | `listing`), and optional `maxItems`. Used by the page-collection agent before URL expansion.
+- **POST `/api/v1/page-collection`** — Persist ticker-agnostic articles collected from curated sources.
+- **POST `/api/v1/page-collection-existing-urls`** — Global dedup lookup for candidate article URLs.
+- **GET `/api/v1/page-collection-articles`** — Paginated list of page-collection articles with optional gate and analysis filters.
 
 ## Versioning
 

--- a/dev-docs/docs/mediapulse/apps/domain-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/domain-api.mdx
@@ -15,7 +15,7 @@ icon: Server
   - `POST /v1/preview-expansion`
   - `POST /v1/expand-step-inputs`
 - Serves **Hermes dashboard** HTTP for registered `table-v1` resources (list, meta, create/update/delete) under `/v1/hermes-dashboard/...`, including optional **custom actions** declared in the integration manifest (for example `POST /v1/hermes-dashboard/tickers/import-idx-json` with body `{ "payloadJson": "<stringified IDX JSON>" }` for IDX ticker import via `@mediapulse/idx-tickers-importer`).
-- Registered table-v1 resources include `tickers`, `mediapulse-users`, `entity-types`, `relation-types`, `entities`, `entity-relations` (full CRUD on edges by canonical entity names and relation type label, plus a **Reset all relations** custom action that deletes every `entity_relation` row after confirm), `data-sources` (read-only list with ticker, collected-by, and created-date filters), `search-query-sets` (full CRUD with full-page create/edit and detail blocks for strategy snapshot + queries), `search-queries` (list + delete per query row), `delivery-runs`, and `newsletters` (read-only list with subject/ticker/date filters and a delivery cell that shows checkpoint-vs-enabled counts). The newsletters resource also exposes a read-only `GET /resources/newsletters/:id` detail handler that returns subject/ticker/agent metadata, the per-newsletter recipients table (capped at 2,000 rows with `recipientsTruncated`), the selected sources for that day's UTC window, the active SearchQuerySet at send time, and the Hermes execution links (schedule, execution, pipeline run/step, content-generation run, delivery run ids). The manifest declares `detailBlocks` so the Hermes dashboard renders metadata and Hermes-links blocks without per-resource code.
+- Registered table-v1 resources include `tickers`, `mediapulse-users`, `entity-types`, `relation-types`, `entities`, `entity-relations` (full CRUD on edges by canonical entity names and relation type label, plus a **Reset all relations** custom action that deletes every `entity_relation` row after confirm), `data-sources` (read-only list with ticker, collected-by, and created-date filters), `search-query-sets` (full CRUD with full-page create/edit and detail blocks for strategy snapshot + queries), `search-queries` (list + delete per query row), `delivery-runs`, `newsletters` (read-only list with subject/ticker/date filters and a delivery cell that shows checkpoint-vs-enabled counts), and **`curated-sources`** (operator-managed page-collection URLs with a required **`linkType`** of `page` or `listing`). The newsletters resource also exposes a read-only `GET /resources/newsletters/:id` detail handler that returns subject/ticker/agent metadata, the per-newsletter recipients table (capped at 2,000 rows with `recipientsTruncated`), the selected sources for that day's UTC window, the active SearchQuerySet at send time, and the Hermes execution links (schedule, execution, pipeline run/step, content-generation run, delivery run ids). The manifest declares `detailBlocks` so the Hermes dashboard renders metadata and Hermes-links blocks without per-resource code.
 - Runs Mediapulse DB expansion logic using `@mediapulse/hermes-integration`.
 - Self-registers to Hermes via `POST /api/domain-integrations/register`.
 
@@ -59,6 +59,19 @@ pnpm --filter @mediapulse/domain-api generate:prisma-write-field-metadata
 ```
 
 You can also run `pnpm --filter @mediapulse/domain-api generate` or rely on `turbo run build --filter=@mediapulse/domain-api` to refresh the file. Then run `pnpm code-quality` from the repo root when you are ready to ship.
+
+### Curated sources (`curated-sources`)
+
+Hermes **Curated Sources** lets operators register URLs for the page-collection agent. Each row stores:
+
+| Field        | Description                                                                                                         |
+| ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `listingUrl` | The source URL (unique).                                                                                            |
+| `linkType`   | `page` — fetch this URL as a single article; `listing` — expand via RSS/sitemap heuristics or HTML link extraction. |
+| `enabled`    | When `false`, resolve-sources skips the row.                                                                        |
+| `maxItems`   | Optional cap on discovered URLs per run.                                                                            |
+
+Existing rows default to `listing` after migration. The create/update modal exposes `linkType` as a select field derived from the Prisma enum.
 
 ## Key environment variables
 

--- a/packages/mediapulse/database/prisma/migrations/20260617120000_add_curated_source_link_type/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260617120000_add_curated_source_link_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "CuratedSourceLinkType" AS ENUM ('page', 'listing');
+
+-- AlterTable
+ALTER TABLE "curated_source" ADD COLUMN "link_type" "CuratedSourceLinkType" NOT NULL DEFAULT 'listing';

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -53,15 +53,21 @@ enum ArticleAssociationSource {
   manual
 }
 
+enum CuratedSourceLinkType {
+  page
+  listing
+}
+
 /// Operator-managed listing URLs for page-collection (RSS, sitemap, or single article).
 model CuratedSource {
-  id         String   @id @default(uuid())
+  id         String                @id @default(uuid())
   name       String?
-  listingUrl String   @unique @map("listing_url")
-  enabled    Boolean  @default(true)
-  maxItems   Int?     @map("max_items")
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt @map("updated_at")
+  listingUrl String                @unique @map("listing_url")
+  linkType   CuratedSourceLinkType @default(listing) @map("link_type")
+  enabled    Boolean               @default(true)
+  maxItems   Int?                  @map("max_items")
+  createdAt  DateTime              @default(now()) @map("created_at")
+  updatedAt  DateTime              @updatedAt @map("updated_at")
 
   articles              DataSource[]
   collectionUrlOutcomes CollectionUrlOutcome[]

--- a/packages/shared/agent-data-api-contract/src/page-collection.ts
+++ b/packages/shared/agent-data-api-contract/src/page-collection.ts
@@ -37,11 +37,14 @@ export const postPageCollectionResolveSourcesBodySchema = z.object({
   listingUrls: z.array(z.string().url()),
 });
 
+export const curatedSourceLinkTypeSchema = z.enum(["page", "listing"]);
+
 export const postPageCollectionResolveSourcesResponseSchema = z.object({
   sources: z.array(
     z.object({
       listingUrl: z.string().url(),
       curatedSourceId: z.string().uuid(),
+      linkType: curatedSourceLinkTypeSchema,
       maxItems: z.number().int().positive().nullable(),
     }),
   ),


### PR DESCRIPTION
## Summary

Curated sources in Hermes now have a `linkType` field (`page` or `listing`). Operators pick the type when adding a source; page-collection reads it from resolve-sources and expands listing URLs through RSS/sitemap heuristics or HTML link extraction instead of treating every non-feed URL as a single article.

## Related issues

Closes #805

## Important changes

- Added `CuratedSourceLinkType` Prisma enum and `link_type` column (default `listing` for existing rows).
- Hermes curated-sources create/edit form shows a link type select; list and detail views display it.
- `POST /page-collection/resolve-sources` returns `linkType`; the page-collection agent passes it into `expandSourceUrl`.
- Listing sources try RSS/sitemap heuristics first, then `generic-links`; page sources always resolve to one URL.

## Other changes

- Unit tests for domain-api routes, resolve-sources service, and expand-source-urls.
- Dev-docs updates for domain-api and agent-data-api.
- Legacy migrate script sets `linkType: listing` on upsert.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` — enum and model field.
- `apps/mediapulse/domain-api/src/resources/curated-sources/` — form schema, mappers, dashboard manifest.
- `packages/shared/agent-data-api-contract/src/page-collection.ts` — resolve-sources response shape.
- `apps/mediapulse/agents/page-collection/src/utilities/expand-source-urls.ts` — page vs listing branching.

## How to test

1. Apply migration: `pnpm --filter @mediapulse/database db:migrate:deploy`
2. Rebuild contract: `pnpm --filter @workspace/agent-data-api-contract build`
3. In Hermes → Curated Sources, create one `page` source and one `listing` source (e.g. a `/news` index URL).
4. Run page-collection against both URLs and confirm the page source yields one candidate while the listing source expands to multiple article URLs.
5. Run `pnpm --filter @mediapulse/domain-api test` and `pnpm --filter @mediapulse/page-collection test`.
