### PR TITLE
Re-add Diffbot, Firecrawl, and Jina to data-collection fetch pool

### DIFF
--- a/apps/mediapulse/agents/data-collection/README.md
+++ b/apps/mediapulse/agents/data-collection/README.md
@@ -6,10 +6,11 @@ Collects web sources for a ticker through one linear pipeline:
 get queries → search → fetch → filter → save  (repeat until the daily target)
 ```
 
-Search and fetch each run over a round-robin pool of providers (Serper, Tavily, Exa) with
-failover. The filter drops duplicates, thin content, and stale pages cheaply, then judges
-relevance with an LLM against the agent contract brief (falling back to keyword matching).
-Results are persisted to the Agent Data API.
+Search and fetch each run over a round-robin pool of providers with failover. Search uses
+Serper, Tavily, and Exa; fetch adds the fetch-only providers Diffbot, Firecrawl, and Jina.
+The filter drops duplicates, thin content, and stale pages cheaply, then judges relevance with
+an LLM against the agent contract brief (falling back to keyword matching). Results are
+persisted to the Agent Data API.
 
 ## Configuration
 
@@ -19,14 +20,17 @@ An empty `{}` validates into the recommended end-to-end setup; override only wha
 
 Create these variables in Hermes so placeholder defaults resolve at run time:
 
-| Variable         | Used for                                        |
-| ---------------- | ----------------------------------------------- |
-| `SERPER_API_KEY` | Serper search and fetch provider                |
-| `TAVILY_API_KEY` | Tavily search and fetch provider                |
-| `EXA_API_KEY`    | Exa search and fetch provider                   |
-| `AI_API_KEY`     | LLM relevance filter (OpenAI-compatible key)    |
-| `AI_MODEL`       | LLM relevance filter model id                   |
-| `AI_BASE_URL`    | LLM relevance filter base URL (e.g. OpenRouter) |
+| Variable            | Used for                                        |
+| ------------------- | ----------------------------------------------- |
+| `SERPER_API_KEY`    | Serper search and fetch provider                |
+| `TAVILY_API_KEY`    | Tavily search and fetch provider                |
+| `EXA_API_KEY`       | Exa search and fetch provider                   |
+| `DIFFBOT_API_KEY`   | Diffbot fetch provider (fetch-only)             |
+| `FIRECRAWL_API_KEY` | Firecrawl fetch provider (fetch-only)           |
+| `JINA_API_KEY`      | Jina Reader fetch provider (fetch-only)         |
+| `AI_API_KEY`        | LLM relevance filter (OpenAI-compatible key)    |
+| `AI_MODEL`          | LLM relevance filter model id                   |
+| `AI_BASE_URL`       | LLM relevance filter base URL (e.g. OpenRouter) |
 
 If a variable is missing, the literal `{{NAME}}` is passed through and the affected provider
 fails with a clear auth error.
@@ -36,7 +40,8 @@ fails with a clear auth error.
 1. **web_search** — round-robin search provider pool (`{ provider, apiKey }` entries).
 2. **web_search_locales** — `{ gl, hl }` locales the query fans out across. gl/hl steer Serper,
    map to Tavily's country, and are ignored by Exa.
-3. **web_fetch** — round-robin fetch provider pool (`{ provider, apiKey }` entries).
+3. **web_fetch** — round-robin fetch provider pool (`{ provider, apiKey }` entries). Accepts the
+   search providers plus the fetch-only Diffbot, Firecrawl, and Jina.
 4. **relevance** — LLM filter credentials (`apiKey`, `model`, optional `baseUrl`).
 5. **collection** — `targetSavedSources` (default 15) and `maxRounds` (default 3) for the repeat loop.
 

--- a/apps/mediapulse/agents/data-collection/config.example.jsonc
+++ b/apps/mediapulse/agents/data-collection/config.example.jsonc
@@ -16,10 +16,14 @@
   "web_search_locales": [{ "gl": "id", "hl": "id" }],
 
   // Web-fetch provider pool. Same round-robin + failover behavior.
+  // Diffbot, Firecrawl, and Jina are fetch-only (no search support).
   "web_fetch": [
     { "provider": "serper", "apiKey": "{{SERPER_API_KEY}}" },
     { "provider": "tavily", "apiKey": "{{TAVILY_API_KEY}}" },
     { "provider": "exa", "apiKey": "{{EXA_API_KEY}}" },
+    { "provider": "diffbot", "apiKey": "{{DIFFBOT_API_KEY}}" },
+    { "provider": "firecrawl", "apiKey": "{{FIRECRAWL_API_KEY}}" },
+    { "provider": "jina", "apiKey": "{{JINA_API_KEY}}" },
   ],
 
   // LLM relevance filter (OpenAI-compatible). Judges each fetched page against

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -52,6 +52,9 @@ describe("dataCollectionAgentConfigSchema", () => {
       "serper",
       "tavily",
       "exa",
+      "diffbot",
+      "firecrawl",
+      "jina",
     ]);
     expect(parsed.web_search_locales).toEqual([{ gl: "id", hl: "id" }]);
     expect(parsed.relevance).toEqual({
@@ -80,7 +83,7 @@ describe("dataCollectionAgentConfigSchema", () => {
 
     expect(parsed.collection.maxRounds).toBe(5);
     expect(parsed.collection.targetSavedSources).toBe(15);
-    expect(parsed.web_fetch).toHaveLength(3);
+    expect(parsed.web_fetch).toHaveLength(6);
   });
 
   it("accepts a custom provider pool", () => {
@@ -101,6 +104,30 @@ describe("dataCollectionAgentConfigSchema", () => {
     ).toThrow();
     expect(() =>
       dataCollectionAgentConfigSchema.parse({ web_fetch: [] }),
+    ).toThrow();
+  });
+
+  it("accepts the fetch-only providers in web_fetch", () => {
+    const parsed = dataCollectionAgentConfigSchema.parse({
+      web_fetch: [
+        { provider: "diffbot", apiKey: "diff-key" },
+        { provider: "firecrawl", apiKey: "fire-key" },
+        { provider: "jina", apiKey: "jina-key" },
+      ],
+    });
+
+    expect(parsed.web_fetch.map((entry) => entry.provider)).toEqual([
+      "diffbot",
+      "firecrawl",
+      "jina",
+    ]);
+  });
+
+  it("rejects fetch-only providers in web_search", () => {
+    expect(() =>
+      dataCollectionAgentConfigSchema.parse({
+        web_search: [{ provider: "jina", apiKey: "k" }],
+      }),
     ).toThrow();
   });
 

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -1,12 +1,24 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
-/** Web providers that support both search and fetch in this agent. */
+/** Web providers that support search. Search adapters exist only for these. */
 export const providerNameSchema = z.enum(["serper", "tavily", "exa"]);
 
 export type ProviderName = z.infer<typeof providerNameSchema>;
 
-/** A single provider entry: the operator only picks a provider and pastes an API key. */
+/** Web providers usable for fetch. Diffbot, Firecrawl, and Jina are fetch-only. */
+export const fetchProviderNameSchema = z.enum([
+  "serper",
+  "tavily",
+  "exa",
+  "diffbot",
+  "firecrawl",
+  "jina",
+]);
+
+export type FetchProviderName = z.infer<typeof fetchProviderNameSchema>;
+
+/** A single search provider entry: the operator only picks a provider and pastes an API key. */
 const providerEntrySchema = z.object({
   provider: providerNameSchema.describe("Provider identifier."),
   apiKey: z
@@ -18,11 +30,33 @@ const providerEntrySchema = z.object({
 
 export type ProviderEntry = z.infer<typeof providerEntrySchema>;
 
-/** Default round-robin pool used for both web search and web fetch. */
+/** A single fetch provider entry: the operator only picks a provider and pastes an API key. */
+const fetchProviderEntrySchema = z.object({
+  provider: fetchProviderNameSchema.describe("Fetch provider identifier."),
+  apiKey: z
+    .string()
+    .describe(
+      "Provider API key or a Hermes variable placeholder such as {{SERPER_API_KEY}}.",
+    ),
+});
+
+export type FetchProviderEntry = z.infer<typeof fetchProviderEntrySchema>;
+
+/** Default round-robin pool used for web search (search-capable providers only). */
 const defaultProviderPool: ProviderEntry[] = [
   { provider: "serper", apiKey: "{{SERPER_API_KEY}}" },
   { provider: "tavily", apiKey: "{{TAVILY_API_KEY}}" },
   { provider: "exa", apiKey: "{{EXA_API_KEY}}" },
+];
+
+/** Default round-robin pool used for web fetch, including the fetch-only providers. */
+const defaultFetchProviderPool: FetchProviderEntry[] = [
+  { provider: "serper", apiKey: "{{SERPER_API_KEY}}" },
+  { provider: "tavily", apiKey: "{{TAVILY_API_KEY}}" },
+  { provider: "exa", apiKey: "{{EXA_API_KEY}}" },
+  { provider: "diffbot", apiKey: "{{DIFFBOT_API_KEY}}" },
+  { provider: "firecrawl", apiKey: "{{FIRECRAWL_API_KEY}}" },
+  { provider: "jina", apiKey: "{{JINA_API_KEY}}" },
 ];
 
 const webSearchSchema = z
@@ -34,9 +68,9 @@ const webSearchSchema = z
   );
 
 const webFetchSchema = z
-  .array(providerEntrySchema)
+  .array(fetchProviderEntrySchema)
   .min(1)
-  .default([...defaultProviderPool])
+  .default([...defaultFetchProviderPool])
   .describe(
     "Web-fetch provider pool. Each request rotates the starting provider (round-robin) and falls back to the rest on failure.",
   );

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.test.ts
@@ -1,0 +1,72 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { buildFetchProviderConfigs } from "./fetch-provider-config";
+
+describe("buildFetchProviderConfigs", () => {
+  it("expands the fetch-only providers to their transport defaults", () => {
+    const configs = buildFetchProviderConfigs([
+      { provider: "diffbot", apiKey: "diff-key" },
+      { provider: "firecrawl", apiKey: "fire-key" },
+      { provider: "jina", apiKey: "jina-key" },
+    ]);
+
+    expect(configs).toEqual([
+      {
+        type: "diffbot",
+        baseUrl: "https://api.diffbot.com",
+        authentication: { type: "none", apiKey: "diff-key" },
+        rateLimit: { requests: 1, perSeconds: 1 },
+        concurrency: 1,
+        timeoutMs: 45_000,
+        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+      },
+      {
+        type: "firecrawl",
+        baseUrl: "https://api.firecrawl.dev",
+        authentication: {
+          type: "bearer",
+          headerName: "Authorization",
+          apiKey: "fire-key",
+        },
+        rateLimit: { requests: 1, perSeconds: 1 },
+        concurrency: 1,
+        timeoutMs: 45_000,
+        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+      },
+      {
+        type: "jina",
+        baseUrl: "https://r.jina.ai/",
+        authentication: {
+          type: "bearer",
+          headerName: "Authorization",
+          apiKey: "jina-key",
+        },
+        rateLimit: { requests: 1, perSeconds: 1 },
+        concurrency: 1,
+        timeoutMs: 45_000,
+        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+      },
+    ]);
+  });
+
+  it("threads the configured API key into the search-capable providers", () => {
+    const configs = buildFetchProviderConfigs([
+      { provider: "serper", apiKey: "serper-key" },
+      { provider: "tavily", apiKey: "tavily-key" },
+      { provider: "exa", apiKey: "exa-key" },
+    ]);
+
+    expect(configs.map((config) => config.type)).toEqual([
+      "serper",
+      "tavily",
+      "exa",
+    ]);
+    expect(configs.map((config) => config.authentication.apiKey)).toEqual([
+      "serper-key",
+      "tavily-key",
+      "exa-key",
+    ]);
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts
@@ -1,14 +1,14 @@
 import type { FetchProviderConfig } from "@workspace/agent-ingestion";
 
 import type {
-  ProviderEntry,
-  ProviderName,
+  FetchProviderEntry,
+  FetchProviderName,
   WebFetchConfig,
 } from "./config-schema";
 
 /** Per-provider fetch transport defaults. The config only supplies the API key. */
 const FETCH_PROVIDER_DEFAULTS: Record<
-  ProviderName,
+  FetchProviderName,
   Pick<FetchProviderConfig, "baseUrl" | "authentication">
 > = {
   serper: {
@@ -22,6 +22,18 @@ const FETCH_PROVIDER_DEFAULTS: Record<
   exa: {
     baseUrl: "https://api.exa.ai/contents",
     authentication: { type: "none", headerName: "x-api-key" },
+  },
+  diffbot: {
+    baseUrl: "https://api.diffbot.com",
+    authentication: { type: "none" },
+  },
+  firecrawl: {
+    baseUrl: "https://api.firecrawl.dev",
+    authentication: { type: "bearer", headerName: "Authorization" },
+  },
+  jina: {
+    baseUrl: "https://r.jina.ai/",
+    authentication: { type: "bearer", headerName: "Authorization" },
   },
 };
 
@@ -39,7 +51,9 @@ const FETCH_RETRY = {
  *
  * @param entry - Provider name and API key from agent config.
  */
-const toFetchProviderConfig = (entry: ProviderEntry): FetchProviderConfig => {
+const toFetchProviderConfig = (
+  entry: FetchProviderEntry,
+): FetchProviderConfig => {
   const defaults = FETCH_PROVIDER_DEFAULTS[entry.provider];
 
   return {


### PR DESCRIPTION
## Summary

#844 collapsed web search and web fetch onto one shared provider enum (`serper`, `tavily`, `exa`), which dropped Diffbot, Firecrawl, and Jina from the fetch chain. This puts those three back in the `web_fetch` pool. Since they have no search adapter, the fetch pool now has its own wider enum instead of reusing the search one.

## Related issues

Closes #851

## Important changes

- Added a separate `fetchProviderNameSchema` (`serper`, `tavily`, `exa`, `diffbot`, `firecrawl`, `jina`) so the fetch pool accepts the fetch-only providers while `web_search` stays limited to the three that can actually search.
- The default `web_fetch` pool now includes all six providers; an empty config validates into that pool.
- Restored transport defaults for Diffbot (`api.diffbot.com`, query-param token), Firecrawl (`api.firecrawl.dev`, bearer), and Jina (`r.jina.ai`, bearer) in the fetch-config builder.

## Other changes

- Documented `DIFFBOT_API_KEY`, `FIRECRAWL_API_KEY`, and `JINA_API_KEY` in the README and added the three providers to `config.example.jsonc`.
- Config keeps the simple `{ provider, apiKey }` shape — no per-provider option knobs.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts` — the search/fetch enum split and default pools.
- `apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts` — transport defaults for the three providers.
- `apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts` and `fetch-provider-config.test.ts` — coverage for accept-in-fetch, reject-in-search, and config expansion.

## How to test

1. `pnpm --filter @mediapulse/data-collection test` — 85 tests pass, including the new fetch-provider cases.
2. `pnpm --filter @mediapulse/data-collection type:check` — clean.
3. Parse an empty config and confirm `web_fetch` resolves to the six-provider pool, and that putting `jina` in `web_search` is rejected.
