### PR TITLE
Fix Outlook compose URL showing + instead of spaces

### DIFF
--- a/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
@@ -50,6 +50,8 @@ describe("buildOutlookComposeUrl", () => {
 
     expect(url.startsWith("ms-outlook://compose?")).toBe(true);
     expect(url).toContain("to=registration%40test.example");
+    expect(url).toContain(encodeURIComponent("Name: Jane Doe"));
+    expect(url).not.toMatch(/[?&][^=]*\+/);
   });
 
   it("uses the iOS Outlook deep link path for iPhone user agents", () => {

--- a/apps/mediapulse/user-registration/lib/mail-app-urls.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.ts
@@ -85,18 +85,14 @@ export const buildOutlookComposeUrl = (
     registrationEmail,
   });
 
-  const params = new URLSearchParams({
-    to: registrationEmail,
-    subject,
-    body,
-  });
-
   const composePath =
     options.userAgent && detectIsIosUserAgent(options.userAgent)
       ? "emails/new"
       : "compose";
 
-  return `ms-outlook://${composePath}?${params.toString()}`;
+  // Use encodeURIComponent (not URLSearchParams) so spaces become %20 instead of +.
+  // Outlook on iOS displays literal + signs when + is used for whitespace.
+  return `ms-outlook://${composePath}?to=${encodeURIComponent(registrationEmail)}&subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
 };
 
 /**


### PR DESCRIPTION
## Summary

Outlook on iOS was showing `+` signs everywhere the registration draft should have spaces. The compose URL was built with `URLSearchParams`, which encodes whitespace as `+`. Outlook treats those literally instead of decoding them.

This switches Outlook compose URLs to `encodeURIComponent` (same approach as `mailto:`), so spaces become `%20`. The iOS-specific `ms-outlook://emails/new` path is unchanged.

## Important changes

- `buildOutlookComposeUrl` now encodes `to`, `subject`, and `body` with `encodeURIComponent` instead of `URLSearchParams`.
- Added a test asserting the URL does not contain `+` in query values.

## How to test

1. Open user-registration on an iPhone (or simulate iOS user agent).
2. Start a newsletter subscription and choose Outlook.
3. Confirm the draft subject and body show normal spaces, not `+` characters.

## Related issues

Closes #841
