### PR TITLE
Add agent insights for the newsletter-feedback agent

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -83,6 +83,7 @@ import { createDataCollectionInsightsProvider } from "./services/insights/data-c
 import { createDeliveryInsightsProvider } from "./services/insights/delivery-insights-provider.js";
 import { createQueryAnalysisInsightsProvider } from "./services/insights/query-analysis-insights-provider.js";
 import { createArticleAnalysisInsightsProvider } from "./services/insights/article-analysis-insights-provider.js";
+import { createNewsletterFeedbackInsightsProvider } from "./services/insights/newsletter-feedback-insights-provider.js";
 import { registerInsightsProvider } from "./services/agent-insights-registry.js";
 import {
   registerAgentDataApiRoutes,
@@ -296,6 +297,12 @@ registerInsightsProvider(
     searchQuerySet: prisma.searchQuerySet,
     searchQuery: prisma.searchQuery,
     searchQueryYield: prisma.searchQueryYield,
+  }),
+);
+
+registerInsightsProvider(
+  createNewsletterFeedbackInsightsProvider({
+    newsletterFeedback: prisma.newsletterFeedback,
   }),
 );
 

--- a/apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest";
+import { insightsPayloadSchema } from "@workspace/agent-data-api-contract";
+
+import { createNewsletterFeedbackInsightsProvider } from "./newsletter-feedback-insights-provider.js";
+
+const now = new Date();
+
+type Sentiment = "positive" | "negative" | "neutral" | "mixed";
+type Category =
+  | "praise"
+  | "complaint"
+  | "feature_request"
+  | "bug"
+  | "question"
+  | "other";
+
+function makeRow(
+  offsetMs: number,
+  overrides: Partial<{
+    senderEmail: string;
+    sentiment: Sentiment | null;
+    category: Category | null;
+    userId: string | null;
+  }> = {},
+) {
+  const at = new Date(now.getTime() - offsetMs);
+
+  return {
+    senderEmail: overrides.senderEmail ?? "reader@example.com",
+    receivedAt: at,
+    createdAt: at,
+    // Use `in` checks so an explicit `null` (unclassified / unmatched) is honored
+    // rather than coalesced back to the default.
+    sentiment:
+      "sentiment" in overrides ? (overrides.sentiment ?? null) : "positive",
+    category: "category" in overrides ? (overrides.category ?? null) : "praise",
+    userId: "userId" in overrides ? (overrides.userId ?? null) : "user-1",
+  };
+}
+
+function makeProvider(rows: ReturnType<typeof makeRow>[]) {
+  return createNewsletterFeedbackInsightsProvider({
+    newsletterFeedback: {
+      findMany: async () => rows,
+    },
+  });
+}
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("createNewsletterFeedbackInsightsProvider", () => {
+  it("produces a payload that validates against the contract schema", async () => {
+    // Setup
+    const provider = makeProvider([
+      makeRow(2 * HOUR, { sentiment: "positive", category: "praise" }),
+      makeRow(3 * HOUR, { sentiment: "negative", category: "bug" }),
+    ]);
+
+    // Act
+    const payload = await provider.compute({ window: "7d" });
+
+    // Assert
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.agentId).toBe("newsletter-feedback");
+  });
+
+  it("computes negative share, classified, and matched KPIs", async () => {
+    // Setup
+    const provider = makeProvider([
+      makeRow(1 * HOUR, { sentiment: "negative", category: "complaint" }),
+      makeRow(2 * HOUR, { sentiment: "mixed", category: "bug" }),
+      makeRow(3 * HOUR, { sentiment: "positive", category: "praise" }),
+      makeRow(4 * HOUR, {
+        sentiment: null,
+        category: null,
+        userId: null,
+      }),
+    ]);
+
+    // Act
+    const payload = await provider.compute({ window: "7d" });
+    const byId = Object.fromEntries(payload.kpis.map((kpi) => [kpi.id, kpi]));
+
+    // Assert
+    expect(byId.replies?.value).toBe(4);
+    expect(byId.negative_share?.value).toBe(67);
+    expect(byId.negative_share?.tone).toBe("critical");
+    expect(byId.classified?.value).toBe(75);
+    expect(byId.matched_subscriber?.value).toBe(75);
+    expect(byId.actionable?.value).toBe(2);
+  });
+
+  it("excludes prior-window rows from current counts but uses them for deltas", async () => {
+    // Setup
+    const provider = makeProvider([
+      makeRow(1 * HOUR),
+      makeRow(2 * HOUR),
+      makeRow(10 * DAY),
+    ]);
+
+    // Act
+    const payload = await provider.compute({ window: "7d" });
+    const replies = payload.kpis.find((kpi) => kpi.id === "replies");
+
+    // Assert
+    expect(replies?.value).toBe(2);
+    expect(replies?.delta).toBe(1);
+  });
+
+  it("flags low classification coverage", async () => {
+    // Setup
+    const rows = [
+      makeRow(1 * HOUR, { sentiment: "positive" }),
+      ...Array.from({ length: 5 }, (_unused, index) =>
+        makeRow((index + 2) * HOUR, { sentiment: null, category: null }),
+      ),
+    ];
+    const provider = makeProvider(rows);
+
+    // Act
+    const payload = await provider.compute({ window: "7d" });
+
+    // Assert
+    expect(
+      payload.alerts.some(
+        (alert) => alert.id === "low-classification-coverage",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns a valid, empty payload when there is no feedback", async () => {
+    // Setup
+    const provider = makeProvider([]);
+
+    // Act
+    const payload = await provider.compute({ window: "30d" });
+
+    // Assert
+    expect(() => insightsPayloadSchema.parse(payload)).not.toThrow();
+    expect(payload.sections).toEqual([]);
+    expect(payload.kpis.find((kpi) => kpi.id === "replies")?.value).toBe(0);
+    expect(payload.alerts.some((alert) => alert.id === "no-replies")).toBe(
+      true,
+    );
+  });
+
+  it("masks sender emails in the recent-feedback table", async () => {
+    // Setup
+    const provider = makeProvider([
+      makeRow(1 * HOUR, { senderEmail: "jane.doe@gmail.com" }),
+    ]);
+
+    // Act
+    const payload = await provider.compute({ window: "7d" });
+    const recent = payload.sections.find(
+      (section) => section.id === "recent-feedback",
+    );
+    const serialized = JSON.stringify(recent);
+
+    // Assert
+    expect(recent?.widget.kind).toBe("table");
+    expect(serialized).not.toContain("jane.doe@gmail.com");
+    expect(serialized).toContain("j***@gmail.com");
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.ts
+++ b/apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.ts
@@ -1,0 +1,380 @@
+import type {
+  InsightsPayload,
+  KpiCard,
+  InsightAlert,
+  InsightSection,
+} from "@workspace/agent-data-api-contract";
+
+import type {
+  AgentInsightsProvider,
+  InsightsContext,
+} from "../agent-insights-registry.js";
+
+const RECENT_LIMIT = 10;
+const LOW_CLASSIFICATION_PCT = 80;
+
+const WINDOW_MS: Record<"24h" | "7d" | "30d", number> = {
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+  "30d": 30 * 24 * 60 * 60 * 1000,
+};
+
+type FeedbackSentiment = "positive" | "negative" | "neutral" | "mixed";
+type FeedbackCategory =
+  | "praise"
+  | "complaint"
+  | "feature_request"
+  | "bug"
+  | "question"
+  | "other";
+
+const SENTIMENTS: FeedbackSentiment[] = [
+  "positive",
+  "negative",
+  "neutral",
+  "mixed",
+];
+const CATEGORIES: FeedbackCategory[] = [
+  "praise",
+  "complaint",
+  "feature_request",
+  "bug",
+  "question",
+  "other",
+];
+const ACTIONABLE_CATEGORIES = new Set<FeedbackCategory>([
+  "bug",
+  "complaint",
+  "feature_request",
+]);
+
+type FeedbackRow = {
+  senderEmail: string;
+  receivedAt: Date;
+  createdAt: Date;
+  sentiment: FeedbackSentiment | null;
+  category: FeedbackCategory | null;
+  userId: string | null;
+};
+
+type NewsletterFeedbackInsightsDeps = {
+  newsletterFeedback: {
+    findMany: (args: {
+      where: {
+        createdAt: { gte: Date };
+        userTicker?: { tickerId: string };
+      };
+      select: {
+        senderEmail: boolean;
+        receivedAt: boolean;
+        createdAt: boolean;
+        sentiment: boolean;
+        category: boolean;
+        userId: boolean;
+      };
+    }) => Promise<FeedbackRow[]>;
+  };
+};
+
+/**
+ * Masks an email for display in insights: keeps the first character of the
+ * local part and the full domain (`j***@gmail.com`). Never exposes the raw
+ * address (PII) in a payload that surfaces in the dashboard.
+ *
+ * @param email - Raw sender email.
+ */
+function maskEmail(email: string): string {
+  const trimmed = email.trim();
+  const atIndex = trimmed.lastIndexOf("@");
+  if (atIndex <= 0) {
+    return "***";
+  }
+  const local = trimmed.slice(0, atIndex);
+  const domain = trimmed.slice(atIndex);
+  const firstChar = local.slice(0, 1);
+
+  return `${firstChar}***${domain}`;
+}
+
+function buildWindowDates(
+  windowStart: Date,
+  windowEnd: Date,
+): Map<string, number> {
+  const buckets = new Map<string, number>();
+  const current = new Date(windowStart);
+  while (current <= windowEnd) {
+    const key = current.toISOString().slice(0, 10);
+    buckets.set(key, 0);
+    current.setUTCDate(current.getUTCDate() + 1);
+  }
+
+  return buckets;
+}
+
+function pct(part: number, total: number): number {
+  return total > 0 ? Math.round((part / total) * 100) : 0;
+}
+
+/**
+ * Builds the agent-insights provider for the newsletter-feedback agent. Surfaces
+ * reply volume, sentiment and category mix, classification coverage, and how well
+ * replies correlate back to a subscriber.
+ *
+ * @param deps - Injected `newsletterFeedback` delegate (Prisma) for testability.
+ */
+export function createNewsletterFeedbackInsightsProvider(
+  deps: NewsletterFeedbackInsightsDeps,
+): AgentInsightsProvider {
+  return {
+    agentId: "newsletter-feedback",
+
+    async compute(ctx: InsightsContext): Promise<InsightsPayload> {
+      const windowMs = WINDOW_MS[ctx.window];
+      const now = new Date();
+      const windowStart = new Date(now.getTime() - windowMs);
+      const priorStart = new Date(windowStart.getTime() - windowMs);
+
+      // The feedback model has no tickerId; scope through the userTicker relation
+      // when a tickerId filter is provided.
+      const tickerFilter = ctx.tickerId
+        ? { userTicker: { tickerId: ctx.tickerId } }
+        : {};
+
+      const rows = await deps.newsletterFeedback.findMany({
+        where: { createdAt: { gte: priorStart }, ...tickerFilter },
+        select: {
+          senderEmail: true,
+          receivedAt: true,
+          createdAt: true,
+          sentiment: true,
+          category: true,
+          userId: true,
+        },
+      });
+
+      const current = rows.filter((row) => row.createdAt >= windowStart);
+      const prior = rows.filter(
+        (row) => row.createdAt >= priorStart && row.createdAt < windowStart,
+      );
+
+      const total = current.length;
+      const classified = current.filter((row) => row.sentiment !== null);
+      const negative = classified.filter(
+        (row) => row.sentiment === "negative" || row.sentiment === "mixed",
+      ).length;
+      const matched = current.filter((row) => row.userId !== null).length;
+      const actionable = current.filter(
+        (row) =>
+          row.category !== null && ACTIONABLE_CATEGORIES.has(row.category),
+      ).length;
+
+      const negativeShare = pct(negative, classified.length);
+      const classifiedPct = pct(classified.length, total);
+      const matchedPct = pct(matched, total);
+
+      const priorActionable = prior.filter(
+        (row) =>
+          row.category !== null && ACTIONABLE_CATEGORIES.has(row.category),
+      ).length;
+      const priorClassified = prior.filter((row) => row.sentiment !== null);
+      const priorNegative = priorClassified.filter(
+        (row) => row.sentiment === "negative" || row.sentiment === "mixed",
+      ).length;
+      const priorNegativeShare = pct(priorNegative, priorClassified.length);
+
+      const negativeTone =
+        negativeShare >= 50
+          ? "critical"
+          : negativeShare >= 30
+            ? "warning"
+            : "neutral";
+
+      const kpis: KpiCard[] = [
+        {
+          id: "replies",
+          label: "Replies",
+          value: total,
+          delta: total - prior.length,
+        },
+        {
+          id: "negative_share",
+          label: "Negative share",
+          value: negativeShare,
+          unit: "%",
+          tone: negativeTone,
+        },
+        {
+          id: "actionable",
+          label: "Actionable",
+          value: actionable,
+          delta: actionable - priorActionable,
+        },
+        {
+          id: "matched_subscriber",
+          label: "Matched to a subscriber",
+          value: matchedPct,
+          unit: "%",
+        },
+        {
+          id: "classified",
+          label: "Classified",
+          value: classifiedPct,
+          unit: "%",
+        },
+      ];
+
+      const alerts: InsightAlert[] = [];
+
+      if (
+        classified.length >= 5 &&
+        priorClassified.length > 0 &&
+        negativeShare > priorNegativeShare + 20
+      ) {
+        alerts.push({
+          id: "negative-sentiment-spike",
+          severity: "warning",
+          message: `Negative feedback share rose from ${priorNegativeShare}% to ${negativeShare}%`,
+          sectionRef: "sentiment-breakdown",
+        });
+      }
+
+      if (
+        priorActionable > 0 &&
+        actionable > priorActionable * 2 &&
+        actionable > 3
+      ) {
+        alerts.push({
+          id: "actionable-surge",
+          severity: "warning",
+          message: `Bug, complaint, and feature-request replies surged: ${actionable} vs ${priorActionable} in the prior window`,
+          sectionRef: "feedback-by-category",
+        });
+      }
+
+      if (total >= 5 && classifiedPct < LOW_CLASSIFICATION_PCT) {
+        alerts.push({
+          id: "low-classification-coverage",
+          severity: "warning",
+          message: `Only ${classifiedPct}% of replies were classified — the classifier step may be failing`,
+        });
+      }
+
+      if (total === 0 && ctx.window !== "24h") {
+        alerts.push({
+          id: "no-replies",
+          severity: "info",
+          message: "No newsletter replies in the window",
+        });
+      }
+
+      const sections: InsightSection[] = [];
+
+      if (total > 0) {
+        const sentimentCounts = new Map<string, number>();
+        for (const sentiment of SENTIMENTS) {
+          sentimentCounts.set(sentiment, 0);
+        }
+        let unclassified = 0;
+        for (const row of current) {
+          if (row.sentiment === null) {
+            unclassified += 1;
+          } else {
+            sentimentCounts.set(
+              row.sentiment,
+              (sentimentCounts.get(row.sentiment) ?? 0) + 1,
+            );
+          }
+        }
+        const sentimentSlices = [
+          ...SENTIMENTS.map((sentiment) => ({
+            label: sentiment,
+            value: sentimentCounts.get(sentiment) ?? 0,
+          })),
+          { label: "unclassified", value: unclassified },
+        ]
+          .filter((slice) => slice.value > 0)
+          .map((slice) => ({
+            label: slice.label,
+            value: slice.value,
+            fraction: slice.value / total,
+          }));
+
+        sections.push({
+          id: "sentiment-breakdown",
+          category: "what",
+          title: "Sentiment breakdown",
+          widget: { kind: "breakdown", slices: sentimentSlices },
+        });
+
+        const categoryBars = CATEGORIES.map((category) => ({
+          label: category,
+          value: current.filter((row) => row.category === category).length,
+        }))
+          .filter((bar) => bar.value > 0)
+          .sort((a, b) => b.value - a.value);
+
+        if (categoryBars.length > 0) {
+          sections.push({
+            id: "feedback-by-category",
+            category: "why",
+            title: "Feedback by category",
+            widget: {
+              kind: "categoryBar",
+              bars: categoryBars,
+              unit: "replies",
+            },
+          });
+        }
+
+        const dailyBuckets = buildWindowDates(windowStart, now);
+        for (const row of current) {
+          const dayKey = row.createdAt.toISOString().slice(0, 10);
+          if (dailyBuckets.has(dayKey)) {
+            dailyBuckets.set(dayKey, (dailyBuckets.get(dayKey) ?? 0) + 1);
+          }
+        }
+        sections.push({
+          id: "replies-over-time",
+          category: "when",
+          title: "Replies over time",
+          widget: {
+            kind: "timeSeries",
+            points: Array.from(dailyBuckets.entries()).map(([ts, value]) => ({
+              ts: `${ts}T00:00:00.000Z`,
+              value,
+            })),
+            unit: "replies",
+          },
+        });
+
+        const recent = [...current]
+          .sort((a, b) => b.receivedAt.getTime() - a.receivedAt.getTime())
+          .slice(0, RECENT_LIMIT);
+        sections.push({
+          id: "recent-feedback",
+          category: "other",
+          title: "Recent feedback",
+          widget: {
+            kind: "table",
+            columns: ["Received", "Sentiment", "Category", "From"],
+            rows: recent.map((row) => [
+              row.receivedAt.toISOString(),
+              row.sentiment ?? "unclassified",
+              row.category ?? "unclassified",
+              maskEmail(row.senderEmail),
+            ]),
+          },
+        });
+      }
+
+      return {
+        agentId: "newsletter-feedback",
+        window: ctx.window,
+        generatedAt: now.toISOString(),
+        kpis,
+        alerts,
+        sections,
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Adds an agent-insights provider for the `newsletter-feedback` agent (shipped in #828), the only agent that lacked one. It surfaces reply volume, sentiment and category mix, classification coverage, and how well replies correlate back to a subscriber through the existing agent-insights endpoint and Hermes dashboard. Purely additive — no contract, schema, or migration changes.

## Related issues

Closes #829

## Important changes

- New `createNewsletterFeedbackInsightsProvider` (`apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.ts`), registered under `agentId: "newsletter-feedback"`. It reads the `NewsletterFeedback` table for the requested window (with a prior window for deltas) and returns:
  - **KPIs:** replies (with delta), negative-sentiment share, actionable replies (bug/complaint/feature-request), subscriber-match rate, and classification coverage.
  - **Sections:** sentiment breakdown, feedback by category, replies over time, and a recent-feedback table.
  - **Alerts:** negative-sentiment spike, actionable surge, low classification coverage, and no-replies.
- Section headings use plain, natural titles rather than the What/When/Where framing.
- Sender emails are masked (`j***@gmail.com`) in the recent-feedback table so no raw PII reaches the dashboard.

## Other changes

- Registered the provider in `apps/mediapulse/agent-data-api/src/index.ts` alongside the existing seven.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.ts` — aggregation, KPIs, alerts, sections, and email masking.
- `apps/mediapulse/agent-data-api/src/services/insights/newsletter-feedback-insights-provider.test.ts` — schema validation, KPI math, prior-window deltas, empty state, PII masking.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test newsletter-feedback-insights` (or the full suite — 302 tests).
2. With agent-data-api running and a few `newsletter_feedback` rows seeded, `GET /api/v1/agent-insights?agentId=newsletter-feedback&window=7d` returns a 200 payload with the KPIs and sentiment/category sections, and renders in the Hermes dashboard insights view.
