### PR TITLE
Fix page-collection persist 500 on Agent Data API

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -79,6 +79,7 @@ vi.mock("@mediapulse/database", () => ({
       findMany: vi.fn(),
     },
     dataSource: {
+      create: vi.fn(),
       createMany: vi.fn(),
       findMany: vi.fn().mockResolvedValue([]),
     },
@@ -751,7 +752,9 @@ describe("agent-data-api", () => {
   describe(`POST ${dataCollectionPath}`, () => {
     it("returns 200 when body is valid array with tickerId + searchQueryId per item", async () => {
       const { prisma } = await getDatabase();
-      vi.mocked(prisma.dataSource.createMany).mockResolvedValue({ count: 1 });
+      vi.mocked(prisma.dataSource.create).mockResolvedValue({
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      } as never);
 
       const { app } = await import("./index.js");
       const res = await app.request(`http://localhost${dataCollectionPath}`, {
@@ -771,18 +774,15 @@ describe("agent-data-api", () => {
 
       expect(res.status).toBe(200);
       expect(body.message).toBe("Success");
-      expect(prisma.dataSource.createMany).toHaveBeenCalledWith({
-        data: [
-          {
-            url: "https://example.com",
-            canonicalUrl: "https://example.com",
-            title: "Example",
-            content: "Content",
-            tickerId: TICKER_ID,
-            searchQueryId: SEARCH_QUERY_ID,
-          },
-        ],
-        skipDuplicates: true,
+      expect(prisma.dataSource.create).toHaveBeenCalledWith({
+        data: {
+          url: "https://example.com",
+          canonicalUrl: "https://example.com",
+          title: "Example",
+          content: "Content",
+          tickerId: TICKER_ID,
+          searchQueryId: SEARCH_QUERY_ID,
+        },
       });
     });
   });

--- a/apps/mediapulse/agent-data-api/src/routes/data-collection.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/data-collection.ts
@@ -8,6 +8,7 @@ import { internalError } from "@workspace/api-utils";
 import { canonicalizeUrl } from "@workspace/utils";
 import { prisma } from "@mediapulse/database";
 
+import { insertDataSourcesIdempotently } from "../services/insert-data-sources-idempotently.js";
 import { aggregateSearchQueryYieldForTicker } from "../services/search-query-yield.js";
 
 export async function getDataCollection(context: Context): Promise<Response> {
@@ -39,8 +40,8 @@ export async function postDataCollection(context: Context): Promise<Response> {
   try {
     const body = await context.req.json();
     const data = await dataCollectionBodySchema.parseAsync(body);
-    await prisma.dataSource.createMany({
-      data: data.map((row) => {
+    await insertDataSourcesIdempotently(
+      data.map((row) => {
         let canonicalUrl: string;
         try {
           canonicalUrl = canonicalizeUrl(row.url);
@@ -55,8 +56,8 @@ export async function postDataCollection(context: Context): Promise<Response> {
             : {}),
         };
       }),
-      skipDuplicates: true,
-    });
+      { dataSource: prisma.dataSource },
+    );
 
     const tickerIds = [...new Set(data.map((row) => row.tickerId))];
     await Promise.all(

--- a/apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.test.ts
@@ -1,0 +1,68 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { insertDataSourcesIdempotently } from "./insert-data-sources-idempotently";
+
+describe("insertDataSourcesIdempotently", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("counts only rows that were inserted", async () => {
+    // Setup
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "1" })
+      .mockRejectedValueOnce({ code: "P2002" })
+      .mockResolvedValueOnce({ id: "3" });
+
+    // Act
+    const inserted = await insertDataSourcesIdempotently(
+      [
+        {
+          url: "https://example.com/a",
+          canonicalUrl: "https://example.com/a",
+          title: "A",
+          content: "A",
+        },
+        {
+          url: "https://example.com/b",
+          canonicalUrl: "https://example.com/b",
+          title: "B",
+          content: "B",
+        },
+        {
+          url: "https://example.com/c",
+          canonicalUrl: "https://example.com/c",
+          title: "C",
+          content: "C",
+        },
+      ],
+      { dataSource: { create } },
+    );
+
+    // Assert
+    expect(inserted).toBe(2);
+    expect(create).toHaveBeenCalledTimes(3);
+  });
+
+  it("rethrows non-unique Prisma errors", async () => {
+    // Setup
+    const create = vi.fn().mockRejectedValue({ code: "P2003" });
+
+    // Act / Assert
+    await expect(
+      insertDataSourcesIdempotently(
+        [
+          {
+            url: "https://example.com/a",
+            canonicalUrl: "https://example.com/a",
+            title: "A",
+            content: "A",
+          },
+        ],
+        { dataSource: { create } },
+      ),
+    ).rejects.toEqual({ code: "P2003" });
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.ts
@@ -1,0 +1,38 @@
+import type { Prisma } from "@mediapulse/database";
+import type { prisma } from "@mediapulse/database";
+
+import { isPrismaUniqueViolation } from "./is-prisma-unique-violation.js";
+
+type DataSourceCreateDelegate = Pick<typeof prisma.dataSource, "create">;
+
+/**
+ * Inserts data source rows one at a time, skipping canonical-url duplicates.
+ *
+ * `createMany({ skipDuplicates: true })` cannot target PostgreSQL partial unique
+ * indexes on `canonical_url`, so concurrent page-collection runs would 500.
+ *
+ * @param rows - Rows to insert.
+ * @param deps - `dataSource.create` delegate.
+ * @returns Count of rows actually inserted.
+ */
+export const insertDataSourcesIdempotently = async (
+  rows: Prisma.DataSourceCreateManyInput[],
+  deps: { dataSource: DataSourceCreateDelegate },
+): Promise<number> => {
+  const { dataSource } = deps;
+  let inserted = 0;
+
+  for (const row of rows) {
+    try {
+      await dataSource.create({ data: row });
+      inserted += 1;
+    } catch (error) {
+      if (isPrismaUniqueViolation(error)) {
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  return inserted;
+};

--- a/apps/mediapulse/agent-data-api/src/services/is-prisma-unique-violation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/is-prisma-unique-violation.test.ts
@@ -1,0 +1,30 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { isPrismaUniqueViolation } from "./is-prisma-unique-violation";
+
+describe("isPrismaUniqueViolation", () => {
+  it("returns true for Prisma P2002 errors", () => {
+    // Act
+    const result = isPrismaUniqueViolation({ code: "P2002" });
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("returns false for other Prisma errors", () => {
+    // Act
+    const result = isPrismaUniqueViolation({ code: "P2025" });
+
+    // Assert
+    expect(result).toBe(false);
+  });
+
+  it("returns false for non-object errors", () => {
+    // Act
+    const result = isPrismaUniqueViolation("boom");
+
+    // Assert
+    expect(result).toBe(false);
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/is-prisma-unique-violation.ts
+++ b/apps/mediapulse/agent-data-api/src/services/is-prisma-unique-violation.ts
@@ -1,0 +1,10 @@
+/**
+ * Returns true when the error is a Prisma unique-constraint violation (P2002).
+ *
+ * @param error - Caught unknown from a Prisma write.
+ */
+export const isPrismaUniqueViolation = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  (error as { code: string }).code === "P2002";

--- a/apps/mediapulse/agent-data-api/src/services/page-collection.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/page-collection.test.ts
@@ -5,7 +5,10 @@ vi.mock("@mediapulse/database", () => ({
   prisma: {},
 }));
 
-import { resolveCuratedSourcesByListingUrls } from "./page-collection";
+import {
+  persistPageCollectionArticles,
+  resolveCuratedSourcesByListingUrls,
+} from "./page-collection";
 
 describe("resolveCuratedSourcesByListingUrls", () => {
   it("returns linkType with resolved curated sources", async () => {
@@ -64,5 +67,61 @@ describe("resolveCuratedSourcesByListingUrls", () => {
         },
       ],
     });
+  });
+});
+
+describe("persistPageCollectionArticles", () => {
+  it("inserts rows idempotently via dataSource.create", async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ id: "ds-1" })
+      .mockResolvedValueOnce({ id: "ds-2" });
+    const findMany = vi.fn().mockResolvedValue([
+      {
+        id: "curated-1",
+        listingUrl: "https://example.com/news",
+      },
+    ]);
+
+    const count = await persistPageCollectionArticles(
+      [
+        {
+          url: "https://example.com/article/1",
+          title: "One",
+          content: "Body one",
+          curatedSourceListingUrl: "https://example.com/news",
+          collectionGateStatus: "passed",
+        },
+        {
+          url: "https://example.com/article/2",
+          title: "Two",
+          content: "Body two",
+          curatedSourceListingUrl: "https://example.com/news",
+          collectionGateStatus: "passed",
+        },
+      ],
+      { db: { curatedSource: { findMany }, dataSource: { create } } },
+    );
+
+    expect(count).toBe(2);
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(create.mock.calls[0]?.[0]?.data).toMatchObject({
+      canonicalUrl: "https://example.com/article/1",
+      curatedSourceId: "curated-1",
+      tickerId: null,
+      searchQueryId: null,
+      collectionGateStatus: "passed",
+    });
+  });
+
+  it("returns zero for an empty payload", async () => {
+    const create = vi.fn();
+
+    const count = await persistPageCollectionArticles([], {
+      db: { curatedSource: { findMany: vi.fn() }, dataSource: { create } },
+    });
+
+    expect(count).toBe(0);
+    expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/page-collection.ts
+++ b/apps/mediapulse/agent-data-api/src/services/page-collection.ts
@@ -9,10 +9,9 @@ import type {
 import { canonicalizeUrl } from "@workspace/utils";
 import { prisma } from "@mediapulse/database";
 
-type PageCollectionDb = Pick<
-  typeof prisma,
-  "dataSource" | "curatedSource" | "$transaction"
->;
+import { insertDataSourcesIdempotently } from "./insert-data-sources-idempotently.js";
+
+type PageCollectionDb = Pick<typeof prisma, "curatedSource" | "dataSource">;
 
 const defaultDb: PageCollectionDb = prisma;
 
@@ -68,12 +67,9 @@ export const persistPageCollectionArticles = async (
     } satisfies Prisma.DataSourceCreateManyInput;
   });
 
-  const result = await db.dataSource.createMany({
-    data: createData,
-    skipDuplicates: true,
+  return insertDataSourcesIdempotently(createData, {
+    dataSource: db.dataSource,
   });
-
-  return result.count;
 };
 
 /**

--- a/apps/mediapulse/agent-data-api/src/services/page-collection.ts
+++ b/apps/mediapulse/agent-data-api/src/services/page-collection.ts
@@ -11,7 +11,10 @@ import { prisma } from "@mediapulse/database";
 
 import { insertDataSourcesIdempotently } from "./insert-data-sources-idempotently.js";
 
-type PageCollectionDb = Pick<typeof prisma, "curatedSource" | "dataSource">;
+type PageCollectionDb = {
+  curatedSource: Pick<typeof prisma.curatedSource, "findMany">;
+  dataSource: Pick<typeof prisma.dataSource, "create">;
+};
 
 const defaultDb: PageCollectionDb = prisma;
 


### PR DESCRIPTION
## Summary

Page-collection runs were dying on persist: after RSS expansion and web fetch succeeded, `POST /page-collection` hit a PostgreSQL error and returned 500. The page-collection redesign added partial unique indexes on `data_source.canonical_url`, but persistence still called `createMany({ skipDuplicates: true })`, which cannot target those indexes.

This PR inserts rows one at a time and skips `P2002` unique violations instead. The same helper is wired into ticker-scoped `POST /data-collection`.

## Related issues

Closes #813

## Important changes

- Add `insertDataSourcesIdempotently` to insert `data_source` rows and skip canonical-url duplicates under partial unique indexes.
- Switch `persistPageCollectionArticles` and `POST /data-collection` away from `createMany({ skipDuplicates: true })`.
- Add unit tests for the helper and page-collection persist wiring.

## Other changes

- Update agent-data-api route integration test to expect `dataSource.create` instead of `createMany`.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.ts` - core idempotent insert loop.
- `apps/mediapulse/agent-data-api/src/services/page-collection.ts` - page-collection persist path.
- `apps/mediapulse/agent-data-api/src/routes/data-collection.ts` - ticker-scoped persist path.
- `apps/mediapulse/agent-data-api/src/services/insert-data-sources-idempotently.test.ts` - P2002 skip and error propagation.

## How to test

1. Run `pnpm --filter @mediapulse/agent-data-api test`.
2. Deploy agent-data-api to staging.
3. Re-run a page-collection pipeline against a curated RSS source (e.g. Kumparan).
4. Confirm invocations persist articles and no longer show `Agent data API error: 500` after fetch.
