### PR TITLE
Fix Outlook compose on macOS in user registration

### DIFF
--- a/apps/mediapulse/user-registration/lib/detect-mail-platform.test.ts
+++ b/apps/mediapulse/user-registration/lib/detect-mail-platform.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   detectIsIosUserAgent,
+  detectIsMacOsUserAgent,
   detectMailPlatform,
   getMailAppChoiceOptions,
 } from "./detect-mail-platform";
@@ -18,6 +19,28 @@ describe("detectIsIosUserAgent", () => {
     expect(
       detectIsIosUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)"),
     ).toBe(false);
+  });
+});
+
+describe("detectIsMacOsUserAgent", () => {
+  it("detects macOS desktop user agents", () => {
+    expect(
+      detectIsMacOsUserAgent(
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false for iPhone user agents that include Mac OS X", () => {
+    expect(
+      detectIsMacOsUserAgent(
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for Windows user agents", () => {
+    expect(detectIsMacOsUserAgent("Mozilla/5.0 (Windows NT 10.0)")).toBe(false);
   });
 });
 
@@ -45,6 +68,7 @@ describe("getMailAppChoiceOptions", () => {
       "native-mail",
       "other",
     ]);
+    expect(options[0]?.description).toContain("default mail app");
   });
 
   it("returns Outlook, Windows Mail, and Other on Windows", () => {

--- a/apps/mediapulse/user-registration/lib/detect-mail-platform.ts
+++ b/apps/mediapulse/user-registration/lib/detect-mail-platform.ts
@@ -11,6 +11,15 @@ export const detectIsIosUserAgent = (userAgent: string): boolean =>
   /iPhone|iPad|iPod/i.test(userAgent);
 
 /**
+ * Returns whether the user agent belongs to macOS desktop (not iOS).
+ *
+ * @param userAgent - Browser user agent string.
+ * @returns True when the client is macOS Safari, Chrome, or another desktop browser.
+ */
+export const detectIsMacOsUserAgent = (userAgent: string): boolean =>
+  /Macintosh|Mac OS X/i.test(userAgent) && !detectIsIosUserAgent(userAgent);
+
+/**
  * Detects the user's platform from the browser user agent for mail-app labels.
  *
  * @param userAgent - Browser user agent string.
@@ -44,7 +53,10 @@ export const getMailAppChoiceOptions = (
   const outlook: MailAppChoiceOption = {
     id: "outlook",
     title: "Microsoft Outlook",
-    description: "Opens a draft in Outlook. Make sure Outlook is installed.",
+    description:
+      platform === "macos"
+        ? "Opens a draft in Outlook. Set Outlook as your default mail app if Mail opens instead."
+        : "Opens a draft in Outlook. Make sure Outlook is installed.",
   };
 
   const other: MailAppChoiceOption = {

--- a/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.test.ts
@@ -68,6 +68,22 @@ describe("buildOutlookComposeUrl", () => {
 
     expect(url.startsWith("ms-outlook://emails/new?")).toBe(true);
   });
+
+  it("uses mailto on macOS desktop because Outlook for Mac lacks ms-outlook://", () => {
+    const url = buildOutlookComposeUrl(
+      ticker,
+      "Jane Doe",
+      "en",
+      "registration@test.example",
+      {
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36",
+      },
+    );
+
+    expect(url.startsWith("mailto:registration@test.example?")).toBe(true);
+    expect(url).not.toContain("ms-outlook://");
+  });
 });
 
 describe("openMailClientUrl", () => {

--- a/apps/mediapulse/user-registration/lib/mail-app-urls.ts
+++ b/apps/mediapulse/user-registration/lib/mail-app-urls.ts
@@ -1,4 +1,7 @@
-import { detectIsIosUserAgent } from "@/lib/detect-mail-platform";
+import {
+  detectIsIosUserAgent,
+  detectIsMacOsUserAgent,
+} from "@/lib/detect-mail-platform";
 import type { RegistrationLanguage, Ticker } from "@/lib/tickers";
 import { MAILTO_BODY_SECTION_SEPARATOR } from "@/lib/tickers";
 
@@ -69,7 +72,7 @@ export const buildMailtoUrl = (
  * @param language - Preferred newsletter language code.
  * @param registrationEmail - Target inbox for registration.
  * @param options - Optional client hints for platform-specific Outlook paths.
- * @returns Encoded ms-outlook compose URL string.
+ * @returns Encoded ms-outlook compose URL string, or mailto on macOS desktop.
  */
 export const buildOutlookComposeUrl = (
   ticker: Ticker,
@@ -84,6 +87,11 @@ export const buildOutlookComposeUrl = (
     language,
     registrationEmail,
   });
+
+  // Outlook for Mac does not register ms-outlook://; mailto opens the default mail app.
+  if (options.userAgent && detectIsMacOsUserAgent(options.userAgent)) {
+    return buildMailtoUrl(ticker, name, language, registrationEmail);
+  }
 
   const composePath =
     options.userAgent && detectIsIosUserAgent(options.userAgent)

--- a/dev-docs/docs/mediapulse/apps/user-registration.mdx
+++ b/dev-docs/docs/mediapulse/apps/user-registration.mdx
@@ -20,7 +20,7 @@ When you implement real signups, create **`MediapulseUser`** rows (and `user_tic
 
 After the user fills in name, language, and ticker and clicks **Subscribe**, a modal offers platform-aware mail-app choices:
 
-- **Microsoft Outlook** — opens an `ms-outlook://` compose draft (Outlook must be installed; iOS uses `ms-outlook://emails/new`).
+- **Microsoft Outlook** — opens an `ms-outlook://` compose draft on mobile and Windows (Outlook must be installed; iOS uses `ms-outlook://emails/new`). On macOS desktop, Outlook does not register that scheme, so the app uses `mailto:` instead (Outlook opens when it is the default mail handler).
 - **Apple Mail / Windows Mail / Default mail app** — opens the existing `mailto:` draft flow.
 - **Other** — second modal collects the user's email address; MediaPulse sends a confirmation link via Resend.
 


### PR DESCRIPTION
## Summary

Choosing Microsoft Outlook on macOS did nothing because Outlook for Mac never registers the `ms-outlook://` handler. The registration flow now falls back to `mailto:` on desktop Mac, which opens Outlook when it is the default mail app.

## Related issues

Closes #845

## Important changes

- `buildOutlookComposeUrl` returns a `mailto:` URL on macOS desktop instead of `ms-outlook://compose`.
- Added `detectIsMacOsUserAgent` so iPhone/iPad agents still get the iOS deep link.
- Updated the Outlook option description on macOS to mention the default mail app requirement.

## Other changes

- Dev docs updated to describe platform-specific Outlook behavior.

## Key files to review

- `apps/mediapulse/user-registration/lib/mail-app-urls.ts` — macOS mailto fallback in Outlook path.
- `apps/mediapulse/user-registration/lib/detect-mail-platform.ts` — macOS desktop detection and modal copy.
- `apps/mediapulse/user-registration/lib/mail-app-urls.test.ts` — macOS fallback coverage.

## How to test

1. On a Mac, open the user-registration app and complete the subscribe form.
2. Choose **Microsoft Outlook** in the mail-app modal.
3. Confirm a compose window opens (Outlook if it is the default mail handler, otherwise the system default).
4. Run `pnpm --filter @mediapulse/user-registration test` — all tests should pass.
