### PR TITLE
Capture subscriber newsletter language at registration

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
@@ -126,7 +126,12 @@ describe("getDeliveryData", () => {
 
     expect(prisma.userTicker.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { tickerId: "t1", enabled: true, user: { enabled: true } },
+        where: {
+          tickerId: "t1",
+          enabled: true,
+          language: "en",
+          user: { enabled: true },
+        },
       }),
     );
     expect(result).toEqual({

--- a/apps/mediapulse/agent-data-api/src/services/delivery.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.ts
@@ -24,8 +24,16 @@ export async function getDeliveryData(tickerId: string) {
       where: { newsletterId: newsletter.id },
       select: { userTickerId: true },
     }),
+    // Indonesian newsletters are not generated yet, so only English subscriptions are
+    // delivered for now. This also avoids duplicate sends to a subscriber who registered
+    // the same ticker in both languages (each row has its own delivery checkpoint).
     mediapulsePrisma.userTicker.findMany({
-      where: { tickerId, enabled: true, user: { enabled: true } },
+      where: {
+        tickerId,
+        enabled: true,
+        language: "en",
+        user: { enabled: true },
+      },
       include: { user: true },
     }),
   ]);

--- a/apps/mediapulse/agent-data-api/src/services/user-registration.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/user-registration.test.ts
@@ -126,10 +126,83 @@ describe("processRegistration", () => {
         userId: USER.id,
         tickerId: TICKER.id,
         enabled: true,
+        language: "en",
         registrationConfirmedAt: null,
       },
     });
     expect(prisma.userTicker.update).not.toHaveBeenCalled();
