### PR TITLE
Fix stuck data-collection activity spinner and simplify the feed

### DIFF
--- a/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
+++ b/apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx
@@ -6,6 +6,7 @@ import {
   ArrowUpDown,
   CheckCircle2,
   Loader2,
+  XCircle,
 } from "lucide-react";
 import { format } from "date-fns";
 
@@ -137,6 +138,7 @@ export const ScheduleExecutionInvocationsTable = ({
   const {
     open: activityOpen,
     jobId: activityJobId,
+    outcome: activityOutcome,
     rows: activityRows,
     loading: activityLoading,
     openModal: openActivityModal,
@@ -260,7 +262,7 @@ export const ScheduleExecutionInvocationsTable = ({
                         variant="ghost"
                         size="sm"
                         onClick={() => {
-                          void openActivityModal(j.jobId);
+                          void openActivityModal(j.jobId, outcome);
                         }}
                       >
                         Show activity
@@ -341,10 +343,18 @@ export const ScheduleExecutionInvocationsTable = ({
           ) : (
             <div className="flex flex-col">
               {activityRows.map((row, index) => {
+                const jobIsActive =
+                  activityOutcome === "running" ||
+                  activityOutcome === "pending";
+                const jobFailed =
+                  activityOutcome === "failure" ||
+                  activityOutcome === "cancelled";
+                const isLastRow = index === activityRows.length - 1;
                 const inProgress = isActivityRowInProgress(
                   row,
                   index,
                   activityRows.length,
+                  jobIsActive,
                 );
                 const showLiveElapsed = inProgress;
                 const durationLabel =
@@ -368,6 +378,8 @@ export const ScheduleExecutionInvocationsTable = ({
                         ) : null}
                         {inProgress ? (
                           <Loader2 className="size-4 animate-spin text-muted-foreground" />
+                        ) : isLastRow && jobFailed ? (
+                          <XCircle className="size-4 text-destructive" />
                         ) : (
                           <CheckCircle2 className="size-4 text-green-500" />
                         )}

--- a/apps/hermes/dashboard/components/use-agent-activity-modal.ts
+++ b/apps/hermes/dashboard/components/use-agent-activity-modal.ts
@@ -18,31 +18,37 @@ export type { ActivityRow } from "@/lib/derive-activity-row-durations";
 export const useAgentActivityModal = () => {
   const [open, setOpen] = useState(false);
   const [jobId, setJobId] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState<string | null>(null);
   const [rows, setRows] = useState<ActivityRow[] | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const openModal = useCallback(async (nextJobId: string) => {
-    setJobId(nextJobId);
-    setOpen(true);
-    setLoading(true);
-    setRows(null);
+  const openModal = useCallback(
+    async (nextJobId: string, nextOutcome: string) => {
+      setJobId(nextJobId);
+      setOutcome(nextOutcome);
+      setOpen(true);
+      setLoading(true);
+      setRows(null);
 
-    try {
-      const data = await fetchAgentActivitiesAction(nextJobId);
-      setRows(attachActivityRowDurations(data));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      try {
+        const data = await fetchAgentActivitiesAction(nextJobId);
+        setRows(attachActivityRowDurations(data));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [],
+  );
 
   const onOpenChange = useCallback((next: boolean) => {
     setOpen(next);
     if (!next) {
       setJobId(null);
+      setOutcome(null);
       setRows(null);
       setLoading(false);
     }
   }, []);
 
-  return { open, jobId, rows, loading, openModal, onOpenChange };
+  return { open, jobId, outcome, rows, loading, openModal, onOpenChange };
 };

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.test.ts
@@ -11,13 +11,21 @@ describe("isActivityRowInProgress", () => {
       status: "processing" as const,
     };
 
-    expect(isActivityRowInProgress(row, 0, 3)).toBe(false);
-    expect(isActivityRowInProgress(row, 1, 3)).toBe(false);
-    expect(isActivityRowInProgress(row, 2, 3)).toBe(true);
+    expect(isActivityRowInProgress(row, 0, 3, true)).toBe(false);
+    expect(isActivityRowInProgress(row, 1, 3, true)).toBe(false);
+    expect(isActivityRowInProgress(row, 2, 3, true)).toBe(true);
   });
 
   it("returns false for the last row when the run is completed", () => {
-    expect(isActivityRowInProgress({ status: "completed" }, 2, 3)).toBe(false);
+    expect(isActivityRowInProgress({ status: "completed" }, 2, 3, true)).toBe(
+      false,
+    );
+  });
+
+  it("returns false for a stuck processing last row when the job is terminal", () => {
+    expect(isActivityRowInProgress({ status: "processing" }, 2, 3, false)).toBe(
+      false,
+    );
   });
 });
 

--- a/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
+++ b/apps/hermes/dashboard/lib/derive-activity-row-durations.ts
@@ -14,18 +14,23 @@ type ActivityRowFromServer = Omit<ActivityRow, "durationMs">;
  * Whether the row should show an in-progress spinner in the activity dialog.
  *
  * New checkpoints complete prior `processing` rows on the server; older runs may
- * still have stale status until the UI infers completion from row order.
+ * still have stale status until the UI infers completion from row order. A
+ * terminal job (cancelled, failed, or completed) never spins, even when its last
+ * row is stuck on `processing` because the agent could not post a final step.
  *
  * @param row - Activity row from the server.
  * @param index - Zero-based index in the ordered list.
  * @param rowCount - Total rows for the job.
+ * @param jobIsActive - Whether the owning job is still running (not terminal).
  * @returns True only for the last row while the run is still open.
  */
 export const isActivityRowInProgress = (
   row: Pick<ActivityRow, "status">,
   index: number,
   rowCount: number,
-): boolean => index === rowCount - 1 && row.status === "processing";
+  jobIsActive: boolean,
+): boolean =>
+  jobIsActive && index === rowCount - 1 && row.status === "processing";
 
 /**
  * Derives per-step durations from consecutive `createdAt` timestamps.

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -9,12 +9,8 @@ import type { BodySchemaType } from "./utilities/body-schema";
 import type { ConfigSchemaType } from "./utilities/config-schema";
 import {
   narrativeRunStart,
-  narrativeQueriesLoaded,
-  narrativeDailyQuota,
-  narrativeSearchRound,
-  narrativeFilteredResults,
-  narrativeFetchStart,
-  narrativeSavingSources,
+  narrativeSearching,
+  narrativeFetching,
   narrativeRunComplete,
 } from "./utilities/build-activity-narrative";
 import {
@@ -175,8 +171,6 @@ export async function runDataCollection(
     tickerId: input.tickerId,
   });
 
-  report(...narrativeQueriesLoaded(subject, queries.length));
-
   log.info(
     { queryCount: queries.length },
     "loaded search queries from Agent Data API",
@@ -201,14 +195,6 @@ export async function runDataCollection(
     limit: 1,
   });
   const existingTodaySourceCount = baselineToday.dataSourceTotalCount;
-
-  report(
-    ...narrativeDailyQuota(
-      subject,
-      existingTodaySourceCount,
-      targetSavedSources,
-    ),
-  );
 
   let roundsExecuted = 0;
   let refillStopReason:
@@ -249,33 +235,13 @@ export async function runDataCollection(
   let throttleEvents = 0;
 
   if (queries.length === 0) {
-    report(
-      "No search queries configured",
-      `${subject.symbol} (${subject.name}) has no active search queries. Skipping collection.`,
-      "completed",
-    );
     refillStopReason = "no_queries";
   } else if (existingTodaySourceCount >= targetSavedSources) {
-    report(
-      "Daily target already met",
-      `${subject.symbol} already has ${existingTodaySourceCount} saved source${existingTodaySourceCount === 1 ? "" : "s"} today, meeting the target of ${targetSavedSources}. Skipping collection.`,
-      "completed",
-    );
     refillStopReason = "daily_target_met_before_start";
   } else {
-    report(...narrativeSearchRound(subject, queries.length, 1, maxTotalRounds));
+    report(...narrativeSearching(subject, queries.length));
 
     for (let round = 1; round <= maxTotalRounds; round += 1) {
-      if (round > 1) {
-        report(
-          ...narrativeSearchRound(
-            subject,
-            queries.length,
-            round,
-            maxTotalRounds,
-          ),
-        );
-      }
       roundsExecuted += 1;
       const searchAttemptResults = await performWebSearch(queries, {
         config: config.web_search,
@@ -494,18 +460,9 @@ export async function runDataCollection(
         );
       }
 
-      const roundDroppedBeforeFetch =
-        roundSearchSuccesses.length - searchSuccessesAfterHostBreaker.length;
-      report(
-        ...narrativeFilteredResults(
-          searchSuccessesAfterHostBreaker.length,
-          roundDroppedBeforeFetch,
-        ),
-      );
-
-      report(
-        ...narrativeFetchStart(subject, searchSuccessesAfterHostBreaker.length),
-      );
+      if (round === 1) {
+        report(...narrativeFetching(subject));
+      }
 
       let persistedThisRoundCount = 0;
       const roundQualityDrops: QualityDropForDeadUrl[] = [];
@@ -663,13 +620,6 @@ export async function runDataCollection(
         persistedThisRoundCount += 1;
         fetchSuccessCount += 1;
       };
-
-      report(
-        ...narrativeSavingSources(
-          subject,
-          searchSuccessesAfterHostBreaker.length,
-        ),
-      );
 
       const fetchThrottleStats = { throttleEvents: 0 };
       const fetchAttemptResults = await performWebFetch(

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
@@ -3,14 +3,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
-  narrativeDailyQuota,
-  narrativeFilteredResults,
-  narrativeFetchStart,
-  narrativeQueriesLoaded,
+  narrativeFetching,
   narrativeRunComplete,
   narrativeRunStart,
-  narrativeSearchRound,
-  narrativeSavingSources,
+  narrativeSearching,
 } from "./build-activity-narrative";
 
 const UUID_PATTERN = /[0-9a-f]{8}-[0-9a-f]{4}/;
@@ -36,78 +32,36 @@ describe("narrativeRunStart", () => {
   });
 });
 
-describe("narrativeQueriesLoaded", () => {
-  it("returns correct title and description when queryCount is 0", () => {
-    const [title, description] = narrativeQueriesLoaded(subject, 0);
-    expect(title).toBe("No search queries configured");
-    expect(description).toContain("BUVA");
-  });
-
+describe("narrativeSearching", () => {
   it("uses singular form when queryCount is 1", () => {
-    const [, description] = narrativeQueriesLoaded(subject, 1);
+    const [title, description] = narrativeSearching(subject, 1);
+    expect(title).toBe("Searching the web");
     expect(description).toContain("1 search query");
     expect(description).not.toContain("queries");
   });
 
   it("uses plural form when queryCount is 5", () => {
-    const [, description] = narrativeQueriesLoaded(subject, 5);
+    const [, description] = narrativeSearching(subject, 5);
     expect(description).toContain("5 search queries");
+    expect(description).toContain("BUVA");
   });
 
   it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeQueriesLoaded(subject, 3);
+    const [title, description] = narrativeSearching(subject, 3);
     expect(title).not.toMatch(UUID_PATTERN);
     expect(description).not.toMatch(UUID_PATTERN);
   });
 });
 
-describe("narrativeDailyQuota", () => {
-  it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeDailyQuota(subject, 3, 10);
-    expect(title).not.toMatch(UUID_PATTERN);
-    expect(description).not.toMatch(UUID_PATTERN);
-  });
-});
-
-describe("narrativeSearchRound", () => {
-  it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeSearchRound(subject, 5, 1, 3);
-    expect(title).not.toMatch(UUID_PATTERN);
-    expect(description).not.toMatch(UUID_PATTERN);
-  });
-});
-
-describe("narrativeFilteredResults", () => {
-  it("mentions URL count and no removal when droppedCount is 0", () => {
-    const [, description] = narrativeFilteredResults(10, 0);
-    expect(description).toContain("10 URLs");
-    expect(description).not.toContain("removing");
-  });
-
-  it("mentions both readyCount and droppedCount when droppedCount is positive", () => {
-    const [, description] = narrativeFilteredResults(7, 5);
-    expect(description).toContain("7");
-    expect(description).toContain("5");
+describe("narrativeFetching", () => {
+  it("titles the combined fetch and filter phase", () => {
+    const [title, description] = narrativeFetching(subject);
+    expect(title).toBe("Fetching & filtering articles");
+    expect(description).toContain("BUVA");
   });
 
   it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeFilteredResults(10, 3);
-    expect(title).not.toMatch(UUID_PATTERN);
-    expect(description).not.toMatch(UUID_PATTERN);
-  });
-});
-
-describe("narrativeFetchStart", () => {
-  it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeFetchStart(subject, 5);
-    expect(title).not.toMatch(UUID_PATTERN);
-    expect(description).not.toMatch(UUID_PATTERN);
-  });
-});
-
-describe("narrativeSavingSources", () => {
-  it("does not contain a UUID pattern", () => {
-    const [title, description] = narrativeSavingSources(subject, 8);
+    const [title, description] = narrativeFetching(subject);
     expect(title).not.toMatch(UUID_PATTERN);
     expect(description).not.toMatch(UUID_PATTERN);
   });
@@ -159,6 +113,36 @@ describe("narrativeRunComplete", () => {
       targetSavedSources: 10,
     });
     expect(description).toContain("10");
+  });
+
+  it("notes the missing search queries when stopReason is no_queries", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "success",
+      persisted: 0,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: "no_queries",
+      roundsExecuted: 0,
+      targetSavedSources: 5,
+    });
+    expect(description).toContain("No active search queries were configured.");
+  });
+
+  it("notes the target when stopReason is daily_target_met_before_start", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "success",
+      persisted: 0,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: "daily_target_met_before_start",
+      roundsExecuted: 0,
+      targetSavedSources: 8,
+    });
+    expect(description).toContain("daily target of 8 was reached");
   });
 
   it("title is 'Collection failed' when status is failed", () => {

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
@@ -11,81 +11,20 @@ export function narrativeRunStart(subject: TickerSubject): [string, string] {
   ];
 }
 
-export function narrativeQueriesLoaded(
+export function narrativeSearching(
   subject: TickerSubject,
   queryCount: number,
 ): [string, string] {
-  if (queryCount === 0) {
-    return [
-      "No search queries configured",
-      `${subject.symbol} (${subject.name}) has no active search queries. Skipping collection.`,
-    ];
-  }
   return [
-    "Search queries loaded",
-    `${n(queryCount, "search query", "search queries")} ready for ${subject.symbol}.`,
+    "Searching the web",
+    `Running ${n(queryCount, "search query", "search queries")} for ${subject.symbol}.`,
   ];
 }
 
-export function narrativeDailyQuota(
-  subject: TickerSubject,
-  existingCount: number,
-  target: number,
-): [string, string] {
+export function narrativeFetching(subject: TickerSubject): [string, string] {
   return [
-    "Checking daily quota",
-    `${subject.symbol} has ${n(existingCount, "saved source")} today against a target of ${target}.`,
-  ];
-}
-
-export function narrativeSearchRound(
-  subject: TickerSubject,
-  queryCount: number,
-  round: number,
-  maxRounds: number,
-): [string, string] {
-  if (round === 1) {
-    return [
-      "Searching the web",
-      `Running ${n(queryCount, "search query", "search queries")} for ${subject.symbol}.`,
-    ];
-  }
-  return [
-    "Search refill round",
-    `Refill round ${round} of ${maxRounds}: running ${n(queryCount, "search query", "search queries")} for ${subject.symbol} to reach the daily target.`,
-  ];
-}
-
-export function narrativeFilteredResults(
-  readyCount: number,
-  droppedCount: number,
-): [string, string] {
-  if (droppedCount === 0) {
-    return ["Filtering results", `${n(readyCount, "URL")} ready to fetch.`];
-  }
-  return [
-    "Filtering results",
-    `${n(readyCount, "URL")} ready to fetch, after removing ${n(droppedCount, "result")} that were already saved, noisy, or known to be dead.`,
-  ];
-}
-
-export function narrativeFetchStart(
-  subject: TickerSubject,
-  urlCount: number,
-): [string, string] {
-  return [
-    "Fetching articles",
-    `Downloading ${n(urlCount, "candidate URL")} for ${subject.symbol}.`,
-  ];
-}
-
-export function narrativeSavingSources(
-  subject: TickerSubject,
-  fetchedCount: number,
-): [string, string] {
-  return [
-    "Saving sources",
-    `Applying relevance, freshness, and quality checks to ${n(fetchedCount, "fetched page")} for ${subject.symbol}.`,
+    "Fetching & filtering articles",
+    `Downloading candidate articles for ${subject.symbol} and applying relevance, freshness, and quality checks.`,
   ];
 }
 
@@ -137,6 +76,8 @@ export function narrativeRunComplete(
     stopClause = ` The maximum number of search rounds was reached.`;
   } else if (opts.stopReason === "no_progress") {
     stopClause = ` No new articles were found in the last round.`;
+  } else if (opts.stopReason === "no_queries") {
+    stopClause = ` No active search queries were configured.`;
   }
 
   const failureClause =


### PR DESCRIPTION
## Summary

The data-collection "Show activity" dialog kept spinning on the last step when a run was cancelled or errored, and it posted a noisy, repetitive feed. This reads the job's real status so a finished run never spins, marks failed/cancelled runs with an error icon, and collapses the agent's reporting to four phases.

## Related issues

Closes #859

## Important changes

- **Spinner respects job status.** `isActivityRowInProgress` now takes a `jobIsActive` flag; the last row spins only while the job is actually running. A cancelled/errored job whose last row is stuck on `processing` no longer spins.
- **Failure is visible.** The dialog shows a red `XCircle` on the final row for `failure`/`cancelled` outcomes, and the green check for success.
- **Simpler feed.** The agent collapses to four phases: Collecting news → Searching the web → Fetching & filtering articles → Collection complete/failed. The per-round Search/Filter/Fetch/Save spam and the standalone skip rows are gone; the final summary still carries the stop reason (including no-queries and daily-target-already-met).

## Other changes

- `useAgentActivityModal` carries the job outcome so the dialog knows the run's real state.
- Removed the now-unused narrative helpers and their tests; added coverage for the new helpers and stop-reason clauses.

## Key files to review

- `apps/hermes/dashboard/lib/derive-activity-row-durations.ts` - the `jobIsActive` gate on the spinner.
- `apps/hermes/dashboard/components/schedule-execution-invocations-table.tsx` - outcome threading and the error-icon logic.
- `apps/mediapulse/agents/data-collection/src/run.ts` - reduced `report()` calls down to the four phases.
- `apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts` - new `narrativeSearching`/`narrativeFetching` and extended stop clauses.

## How to test

1. `pnpm --filter @hermes/dashboard test derive-activity-row-durations` and `pnpm --filter @mediapulse/data-collection test build-activity-narrative` - all green.
2. In the Hermes dashboard schedule-execution invocations table, click **Show activity** on a successful run: four rows, green check on the last, no spinner.
3. Open a failed or cancelled run: last row shows the red error icon, no spinner.
4. Open an in-flight run: last `processing` row still shows the live spinner and elapsed timer.
