### PR TITLE
Fix zombie schedule executions blocking new ticks

### DIFF
--- a/apps/hermes/worker/src/job-handlers.test.ts
+++ b/apps/hermes/worker/src/job-handlers.test.ts
@@ -8,6 +8,7 @@ import {
   getDueSchedules,
   invokeAgentPost,
   parseAgentResponseEnvelope,
+  reconcileZombieExecutions,
 } from "@hermes/scheduler";
 import { logger } from "@workspace/logger";
 import { executeHttpTrigger } from "./execute-http-trigger";
@@ -98,6 +99,7 @@ vi.mock("@hermes/scheduler", async (importOriginal) => {
     invokeAgentPost: vi.fn(),
     parseAgentResponseEnvelope: vi.fn(),
     applyInvocationCompletion: vi.fn().mockResolvedValue(undefined),
+    reconcileZombieExecutions: vi.fn().mockResolvedValue(0),
   };
 });
 
@@ -1064,6 +1066,7 @@ describe("jobHandlers", () => {
         reEnqueued: 2,
         settled: 1,
       });
+      vi.mocked(reconcileZombieExecutions).mockResolvedValue(4);
 
       // Act
       await jobHandlers.cleanup_orphaned_executions(
@@ -1084,8 +1087,14 @@ describe("jobHandlers", () => {
           dataQueuePool: expect.any(Object),
         }),
       );
+      expect(reconcileZombieExecutions).toHaveBeenCalledTimes(1);
       expect(logger.info).toHaveBeenCalledWith(
-        { resolved: 3, reEnqueued: 2, reconciledSettled: 1 },
+        {
+          resolved: 3,
+          reEnqueued: 2,
+          reconciledSettled: 1,
+          zombiesFinalized: 4,
+        },
         "cleanup_orphaned_executions: sweep complete",
       );
     });

