### PR TITLE
Fix 404 on data source expansions dashboard list page

### DIFF
--- a/apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.test.tsx
+++ b/apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.test.tsx
@@ -50,6 +50,7 @@ describe("IntegrationDashboardViewPage", () => {
 
   it("renders resource-table view via DomainTablePage", async () => {
     getDomainIntegrationByIntegrationIdMock.mockResolvedValue({
+      capabilities: [],
       dashboard: {
         views: [
           {
@@ -90,6 +91,7 @@ describe("IntegrationDashboardViewPage", () => {
 
   it("renders html content view via DomainContentViewPage", async () => {
     getDomainIntegrationByIntegrationIdMock.mockResolvedValue({
+      capabilities: [],
       dashboard: {
         views: [
           {
@@ -116,6 +118,48 @@ describe("IntegrationDashboardViewPage", () => {
 
     expect(screen.getByTestId("domain-content-view-page")).toBeInTheDocument();
     expect(domainContentViewPageMock).toHaveBeenCalled();
+  });
+
+  it("renders synthetic data-source-expansions when manifest omits it but capability is present", async () => {
+    getDomainIntegrationByIntegrationIdMock.mockResolvedValue({
+      id: "i1",
+      integrationId: "mediapulse",
+      capabilities: ["expand-step-inputs", "preview-expansion"],
+      dashboard: {
+        views: [
+          {
+            id: "tickers",
+            kind: "resource-table",
+            placement: "sidebar",
+            pathSegment: "tickers",
+            label: "Tickers",
+            order: 1,
+            apiPrefix: "/v1/tickers",
+            columns: [],
+            searchableFields: [],
+            sortableFields: [],
+            actions: {},
+          },
+        ],
+      },
+    });
+
+    const component = await IntegrationDashboardViewPage({
+      params: Promise.resolve({
+        integrationId: "mediapulse",
+        resource: "data-source-expansions",
+      }),
+      searchParams: {},
+    });
+    render(component);
+
+    expect(screen.getByTestId("domain-table-page")).toBeInTheDocument();
+    expect(domainTablePageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        integrationId: "mediapulse",
+        resource: "data-source-expansions",
+      }),
+    );
   });
 
   it("calls notFound when integration is missing", async () => {

--- a/apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.tsx
+++ b/apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.tsx
@@ -5,6 +5,7 @@ import DomainContentViewPage from "@/app/dashboard/domain-content-view-page";
 import { withAuthProtection } from "@/components/with-auth-protection";
 import { getDomainIntegrationByIntegrationId } from "@/lib/domain-integrations";
 import type { DomainTableSearchParams } from "@/lib/domain-table-list-params";
+import { mergeDomainIntegrationNavViews } from "@/lib/merge-domain-integration-nav-pages";
 
 /**
  * Domain integration dashboard view. Dispatches by manifest `kind` for sidebar views.
@@ -22,8 +23,8 @@ const IntegrationDashboardViewPage = async ({
     notFound();
   }
 
-  const view = integration.dashboard.views.find(
-    (entry) => entry.placement === "sidebar" && entry.pathSegment === resource,
+  const view = mergeDomainIntegrationNavViews(integration).find(
+    (entry) => entry.pathSegment === resource,
   );
 
   if (!view) {


### PR DESCRIPTION
## Summary

The Data source expansions list page 404'd at `/dashboard/mediapulse/data-source-expansions` while the sidebar still linked to it. Hermes injects that nav item for integrations with `expand-step-inputs`, but the route only checked manifest views. It now uses `mergeDomainIntegrationNavViews`, the same helper as the sidebar.

## Related issues

Closes #809

## Important changes

- Resolve integration dashboard views through `mergeDomainIntegrationNavViews` so synthetic `data-source-expansions` entries match sidebar navigation.
- Add a regression test for the list route when the manifest omits the view but the capability is present.

## Other changes

- Existing page tests now pass `capabilities: []` on mock integrations (required by the nav merge helper).

## Key files to review

- `apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.tsx` — view lookup now includes synthetic sidebar entries.
- `apps/hermes/dashboard/app/dashboard/[integrationId]/[resource]/page.test.tsx` — regression test for `data-source-expansions`.

## How to test

1. Open `/dashboard/mediapulse/data-source-expansions` on Hermes (or run the dashboard locally with a mediapulse integration that has `expand-step-inputs`).
2. Confirm the expansion templates table loads instead of 404.
3. Run `cd apps/hermes/dashboard && pnpm exec vitest run "app/dashboard/[integrationId]/[resource]/page.test.tsx"`.
4. Run `pnpm format:check` from the repo root.
