### PR TITLE
Fix 404 on feedback resource meta endpoint

### DIFF
--- a/apps/mediapulse/domain-api/src/resources/feedback/routes.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/routes.test.ts
@@ -111,6 +111,21 @@ describe("feedbackRoutes", () => {
     );
   });
 
+  it("serves table metadata at /meta without hitting the detail handler", async () => {
+    const res = await feedbackRoutes.request("http://localhost/meta", {
+      method: "GET",
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      title: string;
+      columns: Array<{ key: string }>;
+    };
+    expect(body.title).toBe("Feedback");
+    expect(body.columns.map((column) => column.key)).toContain("senderEmail");
+    expect(prisma.newsletterFeedback.findUnique).not.toHaveBeenCalled();
+  });
+
   it("returns a detail payload for an existing row", async () => {
     vi.mocked(prisma.newsletterFeedback.findUnique).mockResolvedValue(
       row as never,

--- a/apps/mediapulse/domain-api/src/resources/feedback/routes.ts
+++ b/apps/mediapulse/domain-api/src/resources/feedback/routes.ts
@@ -11,12 +11,14 @@ import {
 } from "@mediapulse/database";
 import { Hono } from "hono";
 
+import { buildMetaPayloadForPathSegment } from "../../hermes-dashboard/templates/table-v1/meta-for-path-segment";
 import { parseCreatedDateBound } from "../../lib/parse-created-date-bound";
 import { parsePagination } from "../../lib/list-pagination";
+import { feedbackHermesPathSegment } from "./dashboard-page";
 import { mapRowToDetailItem } from "./detail-mapper";
 import { mapRowToListItem } from "./list-mapper";
 
-/** Hermes `resource-table` API for read-only newsletter feedback (list, detail). */
+/** Hermes `resource-table` API for read-only newsletter feedback (list, meta, detail). */
 export const feedbackRoutes = new Hono();
 
 const SENTIMENT_VALUES = new Set<FeedbackSentiment>([
@@ -159,6 +161,20 @@ feedbackRoutes.get("/", async (c) => {
   });
 
   return c.json(payload);
+});
+
+/**
+ * Table metadata (columns, filters, detail blocks) for the feedback resource.
+ * Declared here because the `/:id` route below would otherwise capture the
+ * `meta` segment before the central manifest handler sees it.
+ */
+feedbackRoutes.get("/meta", (c) => {
+  const meta = buildMetaPayloadForPathSegment(feedbackHermesPathSegment);
+  if (!meta) {
+    return c.json({ message: "Unknown dashboard resource" }, 404);
+  }
+
+  return c.json(meta);
 });
 
 /** Detail payload for a single newsletter feedback row. */


### PR DESCRIPTION
## Summary

The feedback dashboard resource added in #868 returned a 404 when the Hermes dashboard loaded its table metadata. The dashboard calls `GET /v1/hermes-dashboard/feedback/meta`, but that request was matching the resource's `GET /:id` detail handler with `id="meta"`, which looked up a feedback row, found none, and returned 404. This adds an explicit `/meta` route so the metadata resolves correctly.

## Related issues

Closes #869
Refs #868

## Important changes

- Added a `GET /meta` route to the feedback resource that returns the table metadata (columns, filters, detail blocks). It is declared before `/:id` so the `meta` segment is not swallowed by the detail handler. This mirrors how the newsletters resource handles the same situation.

## Other changes

- Added a regression test asserting `/meta` returns 200 with the resource columns and never calls the detail lookup.

## Key files to review

- `apps/mediapulse/domain-api/src/resources/feedback/routes.ts` - the new `/meta` handler and its placement before `/:id`.
- `apps/mediapulse/domain-api/src/resources/feedback/routes.test.ts` - the regression test.

## How to test

1. `pnpm --filter @mediapulse/domain-api exec vitest run src/resources/feedback` - 12 tests pass, including the new `/meta` case.
2. Run the domain-api and call `GET /v1/hermes-dashboard/feedback/meta`; it returns 200 with the feedback columns and filters instead of 404.
3. In the Hermes dashboard, open the Feedback table and confirm its columns and filters load.

## Background

Resources that define `GET /:id` must declare their own `/meta` route, because each resource sub-app is mounted before the central `:resource/meta` handler. Resources without `GET /:id` (for example mediapulse-users) fall through to the central handler and do not need this.
