### PR TITLE
Add newsletter feedback to the Hermes dashboard sidebar

### DIFF
--- a/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
+++ b/apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts
@@ -8,6 +8,7 @@ import { deliveryRunsHermesDashboardResource } from "../resources/delivery-runs/
 import { entitiesHermesDashboardResource } from "../resources/entities/resource-definition";
 import { entityRelationsHermesDashboardResource } from "../resources/entity-relations/resource-definition";
 import { entityTypesHermesDashboardResource } from "../resources/entity-types/resource-definition";
+import { feedbackHermesDashboardResource } from "../resources/feedback/resource-definition";
 import { mediapulseUsersHermesDashboardResource } from "../resources/mediapulse-users/resource-definition";
 import { newslettersHermesDashboardResource } from "../resources/newsletters/resource-definition";
 import { relationTypesHermesDashboardResource } from "../resources/relation-types/resource-definition";
@@ -35,6 +36,7 @@ export const hermesDashboardResources = [
   searchQueriesHermesDashboardResource,
   deliveryRunsHermesDashboardResource,
   newslettersHermesDashboardResource,
+  feedbackHermesDashboardResource,
 ] as const satisfies readonly HermesDashboardResourceDefinition<
   string,
   string

--- a/apps/mediapulse/domain-api/src/hermes-dashboard/templates/table-v1/list-filter-definitions.ts
+++ b/apps/mediapulse/domain-api/src/hermes-dashboard/templates/table-v1/list-filter-definitions.ts
@@ -87,3 +87,41 @@ export const collectionGateStatusSelectListFilter = {
   placeholderAll: "All",
   optionsMetaKey: "collectionGateStatusOptions",
 } satisfies TableV1ListFilterDefinition;
+
+/** Newsletter feedback sentiment filter (`sentiment` query param). */
+export const feedbackSentimentSelectListFilter = {
+  key: "sentiment",
+  label: "Sentiment",
+  ui: "select",
+  placeholderAll: "All sentiments",
+  staticOptions: [
+    { value: "positive", label: "Positive" },
+    { value: "negative", label: "Negative" },
+    { value: "neutral", label: "Neutral" },
+    { value: "mixed", label: "Mixed" },
+  ],
+} satisfies TableV1ListFilterDefinition;
+
+/** Newsletter feedback category filter (`category` query param). */
+export const feedbackCategorySelectListFilter = {
+  key: "category",
+  label: "Category",
+  ui: "select",
+  placeholderAll: "All categories",
+  staticOptions: [
+    { value: "praise", label: "Praise" },
+    { value: "complaint", label: "Complaint" },
+    { value: "feature_request", label: "Feature request" },
+    { value: "bug", label: "Bug" },
+    { value: "question", label: "Question" },
+    { value: "other", label: "Other" },
+  ],
+} satisfies TableV1ListFilterDefinition;
+
+/** Newsletter feedback received-date range filter (`from`/`to` query params). */
+export const feedbackReceivedAtDateRangeListFilter = {
+  key: "receivedAt",
+  label: "Received",
+  ui: "date-range",
+  rangeParams: { from: "from", to: "to" },
+} satisfies TableV1ListFilterDefinition;

