### PR TITLE
Add email fallback note after mail-app signup choice

### DIFF
--- a/apps/mediapulse/user-registration/components/registration-form.test.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.test.tsx
@@ -109,7 +109,9 @@ describe("RegistrationForm", () => {
 
     expect(vi.mocked(openMailClientUrl)).toHaveBeenCalledTimes(1);
     expect(screen.getByText(/Almost done/i)).toBeInTheDocument();
-    expect(screen.getByText(/Send/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/on the draft in your email app to subscribe/i),
+    ).toBeInTheDocument();
   });
 
   it("shows spam/junk reassurance text after mail-app submit", async () => {
@@ -122,6 +124,36 @@ describe("RegistrationForm", () => {
     expect(screen.getByText(/spam|junk/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /Download contact card/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows email fallback when the mail app did not open", async () => {
+    const user = userEvent.setup();
+    render(<RegistrationForm tickers={sampleTickers} />);
+
+    await fillAndSubmitForm(user);
+    await user.click(screen.getByRole("button", { name: /Apple Mail/i }));
+
+    expect(
+      screen.getByText(/If your email app did not open/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Send confirmation email/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the confirmation email modal from the mail-app fallback", async () => {
+    const user = userEvent.setup();
+    render(<RegistrationForm tickers={sampleTickers} />);
+
+    await fillAndSubmitForm(user);
+    await user.click(screen.getByRole("button", { name: /Apple Mail/i }));
+    await user.click(
+      screen.getByRole("button", { name: /Send confirmation email/i }),
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: /Confirm by email/i }),
     ).toBeInTheDocument();
   });
 

--- a/apps/mediapulse/user-registration/components/registration-form.tsx
+++ b/apps/mediapulse/user-registration/components/registration-form.tsx
@@ -78,6 +78,7 @@ const RegistrationForm = ({ tickers }: Props) => {
     handleSelectOutlook,
     handleSelectNativeMail,
     handleSelectOther,
+    openEmailConfirmationFallback,
     handleSendConfirmationEmail,
   } = useRegistrationForm(tickers);
 
@@ -104,30 +105,59 @@ const RegistrationForm = ({ tickers }: Props) => {
     }
 
     return (
-      <div className="flex flex-col items-center gap-6 text-center">
-        <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
-          <Mail className="size-8" aria-hidden />
-        </div>
-        <div className="space-y-1">
-          <h1 className="text-xl font-bold">Almost done</h1>
-          <p className="text-sm text-muted-foreground">
-            Tap <strong>Send</strong> on the draft in your email app to
-            subscribe for <strong>{selectedTicker?.KodeEmiten}</strong>.
-          </p>
-        </div>
-        <div className="w-full rounded-lg border bg-muted/30 px-4 py-3 space-y-3">
-          <p className="text-sm text-muted-foreground">
-            Save MediaPulse to your contacts so newsletters land in your inbox,
-            not spam or junk.
-          </p>
-          <Button variant="outline" className="w-full" onClick={downloadVCard}>
-            Download contact card
+      <>
+        <div className="flex flex-col items-center gap-6 text-center">
+          <div className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Mail className="size-8" aria-hidden />
+          </div>
+          <div className="space-y-1">
+            <h1 className="text-xl font-bold">Almost done</h1>
+            <p className="text-sm text-muted-foreground">
+              Tap <strong>Send</strong> on the draft in your email app to
+              subscribe for <strong>{selectedTicker?.KodeEmiten}</strong>.
+            </p>
+          </div>
+          <div className="w-full rounded-lg border bg-muted/30 px-4 py-3 space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Save MediaPulse to your contacts so newsletters land in your
+              inbox, not spam or junk.
+            </p>
+            <Button
+              variant="outline"
+              className="w-full"
+              onClick={downloadVCard}
+            >
+              Download contact card
+            </Button>
+          </div>
+          <div className="w-full rounded-lg border border-dashed px-4 py-3 space-y-3">
+            <p className="text-sm text-muted-foreground">
+              If your email app did not open, enter your email address and
+              MediaPulse will send you a confirmation link instead.
+            </p>
+            <Button
+              variant="secondary"
+              className="w-full"
+              onClick={openEmailConfirmationFallback}
+            >
+              Send confirmation email
+            </Button>
+          </div>
+          <Button variant="ghost" size="sm" onClick={resetForm}>
+            Subscribe to another ticker
           </Button>
         </div>
-        <Button variant="ghost" size="sm" onClick={resetForm}>
-          Subscribe to another ticker
-        </Button>
-      </div>
+
+        <SendConfirmationEmailModal
+          open={confirmEmailOpen}
+          onOpenChange={setConfirmEmailOpen}
+          email={modalConfirmationEmail}
+          onEmailChange={setConfirmationEmail}
+          onSendEmail={handleSendConfirmationEmail}
+          sending={sendingEmail}
+          tickerSymbol={selectedTicker?.KodeEmiten}
+        />
+      </>
     );
   }
 

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.test.ts
@@ -97,6 +97,27 @@ describe("useRegistrationForm", () => {
     expect(result.current.submissionMode).toBe("mailto");
   });
 
+  it("opens email confirmation fallback from mail-app submit state", () => {
+    const { result } = renderHook(() => useRegistrationForm(sampleTickers));
+
+    act(() => {
+      result.current.setName("Test User");
+      result.current.handleTickerSelect(sampleTickers[1]!);
+    });
+
+    act(() => {
+      result.current.handleSelectNativeMail();
+    });
+
+    act(() => {
+      result.current.openEmailConfirmationFallback();
+    });
+
+    expect(result.current.confirmEmailOpen).toBe(true);
+    expect(result.current.submitted).toBe(true);
+    expect(result.current.submissionMode).toBe("mailto");
+  });
+
   it("keeps name and language when resetForm is called after submit", () => {
     const { result } = renderHook(() => useRegistrationForm(sampleTickers));
 

--- a/apps/mediapulse/user-registration/hooks/use-registration-form.ts
+++ b/apps/mediapulse/user-registration/hooks/use-registration-form.ts
@@ -55,6 +55,7 @@ export const useRegistrationForm = (tickers: Ticker[]) => {
     handleSelectOutlook,
     handleSelectNativeMail,
     handleSelectOther,
+    openEmailConfirmationFallback,
     handleSendConfirmationEmail,
     resetSubscribeModals,
   } = useSubscribeMailAppModal({
@@ -154,6 +155,7 @@ export const useRegistrationForm = (tickers: Ticker[]) => {
     handleSelectOutlook,
     handleSelectNativeMail,
     handleSelectOther,
+    openEmailConfirmationFallback,
     handleSendConfirmationEmail,
   };
 };

--- a/apps/mediapulse/user-registration/hooks/use-subscribe-mail-app-modal.ts
+++ b/apps/mediapulse/user-registration/hooks/use-subscribe-mail-app-modal.ts
@@ -145,6 +145,13 @@ export const useSubscribeMailAppModal = ({
   };
 
   /**
+   * Opens the email confirmation modal when the mail-app path did not launch.
+   */
+  const openEmailConfirmationFallback = () => {
+    setConfirmEmailOpen(true);
+  };
+
+  /**
    * Sends the confirmation email via the server route.
    */
   const handleSendConfirmationEmail = async () => {
@@ -192,6 +199,7 @@ export const useSubscribeMailAppModal = ({
     handleSelectOutlook,
     handleSelectNativeMail,
     handleSelectOther,
+    openEmailConfirmationFallback,
     handleSendConfirmationEmail,
     resetSubscribeModals,
   };

--- a/dev-docs/docs/mediapulse/apps/user-registration.mdx
+++ b/dev-docs/docs/mediapulse/apps/user-registration.mdx
@@ -26,6 +26,8 @@ After the user fills in name, language, and ticker and clicks **Subscribe**, a m
 
 Both paths converge on the same `user_ticker` rows in the Mediapulse database.
 
+After choosing Outlook or another mail app, the **Almost done** screen explains that if the mail app did not open, the user can enter their email address and MediaPulse will send a confirmation link instead.
+
 ## Ingesting Registrations (Agent)
 
 Signups are processed asynchronously through a dedicated Hermes-scheduled backend agent, `user-registration`.


### PR DESCRIPTION
## Summary

Users who pick Outlook or another mail app on signup now see a clear fallback on the **Almost done** screen if their email client did not open. They can enter their address and MediaPulse will send a confirmation link, using the same modal as the **Other** path.

## Important changes

- Added fallback copy and a **Send confirmation email** button on the mail-app success screen
- Wired the button to the existing confirmation email modal without leaving the submitted state
- Extended unit tests and dev-docs for the new recovery path

## How to test

1. Open the user registration app and complete the form (name, language, ticker).
2. Choose **Microsoft Outlook** or **Apple Mail** / **Default mail app**.
3. On **Almost done**, confirm the dashed fallback box explains what to do if the mail app did not open.
4. Click **Send confirmation email** and verify the confirmation modal opens.
5. Enter an email and send; confirm the **Check your email** screen appears.

## Related issues

Closes #847
