### PR TITLE
Use data-source expansion for page-collection v2 input

### DIFF
--- a/apps/mediapulse/agents/page-collection/src/index.ts
+++ b/apps/mediapulse/agents/page-collection/src/index.ts
@@ -15,7 +15,7 @@ const app = createAgentApp<
     agentId: "page-collection",
     agentVersion: "2.0.0",
     description:
-      "Discovers and fetches article pages from curated listing sources for a ticker.",
+      "Discovers and fetches article pages from one curated listing source per run; use data-source expansion on listingUrl to fan out across enabled curated sources.",
     inputSchema: BodySchema,
     configSchema: ConfigSchema,
     run: runPageCollection,

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -111,7 +111,7 @@ function createContext(
   overrides?: Partial<AgentRunContext<BodySchemaType, ConfigSchemaType>>,
 ): AgentRunContext<BodySchemaType, ConfigSchemaType> {
   return {
-    input: { sourceUrls: [SOURCE_URL] },
+    input: { listingUrl: SOURCE_URL },
     config: baseConfig,
     token: "Bearer test-token",
     ...overrides,

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -36,7 +36,7 @@ import {
  * Executes the page-collection pipeline: expand curated source URLs, fetch article
  * content, apply the content quality gate, and persist ticker-agnostic articles.
  *
- * @param context - Validated input (`sourceUrls`) and config, plus bearer token.
+ * @param context - Validated input (`listingUrl`) and config, plus bearer token.
  * @returns Success with summary counts, or semantic failure when run policy is not met.
  */
 export async function runPageCollection(
@@ -87,16 +87,16 @@ export async function runPageCollection(
     }
   };
 
-  report("Resolving curated sources", `${input.sourceUrls.length} URLs`);
+  const listingUrl = input.listingUrl;
+
+  report("Resolving curated source", listingUrl);
 
   const { sources: resolvedSources } =
     await dataApiClient.pageCollectionResolveSources.create({
-      listingUrls: input.sourceUrls,
+      listingUrls: [listingUrl],
     });
 
-  const sourceMetaByUrl = new Map(
-    resolvedSources.map((s) => [s.listingUrl, s]),
-  );
+  const meta = resolvedSources.find((s) => s.listingUrl === listingUrl);
 
   const discoveryDeps = {
     gotClient: got,
@@ -107,7 +107,7 @@ export async function runPageCollection(
     concurrency: config.discovery.concurrency,
   };
 
-  report("Expanding source URLs", `${input.sourceUrls.length} sources`);
+  report("Expanding source URL", listingUrl);
 
   type CandidateItem = {
     url: string;
@@ -116,25 +116,17 @@ export async function runPageCollection(
     publishedAt?: string;
   };
 
-  const allCandidates: CandidateItem[] = [];
+  const expanded = await expandSourceUrl(listingUrl, discoveryDeps, {
+    maxItems: meta?.maxItems ?? undefined,
+    linkType: meta?.linkType,
+  });
 
-  for (const sourceUrl of input.sourceUrls) {
-    const meta = sourceMetaByUrl.get(sourceUrl);
-    const expanded = await expandSourceUrl(sourceUrl, discoveryDeps, {
-      maxItems: meta?.maxItems ?? undefined,
-      linkType: meta?.linkType,
-    });
-    for (const item of expanded) {
-      allCandidates.push({
-        url: item.url,
-        sourceListingUrl: sourceUrl,
-        ...(meta?.curatedSourceId
-          ? { curatedSourceId: meta.curatedSourceId }
-          : {}),
-        ...(item.publishedAt ? { publishedAt: item.publishedAt } : {}),
-      });
-    }
-  }
+  const allCandidates: CandidateItem[] = expanded.map((item) => ({
+    url: item.url,
+    sourceListingUrl: listingUrl,
+    ...(meta?.curatedSourceId ? { curatedSourceId: meta.curatedSourceId } : {}),
+    ...(item.publishedAt ? { publishedAt: item.publishedAt } : {}),
+  }));
 
   const collectionConfig = config.collection;
   const runConfig = config.run;
@@ -406,7 +398,7 @@ export async function runPageCollection(
       : derivedStatus;
 
   const counters: RunCounters = {
-    queriesTotal: input.sourceUrls.length,
+    queriesTotal: 1,
     urlsTotal: cappedCandidates.length,
     searchSuccess: allCandidates.length,
     searchFailed: 0,

--- a/apps/mediapulse/agents/page-collection/src/utilities/body-schema.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/body-schema.test.ts
@@ -5,15 +5,31 @@ import { describe, expect, it } from "vitest";
 import { BodySchema } from "./body-schema";
 
 describe("BodySchema", () => {
-  it("requires at least one source URL", () => {
-    expect(() => BodySchema.parse({ sourceUrls: [] })).toThrow();
+  it("rejects an empty listingUrl", () => {
+    expect(() => BodySchema.parse({ listingUrl: "" })).toThrow();
+    expect(() => BodySchema.parse({ listingUrl: "   " })).toThrow();
   });
 
-  it("accepts an array of URLs", () => {
+  it("accepts a literal listing URL", () => {
     const result = BodySchema.parse({
-      sourceUrls: ["https://example.com/article"],
+      listingUrl: "https://example.com/article",
     });
 
-    expect(result.sourceUrls).toHaveLength(1);
+    expect(result.listingUrl).toBe("https://example.com/article");
+  });
+
+  it("accepts a db: curatedSource expansion string", () => {
+    const expansion = "db:curatedSource:listingUrl?where.enabled=true";
+    const result = BodySchema.parse({ listingUrl: expansion });
+
+    expect(result.listingUrl).toBe(expansion);
+  });
+
+  it("trims surrounding whitespace from listingUrl", () => {
+    const result = BodySchema.parse({
+      listingUrl: "  https://example.com/article  ",
+    });
+
+    expect(result.listingUrl).toBe("https://example.com/article");
   });
 });

--- a/apps/mediapulse/agents/page-collection/src/utilities/body-schema.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/body-schema.ts
@@ -1,8 +1,14 @@
 import { z } from "zod";
 
-/** Validates page-collection run input: curated source URLs to harvest. */
+/**
+ * Validates page-collection run input: one curated source listing URL per invocation.
+ *
+ * Accepts a literal URL or a Hermes `db:` data-source expansion string
+ * (e.g. `db:curatedSource:listingUrl?where.enabled=true`); expansion is resolved
+ * by the scheduler before the agent is invoked.
+ */
 export const BodySchema = z.object({
-  sourceUrls: z.array(z.string().url()).min(1),
+  listingUrl: z.string().trim().min(1),
 });
 
 export type BodySchemaType = z.infer<typeof BodySchema>;

--- a/dev-docs/docs/integration/data-source-expansion.mdx
+++ b/dev-docs/docs/integration/data-source-expansion.mdx
@@ -75,6 +75,12 @@ db:ticker:id?where.id=123
 
 Single row: ticker where `id` equals `123`.
 
+```text
+db:curatedSource:listingUrl?where.enabled=true
+```
+
+One enabled curated source listing URL per expanded run for `page-collection@2.0.0`.
+
 ## Validation
 
 When saving a pipeline step (add or update step in Hermes), Hermes validates the step input (including data-source expressions) against the agent’s **input schema**. Data-source strings are also validated for:


### PR DESCRIPTION
## Summary

page-collection v2 no longer asks you to add curated source URLs one by one. Pipeline steps now take a single **listingUrl** field that supports Hermes data-source expansion, so one step can fan out across all enabled curated sources at run time.

## Related issues

Closes #807

## Important changes

- Replaced `sourceUrls[]` with `listingUrl` in the page-collection input schema so the pipeline UI shows the expansion picker (Insert…) instead of an array editor.
- Run logic handles one curated source per invocation; Hermes expands `db:curatedSource:listingUrl?where.enabled=true` into separate runs.
- Documented the curatedSource expansion example in dev-docs.

## Other changes

- Updated agent description to mention expansion-based fan-out.
- Extended body-schema tests for literal URLs, expansion strings, and trimming.

## Key files to review

- `apps/mediapulse/agents/page-collection/src/utilities/body-schema.ts` — new single-field input shape.
- `apps/mediapulse/agents/page-collection/src/run.ts` — one listing URL per run instead of a multi-source loop.
- `dev-docs/docs/integration/data-source-expansion.mdx` — curatedSource expansion example.

## How to test

1. Run `cd apps/mediapulse/agents/page-collection && pnpm test` — all 22 tests should pass.
2. In Hermes, open a pipeline with `page-collection@2.0.0` and confirm the Input tab shows a single **Listing Url** field with Insert… for expansions.
3. Save input `{ "listingUrl": "db:curatedSource:listingUrl?where.enabled=true" }`, run the pipeline, and confirm one execution per enabled curated source.
