### PR TITLE
Prefill name and language when subscribing to another ticker

### DIFF
--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -125,6 +125,34 @@ describe("RegistrationForm", () => {
     ).toBeInTheDocument();
   });
 
+  it("keeps name and language when subscribing to another ticker", async () => {
+    const user = userEvent.setup();
+    render(<RegistrationForm tickers={sampleTickers} />);
+
+    await user.type(
+      screen.getByLabelText(/What should we call you\?/i),
+      "John Doe",
+    );
+    await user.selectOptions(
+      screen.getByLabelText(/Newsletter language/i),
+      "id",
+    );
+    await user.click(screen.getByLabelText(/Stock ticker/i));
+    await user.click(screen.getByText(/Bank Central Asia Tbk/i));
+    await user.click(screen.getByRole("button", { name: /^Subscribe$/i }));
+    await user.click(screen.getByRole("button", { name: /Apple Mail/i }));
+
+    await user.click(
+      screen.getByRole("button", { name: /Subscribe to another ticker/i }),
+    );
+
+    expect(screen.getByLabelText(/What should we call you\?/i)).toHaveValue(
+      "John Doe",
+    );
+    expect(screen.getByLabelText(/Newsletter language/i)).toHaveValue("id");
+    expect(screen.getByLabelText(/Stock ticker/i)).toHaveValue("");
+  });
+
   it("triggers a vCard download when download contact card is clicked", async () => {
     const user = userEvent.setup();
     render(<RegistrationForm tickers={sampleTickers} />);

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
@@ -97,7 +97,7 @@ describe("useRegistrationForm", () => {
     expect(result.current.submissionMode).toBe("mailto");
   });
 
-  it("resets form when resetForm is called", () => {
+  it("keeps name and language when resetForm is called after submit", () => {
     const { result } = renderHook(() => useRegistrationForm(sampleTickers));
 
     act(() => {
@@ -111,8 +111,10 @@ describe("useRegistrationForm", () => {
       result.current.resetForm();
     });
 
-    expect(result.current.name).toBe("");
-    expect(result.current.language).toBe("en");
+    expect(result.current.name).toBe("Test");
+    expect(result.current.language).toBe("id");
+    expect(result.current.query).toBe("");
+    expect(result.current.selectedTicker).toBeNull();
     expect(result.current.submitted).toBe(false);
     expect(result.current.mailChoiceOpen).toBe(false);
   });

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.ts
@@ -112,14 +112,16 @@ export const useRegistrationForm = (tickers: Ticker[]) => {
     openMailChoiceModal();
   };
 
+  /**
+   * Returns to the registration form for another ticker while keeping name and language.
+   */
   const resetForm = () => {
     setSubmitted(false);
     setSubmissionMode("mailto");
     setConfirmationEmailState("");
-    setName("");
-    setLanguage("en");
     setQuery("");
     setSelectedTicker(null);
+    setOpen(false);
     resetSubscribeModals();
   };
 


### PR DESCRIPTION
## Summary

When someone finishes subscribing and taps **Subscribe to another ticker**, the form now keeps their name and newsletter language. Only the ticker field is cleared so they can pick a different stock.

## Important changes

- `resetForm` in `use-registration-form` no longer wipes name or language when starting another subscription.
- Ticker query and selection are still cleared, and modals reset as before.
- Hook and component tests assert the preserved fields.

## How to test

1. Open the user-registration app.
2. Fill in name, language, and a ticker, then complete a subscription.
3. Click **Subscribe to another ticker**.
4. Confirm name and language are still filled; ticker field is empty.

## Related issues

Closes #839