+  });
+
+  it("defaults the subscription lookup to English when no language is provided", async () => {
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.ticker.findUnique).mockResolvedValue(TICKER);
+    vi.mocked(prisma.mediapulseUser.upsert).mockResolvedValue(USER);
+    vi.mocked(prisma.userTicker.findUnique).mockResolvedValue(null);
+    vi.mocked(prisma.userTicker.create).mockResolvedValue(
+      makeUserTicker({ registrationConfirmedAt: null }) as unknown as Awaited<
+        ReturnType<typeof prisma.userTicker.create>
+      >,
+    );
+
+    const { processRegistration } = await import("./user-registration.js");
+    await processRegistration({
+      email: "alice@example.com",
+      tickerSymbol: "BBCA",
+    });
+
+    expect(prisma.userTicker.findUnique).toHaveBeenCalledWith({
+      where: {
+        userId_tickerId_language: {
+          userId: USER.id,
+          tickerId: TICKER.id,
+          language: "en",
+        },
+      },
+    });
+  });
+
+  it("creates a separate Indonesian subscription keyed by language", async () => {
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.ticker.findUnique).mockResolvedValue(TICKER);
+    vi.mocked(prisma.mediapulseUser.upsert).mockResolvedValue(USER);
+    vi.mocked(prisma.userTicker.findUnique).mockResolvedValue(null);
+    const indonesianUserTicker = makeUserTicker({
+      id: "ut-uuid-id",
+      registrationConfirmedAt: null,
+    });
+    vi.mocked(prisma.userTicker.create).mockResolvedValue(
+      indonesianUserTicker as unknown as Awaited<
+        ReturnType<typeof prisma.userTicker.create>
+      >,
+    );
+
+    const { processRegistration } = await import("./user-registration.js");
+    const result = await processRegistration({
+      email: "alice@example.com",
+      tickerSymbol: "BBCA",
+      name: "alice",
+      language: "id",
+    });
+
+    expect(result.userTickerId).toBe("ut-uuid-id");
+    expect(prisma.userTicker.findUnique).toHaveBeenCalledWith({
+      where: {
+        userId_tickerId_language: {
+          userId: USER.id,
+          tickerId: TICKER.id,
+          language: "id",
+        },
+      },
+    });
+    expect(prisma.userTicker.create).toHaveBeenCalledWith({
+      data: {
+        userId: USER.id,
+        tickerId: TICKER.id,
+        enabled: true,
+        language: "id",
+        registrationConfirmedAt: null,
+      },
+    });
   });
 
   it("returns isNewSubscription: false and subscriptionChanged: false when subscription already exists and is enabled and confirmed", async () => {
@@ -297,6 +370,7 @@ describe("processRegistration with immediate confirmation", () => {
         userId: USER.id,
         tickerId: TICKER.id,
         enabled: true,
+        language: "en",
         registrationConfirmedAt: expect.any(Date),
       },
     });

--- a/apps/mediapulse/agent-data-api/src/services/user-registration.ts
+++ b/apps/mediapulse/agent-data-api/src/services/user-registration.ts
@@ -1,6 +1,7 @@
 import { prisma as mediapulsePrisma } from "@mediapulse/database";
 import { verifyUnsubscribeToken } from "@workspace/utils";
 import type {
+  UserRegistrationLanguage,
   UserRegistrationUnsubscribeMethod,
   UserRegistrationUnsubscribeResponse,
 } from "@workspace/agent-data-api-contract";
@@ -9,6 +10,9 @@ import type {
  * Processes a new or returning user registration for a given ticker.
  * Creates or updates the user and their subscription, then returns outcome flags
  * that the agent uses to decide whether to send an opt-in email.
+ *
+ * Language is per-subscription, so a user may hold separate subscriptions for the same
+ * ticker in different languages. The lookup and create are therefore keyed by language.
  *
  * @returns `tickerKnown` – whether the symbol exists in the database.
  * @returns `userTickerId` – the UserTicker row id (undefined when ticker is unknown).
@@ -19,11 +23,13 @@ export async function processRegistration({
   email,
   tickerSymbol,
   name,
+  language = "en",
   confirmed,
 }: {
   email: string;
   tickerSymbol: string;
   name?: string | null;
+  language?: UserRegistrationLanguage;
   confirmed?: boolean;
 }) {
   const normalizedSymbol = tickerSymbol.trim().toUpperCase();
@@ -51,9 +57,10 @@ export async function processRegistration({
   // Find existing subscription explicitly first to determine `subscriptionChanged` properly
   const existingSubscription = await mediapulsePrisma.userTicker.findUnique({
     where: {
-      userId_tickerId: {
+      userId_tickerId_language: {
         userId: user.id,
         tickerId: ticker.id,
+        language,
       },
     },
   });
@@ -92,6 +99,7 @@ export async function processRegistration({
         userId: user.id,
         tickerId: ticker.id,
         enabled: true,
+        language,
         registrationConfirmedAt: confirmed ? new Date() : null,
       },
     });

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.test.ts
@@ -5,6 +5,7 @@ import {
   deriveNameFromEmailLocalPart,
   extractSenderEmail,
   extractTickerSymbol,
+  extractLanguage,
   extractSubscriberName,
   extractUsableFromDisplayName,
   resolveSubscriberDisplayName,
@@ -154,6 +155,40 @@ describe("Parser Helpers", () => {
         extractTickerSymbol("Random email", "Just saying hello"),
       ).toBeNull();
       expect(extractTickerSymbol(null, null)).toBeNull();
+    });
+  });
+
+  describe("extractLanguage", () => {
+    it("defaults to English when no language line is present", () => {
+      expect(extractLanguage(undefined)).toBe("en");
+      expect(extractLanguage(null)).toBe("en");
+      expect(extractLanguage("")).toBe("en");
+      expect(extractLanguage("Name: Jane\nTicker: BBCA")).toBe("en");
+    });
+
+    it("parses the English code", () => {
+      const body = "Name: Jane  |  Ticker: BBCA  |  Language: en  |  ---";
+      expect(extractLanguage(body)).toBe("en");
+    });
+
+    it("parses the Indonesian code", () => {
+      const body = "Name: Jane  |  Ticker: BBCA  |  Language: id  |  ---";
+      expect(extractLanguage(body)).toBe("id");
+    });
+
+    it("accepts full language words case-insensitively", () => {
+      expect(extractLanguage("Language: Indonesian")).toBe("id");
+      expect(extractLanguage("Language: ENGLISH")).toBe("en");
+    });
+
+    it("parses the language from HTML body content", () => {
+      const body =
+        "<div>Ticker: BBCA</div><div>Language: id</div><div>---</div>";
+      expect(extractLanguage(body)).toBe("id");
+    });
+
+    it("defaults to English for an unrecognized language value", () => {
+      expect(extractLanguage("Language: french")).toBe("en");
     });
   });
 

--- a/apps/mediapulse/agents/user-registration/src/lib/parser.ts
+++ b/apps/mediapulse/agents/user-registration/src/lib/parser.ts
@@ -238,3 +238,28 @@ export function extractTickerSymbol(
 
   return null;
 }
+
+/** Newsletter delivery language extracted from a registration email (`en` = English, `id` = Indonesian). */
+export type SubscriberLanguage = "en" | "id";
+
+/**
+ * Extracts the requested newsletter language from the email body.
+ * Matches a `Language:` segment, accepting both codes (`en`/`id`) and words
+ * (`English`/`Indonesian`). Defaults to English when absent or unrecognized.
+ *
+ * @param bodyContent - Optional `body.content` from Graph (plain or HTML).
+ * @returns The resolved language, defaulting to `"en"`.
+ */
+export function extractLanguage(
+  bodyContent?: string | null,
+): SubscriberLanguage {
+  const normalized = normalizeGraphBodyContentForLineParsing(bodyContent);
+  if (!normalized) return "en";
+
+  const match = normalized.match(/Language:\s*(en|id|english|indonesian)/i);
+  if (!match || !match[1]) return "en";
+
+  const value = match[1].toLowerCase();
+
+  return value === "id" || value === "indonesian" ? "id" : "en";
+}

--- a/apps/mediapulse/agents/user-registration/src/run.test.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.test.ts
@@ -335,6 +335,54 @@ describe("createRunHandler", () => {
         email: "k@run-test.example",
         tickerSymbol: "BBCA",
         name: "Kevin Hermawan",
+        language: "en",
+      }),
+    );
+  });
+
+  it("passes the chosen Indonesian language to userRegistrationRegister", async () => {
+    const registerCreate = vi.fn().mockResolvedValue({
+      tickerKnown: true,
+      isNewSubscription: false,
+    });
+
+    const run = createRunHandler({
+      createInbox: () => ({
+        listMessages: async () =>
+          makeListResult([
+            makeMessage({
+              subject: "[MediaPulse] Newsletter Subscription - BBCA",
+              body: {
+                content:
+                  "Name: Kevin Hermawan  |  Ticker: BBCA  |  Language: id  |  ---",
+                contentType: "text",
+              },
+              from: { emailAddress: { address: "k@run-test.example" } },
+            }),
+          ]),
+        archiveMessage: vi.fn().mockResolvedValue(undefined),
+        markMessageRead: vi.fn(),
+        processMessages: vi.fn(),
+        deleteMessage: vi.fn(),
+      }),
+      ResendClient: class {
+        emails = { send: vi.fn() };
+        constructor() {}
+      } as any,
+      createDataApi: () =>
+        ({
+          userRegistrationRegister: { create: registerCreate },
+          userRegistrationConfirm: { create: vi.fn() },
+        }) as any,
+    });
+
+    await run(makeCtx() as any);
+
+    expect(registerCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "k@run-test.example",
+        tickerSymbol: "BBCA",
+        language: "id",
       }),
     );
   });

