### PR TITLE
Add Indonesian newsletter translations

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -868,8 +868,11 @@ describe("agent-data-api", () => {
           content: "Body",
           id: NL_ID,
           symbol: "AAPL",
+          translations: [],
         },
-        subscribers: [{ userTickerId: UT_ID, email: "u@example.com" }],
+        subscribers: [
+          { userTickerId: UT_ID, email: "u@example.com", language: "en" },
+        ],
         deliveredUserTickerIds: [],
       });
 

--- a/apps/mediapulse/agent-data-api/src/index.ts
+++ b/apps/mediapulse/agent-data-api/src/index.ts
@@ -50,6 +50,7 @@ import {
 } from "./routes/data-collection-failure.js";
 import { getDeliveryRun, postDeliveryRun } from "./routes/delivery-run.js";
 import { getDelivery, postDeliveryHandler } from "./routes/delivery.js";
+import { postNewsletterTranslationHandler } from "./routes/newsletter-translation.js";
 import {
   postDeliveryClaimHandler,
   postDeliveryClaimReleaseHandler,
@@ -137,6 +138,9 @@ const routeHandlers = {
   },
   contentGenerationBulletsRecent: {
     get: getContentGenerationBulletsRecent,
+  },
+  newsletterTranslation: {
+    post: postNewsletterTranslationHandler,
   },
   dataCollection: {
     get: getDataCollection,

--- a/apps/mediapulse/agent-data-api/src/routes/newsletter-translation.ts
+++ b/apps/mediapulse/agent-data-api/src/routes/newsletter-translation.ts
@@ -1,0 +1,24 @@
+import { Context } from "hono";
+
+import { internalError } from "@workspace/api-utils";
+import {
+  postNewsletterTranslationBodySchema,
+  postNewsletterTranslationResponseSchema,
+} from "@workspace/agent-data-api-contract";
+import { createNewsletterTranslation } from "../services/newsletter-translation.js";
+
+export async function postNewsletterTranslationHandler(
+  context: Context,
+): Promise<Response> {
+  try {
+    const body = await context.req.json();
+    const data = await postNewsletterTranslationBodySchema.parseAsync(body);
+    await createNewsletterTranslation(data);
+    const response = postNewsletterTranslationResponseSchema.parse({
+      message: "Success",
+    });
+    return context.json(response, 200);
+  } catch (error) {
+    return internalError(context, error);
+  }
+}

--- a/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.test.ts
@@ -9,6 +9,7 @@ type UserTickerWithUserRow = {
   userId: string;
   tickerId: string;
   enabled: boolean;
+  language: "en" | "id";
   createdAt: Date;
   updatedAt: Date;
   user: {
@@ -53,7 +54,7 @@ describe("getDeliveryData", () => {
     expect(prisma.userTicker.findMany).not.toHaveBeenCalled();
   });
 
-  it("returns newsletter, subscribers with userTickerId, and checkpoint ids", async () => {
+  it("returns newsletter with translations, subscribers with language, and checkpoint ids", async () => {
     const { prisma } = await import("@mediapulse/database");
     const newsletter = {
       id: "n1",
@@ -72,8 +73,27 @@ describe("getDeliveryData", () => {
       createdAt: new Date("2026-01-01T00:00:00.000Z"),
       updatedAt: new Date("2026-01-01T00:00:00.000Z"),
       ticker: { symbol: "AAPL" },
+      translations: [
+        {
+          id: "tr1",
+          newsletterId: "n1",
+          language: "id" as const,
+          subject: "Subjek",
+          content: "Isi",
+          model: null,
+          promptTokens: null,
+          completionTokens: null,
+          totalTokens: null,
+          createdAt: new Date("2026-01-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+        },
+      ],
     };
-    vi.mocked(prisma.newsletter.findFirst).mockResolvedValue(newsletter);
+    vi.mocked(prisma.newsletter.findFirst).mockResolvedValue(
+      newsletter as unknown as Awaited<
+        ReturnType<typeof prisma.newsletter.findFirst>
+      >,
+    );
     vi.mocked(prisma.newsletterDeliveryCheckpoint.findMany).mockResolvedValue([
       {
         id: "cp1",
@@ -89,6 +109,7 @@ describe("getDeliveryData", () => {
         userId: "u1",
         tickerId: "t1",
         enabled: true,
+        language: "en",
         createdAt: new Date(),
         updatedAt: new Date(),
         user: {
@@ -105,6 +126,7 @@ describe("getDeliveryData", () => {
         userId: "u2",
         tickerId: "t1",
         enabled: true,
+        language: "id",
         createdAt: new Date(),
         updatedAt: new Date(),
         user: {
@@ -129,7 +151,6 @@ describe("getDeliveryData", () => {
         where: {
           tickerId: "t1",
           enabled: true,
-          language: "en",
           user: { enabled: true },
         },
       }),
@@ -140,10 +161,11 @@ describe("getDeliveryData", () => {
         subject: "Subj",
         content: "Body",
         symbol: "AAPL",
+        translations: [{ language: "id", subject: "Subjek", content: "Isi" }],
       },
       subscribers: [
-        { userTickerId: "ut1", email: "a@example.com" },
-        { userTickerId: "ut2", email: "b@example.com" },
+        { userTickerId: "ut1", email: "a@example.com", language: "en" },
+        { userTickerId: "ut2", email: "b@example.com", language: "id" },
       ],
       deliveredUserTickerIds: ["ut2"],
     });
@@ -168,6 +190,7 @@ describe("getDeliveryData", () => {
       createdAt: new Date(),
       updatedAt: new Date(),
       ticker: { symbol: "BBRI" },
+      translations: [],
     };
     vi.mocked(prisma.newsletter.findFirst).mockResolvedValue(
       newsletter as unknown as Awaited<
@@ -183,6 +206,7 @@ describe("getDeliveryData", () => {
         userId: "u1",
         tickerId: "t1",
         enabled: true,
+        language: "en",
         createdAt: new Date(),
         updatedAt: new Date(),
         user: {

--- a/apps/mediapulse/agent-data-api/src/services/delivery.ts
+++ b/apps/mediapulse/agent-data-api/src/services/delivery.ts
@@ -8,13 +8,17 @@ export async function getDeliveryData(tickerId: string) {
   const newsletter = await mediapulsePrisma.newsletter.findFirst({
     where: { tickerId },
     orderBy: { createdAt: "desc" },
-    include: { ticker: true },
+    include: { ticker: true, translations: true },
   });
 
   if (!newsletter) {
     return {
       newsletter: null,
-      subscribers: [] as { userTickerId: string; email: string }[],
+      subscribers: [] as {
+        userTickerId: string;
+        email: string;
+        language: "en" | "id";
+      }[],
       deliveredUserTickerIds: [] as string[],
     };
   }
@@ -24,14 +28,13 @@ export async function getDeliveryData(tickerId: string) {
       where: { newsletterId: newsletter.id },
       select: { userTickerId: true },
     }),
-    // Indonesian newsletters are not generated yet, so only English subscriptions are
-    // delivered for now. This also avoids duplicate sends to a subscriber who registered
-    // the same ticker in both languages (each row has its own delivery checkpoint).
+    // Enabled subscribers in every language. Each (user, ticker, language) row has its own
+    // delivery checkpoint, so a subscriber registered in both languages receives one email per
+    // language without duplicate sends. The delivery agent picks the rendered text per language.
     mediapulsePrisma.userTicker.findMany({
       where: {
         tickerId,
         enabled: true,
-        language: "en",
         user: { enabled: true },
       },
       include: { user: true },
@@ -42,10 +45,19 @@ export async function getDeliveryData(tickerId: string) {
     .map((subscription) => {
       const email = subscription.user.email;
       return email != null && email !== ""
-        ? { userTickerId: subscription.id, email }
+        ? {
+            userTickerId: subscription.id,
+            email,
+            language: subscription.language,
+          }
         : null;
     })
-    .filter((s): s is { userTickerId: string; email: string } => s != null);
+    .filter(
+      (
+        s,
+      ): s is { userTickerId: string; email: string; language: "en" | "id" } =>
+        s != null,
+    );
 
   return {
     newsletter: {
@@ -53,6 +65,11 @@ export async function getDeliveryData(tickerId: string) {
       subject: newsletter.subject,
       content: newsletter.content,
       symbol: newsletter.ticker.symbol,
+      translations: newsletter.translations.map((translation) => ({
+        language: translation.language,
+        subject: translation.subject,
+        content: translation.content,
+      })),
     },
     subscribers,
     deliveredUserTickerIds: checkpoints.map((c) => c.userTickerId),

--- a/apps/mediapulse/agent-data-api/src/services/newsletter-translation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/newsletter-translation.test.ts
@@ -1,0 +1,94 @@
+/** @vitest-environment node */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mediapulse/database", () => ({
+  prisma: {
+    newsletterTranslation: { upsert: vi.fn() },
+  },
+}));
+
+describe("createNewsletterTranslation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("upserts a translation keyed on newsletter id + language with provenance", async () => {
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.newsletterTranslation.upsert).mockResolvedValue(
+      {} as unknown as Awaited<
+        ReturnType<typeof prisma.newsletterTranslation.upsert>
+      >,
+    );
+
+    const { createNewsletterTranslation } =
+      await import("./newsletter-translation.js");
+    await createNewsletterTranslation({
+      newsletterId: "11111111-1111-4111-8111-111111111111",
+      language: "id",
+      subject: "Subjek",
+      content: "Isi",
+      model: "gpt-4o-mini",
+      promptTokens: 120,
+      completionTokens: 80,
+      totalTokens: 200,
+    });
+
+    expect(prisma.newsletterTranslation.upsert).toHaveBeenCalledWith({
+      where: {
+        newsletterId_language: {
+          newsletterId: "11111111-1111-4111-8111-111111111111",
+          language: "id",
+        },
+      },
+      create: {
+        newsletterId: "11111111-1111-4111-8111-111111111111",
+        language: "id",
+        subject: "Subjek",
+        content: "Isi",
+        model: "gpt-4o-mini",
+        promptTokens: 120,
+        completionTokens: 80,
+        totalTokens: 200,
+      },
+      update: {
+        subject: "Subjek",
+        content: "Isi",
+        model: "gpt-4o-mini",
+        promptTokens: 120,
+        completionTokens: 80,
+        totalTokens: 200,
+      },
+    });
+  });
+
+  it("defaults optional provenance fields to null", async () => {
+    const { prisma } = await import("@mediapulse/database");
+    vi.mocked(prisma.newsletterTranslation.upsert).mockResolvedValue(
+      {} as unknown as Awaited<
+        ReturnType<typeof prisma.newsletterTranslation.upsert>
+      >,
+    );
+
+    const { createNewsletterTranslation } =
+      await import("./newsletter-translation.js");
+    await createNewsletterTranslation({
+      newsletterId: "22222222-2222-4222-8222-222222222222",
+      language: "id",
+      subject: "S",
+      content: "C",
+    });
+
+    const callArg = vi.mocked(prisma.newsletterTranslation.upsert).mock
+      .calls[0]?.[0];
+    expect(callArg?.create).toMatchObject({
+      model: null,
+      promptTokens: null,
+      completionTokens: null,
+      totalTokens: null,
+    });
+  });
+});

--- a/apps/mediapulse/agent-data-api/src/services/newsletter-translation.ts
+++ b/apps/mediapulse/agent-data-api/src/services/newsletter-translation.ts
@@ -1,0 +1,39 @@
+import { prisma as mediapulsePrisma } from "@mediapulse/database";
+import type { PostNewsletterTranslationBody } from "@workspace/agent-data-api-contract";
+
+/**
+ * Upserts a translated rendering of a newsletter (unique per newsletter + language)
+ * so a re-run of the content-generation translation pass is idempotent.
+ *
+ * @param body - Newsletter id, target language, translated subject/content, and optional provenance.
+ */
+export async function createNewsletterTranslation(
+  body: PostNewsletterTranslationBody,
+): Promise<void> {
+  await mediapulsePrisma.newsletterTranslation.upsert({
+    where: {
+      newsletterId_language: {
+        newsletterId: body.newsletterId,
+        language: body.language,
+      },
+    },
+    create: {
+      newsletterId: body.newsletterId,
+      language: body.language,
+      subject: body.subject,
+      content: body.content,
+      model: body.model ?? null,
+      promptTokens: body.promptTokens ?? null,
+      completionTokens: body.completionTokens ?? null,
+      totalTokens: body.totalTokens ?? null,
+    },
+    update: {
+      subject: body.subject,
+      content: body.content,
+      model: body.model ?? null,
+      promptTokens: body.promptTokens ?? null,
+      completionTokens: body.completionTokens ?? null,
+      totalTokens: body.totalTokens ?? null,
+    },
+  });
+}

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -622,6 +622,31 @@ const freshnessSchema = z
  * Runtime config for the content-generation agent, supplied by Hermes on each invocation
  * (from the admin-selected agent config for the pipeline step).
  */
+const translationSchema = z
+  .object({
+    enabled: z
+      .boolean()
+      .default(false)
+      .describe(
+        "When true, translate the generated newsletter into each target language after the English newsletter is persisted.",
+      ),
+    targetLanguages: z
+      .array(z.enum(["id"]))
+      .default(["id"])
+      .describe(
+        "Non-English languages to translate the newsletter into (currently only Indonesian).",
+      ),
+    model: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Chat model for the translation pass. If omitted, uses credentials.chatModel.",
+      ),
+  })
+  .strict()
+  .default({});
+
 export const ContentGenerationConfigSchema = z
   .object({
     credentials: credentialsSchema,
@@ -632,6 +657,7 @@ export const ContentGenerationConfigSchema = z
     delivery: deliverySchema,
     freshness: freshnessSchema,
     reliability: reliabilitySchema,
+    translation: translationSchema,
   })
   /** Reject unknown keys (e.g. legacy flat `openai`, `sourceRanking`) so configs fail fast. */
   .strict()
@@ -669,6 +695,7 @@ export type ResolvedContentGenerationConfig = ContentGenerationConfig & {
   brainstormModel: string;
   critiqueModel: string;
   subjectLineModel: string;
+  translationModel: string;
 };
 
 type RetryFields = {
@@ -724,5 +751,6 @@ export function resolveContentGenerationConfig(
     brainstormModel: parsed.creativity.brainstorm.model ?? chatModel,
     critiqueModel: parsed.quality.selfCritique.critiqueModel ?? chatModel,
     subjectLineModel: parsed.delivery.subjectLine.model ?? chatModel,
+    translationModel: parsed.translation.model ?? chatModel,
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -16,6 +16,7 @@ import {
   generateNewsletterWithLlm,
   type SourceForGeneration,
 } from "./llm-generate-newsletter.js";
+import { translateNewsletter } from "./translate-newsletter.js";
 import { dedupLlmInputSources } from "./lib/dedup-llm-input-sources.js";
 import { mapOutcomeToDiagnostic } from "./outcome-to-diagnostic.js";
 import { sanitizeDiagnosticMessage } from "./sanitize-diagnostic-message.js";
@@ -580,6 +581,71 @@ export async function run({
       success: false,
       message: `Failed to store generated newsletter: ${code}`,
     };
+  }
+
+  // -------------------------------------------------------------------------
+  // Translation pass (best-effort)
+  // -------------------------------------------------------------------------
+  // Translate the persisted English newsletter into each configured target language and
+  // store it as a NewsletterTranslation keyed on the canonical newsletter id. This is
+  // best-effort: a failure here must never fail the run or roll back the English newsletter,
+  // because the delivery agent skips non-English subscribers when no translation exists.
+  if (
+    resolvedConfig.translation.enabled &&
+    persistedNewsletterId !== null &&
+    resolvedConfig.translation.targetLanguages.length > 0
+  ) {
+    const newsletterId = persistedNewsletterId;
+    report(
+      "Translating newsletter",
+      resolvedConfig.translation.targetLanguages.join(", "),
+    );
+    for (const targetLanguage of resolvedConfig.translation.targetLanguages) {
+      try {
+        const translated = await translateNewsletter({
+          subject: generated.subject,
+          content: generated.content,
+          targetLanguage,
+          model: resolvedConfig.translationModel,
+          credentials: {
+            openaiApiKey: resolvedConfig.credentials.openaiApiKey,
+            ...(resolvedConfig.credentials.baseUrl
+              ? { baseUrl: resolvedConfig.credentials.baseUrl }
+              : {}),
+          },
+        });
+        await dataApiClient.newsletterTranslation.create({
+          newsletterId,
+          language: targetLanguage,
+          subject: translated.subject,
+          content: translated.content,
+          model: resolvedConfig.translationModel,
+          ...(translated.promptTokens !== null
+            ? { promptTokens: translated.promptTokens }
+            : {}),
+          ...(translated.completionTokens !== null
+            ? { completionTokens: translated.completionTokens }
+            : {}),
+          ...(translated.totalTokens !== null
+            ? { totalTokens: translated.totalTokens }
+            : {}),
+        });
+        logger.info(
+          { tickerId: input.tickerId, newsletterId, language: targetLanguage },
+          "Newsletter translation persisted",
+        );
+      } catch (translateErr) {
+        logger.error(
+          {
+            tickerId: input.tickerId,
+            newsletterId,
+            language: targetLanguage,
+            err: translateErr,
+          },
+          "Newsletter translation failed (best-effort, skipping)",
+        );
+      }
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/apps/mediapulse/agents/content-generation/src/translate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/translate-newsletter.test.ts
@@ -1,0 +1,90 @@
+/** @vitest-environment node */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  translateNewsletter,
+  type TranslateNewsletterObjectFn,
+} from "./translate-newsletter.js";
+
+const credentials = { openaiApiKey: "sk-test" };
+
+const sourceContent = [
+  "Industry Pulse",
+  "- Revenue rose 12.5% to $4.2B in Q1 2026. [Reuters](https://example.com/a)",
+  "- Margin held at 30%. [Bloomberg](https://example.com/b)",
+].join("\n");
+
+describe("translateNewsletter", () => {
+  it("returns the model's translated subject/content and maps token usage", async () => {
+    const generateObjectFn = vi.fn().mockResolvedValue({
+      object: { subject: "Subjek Indonesia", content: "Konten Indonesia" },
+      usage: { inputTokens: 120, outputTokens: 80 },
+    }) satisfies TranslateNewsletterObjectFn;
+
+    const result = await translateNewsletter(
+      {
+        subject: "English Subject",
+        content: sourceContent,
+        targetLanguage: "id",
+        model: "gpt-4o-mini",
+        credentials,
+      },
+      generateObjectFn,
+    );
+
+    expect(result).toEqual({
+      subject: "Subjek Indonesia",
+      content: "Konten Indonesia",
+      promptTokens: 120,
+      completionTokens: 80,
+      totalTokens: 200,
+    });
+  });
+
+  it("passes the source subject and content into the prompt and constrains the system prompt", async () => {
+    const generateObjectFn = vi.fn().mockResolvedValue({
+      object: { subject: "x", content: "y" },
+    }) satisfies TranslateNewsletterObjectFn;
+
+    await translateNewsletter(
+      {
+        subject: "English Subject",
+        content: sourceContent,
+        targetLanguage: "id",
+        model: "gpt-4o-mini",
+        credentials,
+      },
+      generateObjectFn,
+    );
+
+    const callArgs = generateObjectFn.mock.calls[0]?.[0];
+    expect(callArgs?.prompt).toContain("English Subject");
+    expect(callArgs?.prompt).toContain("https://example.com/a");
+    expect(callArgs?.prompt).toContain("12.5%");
+    expect(callArgs?.system).toContain("Indonesian");
+    expect(callArgs?.system).toContain("URL verbatim");
+    expect(callArgs?.system).toMatch(/number|figure/i);
+    expect(callArgs?.maxRetries).toBe(0);
+  });
+
+  it("returns null token counts when usage is absent", async () => {
+    const generateObjectFn = vi.fn().mockResolvedValue({
+      object: { subject: "s", content: "c" },
+    }) satisfies TranslateNewsletterObjectFn;
+
+    const result = await translateNewsletter(
+      {
+        subject: "S",
+        content: "C",
+        targetLanguage: "id",
+        model: "gpt-4o-mini",
+        credentials,
+      },
+      generateObjectFn,
+    );
+
+    expect(result.promptTokens).toBeNull();
+    expect(result.completionTokens).toBeNull();
+    expect(result.totalTokens).toBeNull();
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/translate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/translate-newsletter.ts
@@ -1,0 +1,144 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { generateObject } from "ai";
+import { z } from "zod";
+
+/** Target language codes the translation pass supports (non-English only). */
+export type TranslationTargetLanguage = "id";
+
+const LANGUAGE_NAMES: Record<TranslationTargetLanguage, string> = {
+  id: "Indonesian (Bahasa Indonesia)",
+};
+
+/** Structured output the model must return for a translated newsletter. */
+const translatedNewsletterSchema = z.object({
+  subject: z.string().min(1),
+  content: z.string().min(1),
+});
+
+/** Credentials needed to reach the OpenAI-compatible endpoint. */
+export type TranslationCredentials = {
+  openaiApiKey: string;
+  baseUrl?: string;
+};
+
+/** Arguments for a single translation `generateObject` call. */
+export type TranslateNewsletterObjectArgs = {
+  model: ReturnType<ReturnType<typeof createOpenAI>>;
+  schema: typeof translatedNewsletterSchema;
+  system: string;
+  prompt: string;
+  /** Should always be 0 — retries are managed by the caller. */
+  maxRetries: number;
+};
+
+/** Token usage from a translation `generateObject` response. */
+export type TranslateNewsletterUsage = {
+  promptTokens: number | null;
+  completionTokens: number | null;
+  totalTokens: number | null;
+};
+
+/** Result of translating one newsletter into one target language. */
+export type TranslateNewsletterResult = {
+  subject: string;
+  content: string;
+} & TranslateNewsletterUsage;
+
+/** Injectable wrapper around `generateObject` so tests can substitute the model call. */
+export type TranslateNewsletterObjectFn = (
+  args: TranslateNewsletterObjectArgs,
+) => Promise<{
+  object: z.infer<typeof translatedNewsletterSchema>;
+  usage?: { inputTokens?: number; outputTokens?: number };
+}>;
+
+const defaultTranslateNewsletterObject: TranslateNewsletterObjectFn = async (
+  args,
+) => {
+  const result = await generateObject({ ...args });
+  const usage =
+    result.usage !== undefined
+      ? {
+          inputTokens: result.usage.inputTokens,
+          outputTokens: result.usage.outputTokens,
+        }
+      : undefined;
+
+  return { object: result.object, usage };
+};
+
+/**
+ * Builds the system prompt that constrains the translation to preserve the
+ * newsletter wire structure, citation links, and numeric figures.
+ *
+ * @param languageName - Human-readable target language name.
+ */
+function buildTranslationSystemPrompt(languageName: string): string {
+  return [
+    `You are a professional financial-newsletter translator. Translate the newsletter into ${languageName}.`,
+    "Translate the prose faithfully and naturally, in the same tone and register.",
+    "Preserve the exact structure: keep every line break, section header, label, and bullet marker in the same positions.",
+    "Keep all Markdown links intact — translate the visible [label] text but copy each (https://…) URL verbatim, unchanged.",
+    "Keep every number, percentage, currency figure, date, ticker symbol, and proper noun exactly as written; do not localize, convert, or round them.",
+    "Do not add, drop, summarize, or reorder any content. Return only the translated subject and content.",
+  ].join(" ");
+}
+
+/**
+ * Translates a generated newsletter into a target language, preserving the wire
+ * structure, citation links, and numeric figures.
+ *
+ * @param params - Source subject/content, target language, model, and credentials.
+ * @param generateObjectFn - Injectable model call (defaults to the AI SDK wrapper).
+ * @returns Translated subject/content and token usage.
+ */
+export async function translateNewsletter(
+  params: {
+    subject: string;
+    content: string;
+    targetLanguage: TranslationTargetLanguage;
+    model: string;
+    credentials: TranslationCredentials;
+  },
+  generateObjectFn: TranslateNewsletterObjectFn = defaultTranslateNewsletterObject,
+): Promise<TranslateNewsletterResult> {
+  const openai = createOpenAI({
+    apiKey: params.credentials.openaiApiKey,
+    ...(params.credentials.baseUrl
+      ? { baseURL: params.credentials.baseUrl }
+      : {}),
+  });
+  const model = openai(params.model);
+  const languageName = LANGUAGE_NAMES[params.targetLanguage];
+  const system = buildTranslationSystemPrompt(languageName);
+  const prompt = [
+    "Translate the following newsletter.",
+    "",
+    `SUBJECT:\n${params.subject}`,
+    "",
+    `CONTENT:\n${params.content}`,
+  ].join("\n");
+
+  const result = await generateObjectFn({
+    model,
+    schema: translatedNewsletterSchema,
+    system,
+    prompt,
+    maxRetries: 0,
+  });
+
+  const inputTokens = result.usage?.inputTokens;
+  const outputTokens = result.usage?.outputTokens;
+  const totalTokens =
+    inputTokens !== undefined && outputTokens !== undefined
+      ? inputTokens + outputTokens
+      : null;
+
+  return {
+    subject: result.object.subject,
+    content: result.object.content,
+    promptTokens: inputTokens ?? null,
+    completionTokens: outputTokens ?? null,
+    totalTokens,
+  };
+}

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -12,6 +12,7 @@ import { DeliveryConfigSchema } from "./config-schema.js";
 import {
   buildNewsletterMessageId,
   deliverNewsletterToSubscribers,
+  type DeliveryNewsletter,
 } from "./deliver-newsletter.js";
 
 describe("buildNewsletterMessageId", () => {
@@ -59,12 +60,13 @@ vi.mock("@workspace/email-templates", async () => {
   };
 });
 
-const newsletter = {
+const newsletter: DeliveryNewsletter = {
   id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
   subject: "AAPL Pulse: Subject",
   content: "Body",
   symbol: "AAPL",
-} as const;
+  translations: [],
+};
 
 const userTickerId = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
@@ -93,7 +95,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       baseConfig,
       {
@@ -144,6 +146,68 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(resendMessageIds).toEqual(["re_1"]);
   });
 
+  it("renders the translated subject and content for an id subscriber", async () => {
+    const sendWithRetry = vi
+      .fn()
+      .mockResolvedValue({ id: "re_id", attempts: 1 });
+    const translatedNewsletter: DeliveryNewsletter = {
+      ...newsletter,
+      translations: [
+        { language: "id", subject: "AAPL Pulse: Subjek", content: "Isi" },
+      ],
+    };
+
+    await deliverNewsletterToSubscribers(
+      translatedNewsletter,
+      [{ userTickerId, email: "u@example.com", language: "id" }],
+      [],
+      baseConfig,
+      {
+        resend: {} as Resend,
+        rateLimiter: mockRateLimiter(),
+        sendWithRetry,
+      },
+    );
+
+    const renderCall = vi.mocked(renderNewsletterEmail).mock.calls[0]?.[0];
+    expect(renderCall).toMatchObject({
+      title: "Subjek",
+      bodyText: "Isi",
+    });
+
+    expect(sendWithRetry.mock.calls[0]?.[1]).toMatchObject({
+      subject: "AAPL Pulse: Subjek",
+    });
+  });
+
+  it("skips an id subscriber without acquire or send when no translation exists", async () => {
+    const sendWithRetry = vi.fn();
+    const acquire = vi.fn().mockResolvedValue(0);
+    const claimRecipient = vi.fn().mockResolvedValue(true);
+
+    const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
+      newsletter,
+      [{ userTickerId, email: "u@example.com", language: "id" }],
+      [],
+      baseConfig,
+      {
+        resend: {} as Resend,
+        rateLimiter: mockRateLimiter(acquire),
+        sendWithRetry,
+        claimRecipient,
+      },
+    );
+
+    expect(claimRecipient).not.toHaveBeenCalled();
+    expect(acquire).not.toHaveBeenCalled();
+    expect(sendWithRetry).not.toHaveBeenCalled();
+    expect(results[0]).toMatchObject({
+      status: "skipped",
+      errorCategory: "skipped_missing_translation",
+    });
+    expect(resendMessageIds).toEqual([]);
+  });
+
   it("skips checkpointed subscribers without acquire or send", async () => {
     const sendWithRetry = vi.fn();
     const acquire = vi.fn().mockResolvedValue(0);
@@ -152,7 +216,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [userTickerId],
       baseConfig,
       {
@@ -194,7 +258,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       cfg,
       {
@@ -225,7 +289,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       cfg,
       {
@@ -259,7 +323,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       cfg,
       {
@@ -295,7 +359,7 @@ describe("deliverNewsletterToSubscribers", () => {
     // Act
     await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       cfg,
       {
@@ -318,7 +382,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       baseConfig,
       {
@@ -340,7 +404,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results, resendMessageIds } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       baseConfig,
       {
@@ -370,7 +434,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       baseConfig,
       {
@@ -397,7 +461,7 @@ describe("deliverNewsletterToSubscribers", () => {
 
     const { results } = await deliverNewsletterToSubscribers(
       newsletter,
-      [{ userTickerId, email: "u@example.com" }],
+      [{ userTickerId, email: "u@example.com", language: "en" }],
       [],
       baseConfig,
       {

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -23,6 +23,24 @@ import {
 export type DeliverySubscriber = {
   userTickerId: string;
   email: string;
+  /** Subscription language; selects which rendered text the recipient receives. */
+  language: "en" | "id";
+};
+
+/** A translated rendering of the newsletter for a non-English subscription language. */
+export type DeliveryNewsletterTranslation = {
+  language: "en" | "id";
+  subject: string;
+  content: string;
+};
+
+export type DeliveryNewsletter = {
+  id: string;
+  subject: string;
+  content: string;
+  symbol: string;
+  /** Non-English translations; empty when none exist yet. */
+  translations: DeliveryNewsletterTranslation[];
 };
 
 export type RecipientSendResult = {
@@ -121,7 +139,7 @@ function recipientErrorCategory(
  * @returns Per-recipient results and Resend message ids (for diagnostics).
  */
 export async function deliverNewsletterToSubscribers(
-  newsletter: { id: string; subject: string; content: string; symbol: string },
+  newsletter: DeliveryNewsletter,
   subscribers: DeliverySubscriber[],
   deliveredUserTickerIds: string[],
   config: DeliveryConfig,
@@ -157,6 +175,29 @@ export async function deliverNewsletterToSubscribers(
         errorCategory: "skipped_already_delivered",
       });
       continue;
+    }
+
+    // Resolve the rendered text for this subscriber's language. English uses the base
+    // (canonical) newsletter; other languages use a translation. When a non-English
+    // subscriber has no translation yet, skip them — never send English to an id subscriber.
+    let localizedSubject = newsletter.subject;
+    let localizedContent = newsletter.content;
+    if (sub.language !== "en") {
+      const translation = newsletter.translations.find(
+        (t) => t.language === sub.language,
+      );
+      if (!translation) {
+        results.push({
+          userTickerId: sub.userTickerId,
+          status: "skipped",
+          attempts: 0,
+          lastErrorMessage: "missing_translation",
+          errorCategory: "skipped_missing_translation",
+        });
+        continue;
+      }
+      localizedSubject = translation.subject;
+      localizedContent = translation.content;
     }
 
     const ref = recipientLogRef(sub.userTickerId);
@@ -199,10 +240,10 @@ export async function deliverNewsletterToSubscribers(
     const unsubscribeUrl = `${config.unsubscribe.baseUrl}/api/unsubscribe?token=${unsubscribeToken}`;
 
     const renderStart = Date.now();
-    const emailTitle = parseNewsletterEmailSubject(newsletter.subject).title;
+    const emailTitle = parseNewsletterEmailSubject(localizedSubject).title;
     const { html, text } = await renderNewsletterEmail({
       title: emailTitle,
-      bodyText: newsletter.content,
+      bodyText: localizedContent,
       variant: config.template.newsletterVariant,
       unsubscribeUrl,
       tickerSymbol: newsletter.symbol,
@@ -221,7 +262,7 @@ export async function deliverNewsletterToSubscribers(
     const payload: SendEmailPayload = {
       from,
       to: sub.email,
-      subject: newsletter.subject,
+      subject: localizedSubject,
       ...(config.send.includeHtml ? { html } : {}),
       ...(config.send.includeText ? { text } : {}),
       ...(config.resend.replyTo !== undefined

--- a/apps/mediapulse/agents/delivery/src/index.test.ts
+++ b/apps/mediapulse/agents/delivery/src/index.test.ts
@@ -360,6 +360,7 @@ describe("delivery-agent", () => {
         {
           userTickerId: syntheticTestRecipientUserTickerId("test@example.com"),
           email: "test@example.com",
+          language: "en",
         },
       ],
       [],
@@ -407,7 +408,7 @@ describe("delivery-agent", () => {
 
     expect(mockDeliverNewsletter).toHaveBeenCalledWith(
       expect.anything(),
-      [{ userTickerId: UT_ID, email: "u@example.com" }],
+      [{ userTickerId: UT_ID, email: "u@example.com", language: "en" }],
       [],
       expect.anything(),
       expect.anything(),

--- a/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.test.ts
+++ b/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.test.ts
@@ -13,8 +13,8 @@ const UT_A = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 const UT_B = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
 
 const DB_SUBSCRIBERS: DeliverySubscriber[] = [
-  { userTickerId: UT_A, email: "alice@example.com" },
-  { userTickerId: UT_B, email: "bob@example.com" },
+  { userTickerId: UT_A, email: "alice@example.com", language: "id" },
+  { userTickerId: UT_B, email: "bob@example.com", language: "en" },
 ];
 
 describe("normalizeTestEmails", () => {
@@ -77,7 +77,7 @@ describe("resolveDeliveryRecipients", () => {
     });
   });
 
-  it("maps override emails to subscribers with override flag", () => {
+  it("maps override emails to subscribers, defaulting language and reusing a matched subscriber's language", () => {
     const resolved = resolveDeliveryRecipients(
       { emails: ["other@example.com", "alice@example.com"] },
       { subscribers: DB_SUBSCRIBERS },
@@ -87,8 +87,9 @@ describe("resolveDeliveryRecipients", () => {
       {
         userTickerId: syntheticTestRecipientUserTickerId("other@example.com"),
         email: "other@example.com",
+        language: "en",
       },
-      { userTickerId: UT_A, email: "alice@example.com" },
+      { userTickerId: UT_A, email: "alice@example.com", language: "id" },
     ]);
   });
 

--- a/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.ts
+++ b/apps/mediapulse/agents/delivery/src/resolve-delivery-recipients.ts
@@ -98,10 +98,19 @@ export function resolveDeliveryRecipients(
   }
 
   const normalized = normalizeTestEmails(input.emails);
-  const subscribers = normalized.map((email) => ({
-    userTickerId: testRecipientUserTickerId(email, deliveryData.subscribers),
-    email,
-  }));
+  const subscribers = normalized.map((email) => {
+    const match = deliveryData.subscribers.find(
+      (s) => s.email.trim().toLowerCase() === email,
+    );
+
+    return {
+      userTickerId: testRecipientUserTickerId(email, deliveryData.subscribers),
+      email,
+      // Reuse the matched subscriber's language so a test send mirrors what they receive;
+      // unmatched test addresses default to English.
+      language: match?.language ?? ("en" as const),
+    };
+  });
 
   return {
     subscribers,

--- a/packages/mediapulse/database/prisma/migrations/20260629070715_add_newsletter_translation/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260629070715_add_newsletter_translation/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "newsletter_translation" (
+    "id" TEXT NOT NULL,
+    "newsletter_id" TEXT NOT NULL,
+    "language" "Language" NOT NULL,
+    "subject" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+    "model" TEXT,
+    "prompt_tokens" INTEGER,
+    "completion_tokens" INTEGER,
+    "total_tokens" INTEGER,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "newsletter_translation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "newsletter_translation_newsletter_id_language_key" ON "newsletter_translation"("newsletter_id", "language");
+
+-- AddForeignKey
+ALTER TABLE "newsletter_translation" ADD CONSTRAINT "newsletter_translation_newsletter_id_fkey" FOREIGN KEY ("newsletter_id") REFERENCES "newsletter"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -178,8 +178,34 @@ model Newsletter {
   deliveryCheckpoints NewsletterDeliveryCheckpoint[]
   deliveryRuns        DeliveryRun[]
   feedback            NewsletterFeedback[]
+  translations        NewsletterTranslation[]
 
   @@map("newsletter")
+}
+
+/// A translated rendering of a Newsletter for a non-English subscription language.
+/// The base Newsletter row holds the canonical English text, so delivery checkpoints,
+/// the self-describing Message-ID, and feedback correlation all key on the same newsletter id.
+model NewsletterTranslation {
+  id           String   @id @default(uuid())
+  newsletterId String   @map("newsletter_id")
+  language     Language
+  subject      String
+  content      String
+
+  /// Provenance for the translation pass (mirrors Newsletter provenance fields).
+  model            String? @map("model")
+  promptTokens     Int?    @map("prompt_tokens")
+  completionTokens Int?    @map("completion_tokens")
+  totalTokens      Int?    @map("total_tokens")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  newsletter Newsletter @relation(fields: [newsletterId], references: [id], onDelete: Cascade)
+
+  @@unique([newsletterId, language])
+  @@map("newsletter_translation")
 }
 
 /// Admin-managed vocabulary for entity classification used by extraction prompts.

--- a/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
+++ b/packages/shared/agent-data-api-contract/src/agent-data-api-manifest.ts
@@ -22,6 +22,10 @@ import {
   postContentGenerationResponseSchema,
 } from "./content-generation.js";
 import {
+  postNewsletterTranslationBodySchema,
+  postNewsletterTranslationResponseSchema,
+} from "./newsletter-translation.js";
+import {
   dataCollectionBodySchema,
   dataCollectionQuerySchema,
   getDataCollectionResponseSchema,
@@ -237,6 +241,20 @@ export const agentDataApiManifest = defineAgentDataApiManifest({
       post: {
         body: postContentGenerationBodySchema,
         response: postContentGenerationResponseSchema,
+      },
+    },
+  },
+  newsletterTranslation: {
+    v1: {
+      post: {
+        body: postNewsletterTranslationBodySchema,
+        response: postNewsletterTranslationResponseSchema,
+      },
+    },
+    v2: {
+      post: {
+        body: postNewsletterTranslationBodySchema,
+        response: postNewsletterTranslationResponseSchema,
       },
     },
   },

--- a/packages/shared/agent-data-api-contract/src/delivery.ts
+++ b/packages/shared/agent-data-api-contract/src/delivery.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { newsletterLanguageSchema } from "./newsletter-translation.js";
+
 export const getDeliveryQuerySchema = z.object({
   tickerId: z.string().trim().min(1),
 });
@@ -10,16 +12,27 @@ export const postDeliveryBodySchema = z.object({
   resendEmailId: z.string().min(1).optional(),
 });
 
+/** A translated rendering of the newsletter for a non-English subscription language. */
+export const deliveryNewsletterTranslationSchema = z.object({
+  language: newsletterLanguageSchema,
+  subject: z.string(),
+  content: z.string(),
+});
+
 export const deliveryNewsletterSchema = z.object({
   id: z.string().uuid(),
   subject: z.string(),
   content: z.string(),
   symbol: z.string(),
+  /** Non-English translations of this newsletter; empty when none exist yet. */
+  translations: z.array(deliveryNewsletterTranslationSchema),
 });
 
 export const deliverySubscriberSchema = z.object({
   userTickerId: z.string().uuid(),
   email: z.string().email(),
+  /** Subscription language used to pick which rendered text the recipient receives. */
+  language: newsletterLanguageSchema,
 });
 
 export const getDeliveryResponseSchema = z.object({
@@ -33,6 +46,9 @@ export const postDeliveryResponseSchema = z.object({
   message: z.string(),
 });
 
+export type DeliveryNewsletterTranslation = z.infer<
+  typeof deliveryNewsletterTranslationSchema
+>;
 export type GetDeliveryQuery = z.infer<typeof getDeliveryQuerySchema>;
 export type PostDeliveryBody = z.infer<typeof postDeliveryBodySchema>;
 export type GetDeliveryResponse = z.infer<typeof getDeliveryResponseSchema>;

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -124,16 +124,26 @@ export {
 } from "./discovery-source-health.js";
 export {
   deliveryNewsletterSchema,
+  deliveryNewsletterTranslationSchema,
   deliverySubscriberSchema,
   getDeliveryQuerySchema,
   getDeliveryResponseSchema,
   postDeliveryBodySchema,
   postDeliveryResponseSchema,
+  type DeliveryNewsletterTranslation,
   type GetDeliveryQuery,
   type GetDeliveryResponse,
   type PostDeliveryBody,
   type PostDeliveryResponse,
 } from "./delivery.js";
+export {
+  newsletterLanguageSchema,
+  postNewsletterTranslationBodySchema,
+  postNewsletterTranslationResponseSchema,
+  type NewsletterLanguage,
+  type PostNewsletterTranslationBody,
+  type PostNewsletterTranslationResponse,
+} from "./newsletter-translation.js";
 export {
   deliveryClaimBodySchema,
   postDeliveryClaimResponseSchema,

--- a/packages/shared/agent-data-api-contract/src/newsletter-translation.ts
+++ b/packages/shared/agent-data-api-contract/src/newsletter-translation.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+
+/** Newsletter delivery language (mirrors the Prisma `Language` enum). */
+export const newsletterLanguageSchema = z.enum(["en", "id"]);
+
+export const postNewsletterTranslationBodySchema = z.object({
+  newsletterId: z.string().uuid(),
+  language: newsletterLanguageSchema,
+  subject: z.string(),
+  content: z.string(),
+  model: z.string().optional(),
+  promptTokens: z.number().int().nonnegative().optional(),
+  completionTokens: z.number().int().nonnegative().optional(),
+  totalTokens: z.number().int().nonnegative().optional(),
+});
+
+export const postNewsletterTranslationResponseSchema = z.object({
+  message: z.string(),
+});
+
+export type NewsletterLanguage = z.infer<typeof newsletterLanguageSchema>;
+export type PostNewsletterTranslationBody = z.infer<
+  typeof postNewsletterTranslationBodySchema
+>;
+export type PostNewsletterTranslationResponse = z.infer<
+  typeof postNewsletterTranslationResponseSchema
+>;


### PR DESCRIPTION
## Summary

Subscribers can pick an Indonesian subscription, but every newsletter still goes out in English because no Indonesian content is ever produced and delivery hard-filters to `language: "en"`. This adds an Indonesian translation of each newsletter and delivers it to `id` subscribers. The English `Newsletter` row stays canonical; a new `newsletter_translation` table holds the translated text keyed by `(newsletterId, language)`, so delivery checkpoints, the self-describing `Message-ID`, and feedback correlation keep working unchanged — only the rendered subject and body differ per recipient.

## Related issues

Closes #863

## Important changes

- **New `newsletter_translation` table** (FK to `newsletter`, unique on `(newsletter_id, language)`) with migration `20260629070715_add_newsletter_translation`.
- **Content-generation translation pass**: after the English newsletter persists, `translate-newsletter.ts` translates the subject and body to Indonesian (preserving section structure, citation links, and numbers) and stores it via a new `newsletterTranslation` data-API endpoint. It runs only when the new `translation` config block is enabled (default off) and is best-effort — a translation failure never fails the run or rolls back the English newsletter.
- **Delivery is now language-aware**: `getDeliveryData` no longer filters to English; it returns every enabled subscriber with their `language` plus the newsletter's translations. `deliverNewsletterToSubscribers` renders the right text per recipient and **skips** an `id` recipient (no claim, no send) when the newsletter has no Indonesian translation, so English is never sent to someone who chose Indonesian.

## Other changes

- Extended the delivery contract (subscriber gains `language`, newsletter gains `translations`) and registered the `newsletterTranslation` resource in the API manifest, which auto-generates the typed SDK method.
- Test-email overrides reuse a matched subscriber's language and default to English otherwise.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` - the `NewsletterTranslation` model.
- `apps/mediapulse/agents/content-generation/src/translate-newsletter.ts` - translation prompt and structure/link/number preservation.
- `apps/mediapulse/agents/content-generation/src/run.ts` - best-effort wiring after persist.
- `apps/mediapulse/agent-data-api/src/services/delivery.ts` - both-language query and translations in the response.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` - per-recipient language selection and missing-translation skip.

## How to test

1. `pnpm --filter @mediapulse/database db:migrate:dev` and confirm the `newsletter_translation` table plus unique index exist.
2. With the `translation` config enabled, run the content-generation agent for a ticker that has sources and confirm one `Newsletter` row plus one `id` `NewsletterTranslation` row.
3. Register one `en` and one `id` subscriber for that ticker, run the delivery agent (test-email override is fine), and confirm the `id` recipient gets the Indonesian subject/body, the `en` recipient gets English, and both unsubscribe links work.
4. Delete the `id` translation row, re-run delivery, and confirm the `id` recipient is skipped (no English fallback) while the `en` recipient still receives the email.
5. Scoped checks: `pnpm --filter @mediapulse/agent-data-api --filter @mediapulse/content-generation --filter @mediapulse/delivery test` and `pnpm format:check:changed`.