--- a/apps/hermes/worker/src/job-handlers.ts
+++ b/apps/hermes/worker/src/job-handlers.ts
@@ -22,6 +22,7 @@ import {
   invokeAgentPost,
   parseAgentResponseEnvelope,
   parseHttpErrorBodyMessage,
+  reconcileZombieExecutions,
   resolveInvokeAgentJobTimeoutMs,
   willRetryAfterTransientFailure,
   type ExpandStepInputs,
@@ -746,7 +747,7 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
   cleanup_orphaned_executions: async () => {
     const jobQueue = getJobQueue();
     const pool = jobQueue.getPool?.();
-    const [resolved, reconciled] = await Promise.all([
+    const [resolved, reconciled, zombiesFinalized] = await Promise.all([
       cleanupOrphanedExecutions({ db: orchestrationPrisma, logger }),
       pool
         ? reconcileOrphanedPendingExecutions({
@@ -755,12 +756,14 @@ export const jobHandlers: JobHandlers<JobPayloadMap> = {
             logger,
           })
         : Promise.resolve({ reEnqueued: 0, settled: 0 }),
+      reconcileZombieExecutions({ db: orchestrationPrisma, logger }),
     ]);
     logger.info(
       {
         resolved,
         reEnqueued: reconciled.reEnqueued,
         reconciledSettled: reconciled.settled,
+        zombiesFinalized,
       },
       "cleanup_orphaned_executions: sweep complete",
     );

--- a/packages/hermes/scheduler/src/apply-invocation-completion.test.ts
+++ b/packages/hermes/scheduler/src/apply-invocation-completion.test.ts
@@ -1,0 +1,147 @@
+/** @vitest-environment node */
+vi.mock("@hermes/orchestration-database", () => ({
+  AgentJobExecutionStatus: {
+    pending: "pending",
+    running: "running",
+    completed: "completed",
+    failed: "failed",
+    cancelled: "cancelled",
+  },
+  Prisma: {
+    DbNull: Symbol("DbNull"),
+  },
+  ScheduleRunStatus: {
+    pending: "pending",
+    running: "running",
+    succeeded: "succeeded",
+    failed: "failed",
+    partial: "partial",
+    cancelled: "cancelled",
+  },
+  ScheduleStepRollupStatus: {
+    pending: "pending",
+    running: "running",
+    success: "success",
+    failed: "failed",
+    partial: "partial",
+    cancelled: "cancelled",
+    skipped: "skipped",
+  },
+}));
+
+import {
+  AgentJobExecutionStatus,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { applyInvocationCompletion } from "./apply-invocation-completion";
+
+describe("applyInvocationCompletion", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("finalizes parent schedule execution when step rows are missing but all jobs are terminal", async () => {
+    // Setup
+    const scheduleExecutionId = "00000000-0000-4000-8000-000000000020";
+    const pipelineStepId = "00000000-0000-4000-8000-000000000021";
+    const jobId = "00000000-0000-4000-8000-000000000022";
+    const scheduleExecutionUpdateMany = vi.fn().mockResolvedValue({ count: 1 });
+    const agentJobExecutionUpdate = vi.fn().mockResolvedValue(undefined);
+    const scheduleExecutionUpdate = vi.fn().mockResolvedValue(undefined);
+    const tx = {
+      agentJobExecution: {
+        update: agentJobExecutionUpdate,
+        findMany: vi.fn().mockResolvedValue([
+          {
+            status: AgentJobExecutionStatus.failed,
+            error: { message: "orphan" },
+          },
+        ]),
+      },
+      scheduleExecution: {
+        update: scheduleExecutionUpdate,
+        updateMany: scheduleExecutionUpdateMany,
+      },
+      scheduleStepExecution: {
+        findUnique: vi.fn().mockResolvedValue(null),
+      },
+    };
+    const db = {
+      scheduleExecution: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: scheduleExecutionId,
+          runStatus: ScheduleRunStatus.pending,
+          cancelledAt: null,
+          effectiveExecutionConfig: null,
+        }),
+      },
+      $transaction: vi.fn(async (callback: (client: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+    };
+    const logger = { warn: vi.fn(), error: vi.fn() };
+
+    // Act
+    await applyInvocationCompletion(
+      {
+        jobId,
+        scheduleExecutionId,
+        pipelineStepId,
+        terminal: {
+          status: AgentJobExecutionStatus.failed,
+          error: { message: "orphan" },
+        },
+      },
+      { db: db as never, logger },
+    );
+
+    // Assert
+    expect(scheduleExecutionUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: scheduleExecutionId,
+        runStatus: {
+          in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+        },
+      },
+      data: {
+        runStatus: ScheduleRunStatus.failed,
+        succeededInvocationCount: 0,
+        failedInvocationCount: 1,
+      },
+    });
+  });
+
+  it("returns early when parent execution is already terminal", async () => {
+    // Setup
+    const db = {
+      scheduleExecution: {
+        findUnique: vi.fn().mockResolvedValue({
+          id: "00000000-0000-4000-8000-000000000030",
+          runStatus: ScheduleRunStatus.succeeded,
+          cancelledAt: null,
+          effectiveExecutionConfig: null,
+        }),
+      },
+      $transaction: vi.fn(),
+    };
+
+    // Act
+    await applyInvocationCompletion(
+      {
+        jobId: "00000000-0000-4000-8000-000000000031",
+        scheduleExecutionId: "00000000-0000-4000-8000-000000000030",
+        pipelineStepId: "00000000-0000-4000-8000-000000000032",
+        terminal: {
+          status: AgentJobExecutionStatus.failed,
+          error: { message: "late" },
+        },
+      },
+      { db: db as never, logger: { warn: vi.fn(), error: vi.fn() } },
+    );
+
+    // Assert
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hermes/scheduler/src/apply-invocation-completion.ts
+++ b/packages/hermes/scheduler/src/apply-invocation-completion.ts
@@ -18,6 +18,10 @@ import {
   resolveRunStatusForSettledCancelledExecution,
   resolveStepRollupPrismaAfterInvocation,
 } from "./cancel-execution";
+import {
+  countInvocationOutcomesFromTerminalJobs,
+  resolveParentRunStatusWhenStepRowsMissing,
+} from "./finalize-parent-from-terminal-jobs";
 
 export type InvocationCompletionInput = {
   jobId: string;
@@ -292,6 +296,57 @@ export const applyInvocationCompletion = async (
               },
             });
     if (!stepRow) {
+      const jobsWithoutStepRollup =
+        executionKind === "schedule"
+          ? await tx.agentJobExecution.findMany({
+              where: { scheduleExecutionId: input.scheduleExecutionId! },
+              select: { status: true, error: true },
+            })
+          : executionKind === "httpTrigger"
+            ? await tx.agentJobExecution.findMany({
+                where: {
+                  httpTriggerExecutionId: input.httpTriggerExecutionId!,
+                },
+                select: { status: true, error: true },
+              })
+            : await tx.agentJobExecution.findMany({
+                where: { manualExecutionId: input.manualExecutionId! },
+                select: { status: true, error: true },
+              });
+
+      const runWithoutStepRollup = resolveParentRunStatusWhenStepRowsMissing(
+        jobsWithoutStepRollup,
+      );
+      if (runWithoutStepRollup == null) {
+        return;
+      }
+
+      const counts = countInvocationOutcomesFromTerminalJobs(
+        jobsWithoutStepRollup,
+      );
+      const parentWhere = {
+        runStatus: {
+          in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+        },
+      };
+
+      if (executionKind === "schedule") {
+        await tx.scheduleExecution.updateMany({
+          where: { id: input.scheduleExecutionId, ...parentWhere },
+          data: { runStatus: runWithoutStepRollup, ...counts },
+        });
+      } else if (executionKind === "httpTrigger") {
+        await tx.httpTriggerExecution.updateMany({
+          where: { id: input.httpTriggerExecutionId, ...parentWhere },
+          data: { runStatus: runWithoutStepRollup, ...counts },
+        });
+      } else {
+        await tx.manualPipelineExecution.updateMany({
+          where: { id: input.manualExecutionId, ...parentWhere },
+          data: { runStatus: runWithoutStepRollup, ...counts },
+        });
+      }
+
       return;
     }
 

--- a/packages/hermes/scheduler/src/finalize-parent-from-terminal-jobs.test.ts
+++ b/packages/hermes/scheduler/src/finalize-parent-from-terminal-jobs.test.ts
@@ -1,0 +1,98 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@hermes/orchestration-database", () => ({
+  AgentJobExecutionStatus: {
+    pending: "pending",
+    running: "running",
+    completed: "completed",
+    failed: "failed",
+    cancelled: "cancelled",
+  },
+  ScheduleRunStatus: {
+    pending: "pending",
+    running: "running",
+    succeeded: "succeeded",
+    failed: "failed",
+    partial: "partial",
+    cancelled: "cancelled",
+  },
+}));
+
+import {
+  AgentJobExecutionStatus,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+
+import {
+  areAllAgentJobsTerminal,
+  countInvocationOutcomesFromTerminalJobs,
+  resolveParentRunStatusWhenStepRowsMissing,
+  resolveRunStatusFromTerminalJobs,
+} from "./finalize-parent-from-terminal-jobs";
+
+describe("finalize-parent-from-terminal-jobs", () => {
+  it("areAllAgentJobsTerminal returns false for empty or non-terminal jobs", () => {
+    // Assert
+    expect(areAllAgentJobsTerminal([])).toBe(false);
+    expect(
+      areAllAgentJobsTerminal([
+        { status: AgentJobExecutionStatus.completed },
+        { status: AgentJobExecutionStatus.pending },
+      ]),
+    ).toBe(false);
+  });
+
+  it("areAllAgentJobsTerminal returns true when every job is terminal", () => {
+    // Act
+    const result = areAllAgentJobsTerminal([
+      { status: AgentJobExecutionStatus.failed },
+      { status: AgentJobExecutionStatus.completed },
+    ]);
+
+    // Assert
+    expect(result).toBe(true);
+  });
+
+  it("resolveRunStatusFromTerminalJobs maps failed jobs to failed parent status", () => {
+    // Act
+    const result = resolveRunStatusFromTerminalJobs([
+      {
+        status: AgentJobExecutionStatus.failed,
+        error: { message: "boom" },
+      },
+    ]);
+
+    // Assert
+    expect(result).toBe(ScheduleRunStatus.failed);
+  });
+
+  it("countInvocationOutcomesFromTerminalJobs counts successes and non-successes", () => {
+    // Act
+    const result = countInvocationOutcomesFromTerminalJobs([
+      { status: AgentJobExecutionStatus.completed, error: null },
+      { status: AgentJobExecutionStatus.failed, error: { message: "x" } },
+      { status: AgentJobExecutionStatus.cancelled, error: null },
+    ]);
+
+    // Assert
+    expect(result).toEqual({
+      succeededInvocationCount: 1,
+      failedInvocationCount: 2,
+    });
+  });
+
+  it("resolveParentRunStatusWhenStepRowsMissing returns null until all jobs are terminal", () => {
+    // Assert
+    expect(
+      resolveParentRunStatusWhenStepRowsMissing([
+        { status: AgentJobExecutionStatus.running, error: null },
+      ]),
+    ).toBeNull();
+    expect(
+      resolveParentRunStatusWhenStepRowsMissing([
+        { status: AgentJobExecutionStatus.failed, error: { message: "x" } },
+      ]),
+    ).toBe(ScheduleRunStatus.failed);
+  });
+});

--- a/packages/hermes/scheduler/src/finalize-parent-from-terminal-jobs.ts
+++ b/packages/hermes/scheduler/src/finalize-parent-from-terminal-jobs.ts
@@ -1,0 +1,73 @@
+import {
+  AgentJobExecutionStatus,
+  type Prisma,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+
+import { resolveRunStatusForSettledCancelledExecution } from "./cancel-execution";
+
+/** Agent job row shape used to decide parent execution finalization. */
+export type TerminalJobRow = {
+  status: AgentJobExecutionStatus;
+  error: Prisma.JsonValue | null;
+};
+
+const TERMINAL_JOB_STATUSES = new Set<AgentJobExecutionStatus>([
+  AgentJobExecutionStatus.completed,
+  AgentJobExecutionStatus.failed,
+  AgentJobExecutionStatus.cancelled,
+]);
+
+/**
+ * Returns true when every job is terminal and at least one job exists.
+ *
+ * @param jobs - Agent job rows for one parent execution.
+ */
+export const areAllAgentJobsTerminal = (
+  jobs: Array<{ status: AgentJobExecutionStatus }>,
+): boolean =>
+  jobs.length > 0 && jobs.every((job) => TERMINAL_JOB_STATUSES.has(job.status));
+
+/**
+ * Derives the parent execution run status from terminal agent jobs (legacy rows without step rollups).
+ *
+ * @param jobs - Terminal agent job rows for the parent execution.
+ * @returns Resolved parent {@link ScheduleRunStatus}.
+ */
+export const resolveRunStatusFromTerminalJobs = (
+  jobs: TerminalJobRow[],
+): ScheduleRunStatus => resolveRunStatusForSettledCancelledExecution(jobs);
+
+/**
+ * Counts succeeded vs failed invocations from terminal agent jobs for parent row sync.
+ *
+ * @param jobs - Terminal agent job rows for the parent execution.
+ */
+export const countInvocationOutcomesFromTerminalJobs = (
+  jobs: TerminalJobRow[],
+): {
+  succeededInvocationCount: number;
+  failedInvocationCount: number;
+} => ({
+  succeededInvocationCount: jobs.filter(
+    (job) => job.status === AgentJobExecutionStatus.completed,
+  ).length,
+  failedInvocationCount: jobs.filter(
+    (job) => job.status !== AgentJobExecutionStatus.completed,
+  ).length,
+});
+
+/**
+ * Resolves a parent run status when step rollup rows are absent but all agent jobs are terminal.
+ *
+ * @param jobs - Agent job rows for the parent execution.
+ * @returns Parent run status, or null when jobs are not all terminal.
+ */
+export const resolveParentRunStatusWhenStepRowsMissing = (
+  jobs: TerminalJobRow[],
+): ScheduleRunStatus | null => {
+  if (!areAllAgentJobsTerminal(jobs)) {
+    return null;
+  }
+  return resolveRunStatusFromTerminalJobs(jobs);
+};

--- a/packages/hermes/scheduler/src/index.ts
+++ b/packages/hermes/scheduler/src/index.ts
@@ -84,6 +84,18 @@ export {
   type ReconcileSchedulesDb,
   type ScheduleForRecovery,
 } from "./reconcile-overdue-schedules";
+export {
+  reconcileZombieExecutions,
+  type ReconcileZombieExecutionsDeps,
+  type ReconcileZombieExecutionsLogger,
+} from "./reconcile-zombie-executions";
+export {
+  areAllAgentJobsTerminal,
+  countInvocationOutcomesFromTerminalJobs,
+  resolveParentRunStatusWhenStepRowsMissing,
+  resolveRunStatusFromTerminalJobs,
+  type TerminalJobRow,
+} from "./finalize-parent-from-terminal-jobs";
 export { willRetryAfterTransientFailure } from "./will-retry-after-transient-failure";
 export {
   applyHermesInvokeCorrelationHeaders,

--- a/packages/hermes/scheduler/src/reconcile-zombie-executions.test.ts
+++ b/packages/hermes/scheduler/src/reconcile-zombie-executions.test.ts
@@ -1,0 +1,127 @@
+/** @vitest-environment node */
+vi.mock("@hermes/orchestration-database", () => ({
+  AgentJobExecutionStatus: {
+    pending: "pending",
+    running: "running",
+    completed: "completed",
+    failed: "failed",
+    cancelled: "cancelled",
+  },
+  ScheduleRunStatus: {
+    pending: "pending",
+    running: "running",
+    succeeded: "succeeded",
+    failed: "failed",
+    partial: "partial",
+    cancelled: "cancelled",
+  },
+}));
+
+import {
+  AgentJobExecutionStatus,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { reconcileZombieExecutions } from "./reconcile-zombie-executions";
+
+describe("reconcileZombieExecutions", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("finalizes schedule executions whose agent jobs are already terminal", async () => {
+    // Setup
+    const scheduleExecutionId = "00000000-0000-4000-8000-000000000010";
+    const logger = { info: vi.fn(), warn: vi.fn() };
+    const db = {
+      scheduleExecution: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([{ id: scheduleExecutionId, cancelledAt: null }]),
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
+      httpTriggerExecution: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn(),
+      },
+      manualPipelineExecution: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn(),
+      },
+      agentJobExecution: {
+        findMany: vi.fn().mockResolvedValue([
+          {
+            status: AgentJobExecutionStatus.failed,
+            error: { message: "orphan" },
+          },
+        ]),
+      },
+    };
+
+    // Act
+    const finalized = await reconcileZombieExecutions({
+      db: db as never,
+      logger,
+    });
+
+    // Assert
+    expect(finalized).toBe(1);
+    expect(db.scheduleExecution.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: scheduleExecutionId,
+        runStatus: {
+          in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+        },
+      },
+      data: {
+        runStatus: ScheduleRunStatus.failed,
+        succeededInvocationCount: 0,
+        failedInvocationCount: 1,
+      },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleExecutionId }),
+      "reconcile_zombie_executions: finalized schedule execution from terminal jobs",
+    );
+  });
+
+  it("skips parents that still have non-terminal agent jobs", async () => {
+    // Setup
+    const db = {
+      scheduleExecution: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "00000000-0000-4000-8000-000000000011", cancelledAt: null },
+          ]),
+        updateMany: vi.fn(),
+      },
+      httpTriggerExecution: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn(),
+      },
+      manualPipelineExecution: {
+        findMany: vi.fn().mockResolvedValue([]),
+        updateMany: vi.fn(),
+      },
+      agentJobExecution: {
+        findMany: vi
+          .fn()
+          .mockResolvedValue([
+            { status: AgentJobExecutionStatus.pending, error: null },
+          ]),
+      },
+    };
+
+    // Act
+    const finalized = await reconcileZombieExecutions({
+      db: db as never,
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(finalized).toBe(0);
+    expect(db.scheduleExecution.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/packages/hermes/scheduler/src/reconcile-zombie-executions.ts
+++ b/packages/hermes/scheduler/src/reconcile-zombie-executions.ts
@@ -1,0 +1,193 @@
+import {
+  type PrismaClient,
+  ScheduleRunStatus,
+} from "@hermes/orchestration-database";
+
+import {
+  areAllAgentJobsTerminal,
+  countInvocationOutcomesFromTerminalJobs,
+  resolveRunStatusFromTerminalJobs,
+  type TerminalJobRow,
+} from "./finalize-parent-from-terminal-jobs";
+
+/** Logger shape for zombie execution reconciliation. */
+export type ReconcileZombieExecutionsLogger = {
+  info: (obj: Record<string, unknown>, msg: string) => void;
+  warn: (obj: Record<string, unknown>, msg: string) => void;
+};
+
+export type ReconcileZombieExecutionsDeps = {
+  db: PrismaClient;
+  logger: ReconcileZombieExecutionsLogger;
+};
+
+type NonTerminalParentRow = {
+  id: string;
+  cancelledAt: Date | null;
+};
+
+/**
+ * Finalizes one parent execution when all agent jobs are terminal but the parent is still non-terminal.
+ *
+ * @param db - Prisma client.
+ * @param table - Parent execution table discriminator.
+ * @param parent - Parent execution row id and optional cancel timestamp.
+ * @param jobs - Agent jobs linked to the parent execution.
+ * @returns True when the parent row was updated.
+ */
+const finalizeZombieParent = async (
+  db: PrismaClient,
+  table: "schedule" | "httpTrigger" | "manual",
+  parent: NonTerminalParentRow,
+  jobs: TerminalJobRow[],
+): Promise<boolean> => {
+  if (!areAllAgentJobsTerminal(jobs)) {
+    return false;
+  }
+
+  const runStatus = resolveRunStatusFromTerminalJobs(jobs);
+  const counts = countInvocationOutcomesFromTerminalJobs(jobs);
+  const nonTerminalRunStatuses = [
+    ScheduleRunStatus.pending,
+    ScheduleRunStatus.running,
+  ];
+
+  if (table === "schedule") {
+    const result = await db.scheduleExecution.updateMany({
+      where: {
+        id: parent.id,
+        runStatus: { in: nonTerminalRunStatuses },
+      },
+      data: {
+        runStatus,
+        ...counts,
+      },
+    });
+    return result.count > 0;
+  }
+  if (table === "httpTrigger") {
+    const result = await db.httpTriggerExecution.updateMany({
+      where: {
+        id: parent.id,
+        runStatus: { in: nonTerminalRunStatuses },
+      },
+      data: {
+        runStatus,
+        ...counts,
+      },
+    });
+    return result.count > 0;
+  }
+  const result = await db.manualPipelineExecution.updateMany({
+    where: {
+      id: parent.id,
+      runStatus: { in: nonTerminalRunStatuses },
+    },
+    data: {
+      runStatus,
+      ...counts,
+    },
+  });
+  return result.count > 0;
+};
+
+/**
+ * Finds parent executions stuck in pending/running while all linked agent jobs are already terminal.
+ * Repairs legacy rows that predate step rollups or missed parent finalization during orphan cleanup.
+ *
+ * @param deps - Database client and logger.
+ * @returns Number of parent executions finalized.
+ */
+export const reconcileZombieExecutions = async (
+  deps: ReconcileZombieExecutionsDeps,
+): Promise<number> => {
+  const { db, logger } = deps;
+  let finalized = 0;
+
+  const scheduleParents = await db.scheduleExecution.findMany({
+    where: {
+      runStatus: {
+        in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+      },
+    },
+    select: { id: true, cancelledAt: true },
+  });
+
+  for (const parent of scheduleParents) {
+    const jobs = await db.agentJobExecution.findMany({
+      where: { scheduleExecutionId: parent.id },
+      select: { status: true, error: true },
+    });
+    const updated = await finalizeZombieParent(db, "schedule", parent, jobs);
+    if (updated) {
+      finalized++;
+      logger.warn(
+        {
+          scheduleExecutionId: parent.id,
+          runStatus: resolveRunStatusFromTerminalJobs(jobs),
+        },
+        "reconcile_zombie_executions: finalized schedule execution from terminal jobs",
+      );
+    }
+  }
+
+  const httpTriggerParents = await db.httpTriggerExecution.findMany({
+    where: {
+      runStatus: {
+        in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+      },
+    },
+    select: { id: true, cancelledAt: true },
+  });
+
+  for (const parent of httpTriggerParents) {
+    const jobs = await db.agentJobExecution.findMany({
+      where: { httpTriggerExecutionId: parent.id },
+      select: { status: true, error: true },
+    });
+    const updated = await finalizeZombieParent(db, "httpTrigger", parent, jobs);
+    if (updated) {
+      finalized++;
+      logger.warn(
+        {
+          httpTriggerExecutionId: parent.id,
+          runStatus: resolveRunStatusFromTerminalJobs(jobs),
+        },
+        "reconcile_zombie_executions: finalized HTTP trigger execution from terminal jobs",
+      );
+    }
+  }
+
+  const manualParents = await db.manualPipelineExecution.findMany({
+    where: {
+      runStatus: {
+        in: [ScheduleRunStatus.pending, ScheduleRunStatus.running],
+      },
+    },
+    select: { id: true, cancelledAt: true },
+  });
+
+  for (const parent of manualParents) {
+    const jobs = await db.agentJobExecution.findMany({
+      where: { manualExecutionId: parent.id },
+      select: { status: true, error: true },
+    });
+    const updated = await finalizeZombieParent(db, "manual", parent, jobs);
+    if (updated) {
+      finalized++;
+      logger.warn(
+        {
+          manualExecutionId: parent.id,
+          runStatus: resolveRunStatusFromTerminalJobs(jobs),
+        },
+        "reconcile_zombie_executions: finalized manual pipeline execution from terminal jobs",
+      );
+    }
+  }
+
+  if (finalized > 0) {
+    logger.info({ finalized }, "reconcile_zombie_executions: sweep complete");
+  }
+
+  return finalized;
+};


### PR DESCRIPTION
## Summary

Fixes a case where parent `schedule_execution` rows stayed **`pending`** or **`running`** after all linked agent jobs had already reached a terminal state. That left “zombie” executions that blocked new schedule ticks once the non-terminal guard shipped in #716.

The bug showed up in production on **User Registration Check**: two April executions had failed agent jobs but no `schedule_step_execution` rows (legacy data). `applyInvocationCompletion` bailed out when step rollups were missing, so the parent never finalized.

## Important changes

- **`applyInvocationCompletion`**: when step rollup rows are absent, derive parent `run_status` from terminal agent jobs instead of returning early.
- **`reconcileZombieExecutions`**: periodic sweep (runs with orphan cleanup every 15 minutes) repairs existing zombie parent rows.
- **Tests** for both paths in `@hermes/scheduler`; worker handler test updated for the new sweep.

## How to test

- `pnpm --filter @hermes/scheduler test`
- `pnpm --filter @hermes/worker test`
- After deploy: confirm User Registration Check creates new executions in the Hermes dashboard (zombie rows should be auto-repaired on the next cleanup sweep, or use the one-off SQL from the investigation if needed before deploy).

## Related issues

Closes #825
