### PR TITLE
Improve page-collection error visibility for admins

### DIFF
--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -12,6 +12,7 @@ import crypto from "node:crypto";
 import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
 import { expandSourceUrl } from "./utilities/expand-source-urls";
+import { withApiStep } from "./utilities/with-api-step";
 import {
   performWebFetch,
   createEmptyQualityCounters,
@@ -100,26 +101,28 @@ export async function runPageCollection(
     });
 
     try {
-      await dataApiClient.dataCollectionRun.create({
-        id: runId,
-        scheduleExecutionId,
-        startedAt: startedAt.toISOString(),
-        completedAt: new Date().toISOString(),
-        status: "failed",
-        counters: {
-          queriesTotal: 0,
-          urlsTotal: 0,
-          searchSuccess: 0,
-          searchFailed: 0,
-          fetchSuccess: 0,
-          fetchFailed: 0,
-          retryCount: 0,
-          droppedByRelevance: 0,
-          throttleEvents: 0,
-          durationMs: Date.now() - startedAt.getTime(),
-          agentId: "page-collection",
-        },
-      });
+      await withApiStep("persist crash run record", () =>
+        dataApiClient.dataCollectionRun.create({
+          id: runId,
+          scheduleExecutionId,
+          startedAt: startedAt.toISOString(),
+          completedAt: new Date().toISOString(),
+          status: "failed",
+          counters: {
+            queriesTotal: 0,
+            urlsTotal: 0,
+            searchSuccess: 0,
+            searchFailed: 0,
+            fetchSuccess: 0,
+            fetchFailed: 0,
+            retryCount: 0,
+            droppedByRelevance: 0,
+            throttleEvents: 0,
+            durationMs: Date.now() - startedAt.getTime(),
+            agentId: "page-collection",
+          },
+        }),
+      );
     } catch (persistError) {
       log.warn({ err: persistError }, "failed to persist crash run record");
     }
