### PR TITLE
Fix Outlook compose deep link on iOS Safari

### DIFF
--- a/apps/mediapulse/user-registration/hooks/use-subscribe-mail-app-modal.ts
+++ b/apps/mediapulse/user-registration/hooks/use-subscribe-mail-app-modal.ts
@@ -105,6 +105,7 @@ export const useSubscribeMailAppModal = ({
         name,
         language,
         env.NEXT_PUBLIC_REGISTRATION_EMAIL,
+        { userAgent: navigator.userAgent },
       ),
     );
     setMailChoiceOpen(false);

--- a/apps/mediapulse/user-registration/lib/detect-mail-platform.test.ts
+++ b/apps/mediapulse/user-registration/lib/detect-mail-platform.test.ts
@@ -1,8 +1,25 @@
 import { describe, expect, it } from "vitest";
 import {
+  detectIsIosUserAgent,
   detectMailPlatform,
   getMailAppChoiceOptions,
 } from "./detect-mail-platform";
+
+describe("detectIsIosUserAgent", () => {
+  it("detects iPhone user agents", () => {
+    expect(
+      detectIsIosUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for macOS desktop user agents", () => {
+    expect(
+      detectIsIosUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
+    ).toBe(false);
+  });
+});
 
 describe("detectMailPlatform", () => {
   it("detects macOS user agents", () => {

--- a/apps/mediapulse/user-registration/lib/detect-mail-platform.ts
+++ b/apps/mediapulse/user-registration/lib/detect-mail-platform.ts
@@ -2,6 +2,15 @@
 export type MailPlatform = "macos" | "windows" | "other";
 
 /**
+ * Returns whether the user agent belongs to an iOS device (iPhone, iPad, or iPod).
+ *
+ * @param userAgent - Browser user agent string.
+ * @returns True when the client is iOS Safari or another iOS browser.
+ */
+export const detectIsIosUserAgent = (userAgent: string): boolean =>
+  /iPhone|iPad|iPod/i.test(userAgent);
+
+/**
  * Detects the user's platform from the browser user agent for mail-app labels.
  *
  * @param userAgent - Browser user agent string.

--- a/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
@@ -40,7 +40,7 @@ describe("buildMailtoUrl", () => {
 });
 
 describe("buildOutlookComposeUrl", () => {
-  it("returns an ms-outlook compose URL", () => {
+  it("returns an ms-outlook compose URL with a valid authority", () => {
     const url = buildOutlookComposeUrl(
       ticker,
       "Jane Doe",
@@ -48,8 +48,23 @@ describe("buildOutlookComposeUrl", () => {
       "registration@test.example",
     );
 
-    expect(url.startsWith("ms-outlook:compose?")).toBe(true);
+    expect(url.startsWith("ms-outlook://compose?")).toBe(true);
     expect(url).toContain("to=registration%40test.example");
+  });
+
+  it("uses the iOS Outlook deep link path for iPhone user agents", () => {
+    const url = buildOutlookComposeUrl(
+      ticker,
+      "Jane Doe",
+      "en",
+      "registration@test.example",
+      {
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      },
+    );
+
+    expect(url.startsWith("ms-outlook://emails/new?")).toBe(true);
   });
 });
 

--- a/apps/mediapulse/user-registration/lib/mail-app-urls.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.ts
@@ -1,5 +1,10 @@
+import { detectIsIosUserAgent } from "@/lib/detect-mail-platform";
 import type { RegistrationLanguage, Ticker } from "@/lib/tickers";
 import { MAILTO_BODY_SECTION_SEPARATOR } from "@/lib/tickers";
+
+export type OutlookComposeUrlOptions = {
+  userAgent?: string;
+};
 
 type MailDraftInput = {
   ticker: Ticker;
@@ -63,6 +68,7 @@ export const buildMailtoUrl = (
  * @param name - Subscriber display name.
  * @param language - Preferred newsletter language code.
  * @param registrationEmail - Target inbox for registration.
+ * @param options - Optional client hints for platform-specific Outlook paths.
  * @returns Encoded ms-outlook compose URL string.
  */
 export const buildOutlookComposeUrl = (
@@ -70,6 +76,7 @@ export const buildOutlookComposeUrl = (
   name: string,
   language: RegistrationLanguage,
   registrationEmail: string = "mediapulse@hyperjump.tech",
+  options: OutlookComposeUrlOptions = {},
 ): string => {
   const { subject, body } = buildRegistrationMailDraft({
     ticker,
@@ -84,7 +91,12 @@ export const buildOutlookComposeUrl = (
     body,
   });
 
-  return `ms-outlook:compose?${params.toString()}`;
+  const composePath =
+    options.userAgent && detectIsIosUserAgent(options.userAgent)
+      ? "emails/new"
+      : "compose";
+
+  return `ms-outlook://${composePath}?${params.toString()}`;
 };
 
 /**

--- a/dev-docs/docs/mediapulse/apps/user-registration.mdx
+++ b/dev-docs/docs/mediapulse/apps/user-registration.mdx
@@ -20,7 +20,7 @@ When you implement real signups, create **`MediapulseUser`** rows (and `user_tic
 
 After the user fills in name, language, and ticker and clicks **Subscribe**, a modal offers platform-aware mail-app choices:
 
-- **Microsoft Outlook** — opens an `ms-outlook:compose` draft (Outlook must be installed).
+- **Microsoft Outlook** — opens an `ms-outlook://` compose draft (Outlook must be installed; iOS uses `ms-outlook://emails/new`).
 - **Apple Mail / Windows Mail / Default mail app** — opens the existing `mailto:` draft flow.
 - **Other** — second modal collects the user's email address; MediaPulse sends a confirmation link via Resend.
 


### PR DESCRIPTION
## Summary

iOS Safari was rejecting the Outlook signup deep link with “the address is invalid” because we built `ms-outlook:compose?…` without the `//` authority. This change uses valid `ms-outlook://` URLs and routes iPhone/iPad clients to `ms-outlook://emails/new`, which current Outlook mobile expects.

## Important changes

- `buildOutlookComposeUrl` now emits `ms-outlook://compose?…` on desktop and `ms-outlook://emails/new?…` on iOS.
- Added `detectIsIosUserAgent` and pass `navigator.userAgent` from the subscribe modal hook.
- Tests and user-registration docs updated.

## How to test

1. On an iPhone with Outlook installed, open the user-registration signup page.
2. Complete the form, choose **Microsoft Outlook**, and confirm Safari opens Outlook with a prefilled draft (no invalid-address alert).
3. On macOS Safari, repeat and confirm `ms-outlook://compose` still opens Outlook.

## Related issues

Closes #837
