### PR TITLE
Invite newsletter replies for feedback in the footer

### DIFF
--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -397,6 +397,9 @@ export const DefaultNewsletterEmail = ({
             </Link>
             .
           </Text>
+          <Text style={footer}>
+            Have feedback? Just reply to this email and we&apos;ll read it.
+          </Text>
           <Text style={footer}>{resolvedFooterNote}</Text>
           {unsubscribeUrl !== undefined && unsubscribeUrl !== "" ? (
             <Text style={footerMuted}>

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -325,6 +325,16 @@ describe("renderNewsletterEmail", () => {
     expect(brandingIndex).toBeLessThan(footerNoteIndex);
   });
 
+  it("invites subscribers to reply with feedback in the footer", async () => {
+    const { html, text } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+    });
+
+    expect(html).toMatch(/reply to this email/i);
+    expect(text).toMatch(/reply to this email/i);
+  });
+
   it("renders a CTA link with the item title below each top-news item that has a source URL", async () => {
     // Setup
     const structuredBody = [


### PR DESCRIPTION
## Summary

The newsletter email can already take feedback by reply, but nothing in the email says so. This adds a short footer line inviting subscribers to reply, which surfaces a path that already works end to end.

## Related issues

Closes #865

## Important changes

- `default-newsletter.tsx`: added a footer line, "Have feedback? Just reply to this email and we'll read it.", between the branding block and the subscription disclaimer. It reuses the existing muted `footer` style.

## Other changes

- Added a test asserting the feedback copy shows up in both the HTML and plain-text render.

## Key files to review

- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` - the new footer line and its placement.
- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` - asserts the copy renders in HTML and text.

## How to test

1. `pnpm --filter @workspace/email-templates test`
2. Confirm the new "invites subscribers to reply with feedback in the footer" test passes.
3. Optionally preview the default newsletter and check the line sits above the subscription disclaimer in the muted footer style, in both HTML and plain text.

## Notes

This only surfaces existing behavior: delivery already stamps a self-describing `Message-ID` so a reply correlates back to the newsletter and subscriber. It assumes the sending / `replyTo` address is a monitored inbox rather than a `no-reply` mailbox.