@@ -182,10 +185,13 @@ async function executePageCollectionRun(
 
   report("Resolving curated source", listingUrl);
 
-  const { sources: resolvedSources } =
-    await dataApiClient.pageCollectionResolveSources.create({
-      listingUrls: [listingUrl],
-    });
+  const { sources: resolvedSources } = await withApiStep(
+    "resolve curated sources",
+    () =>
+      dataApiClient.pageCollectionResolveSources.create({
+        listingUrls: [listingUrl],
+      }),
+  );
 
   const meta = resolvedSources.find((s) => s.listingUrl === listingUrl);
 
@@ -302,9 +308,9 @@ async function executePageCollectionRun(
       index,
       index + PAGE_COLLECTION_EXISTING_URLS_MAX,
     );
-    const response = await dataApiClient.pageCollectionExistingUrls.create({
-      urls: chunk,
-    });
+    const response = await withApiStep("lookup existing canonical URLs", () =>
+      dataApiClient.pageCollectionExistingUrls.create({ urls: chunk }),
+    );
     for (const url of response.existingUrls) {
       existingUrlSet.add(url);
     }
@@ -320,7 +326,10 @@ async function executePageCollectionRun(
   if (deadUrlCacheConfig.enabled) {
     const deadUrlSet = await resolveDeadUrlsGlobal(
       candidatesAfterExisting,
-      (body) => dataApiClient.dataCollectionDeadUrlsLookup.create(body),
+      (body) =>
+        withApiStep("lookup dead URLs", () =>
+          dataApiClient.dataCollectionDeadUrlsLookup.create(body),
+        ),
       deadUrlCacheConfig.skipLookupBatchSize,
     );
     if (deadUrlSet.size > 0) {
@@ -454,7 +463,9 @@ async function executePageCollectionRun(
   }
 
   if (sourcesToPersist.length > 0) {
-    const result = await dataApiClient.pageCollection.create(sourcesToPersist);
+    const result = await withApiStep("persist articles", () =>
+      dataApiClient.pageCollection.create(sourcesToPersist),
+    );
     persistedCount += result.persistedCount;
   }
 
@@ -466,7 +477,9 @@ async function executePageCollectionRun(
     );
     if (deadUrlRecords.length > 0) {
       try {
-        await dataApiClient.dataCollectionDeadUrlsRecord.create(deadUrlRecords);
+        await withApiStep("record dead URLs", () =>
+          dataApiClient.dataCollectionDeadUrlsRecord.create(deadUrlRecords),
+        );
       } catch (recordError) {
         log.warn({ err: recordError }, "failed to record dead URLs");
       }
@@ -551,27 +564,33 @@ async function executePageCollectionRun(
     agentId: "page-collection",
   };
 
-  await dataApiClient.dataCollectionRun.create({
-    id: runId,
-    scheduleExecutionId,
-    startedAt: startedAt.toISOString(),
-    completedAt: new Date().toISOString(),
-    status,
-    counters,
-  });
+  await withApiStep("persist run record", () =>
+    dataApiClient.dataCollectionRun.create({
+      id: runId,
+      scheduleExecutionId,
+      startedAt: startedAt.toISOString(),
+      completedAt: new Date().toISOString(),
+      status,
+      counters,
+    }),
+  );
 
   if (failuresPayload.length > 0) {
     log.warn(
       { failureRecords: failuresPayload.length, fetchFailed: fetchFailedCount },
       "recording page collection fetch failures",
     );
-    await dataApiClient.dataCollectionFailure.create(failuresPayload);
+    await withApiStep("record fetch failures", () =>
+      dataApiClient.dataCollectionFailure.create(failuresPayload),
+    );
   }
 
   if (outcomes.length > 0) {
     try {
       await postOutcomesInChunks(outcomes, (batch) =>
-        dataApiClient.collectionUrlOutcome.create(batch),
+        withApiStep("post collection URL outcomes", () =>
+          dataApiClient.collectionUrlOutcome.create(batch),
+        ),
       );
     } catch (outcomeError) {
       log.warn({ err: outcomeError }, "failed to post collection URL outcomes");

--- a/apps/mediapulse/agents/page-collection/src/utilities/with-api-step.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/with-api-step.test.ts
@@ -1,0 +1,54 @@
+/** @vitest-environment node */
+import { describe, expect, it } from "vitest";
+
+import { withApiStep } from "./with-api-step";
+
+describe("withApiStep", () => {
+  it("returns the resolved value when the step succeeds", async () => {
+    // Act
+    const value = await withApiStep("resolve curated sources", async () => 42);
+
+    // Assert
+    expect(value).toBe(42);
+  });
+
+  it("wraps thrown Error with the step label and preserves the cause", async () => {
+    // Setup
+    const original = new Error("Agent data API error: 500");
+
+    // Act
+    let caught: Error | undefined;
+    try {
+      await withApiStep("persist articles", async () => {
+        throw original;
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    // Assert
+    expect(caught).toBeInstanceOf(Error);
+    expect(caught?.message).toBe(
+      'Page collection step "persist articles" failed: Agent data API error: 500',
+    );
+    expect(caught?.cause).toBe(original);
+  });
+
+  it("wraps non-Error throws with the step label", async () => {
+    // Act
+    let caught: Error | undefined;
+    try {
+      await withApiStep("lookup dead urls", async () => {
+        throw "boom";
+      });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    // Assert
+    expect(caught?.message).toBe(
+      'Page collection step "lookup dead urls" failed: boom',
+    );
+    expect(caught?.cause).toBe("boom");
+  });
+});

--- a/apps/mediapulse/agents/page-collection/src/utilities/with-api-step.ts
+++ b/apps/mediapulse/agents/page-collection/src/utilities/with-api-step.ts
@@ -1,0 +1,31 @@
+/**
+ * Runs an Agent Data API call labeled with the originating page-collection step.
+ *
+ * When the call throws, the error is rewrapped so its message starts with
+ * `Page collection step "<step>" failed: ` and the original error is preserved
+ * on `cause`. This lets operators see *which* API endpoint failed instead of a
+ * bare `Agent data API error: 500` with no context.
+ *
+ * @param step - Short human-readable step label (e.g. `persist articles`).
+ * @param fn - Async work that calls into `dataApiClient.*`.
+ * @returns Whatever `fn` returns on success.
+ * @throws Error wrapped with the step label when `fn` rejects.
+ */
+export const withApiStep = async <T>(
+  step: string,
+  fn: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await fn();
+  } catch (error) {
+    const original = error instanceof Error ? error.message : String(error);
+    const wrapped = new Error(
+      `Page collection step "${step}" failed: ${original}`,
+      { cause: error },
+    );
+    if (error instanceof Error && error.stack) {
+      wrapped.stack = error.stack;
+    }
+    throw wrapped;
+  }
+};

--- a/packages/shared/api-utils/package.json
+++ b/packages/shared/api-utils/package.json
@@ -5,6 +5,10 @@
   "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
+  },
   "dependencies": {
     "hono": "catalog:",
     "zod": "catalog:"
@@ -12,6 +16,7 @@
   "devDependencies": {
     "@types/node": "catalog:",
     "@workspace/typescript-config": "workspace:*",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/shared/api-utils/src/errors.test.ts
+++ b/packages/shared/api-utils/src/errors.test.ts
@@ -1,0 +1,197 @@
+/** @vitest-environment node */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Hono } from "hono";
+import { ZodError, z } from "zod";
+
+import { buildInternalErrorDetail, internalError, notFound } from "./errors";
+
+const captureConsoleError = (): { calls: unknown[][]; restore: () => void } => {
+  const calls: unknown[][] = [];
+  const spy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    calls.push(args);
+  });
+  return {
+    calls,
+    restore: () => spy.mockRestore(),
+  };
+};
+
+describe("buildInternalErrorDetail", () => {
+  it("returns the error name, sanitized message, and code when present", () => {
+    // Setup
+    const error = Object.assign(new Error("Unique constraint violated"), {
+      code: "P2002",
+      name: "PrismaClientKnownRequestError",
+    });
+
+    // Act
+    const detail = buildInternalErrorDetail(error);
+
+    // Assert
+    expect(detail).toEqual({
+      name: "PrismaClientKnownRequestError",
+      message: "Unique constraint violated",
+      code: "P2002",
+    });
+  });
+
+  it("falls back to Unknown for non-Error throws", () => {
+    // Act
+    const detail = buildInternalErrorDetail("boom");
+
+    // Assert
+    expect(detail).toEqual({ name: "Unknown", message: "boom" });
+  });
+
+  it("redacts sensitive substrings in the message", () => {
+    // Setup
+    const error = new Error(
+      "Failed: token=secret-xyz; Authorization: Bearer abc.def.ghi",
+    );
+
+    // Act
+    const detail = buildInternalErrorDetail(error);
+
+    // Assert
+    expect(detail.message).not.toContain("secret-xyz");
+    expect(detail.message).not.toContain("abc.def.ghi");
+    expect(detail.message).toContain("[redacted]");
+  });
+
+  it("truncates very long messages with an ellipsis", () => {
+    // Setup
+    const error = new Error("x".repeat(2_000));
+
+    // Act
+    const detail = buildInternalErrorDetail(error);
+
+    // Assert
+    expect(detail.message.length).toBeLessThanOrEqual(501);
+    expect(detail.message.endsWith("…")).toBe(true);
+  });
+});
+
+describe("internalError", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns 500 with a sanitized error detail block and keeps the legacy message", async () => {
+    // Setup
+    const consoleError = captureConsoleError();
+    const app = new Hono();
+    app.get("/boom", (c) =>
+      internalError(
+        c,
+        Object.assign(new Error("Unique constraint violated"), {
+          code: "P2002",
+          name: "PrismaClientKnownRequestError",
+        }),
+      ),
+    );
+
+    // Act
+    const res = await app.request("/boom");
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(500);
+    expect(body).toEqual({
+      message: "Internal Server Error",
+      error: {
+        name: "PrismaClientKnownRequestError",
+        message: "Unique constraint violated",
+        code: "P2002",
+      },
+    });
+    expect(consoleError.calls.length).toBe(1);
+    consoleError.restore();
+  });
+
+  it("returns 400 with Zod issues when the error is a ZodError", async () => {
+    // Setup
+    const app = new Hono();
+    const schema = z.object({ name: z.string() });
+    app.get("/zod", (c) => {
+      try {
+        schema.parse({});
+        return c.json({ ok: true });
+      } catch (error) {
+        return internalError(c, error);
+      }
+    });
+
+    // Act
+    const res = await app.request("/zod");
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.message).toBe("Bad Request");
+    expect(Array.isArray(body.errors)).toBe(true);
+  });
+
+  it("passes Response throws through unchanged", async () => {
+    // Setup
+    const app = new Hono();
+    const upstream = new Response("nope", { status: 503 });
+    app.get("/pass", (c) => internalError(c, upstream));
+
+    // Act
+    const res = await app.request("/pass");
+
+    // Assert
+    expect(res).toBe(upstream);
+    expect(res.status).toBe(503);
+  });
+
+  it("constructs a 400 even when a ZodError is passed directly", async () => {
+    // Setup
+    const app = new Hono();
+    const zodError = new ZodError([
+      {
+        code: "custom",
+        path: ["x"],
+        message: "boom",
+      },
+    ]);
+    app.get("/zod-direct", (c) => internalError(c, zodError));
+
+    // Act
+    const res = await app.request("/zod-direct");
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(400);
+    expect(body.message).toBe("Bad Request");
+  });
+});
+
+describe("notFound", () => {
+  it("returns a 404 with the default message", async () => {
+    // Setup
+    const app = new Hono();
+    app.get("/missing", (c) => notFound(c));
+
+    // Act
+    const res = await app.request("/missing");
+    const body = await res.json();
+
+    // Assert
+    expect(res.status).toBe(404);
+    expect(body).toEqual({ message: "Not found" });
+  });
+
+  it("returns a 404 with a custom message", async () => {
+    // Setup
+    const app = new Hono();
+    app.get("/missing", (c) => notFound(c, "user not found"));
+
+    // Act
+    const res = await app.request("/missing");
+    const body = await res.json();
+
+    // Assert
+    expect(body).toEqual({ message: "user not found" });
+  });
+});

--- a/packages/shared/api-utils/src/errors.ts
+++ b/packages/shared/api-utils/src/errors.ts
@@ -1,10 +1,82 @@
 import type { Context } from "hono";
 import { ZodError } from "zod";
 
+/** Max chars of `error.message` exposed in the 500 response body. */
+const MAX_DETAIL_LENGTH = 500;
+
+/** Sensitive substrings stripped from exposed error details. */
+const SENSITIVE_PATTERNS: ReadonlyArray<RegExp> = [
+  /password=([^\s&"']+)/gi,
+  /token=([^\s&"']+)/gi,
+  /authorization:\s*bearer\s+[^\s"']+/gi,
+];
+
+/**
+ * Strips known sensitive substrings and clamps the message length so the
+ * response body stays safe to display in operator dashboards.
+ *
+ * @param message - Raw error message.
+ * @returns Sanitized, length-bounded message.
+ */
+const sanitizeMessage = (message: string): string => {
+  let cleaned = message;
+  for (const pattern of SENSITIVE_PATTERNS) {
+    cleaned = cleaned.replace(pattern, "[redacted]");
+  }
+  return cleaned.length > MAX_DETAIL_LENGTH
+    ? `${cleaned.slice(0, MAX_DETAIL_LENGTH)}…`
+    : cleaned;
+};
+
+/** Structured diagnostic block attached to 500 responses. */
+export type InternalErrorDetail = {
+  name: string;
+  message: string;
+  code?: string;
+};
+
+/**
+ * Extracts a structured, sanitized diagnostic block from an unknown error.
+ *
+ * Captures `name`, `message`, and an optional `code` (e.g. Prisma `P2002`).
+ * Stack traces are intentionally omitted to avoid leaking file system paths.
+ *
+ * @param error - Caught unknown.
+ * @returns Sanitized detail block suitable for inclusion in 500 responses.
+ */
+export const buildInternalErrorDetail = (
+  error: unknown,
+): InternalErrorDetail => {
+  if (error instanceof Error) {
+    const code =
+      "code" in error && typeof (error as { code: unknown }).code === "string"
+        ? ((error as { code: string }).code as string)
+        : undefined;
+    return {
+      name: error.name || "Error",
+      message: sanitizeMessage(error.message || ""),
+      ...(code ? { code } : {}),
+    };
+  }
+  return {
+    name: "Unknown",
+    message: sanitizeMessage(String(error)),
+  };
+};
+
 export function notFound(context: Context, message = "Not found"): Response {
   return context.json({ message }, 404);
 }
 
+/**
+ * Returns a 500 response with a sanitized diagnostic block so operators can
+ * tell what went wrong without crawling server logs. The legacy
+ * `message: "Internal Server Error"` field is preserved for backwards
+ * compatibility with retry classifiers.
+ *
+ * @param context - Hono request context.
+ * @param error - Caught unknown from the route handler.
+ */
 export function internalError(context: Context, error: unknown): Response {
   if (error instanceof Response) {
     return error;
@@ -14,8 +86,8 @@ export function internalError(context: Context, error: unknown): Response {
     return context.json({ message: "Bad Request", errors: error.issues }, 400);
   }
 
-  const message = error instanceof Error ? error.message : String(error);
-  console.error("API error:", message);
+  const detail = buildInternalErrorDetail(error);
+  console.error("API error:", detail, error);
 
-  return context.json({ message: "Internal Server Error" }, 500);
+  return context.json({ message: "Internal Server Error", error: detail }, 500);
 }

--- a/packages/shared/api-utils/src/index.ts
+++ b/packages/shared/api-utils/src/index.ts
@@ -1,2 +1,7 @@
-export { internalError, notFound } from "./errors";
+export {
+  internalError,
+  notFound,
+  buildInternalErrorDetail,
+  type InternalErrorDetail,
+} from "./errors";
 export { validateBody } from "./validate-body";

--- a/packages/shared/api-utils/vitest.config.ts
+++ b/packages/shared/api-utils/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,7 +297,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -315,7 +315,7 @@ importers:
         version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
-        version: 0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1083,7 +1083,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1502,7 +1502,7 @@ importers:
         version: 0.562.0(react@19.2.4)
       next:
         specifier: 'catalog:'
-        version: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -1804,6 +1804,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.33)(jiti@2.6.1)(jsdom@28.0.0)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/shared/cursor-pr-review-tests:
     devDependencies:
@@ -17402,7 +17405,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -17411,7 +17414,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -18537,12 +18540,12 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.57.1
       fsevents: 2.3.3
 
-  route-action-gen@0.0.10(next@16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  route-action-gen@0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
       glob: 13.0.2
       zod: 3.25.76
     optionalDependencies:
-      next: 16.2.3(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
   router@2.2.0:
@@ -19030,10 +19033,12 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   supports-color@10.2.2: {}
 


### PR DESCRIPTION
## Summary

The persist fix for #813 went out, but Detik and Kumparan RSS runs are still failing with the same opaque `Agent data API error: 500 - {"message":"Internal Server Error"}`. The activity modal tells operators nothing about which step or which underlying Prisma error caused it. This PR makes future failures self-explanatory.

## Related issues

Closes #815
Refs #813

## Important changes

- `internalError` in `@workspace/api-utils` now returns `{ message: "Internal Server Error", error: { name, message, code } }`. Class name and Prisma code are preserved; secrets are redacted and the message is length-bounded. The legacy `message` field stays so retry classifiers keep working.
- `runPageCollection` wraps every `dataApiClient.*` call with `withApiStep("<label>", ...)`. Failures rewrap as `Page collection step "<label>" failed: <original message>`, with the original error attached as `cause`.

## Other changes

- Add vitest setup to `@workspace/api-utils` (`scripts`, `vitest.config.ts`, devDep) so the new tests run under the standard package test script.
- New util `apps/mediapulse/agents/page-collection/src/utilities/with-api-step.ts` plus colocated tests.

## Key files to review

- `packages/shared/api-utils/src/errors.ts` - sanitization, redaction, and the new response shape.
- `packages/shared/api-utils/src/errors.test.ts` - covers the helper, the response, ZodError path, and `notFound`.
- `apps/mediapulse/agents/page-collection/src/utilities/with-api-step.ts` - rewrap helper used at every API call site.
- `apps/mediapulse/agents/page-collection/src/run.ts` - call sites: resolve curated sources, lookup existing canonical URLs, lookup dead URLs, persist articles, record dead URLs, persist run record, record fetch failures, post collection URL outcomes, persist crash run record.

## How to test

1. `pnpm --filter @workspace/api-utils test`
2. `pnpm --filter @mediapulse/agent-data-api test`
3. `pnpm --filter @mediapulse/page-collection test`
4. Deploy agent-data-api and the page-collection agent.
5. Trigger a page-collection pipeline against a curated RSS source. If it fails, confirm the dashboard activity modal now shows a message of the form `Page collection step "<label>" failed: Agent data API error: 500 - {"error": { "name": "...", "code": "...", "message": "..." }}` and tells operators exactly which API step and which Prisma / DB error to look at.
