### PR TITLE
Fix subscribe modal option cards overflowing dialog

### DIFF
--- a/apps/mediapulse/user-registration/components/subscribe-mail-app-modal.tsx
+++ b/apps/mediapulse/user-registration/components/subscribe-mail-app-modal.tsx
@@ -55,17 +55,17 @@ const SubscribeMailAppModal = ({
             you a confirmation link.
           </DialogDescription>
         </DialogHeader>
-        <div className="flex flex-col gap-3">
+        <div className="flex min-w-0 flex-col gap-3">
           {options.map((option) => (
             <Button
               key={option.id}
               type="button"
               variant="outline"
-              className="h-auto flex-col items-start gap-1 px-4 py-3 text-left"
+              className="h-auto w-full min-w-0 shrink whitespace-normal flex-col items-start gap-1 px-4 py-3 text-left"
               onClick={() => handleSelect(option)}
             >
-              <span className="font-medium">{option.title}</span>
-              <span className="text-sm font-normal text-muted-foreground">
+              <span className="w-full font-medium">{option.title}</span>
+              <span className="w-full text-balance text-sm font-normal text-muted-foreground">
                 {option.description}
               </span>
             </Button>


### PR DESCRIPTION
## Summary

The subscribe mail-app choice modal let option cards spill past the right edge of the dialog. This overrides the shared Button defaults so each option stays full-width inside the modal and long descriptions wrap.

## Related issues

Closes #835

## Important changes

- Option buttons in `SubscribeMailAppModal` use `w-full`, `min-w-0`, `shrink`, and `whitespace-normal` so they respect the dialog width.
- Description text uses `text-balance` for readable wrapping on narrow screens.

## Other changes

- None.

## Key files to review

- `apps/mediapulse/user-registration/components/subscribe-mail-app-modal.tsx` — layout classes on the option list and buttons.

## How to test

1. Run `pnpm --filter @mediapulse/user-registration dev`.
2. Open the registration page and submit the form to open the mail-app choice modal.
3. Confirm all three options stay inside the dialog and descriptions wrap instead of overflowing horizontally.