--- a/apps/mediapulse/domain-api/src/resources/feedback/dashboard-page.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/dashboard-page.ts
@@ -1,0 +1,94 @@
+/**
+ * Hermes `resource-table` manifest slice for newsletter feedback and the exported `*HermesPathSegment` for routing.
+ */
+
+import type { DashboardViewInput, DetailBlock } from "@hermes/domain-contract";
+import { hermesDashboardManifestApiPrefix } from "../../hermes-dashboard/hermes-dashboard-path-helpers";
+import {
+  feedbackCategorySelectListFilter,
+  feedbackReceivedAtDateRangeListFilter,
+  feedbackSentimentSelectListFilter,
+} from "../../hermes-dashboard/templates/table-v1/list-filter-definitions";
+import {
+  columnsFor,
+  rowFieldKeysFor,
+} from "../../hermes-dashboard/templates/table-v1/manifest-field-helpers";
+import type { ListItem } from "./list-mapper";
+
+/** URL path segment for this resource under `/v1/hermes-dashboard/`. */
+export const feedbackHermesPathSegment = "feedback" as const;
+
+/**
+ * `keyValue` block describing the reply metadata: sender, classification, and
+ * link rows back to the correlated newsletter and Mediapulse user. Missing
+ * template variables (e.g. an uncorrelated reply) fall back to plain text.
+ */
+const feedbackMetadataBlock = {
+  type: "keyValue",
+  label: "Metadata",
+  rows: [
+    { field: "id", label: "Feedback id", copyAction: true },
+    { field: "senderEmail", label: "From", copyAction: true },
+    { field: "subject", label: "Subject" },
+    { field: "receivedAt", label: "Received", format: "date-time" },
+    { field: "sentiment", label: "Sentiment" },
+    { field: "category", label: "Category" },
+    { field: "classifierModel", label: "Classifier model" },
+    { field: "classifiedAt", label: "Classified at", format: "date-time" },
+    {
+      field: "newsletterId",
+      label: "Newsletter",
+      linkTemplate: "/dashboard/{integrationId}/newsletters/{newsletterId}",
+      copyAction: true,
+    },
+    {
+      field: "userId",
+      label: "Mediapulse user",
+      linkTemplate: "/dashboard/{integrationId}/mediapulse-users/{userId}",
+      copyAction: true,
+    },
+  ],
+} satisfies DetailBlock;
+
+/**
+ * `markdown` block bound to the raw reply body. Long bodies clamp at 4,000
+ * characters with a "show full" expander once they exceed 10,000 characters.
+ */
+const feedbackBodyBlock = {
+  type: "markdown",
+  label: "Reply body",
+  field: "rawBody",
+  clampChars: 4000,
+  clampThreshold: 10000,
+  copyAction: true,
+} satisfies DetailBlock;
+
+/** Hermes `resource-table` manifest page for newsletter feedback (read-only list + detail). */
+export const feedbackDashboardPage = {
+  id: feedbackHermesPathSegment,
+  label: "Feedback",
+  description:
+    "Replies to delivered newsletters, captured and classified by sentiment and category (read-only).",
+  pathSegment: feedbackHermesPathSegment,
+  kind: "resource-table" as const,
+  placement: "sidebar" as const,
+  apiPrefix: hermesDashboardManifestApiPrefix(feedbackHermesPathSegment),
+  order: 65,
+  columns: columnsFor<ListItem>()([
+    { key: "senderEmail", label: "From", type: "text" },
+    { key: "subject", label: "Subject", type: "text" },
+    { key: "sentiment", label: "Sentiment", type: "text" },
+    { key: "category", label: "Category", type: "text" },
+    { key: "receivedAt", label: "Received", type: "date-time" },
+  ]),
+  searchableFields: rowFieldKeysFor<ListItem>()(["senderEmail", "subject"]),
+  sortableFields: rowFieldKeysFor<ListItem>()(["receivedAt", "senderEmail"]),
+  defaultSort: { sortBy: "receivedAt", sortDir: "desc" },
+  listFilters: [
+    feedbackSentimentSelectListFilter,
+    feedbackCategorySelectListFilter,
+    feedbackReceivedAtDateRangeListFilter,
+  ],
+  actions: { create: false, update: false, delete: false, view: true },
+  detailBlocks: [feedbackMetadataBlock, feedbackBodyBlock],
+} satisfies DashboardViewInput;

