### PR TITLE
Show page-collection pre-fetch drop counters in invocation UI

### DIFF
--- a/apps/hermes/dashboard/components/invocation-outcome-detail.test.tsx
+++ b/apps/hermes/dashboard/components/invocation-outcome-detail.test.tsx
@@ -42,4 +42,33 @@ describe("InvocationOutcomeDetailView", () => {
     expect(screen.getByText("Agent HTTP 500")).toBeInTheDocument();
     expect(screen.getByText("Page collection run failed")).toBeInTheDocument();
   });
+
+  it("renders pre-fetch drop counters in run summary", () => {
+    const model = buildInvocationOutcomeDetailModel(null, {
+      status: "success",
+      details: {
+        summary: {
+          discoveredCount: 6,
+          droppedByExistingCanonicalUrl: 4,
+          droppedByDuplicateCanonicalUrl: 0,
+          droppedByUrlNoise: 0,
+          droppedByHostErrorRate: 0,
+          droppedByRunItemCap: 0,
+          droppedByDeadUrlCache: 0,
+          droppedByFetchBudget: 0,
+          fetchSuccess: 0,
+          fetchFailed: 0,
+          droppedByContentQuality: { content_too_short: 2 },
+          totalSources: 0,
+        },
+      },
+    });
+
+    render(<InvocationOutcomeDetailView model={model} transportError={null} />);
+
+    expect(screen.getByText("Dropped (already collected)")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("Content quality drops")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
 });

--- a/apps/hermes/dashboard/components/invocation-outcome-detail.tsx
+++ b/apps/hermes/dashboard/components/invocation-outcome-detail.tsx
@@ -65,11 +65,16 @@ const RunSummaryCounters = ({ summary }: RunSummaryCountersProps) => {
 
   pushNumber("Run status", "status");
   pushNumber("Discovered", "discoveredCount");
-  pushNumber("Persisted", "totalSources");
+  pushNumber("Dropped (run item cap)", "droppedByRunItemCap");
+  pushNumber("Dropped (URL noise)", "droppedByUrlNoise");
+  pushNumber("Dropped (duplicate URL)", "droppedByDuplicateCanonicalUrl");
+  pushNumber("Dropped (already collected)", "droppedByExistingCanonicalUrl");
+  pushNumber("Dropped (dead URL cache)", "droppedByDeadUrlCache");
+  pushNumber("Dropped (host error rate)", "droppedByHostErrorRate");
+  pushNumber("Dropped (fetch budget)", "droppedByFetchBudget");
   pushNumber("Fetch success", "fetchSuccess");
   pushNumber("Fetch failed", "fetchFailed");
-  pushNumber("Dropped (dead URL cache)", "droppedByDeadUrlCache");
-  pushNumber("Dropped (fetch budget)", "droppedByFetchBudget");
+  pushNumber("Persisted", "totalSources");
 
   if (summary.deadlineHit === true) {
     rows.push({ label: "Deadline hit", value: "yes" });

--- a/apps/hermes/dashboard/lib/format-invocation-outcome-summary.ts
+++ b/apps/hermes/dashboard/lib/format-invocation-outcome-summary.ts
@@ -22,6 +22,11 @@ type RunSummary = {
   droppedByContentQuality?: Record<string, number>;
   droppedByDeadUrlCache?: number;
   droppedByFetchBudget?: number;
+  droppedByExistingCanonicalUrl?: number;
+  droppedByDuplicateCanonicalUrl?: number;
+  droppedByUrlNoise?: number;
+  droppedByHostErrorRate?: number;
+  droppedByRunItemCap?: number;
   deadlineHit?: boolean;
 };
 

--- a/apps/mediapulse/agents/page-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.test.ts
@@ -104,6 +104,7 @@ vi.mock("@workspace/agent-ingestion", async (importOriginal) => {
 });
 
 import { performWebFetch } from "@workspace/agent-ingestion";
+import { expandSourceUrl } from "./utilities/expand-source-urls";
 import { runPageCollection } from "./run";
 
 /** Builds a minimal run context for page-collection v2 tests. */
@@ -225,5 +226,46 @@ describe("runPageCollection", () => {
     expect(result.success).toBe(false);
     expect(runCreateMock).toHaveBeenCalledOnce();
     expect(runCreateMock.mock.calls[0]![0].status).toBe("failed");
+  });
+
+  it("includes pre-fetch drop counters in the agent response summary", async () => {
+    const existingUrl = "https://example.com/existing-article";
+    const newUrl = "https://example.com/new-article";
+
+    vi.mocked(expandSourceUrl).mockResolvedValue([
+      { url: existingUrl },
+      { url: newUrl },
+      { url: newUrl },
+    ]);
+
+    existingUrlsCreateMock.mockResolvedValue({ existingUrls: [existingUrl] });
+
+    vi.mocked(performWebFetch).mockResolvedValue([
+      mockFetchSuccess({
+        url: newUrl,
+        title: validArticleTitle,
+        content: validArticleContent,
+        tickerId: "",
+        searchQueryId: "",
+        searchQueryText: "",
+        serpIndex: 0,
+      }),
+    ]);
+
+    const result = await runPageCollection(createContext());
+
+    expect(result.success).toBe(true);
+    expect(result.details?.summary).toEqual(
+      expect.objectContaining({
+        discoveredCount: 3,
+        droppedByExistingCanonicalUrl: 1,
+        droppedByDuplicateCanonicalUrl: 1,
+        droppedByUrlNoise: 0,
+        droppedByHostErrorRate: 0,
+        droppedByRunItemCap: 0,
+        fetchSuccess: 1,
+        totalSources: 1,
+      }),
+    );
   });
 });

--- a/apps/mediapulse/agents/page-collection/src/run.ts
+++ b/apps/mediapulse/agents/page-collection/src/run.ts
@@ -606,6 +606,14 @@ async function executePageCollectionRun(
     droppedByContentQuality,
     droppedByDeadUrlCache,
     droppedByFetchBudget,
+    droppedByExistingCanonicalUrl,
+    droppedByDuplicateCanonicalUrl,
+    droppedByUrlNoise: Object.values(droppedByUrlReason).reduce(
+      (sum, n) => sum + n,
+      0,
+    ),
+    droppedByHostErrorRate,
+    droppedByRunItemCap,
     deadlineHit,
   };
 


### PR DESCRIPTION
## Summary

Page collection invocations were hard to read: six discovered, zero persisted, two quality drops, and four URLs with no explanation. Those four were filtered before fetch (usually already collected), but the Hermes modal never showed that.

This PR adds the pre-fetch drop counters to the agent response summary and lists them in pipeline order in the invocation run summary.

## Related issues

Closes #821

## Important changes

- Page-collection `details.summary` now includes already-collected, duplicate URL, URL noise, host error rate, and run item cap drops
- Invocation modal run summary shows the full funnel from discovery through persist

## Other changes

- Extended `RunSummary` typing in `format-invocation-outcome-summary.ts`

## Key files to review

- `apps/mediapulse/agents/page-collection/src/run.ts` — summary fields added alongside existing counters
- `apps/hermes/dashboard/components/invocation-outcome-detail.tsx` — run summary row order follows the pipeline
- `apps/mediapulse/agents/page-collection/src/run.test.ts` — asserts pre-fetch counters in agent response
- `apps/hermes/dashboard/components/invocation-outcome-detail.test.tsx` — asserts modal renders new rows

## How to test

1. Run `pnpm --filter @mediapulse/agents-page-collection test -- run.test.ts`
2. Run `pnpm --filter @hermes/dashboard test -- invocation-outcome-detail.test.tsx`
3. Trigger a page-collection run against a feed you have run before; open the invocation modal and confirm **Dropped (already collected)** accounts for URLs skipped before fetch