--- a/apps/mediapulse/agents/user-registration/src/run.ts
+++ b/apps/mediapulse/agents/user-registration/src/run.ts
@@ -23,6 +23,7 @@ import type { UserRegistrationConfig } from "./config-schema.js";
 import {
   extractSenderEmail,
   extractTickerSymbol,
+  extractLanguage,
   resolveSubscriberDisplayName,
 } from "./lib/parser.js";
 
@@ -552,6 +553,7 @@ async function processMessage({
   }
 
   const name = resolveSubscriberDisplayName(msg, senderEmail);
+  const language = extractLanguage(msg.body?.content);
 
   try {
     // Step 2: Register via API
@@ -561,6 +563,7 @@ async function processMessage({
           email: senderEmail,
           tickerSymbol,
           name,
+          language,
           audit: {
             graphMessageId: msg.id,
             receivedAt: msg.receivedDateTime,

--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -35,7 +35,7 @@ describe("RegistrationForm", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders the name and ticker search inputs", () => {
+  it("renders the name, language, and ticker search inputs", () => {
     // Act
     render(<RegistrationForm tickers={sampleTickers} openMailto={vi.fn()} />);
 
@@ -44,6 +44,13 @@ describe("RegistrationForm", () => {
       screen.getByLabelText(/What should we call you\?/i),
     ).toBeInTheDocument();
     expect(screen.getByLabelText(/Stock ticker/i)).toBeInTheDocument();
+
+    const languageSelect = screen.getByLabelText(
+      /Newsletter language/i,
+    ) as HTMLSelectElement;
+
+    expect(languageSelect).toBeInTheDocument();
+    expect(languageSelect.value).toBe("en");
   });
 
   it("renders the subscribe button as disabled when no ticker is selected", () => {
@@ -102,11 +109,41 @@ describe("RegistrationForm", () => {
     );
     expect(calledUrl).toContain(encodeURIComponent("Name: John Doe"));
     expect(calledUrl).toContain(encodeURIComponent("Ticker: BBCA"));
+    expect(calledUrl).toContain(encodeURIComponent("Language: en"));
 
     // Assert Success screen rendered
     expect(screen.getByText(/Almost done/i)).toBeInTheDocument();
     expect(screen.getByText(/tap/i)).toBeInTheDocument();
     expect(screen.getByText(/Send/i)).toBeInTheDocument();
+  });
+
+  it("encodes the selected Indonesian language in the mailto URL", async () => {
+    // Setup
+    const user = userEvent.setup();
+    const mockOpenMailto = vi.fn();
+    render(
+      <RegistrationForm tickers={sampleTickers} openMailto={mockOpenMailto} />,
+    );
+
+    // Act
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "John Doe",
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/Newsletter language/i),
+      "id",
+    );
+    await user.click(screen.getByLabelText(/Stock ticker/i));
+    await user.click(screen.getByText(/Bank Central Asia Tbk/i));
+    await user.click(
+      screen.getByRole("button", { name: /Open email app to subscribe/i }),
+    );
+
+    // Assert
+    const calledUrl = mockOpenMailto.mock.calls[0]![0]!;
+
+    expect(calledUrl).toContain(encodeURIComponent("Language: id"));
   });
 
   it("shows spam/junk reassurance text and download contact card button after submit", async () => {

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -6,7 +6,11 @@ import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
 import { Label } from "@workspace/ui/components/label";
 import { cn } from "@workspace/ui/lib/utils";
-import { type Ticker } from "@/lib/tickers";
+import {
+  type Ticker,
+  type RegistrationLanguage,
+  REGISTRATION_LANGUAGE_OPTIONS,
+} from "@/lib/tickers";
 import { useRegistrationForm } from "@/hooks/use-registration-form";
 import { env } from "@mediapulse/env/app-user-registration";
 import { buildVCard } from "@workspace/utils";
@@ -49,6 +53,8 @@ const RegistrationForm = ({
   const {
     name,
     setName,
+    language,
+    setLanguage,
     query,
     handleQueryChange,
     selectedTicker,
@@ -114,6 +120,26 @@ const RegistrationForm = ({
             value={name}
             onChange={(e) => setName(e.target.value)}
           />
+        </div>
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="language">Newsletter language</Label>
+          <select
+            id="language"
+            value={language}
+            onChange={(e) =>
+              setLanguage(e.target.value as RegistrationLanguage)
+            }
+            className={cn(
+              "border-input dark:bg-input/30 h-9 w-full min-w-0 rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none md:text-sm",
+              "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+            )}
+          >
+            {REGISTRATION_LANGUAGE_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
         </div>
         <div className="flex flex-col gap-2">
           <Label htmlFor="ticker-search">Stock ticker</Label>

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
@@ -21,6 +21,7 @@ describe("useRegistrationForm", () => {
     );
 
     expect(result.current.name).toBe("");
+    expect(result.current.language).toBe("en");
     expect(result.current.query).toBe("");
     expect(result.current.selectedTicker).toBeNull();
     expect(result.current.open).toBe(false);
@@ -81,6 +82,30 @@ describe("useRegistrationForm", () => {
     expect(result.current.submitted).toBe(true);
   });
 
+  it("includes the chosen language in the mailto URL on submit", async () => {
+    const mockOpenMailto = vi.fn();
+    const { result } = renderHook(() =>
+      useRegistrationForm(sampleTickers, mockOpenMailto),
+    );
+
+    act(() => {
+      result.current.setName("Test User");
+      result.current.setLanguage("id");
+      result.current.handleTickerSelect(sampleTickers[1]!);
+    });
+
+    await act(async () => {
+      const e = {
+        preventDefault: vi.fn(),
+      } as unknown as React.FormEvent<HTMLFormElement>;
+      await result.current.handleSubmit(e);
+    });
+
+    const mailtoUrl = mockOpenMailto.mock.calls[0]?.[0] as string;
+
+    expect(mailtoUrl).toContain(encodeURIComponent("Language: id"));
+  });
+
   it("does not submit if name or ticker are missing", async () => {
     const mockOpenMailto = vi.fn();
     const { result } = renderHook(() =>
@@ -128,10 +153,12 @@ describe("useRegistrationForm", () => {
 
     act(() => {
       result.current.setName("Test");
+      result.current.setLanguage("id");
       result.current.handleTickerSelect(sampleTickers[1]!);
     });
 
     expect(result.current.name).toBe("Test");
+    expect(result.current.language).toBe("id");
     expect(result.current.selectedTicker).not.toBeNull();
 
     act(() => {
@@ -139,6 +166,7 @@ describe("useRegistrationForm", () => {
     });
 
     expect(result.current.name).toBe("");
+    expect(result.current.language).toBe("en");
     expect(result.current.query).toBe("");
     expect(result.current.selectedTicker).toBeNull();
     expect(result.current.submitted).toBe(false);

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.ts
@@ -7,6 +7,7 @@ import {
   formatTicker,
   buildMailtoUrl,
   type Ticker,
+  type RegistrationLanguage,
 } from "@/lib/tickers";
 
 /**
@@ -21,6 +22,7 @@ export const useRegistrationForm = (
   openMailto: (url: string) => void,
 ) => {
   const [name, setName] = useState("");
+  const [language, setLanguage] = useState<RegistrationLanguage>("en");
   const [query, setQuery] = useState("");
   const [selectedTicker, setSelectedTicker] = useState<Ticker | null>(null);
   const [open, setOpen] = useState(false);
@@ -76,6 +78,7 @@ export const useRegistrationForm = (
     const mailtoUrl = buildMailtoUrl(
       selectedTicker,
       trimmedName,
+      language,
       env.NEXT_PUBLIC_REGISTRATION_EMAIL,
     );
 
@@ -89,6 +92,7 @@ export const useRegistrationForm = (
   const resetForm = () => {
     setSubmitted(false);
     setName("");
+    setLanguage("en");
     setQuery("");
     setSelectedTicker(null);
   };
@@ -96,6 +100,8 @@ export const useRegistrationForm = (
   return {
     name,
     setName,
+    language,
+    setLanguage,
     query,
     handleQueryChange,
     selectedTicker,

--- a/apps/mediapulse/user-registration/lib/tickers.test.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.test.ts
@@ -5,6 +5,7 @@ import {
   formatTicker,
   buildMailtoUrl,
   MAILTO_BODY_SECTION_SEPARATOR,
+  REGISTRATION_LANGUAGE_OPTIONS,
   type Ticker,
 } from "./tickers";
 
@@ -100,7 +101,7 @@ describe("buildMailtoUrl", () => {
 
   it("targets the default registration email", () => {
     // Act
-    const url = buildMailtoUrl(ticker, "Jane Doe");
+    const url = buildMailtoUrl(ticker, "Jane Doe", "en");
 
     // Assert
     expect(url.startsWith(`mailto:${EXPECTED_REG_EMAIL}`)).toBe(true);
@@ -114,7 +115,7 @@ describe("buildMailtoUrl", () => {
     };
 
     // Act
-    const url = buildMailtoUrl(t, "Jane Doe");
+    const url = buildMailtoUrl(t, "Jane Doe", "en");
 
     // Assert
     expect(url).toContain("subject=");
@@ -122,7 +123,7 @@ describe("buildMailtoUrl", () => {
   });
 
   it("joins body sections with spaced pipes for single-line mail clients", () => {
-    const url = buildMailtoUrl(ticker, "Jane Doe");
+    const url = buildMailtoUrl(ticker, "Jane Doe", "en");
     expect(url).toContain(encodeURIComponent(MAILTO_BODY_SECTION_SEPARATOR));
   });
 
@@ -134,7 +135,7 @@ describe("buildMailtoUrl", () => {
     };
 
     // Act
-    const url = buildMailtoUrl(t, "Jane Doe");
+    const url = buildMailtoUrl(t, "Jane Doe", "en");
 
     // Assert
     expect(url).toContain(encodeURIComponent("Name: Jane Doe"));
@@ -144,5 +145,24 @@ describe("buildMailtoUrl", () => {
     );
     expect(url).not.toContain(encodeURIComponent("Subscriber Name:"));
     expect(url).not.toContain(encodeURIComponent("Subscriber Email:"));
+  });
+
+  it("encodes the chosen language code in the body", () => {
+    // Act
+    const englishUrl = buildMailtoUrl(ticker, "Jane Doe", "en");
+    const indonesianUrl = buildMailtoUrl(ticker, "Jane Doe", "id");
+
+    // Assert
+    expect(englishUrl).toContain(encodeURIComponent("Language: en"));
+    expect(indonesianUrl).toContain(encodeURIComponent("Language: id"));
+  });
+});
+
+describe("REGISTRATION_LANGUAGE_OPTIONS", () => {
+  it("offers English first then Indonesian", () => {
+    expect(REGISTRATION_LANGUAGE_OPTIONS).toEqual([
+      { value: "en", label: "English" },
+      { value: "id", label: "Indonesian" },
+    ]);
   });
 });

--- a/apps/mediapulse/user-registration/lib/tickers.ts
+++ b/apps/mediapulse/user-registration/lib/tickers.ts
@@ -41,20 +41,35 @@ export const formatTicker = (ticker: Ticker): string =>
 /** Spaced pipe segments keep mailto bodies readable when clients (e.g. Gmail app) flatten newlines. */
 export const MAILTO_BODY_SECTION_SEPARATOR = "  |  ";
 
+/** Newsletter delivery language a subscriber can choose (`en` = English, `id` = Indonesian). */
+export type RegistrationLanguage = "en" | "id";
+
+/** Human-readable labels for the language selector, ordered for display (English first). */
+export const REGISTRATION_LANGUAGE_OPTIONS: ReadonlyArray<{
+  value: RegistrationLanguage;
+  label: string;
+}> = [
+  { value: "en", label: "English" },
+  { value: "id", label: "Indonesian" },
+];
+
 /**
  * Builds a mailto URL for newsletter subscription with a fixed subject and body.
  * The subscriber's address comes from the mail client's From field when they send.
- * Display name is included as `Name:` for the agent to parse. Sections are joined with
- * spaced pipes so Gmail and similar clients still show separation when the draft is one line.
+ * Display name is included as `Name:` and the chosen language as `Language:` for the agent
+ * to parse. Sections are joined with spaced pipes so Gmail and similar clients still show
+ * separation when the draft is one line.
  *
  * @param ticker - Ticker the user wants to subscribe to.
  * @param name - Subscriber display name (included in the body for processing).
+ * @param language - Preferred newsletter language code (included in the body for processing).
  * @param registrationEmail - The target email address for registration (defaults to mediapulse@hyperjump.tech).
  * @returns Encoded mailto: URL string.
  */
 export const buildMailtoUrl = (
   ticker: Ticker,
   name: string,
+  language: RegistrationLanguage,
   registrationEmail: string = "mediapulse@hyperjump.tech",
 ): string => {
   const subject = `[MediaPulse] Newsletter Subscription - ${ticker.KodeEmiten}`;
@@ -62,6 +77,7 @@ export const buildMailtoUrl = (
   const body = [
     `Name: ${name.trim()}`,
     `Ticker: ${ticker.KodeEmiten}`,
+    `Language: ${language}`,
     "---",
     "Please do not modify the subject or content of this email before sending.",
   ].join(MAILTO_BODY_SECTION_SEPARATOR);

--- a/packages/mediapulse/database/prisma/migrations/20260622000000_add_user_ticker_language/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260622000000_add_user_ticker_language/migration.sql
@@ -1,0 +1,11 @@
+-- CreateEnum
+CREATE TYPE "Language" AS ENUM ('en', 'id');
+
+-- DropIndex
+DROP INDEX "user_ticker_user_id_ticker_id_key";
+
+-- AlterTable
+ALTER TABLE "user_ticker" ADD COLUMN     "language" "Language" NOT NULL DEFAULT 'en';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_ticker_user_id_ticker_id_language_key" ON "user_ticker"("user_id", "ticker_id", "language");

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -449,6 +449,8 @@ model UserTicker {
   userId                  String    @map("user_id")
   tickerId                String    @map("ticker_id")
   enabled                 Boolean   @default(true)
+  /// Newsletter language for this subscription (en = English, id = Indonesian).
+  language                Language  @default(en)
   registrationConfirmedAt DateTime? @map("registration_confirmed_at")
   /// When the user voluntarily unsubscribed (null for admin/manual disables).
   unsubscribedAt          DateTime? @map("unsubscribed_at")
@@ -461,8 +463,14 @@ model UserTicker {
   ticker              Ticker                         @relation(fields: [tickerId], references: [id], onDelete: Cascade)
   deliveryCheckpoints NewsletterDeliveryCheckpoint[]
 
-  @@unique([userId, tickerId])
+  @@unique([userId, tickerId, language])
   @@map("user_ticker")
+}
+
+/// Newsletter delivery language for a subscription (en = English, id = Indonesian).
+enum Language {
+  en
+  id
 }
 
 /// Idempotent record that a newsletter was delivered to a subscriber (avoids duplicate sends on job replay).

--- a/packages/shared/agent-data-api-contract/src/user-registration.ts
+++ b/packages/shared/agent-data-api-contract/src/user-registration.ts
@@ -14,11 +14,16 @@ export const getUserRegistrationTickersResponseSchema = z.object({
   tickers: z.array(userRegistrationTickerListItemSchema),
 });
 
+/** Newsletter delivery language for a subscription (`en` = English, `id` = Indonesian). */
+export const userRegistrationLanguageSchema = z.enum(["en", "id"]);
+
 // Request schemas
 export const postUserRegistrationRegisterBodySchema = z.object({
   email: z.string().email(),
   tickerSymbol: z.string(),
   name: z.string().nullable().optional(),
+  /** Preferred newsletter language; omitted requests default to English on the server. */
+  language: userRegistrationLanguageSchema.optional(),
   confirmed: z.boolean().optional(),
   audit: z
     .object({
@@ -73,6 +78,9 @@ export const userRegistrationUnsubscribeResponseSchema = z.object({
   displaySymbol: z.string().optional(),
 });
 
+export type UserRegistrationLanguage = z.infer<
+  typeof userRegistrationLanguageSchema
+>;
 export type PostUserRegistrationRegisterBody = z.infer<
   typeof postUserRegistrationRegisterBodySchema
 >;


### PR DESCRIPTION
## Summary

Subscribers can now pick a newsletter language, English or Indonesian, when they register, and that choice is stored on the subscription. This is groundwork: Indonesian newsletters do not exist yet, so delivery stays English-only and Indonesian subscribers are not sent the English edition in the meantime.

## Related issues

Closes #823

## Important changes

- `UserTicker` gains a `language` column (`en`/`id`, default `en`) and the unique key becomes `(userId, tickerId, language)`, so a subscriber can hold separate English and Indonesian subscriptions for the same ticker while duplicates within a language are still rejected. Migration `20260622000000_add_user_ticker_language` backfills existing rows to English.
- The registration write path carries the choice end to end: a language selector on the form encodes a `Language:` line in the mailto body, the inbox agent parses it (`extractLanguage`, defaulting to English), the agent-data-api contract accepts an optional `language`, and `processRegistration` keys the lookup and create by language.
- The delivery query filters to `language: "en"`, which keeps the current newsletter going only to English subscriptions and avoids duplicate sends to anyone subscribed in both languages.

## Other changes

- Added a reusable `userRegistrationLanguageSchema` and `RegistrationLanguage` option list so the form, hook, and contract share one source of truth.
- Tests across every layer: parser, contract, registration service (including the two-language case), delivery filter, mailto builder, hook, and form.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` and the new migration - the model change and composite unique key.
- `apps/mediapulse/agent-data-api/src/services/user-registration.ts` - language-keyed lookup and create.
- `apps/mediapulse/agent-data-api/src/services/delivery.ts` - the English-only delivery filter (the intentional gate).
- `apps/mediapulse/agents/user-registration/src/lib/parser.ts` - `extractLanguage` and its default.
- `apps/mediapulse/user-registration/components/registration-form.tsx` and `lib/tickers.ts` - the selector and mailto encoding.

## How to test

1. `pnpm --filter @mediapulse/database db:migrate:deploy` against a local database, then confirm `user_ticker` has a `language` column and a `(user_id, ticker_id, language)` unique index.
2. Run the registration app and submit with Indonesian selected, then confirm the drafted mailto body contains `Language: id`.
3. POST the register endpoint twice for the same email and ticker, once with `language: "en"` and once with `"id"`, and confirm two `UserTicker` rows exist with distinct languages.
4. Hit the delivery endpoint for that ticker and confirm only the English subscription comes back.
5. Scoped checks: `pnpm format:check`, plus `lint`, `type:check`, and `test` for the touched packages.