--- a/apps/mediapulse/domain-api/src/resources/feedback/detail-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/detail-mapper.ts
@@ -1,0 +1,57 @@
+/**
+ * Maps a `NewsletterFeedback` row to the detail payload for the feedback Hermes table API.
+ */
+
+import type { NewsletterFeedback } from "@mediapulse/database";
+import { formatCategory, formatSentiment } from "./list-mapper";
+
+/** Prisma row shape passed to {@link mapRowToDetailItem}. */
+export type NewsletterFeedbackDetailRow = NewsletterFeedback;
+
+/** Shape of the detail payload exposed by `GET /resources/feedback/:id`. */
+export type DetailItem = {
+  id: string;
+  title: string;
+  senderEmail: string;
+  subject: string | null;
+  receivedAt: string;
+  sentiment: string;
+  category: string;
+  classifierModel: string | null;
+  classifiedAt: string | null;
+  userId: string | null;
+  userTickerId: string | null;
+  newsletterId: string | null;
+  rawBody: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * Maps a Prisma newsletter feedback row to the detail response.
+ *
+ * `title` is what the generic dashboard detail page renders as the header; it
+ * falls back to the sender when the reply has no subject.
+ *
+ * @param row - Newsletter feedback row.
+ * @returns Detail item for the Hermes dashboard.
+ */
+export const mapRowToDetailItem = (
+  row: NewsletterFeedbackDetailRow,
+): DetailItem => ({
+  id: row.id,
+  title: row.subject ?? `Reply from ${row.senderEmail}`,
+  senderEmail: row.senderEmail,
+  subject: row.subject,
+  receivedAt: row.receivedAt.toISOString(),
+  sentiment: formatSentiment(row.sentiment),
+  category: formatCategory(row.category),
+  classifierModel: row.classifierModel,
+  classifiedAt: row.classifiedAt?.toISOString() ?? null,
+  userId: row.userId,
+  userTickerId: row.userTickerId,
+  newsletterId: row.newsletterId,
+  rawBody: row.rawBody,
+  createdAt: row.createdAt.toISOString(),
+  updatedAt: row.updatedAt.toISOString(),
+});

--- a/apps/mediapulse/domain-api/src/resources/feedback/list-mapper.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/list-mapper.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for newsletter feedback list mapping.
+ */
+
+/** @vitest-environment node */
+import type { NewsletterFeedbackListRow } from "./list-mapper";
+import { describe, expect, it } from "vitest";
+import {
+  formatCategory,
+  formatSentiment,
+  mapRowToListItem,
+} from "./list-mapper";
+
+describe("formatSentiment", () => {
+  it("maps each sentiment to a label", () => {
+    expect(formatSentiment("positive")).toBe("Positive");
+    expect(formatSentiment("negative")).toBe("Negative");
+    expect(formatSentiment("neutral")).toBe("Neutral");
+    expect(formatSentiment("mixed")).toBe("Mixed");
+  });
+
+  it("returns an em dash when unclassified", () => {
+    expect(formatSentiment(null)).toBe("—");
+  });
+});
+
+describe("formatCategory", () => {
+  it("maps each category to a label", () => {
+    expect(formatCategory("feature_request")).toBe("Feature request");
+    expect(formatCategory("bug")).toBe("Bug");
+  });
+
+  it("returns an em dash when unclassified", () => {
+    expect(formatCategory(null)).toBe("—");
+  });
+});
+
+const baseRow: NewsletterFeedbackListRow = {
+  id: "fb-1",
+  senderEmail: "reader@example.com",
+  subject: "Loved it",
+  rawBody: "Great newsletter!",
+  receivedAt: new Date("2026-06-20T08:00:00.000Z"),
+  graphMessageId: "graph-1",
+  inReplyTo: "<nl.n1.ut1@example.com>",
+  sentiment: "positive",
+  category: "praise",
+  classifierModel: "claude-haiku-4-5",
+  classifiedAt: new Date("2026-06-20T08:05:00.000Z"),
+  userId: "user-1",
+  userTickerId: "ut-1",
+  newsletterId: "n-1",
+  createdAt: new Date("2026-06-20T08:06:00.000Z"),
+  updatedAt: new Date("2026-06-20T08:06:00.000Z"),
+};
+
+describe("mapRowToListItem", () => {
+  it("maps scalar fields, classification labels, and ISO dates", () => {
+    const item = mapRowToListItem(baseRow);
+
+    expect(item).toEqual({
+      id: "fb-1",
+      senderEmail: "reader@example.com",
+      subject: "Loved it",
+      sentiment: "Positive",
+      category: "Praise",
+      receivedAt: baseRow.receivedAt.toISOString(),
+      createdAt: baseRow.createdAt.toISOString(),
+    });
+  });
+
+  it("falls back to an em dash for null subject and unclassified rows", () => {
+    const row: NewsletterFeedbackListRow = {
+      ...baseRow,
+      subject: null,
+      sentiment: null,
+      category: null,
+    };
+
+    const item = mapRowToListItem(row);
+
+    expect(item.subject).toBe("—");
+    expect(item.sentiment).toBe("—");
+    expect(item.category).toBe("—");
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/feedback/list-mapper.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/list-mapper.ts
@@ -1,0 +1,81 @@
+/**
+ * Maps `NewsletterFeedback` rows to list items for the feedback Hermes table API.
+ */
+
+import type {
+  FeedbackCategory,
+  FeedbackSentiment,
+  NewsletterFeedback,
+} from "@mediapulse/database";
+
+/** Prisma row shape for the feedback list query. */
+export type NewsletterFeedbackListRow = NewsletterFeedback;
+
+const sentimentLabels: Record<FeedbackSentiment, string> = {
+  positive: "Positive",
+  negative: "Negative",
+  neutral: "Neutral",
+  mixed: "Mixed",
+};
+
+const categoryLabels: Record<FeedbackCategory, string> = {
+  praise: "Praise",
+  complaint: "Complaint",
+  feature_request: "Feature request",
+  bug: "Bug",
+  question: "Question",
+  other: "Other",
+};
+
+/**
+ * Returns a human-readable label for a classified feedback sentiment.
+ *
+ * @param sentiment - Prisma `FeedbackSentiment` value, or `null` when unclassified.
+ * @returns Display label, or `"—"` when there is no sentiment.
+ */
+export const formatSentiment = (
+  sentiment: FeedbackSentiment | null,
+): string => {
+  if (sentiment === null) return "—";
+
+  return sentimentLabels[sentiment];
+};
+
+/**
+ * Returns a human-readable label for a classified feedback category.
+ *
+ * @param category - Prisma `FeedbackCategory` value, or `null` when unclassified.
+ * @returns Display label, or `"—"` when there is no category.
+ */
+export const formatCategory = (category: FeedbackCategory | null): string => {
+  if (category === null) return "—";
+
+  return categoryLabels[category];
+};
+
+/** Shape of one row in the feedback list table. */
+export type ListItem = {
+  id: string;
+  senderEmail: string;
+  subject: string;
+  sentiment: string;
+  category: string;
+  receivedAt: string;
+  createdAt: string;
+};
+
+/**
+ * Maps a Prisma newsletter feedback row to the JSON list item.
+ *
+ * @param row - Row from `prisma.newsletterFeedback.findMany`.
+ * @returns Serializable list row for the Hermes dashboard.
+ */
+export const mapRowToListItem = (row: NewsletterFeedbackListRow): ListItem => ({
+  id: row.id,
+  senderEmail: row.senderEmail,
+  subject: row.subject ?? "—",
+  sentiment: formatSentiment(row.sentiment),
+  category: formatCategory(row.category),
+  receivedAt: row.receivedAt.toISOString(),
+  createdAt: row.createdAt.toISOString(),
+});

--- a/apps/mediapulse/domain-api/src/resources/feedback/resource-definition.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/resource-definition.ts
@@ -1,0 +1,19 @@
+/**
+ * Registers newsletter feedback with the central Hermes dashboard resource registry.
+ */
+
+import { defineHermesDashboardResource } from "../../hermes-dashboard/hermes-dashboard-resource-types";
+import {
+  feedbackDashboardPage,
+  feedbackHermesPathSegment,
+} from "./dashboard-page";
+import { feedbackRoutes } from "./routes";
+
+/** Hermes dashboard registration for the read-only newsletter feedback list. */
+export const feedbackHermesDashboardResource = defineHermesDashboardResource({
+  resourceKey: "feedback",
+  pathSegment: feedbackHermesPathSegment,
+  order: 65,
+  routes: feedbackRoutes,
+  dashboardPage: feedbackDashboardPage,
+});

--- a/apps/mediapulse/domain-api/src/resources/feedback/routes.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/routes.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Route wiring for newsletter feedback: list and detail handlers.
+ */
+
+/** @vitest-environment node */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@mediapulse/database", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@mediapulse/database")>();
+  return {
+    ...actual,
+    prisma: {
+      ...actual.prisma,
+      newsletterFeedback: {
+        findMany: vi.fn(),
+        count: vi.fn(),
+        findUnique: vi.fn(),
+      },
+    },
+  };
+});
+
+import { prisma } from "@mediapulse/database";
+
+import { feedbackRoutes } from "./routes";
+
+const row = {
+  id: "fb-1",
+  senderEmail: "reader@example.com",
+  subject: "Loved it",
+  rawBody: "Great newsletter!",
+  receivedAt: new Date("2026-06-20T08:00:00.000Z"),
+  graphMessageId: "graph-1",
+  inReplyTo: null,
+  sentiment: "positive",
+  category: "praise",
+  classifierModel: "claude-haiku-4-5",
+  classifiedAt: new Date("2026-06-20T08:05:00.000Z"),
+  userId: "user-1",
+  userTickerId: "ut-1",
+  newsletterId: "n-1",
+  createdAt: new Date("2026-06-20T08:06:00.000Z"),
+  updatedAt: new Date("2026-06-20T08:06:00.000Z"),
+};
+
+describe("feedbackRoutes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns paginated list items with classification labels", async () => {
+    vi.mocked(prisma.newsletterFeedback.findMany).mockResolvedValue([
+      row,
+    ] as never);
+    vi.mocked(prisma.newsletterFeedback.count).mockResolvedValue(1);
+
+    const res = await feedbackRoutes.request("http://localhost/", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      items: Array<{ id: string; sentiment: string; category: string }>;
+    };
+    expect(body.items).toHaveLength(1);
+    expect(body.items[0]?.id).toBe("fb-1");
+    expect(body.items[0]?.sentiment).toBe("Positive");
+    expect(body.items[0]?.category).toBe("Praise");
+    expect(prisma.newsletterFeedback.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { receivedAt: "desc" },
+      }),
+    );
+  });
+
+  it("passes sentiment and category filters to Prisma findMany", async () => {
+    vi.mocked(prisma.newsletterFeedback.findMany).mockResolvedValue(
+      [] as never,
+    );
+    vi.mocked(prisma.newsletterFeedback.count).mockResolvedValue(0);
+
+    const res = await feedbackRoutes.request(
+      "http://localhost/?sentiment=negative&category=bug",
+      { method: "GET" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(prisma.newsletterFeedback.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { AND: [{ sentiment: "negative" }, { category: "bug" }] },
+      }),
+    );
+  });
+
+  it("ignores invalid filter values", async () => {
+    vi.mocked(prisma.newsletterFeedback.findMany).mockResolvedValue(
+      [] as never,
+    );
+    vi.mocked(prisma.newsletterFeedback.count).mockResolvedValue(0);
+
+    const res = await feedbackRoutes.request(
+      "http://localhost/?sentiment=angry&category=spam",
+      { method: "GET" },
+    );
+
+    expect(res.status).toBe(200);
+    expect(prisma.newsletterFeedback.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: undefined,
+      }),
+    );
+  });
+
+  it("returns a detail payload for an existing row", async () => {
+    vi.mocked(prisma.newsletterFeedback.findUnique).mockResolvedValue(
+      row as never,
+    );
+
+    const res = await feedbackRoutes.request("http://localhost/fb-1", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      id: string;
+      title: string;
+      rawBody: string;
+      newsletterId: string;
+    };
+    expect(body.id).toBe("fb-1");
+    expect(body.title).toBe("Loved it");
+    expect(body.rawBody).toBe("Great newsletter!");
+    expect(body.newsletterId).toBe("n-1");
+  });
+
+  it("returns 404 when the row is missing", async () => {
+    vi.mocked(prisma.newsletterFeedback.findUnique).mockResolvedValue(
+      null as never,
+    );
+
+    const res = await feedbackRoutes.request("http://localhost/missing", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/apps/mediapulse/domain-api/src/resources/feedback/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/routes.ts
@@ -1,0 +1,175 @@
+/**
+ * HTTP handlers for read-only newsletter feedback: list and detail.
+ */
+
+import { tableV1ListResponseSchema } from "@hermes/domain-contract";
+import {
+  prisma,
+  Prisma,
+  type FeedbackCategory,
+  type FeedbackSentiment,
+} from "@mediapulse/database";
+import { Hono } from "hono";
+
+import { parseCreatedDateBound } from "../../lib/parse-created-date-bound";
+import { parsePagination } from "../../lib/list-pagination";
+import { mapRowToDetailItem } from "./detail-mapper";
+import { mapRowToListItem } from "./list-mapper";
+
+/** Hermes `resource-table` API for read-only newsletter feedback (list, detail). */
+export const feedbackRoutes = new Hono();
+
+const SENTIMENT_VALUES = new Set<FeedbackSentiment>([
+  "positive",
+  "negative",
+  "neutral",
+  "mixed",
+]);
+
+const CATEGORY_VALUES = new Set<FeedbackCategory>([
+  "praise",
+  "complaint",
+  "feature_request",
+  "bug",
+  "question",
+  "other",
+]);
+
+/**
+ * Parses the optional sentiment filter from the query string.
+ *
+ * @param raw - Raw `sentiment` query parameter.
+ * @returns A valid `FeedbackSentiment`, or `undefined` when unset or invalid.
+ */
+const parseSentimentFilter = (
+  raw: string | undefined,
+): FeedbackSentiment | undefined => {
+  const trimmed = raw?.trim();
+  if (trimmed && SENTIMENT_VALUES.has(trimmed as FeedbackSentiment)) {
+    return trimmed as FeedbackSentiment;
+  }
+
+  return undefined;
+};
+
+/**
+ * Parses the optional category filter from the query string.
+ *
+ * @param raw - Raw `category` query parameter.
+ * @returns A valid `FeedbackCategory`, or `undefined` when unset or invalid.
+ */
+const parseCategoryFilter = (
+  raw: string | undefined,
+): FeedbackCategory | undefined => {
+  const trimmed = raw?.trim();
+  if (trimmed && CATEGORY_VALUES.has(trimmed as FeedbackCategory)) {
+    return trimmed as FeedbackCategory;
+  }
+
+  return undefined;
+};
+
+/**
+ * Builds the Prisma `where` clause for the feedback list endpoint.
+ *
+ * @param filters - Parsed search and filter values from the query string.
+ * @returns Combined where input, or `undefined` when no filters apply.
+ */
+const buildFeedbackListWhere = (filters: {
+  q: string | undefined;
+  sentiment: FeedbackSentiment | undefined;
+  category: FeedbackCategory | undefined;
+  from: Date | undefined;
+  to: Date | undefined;
+}): Prisma.NewsletterFeedbackWhereInput | undefined => {
+  const parts: Prisma.NewsletterFeedbackWhereInput[] = [];
+
+  if (filters.q) {
+    parts.push({
+      OR: [
+        { senderEmail: { contains: filters.q, mode: "insensitive" as const } },
+        { subject: { contains: filters.q, mode: "insensitive" as const } },
+      ],
+    });
+  }
+
+  if (filters.sentiment !== undefined) {
+    parts.push({ sentiment: filters.sentiment });
+  }
+
+  if (filters.category !== undefined) {
+    parts.push({ category: filters.category });
+  }
+
+  if (filters.from !== undefined || filters.to !== undefined) {
+    parts.push({
+      receivedAt: {
+        ...(filters.from !== undefined ? { gte: filters.from } : {}),
+        ...(filters.to !== undefined ? { lte: filters.to } : {}),
+      },
+    });
+  }
+
+  if (parts.length === 0) return undefined;
+  if (parts.length === 1) return parts[0];
+
+  return { AND: parts };
+};
+
+/** Paginated list of newsletter feedback for the Hermes dashboard table. */
+feedbackRoutes.get("/", async (c) => {
+  const { page, pageSize } = parsePagination(
+    c.req.query("page"),
+    c.req.query("pageSize"),
+  );
+  const skip = (page - 1) * pageSize;
+
+  const where = buildFeedbackListWhere({
+    q: c.req.query("q")?.trim() || undefined,
+    sentiment: parseSentimentFilter(c.req.query("sentiment")),
+    category: parseCategoryFilter(c.req.query("category")),
+    from: parseCreatedDateBound(c.req.query("from"), "start"),
+    to: parseCreatedDateBound(c.req.query("to"), "end"),
+  });
+
+  const sortDir: Prisma.SortOrder =
+    c.req.query("sortDir") === "asc" ? "asc" : "desc";
+  const orderBy =
+    c.req.query("sortBy") === "senderEmail"
+      ? { senderEmail: sortDir }
+      : { receivedAt: sortDir };
+
+  const findManyArgs = {
+    where,
+    skip,
+    take: pageSize,
+    orderBy,
+  } satisfies Prisma.NewsletterFeedbackFindManyArgs;
+
+  const [rows, total] = await Promise.all([
+    prisma.newsletterFeedback.findMany(findManyArgs),
+    prisma.newsletterFeedback.count({ where }),
+  ]);
+
+  const payload = tableV1ListResponseSchema.parse({
+    items: rows.map(mapRowToListItem),
+    total,
+    page,
+    pageSize,
+  });
+
+  return c.json(payload);
+});
+
+/** Detail payload for a single newsletter feedback row. */
+feedbackRoutes.get("/:id", async (c) => {
+  const row = await prisma.newsletterFeedback.findUnique({
+    where: { id: c.req.param("id") },
+  });
+
+  if (!row) {
+    return c.json({ message: "Feedback not found" }, 404);
+  }
+
+  return c.json(mapRowToDetailItem(row));
+});


### PR DESCRIPTION
## Summary

Newsletter replies were being captured and classified in `NewsletterFeedback`, but operators had no way to read them. This adds a read-only Feedback entry to the Mediapulse section of the Hermes dashboard sidebar, with a list and a detail view. The dashboard renders both from the manifest, so no agent-data-api, SDK, Hermes UI, or database changes were needed.

## Related issues

Closes #867

## Important changes

- New `feedback` Hermes dashboard resource in the MediaPulse domain-api, served at `/v1/hermes-dashboard/feedback`. The list paginates, searches sender and subject, and filters by sentiment, category, and received date; the detail view shows the reply metadata and body.
- Registered the resource in the domain-api resource registry so it shows up under the Mediapulse sidebar group and its routes get mounted. This is the single wiring point that feeds both the manifest and the route mounts.

## Other changes

- Added sentiment, category, and received-date filter definitions to the shared table-v1 filter list.
- Sentiment and category enum values render as readable labels (for example `feature_request` becomes "Feature request"), falling back to an em dash when a reply has not been classified.

## Key files to review

- `apps/mediapulse/domain-api/src/resources/feedback/routes.ts` - list and detail handlers, filter parsing, and the Prisma where clause.
- `apps/mediapulse/domain-api/src/resources/feedback/dashboard-page.ts` - the manifest view: columns, filters, and detail blocks.
- `apps/mediapulse/domain-api/src/hermes-dashboard/hermes-dashboard-resource-registry.ts` - where the resource is registered.
- `apps/mediapulse/domain-api/src/resources/feedback/list-mapper.ts` and `detail-mapper.ts` - row mapping and label formatting.

## How to test

1. `pnpm --filter @mediapulse/domain-api run test` - 321 tests pass, including the new `feedback/list-mapper.test.ts` and `feedback/routes.test.ts`.
2. `pnpm --filter @mediapulse/domain-api run type:check` and `run lint` - both clean.
3. Run the domain-api and hit `GET /v1/hermes-dashboard/feedback?page=1&pageSize=20` for a list payload, and `GET /v1/hermes-dashboard/feedback/{id}` for a detail payload.
4. With the integration registered against a local Hermes, open the dashboard and confirm a Feedback entry under the Mediapulse sidebar group that lists rows, filters by sentiment, category, and date, and opens a detail page.
