### PR TITLE
Stop marking boolean form fields as required

### DIFF
--- a/apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.test.ts
+++ b/apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.test.ts
@@ -35,6 +35,24 @@ describe("hermesFormJsonSchemaFromZod", () => {
     const props = json.properties as Record<string, { title?: string }>;
     expect(props.name?.title).toBe("Name");
   });
+
+  it("drops boolean fields from required so checkboxes are optional", () => {
+    // Setup
+    const schema = z
+      .object({
+        email: z.string().email(),
+        enabled: z.boolean(),
+      })
+      .strict();
+
+    // Act
+    const json = hermesFormJsonSchemaFromZod(schema);
+
+    // Assert
+    const required = json.required as string[];
+    expect(required).toContain("email");
+    expect(required).not.toContain("enabled");
+  });
 });
 
 describe("mergeHermesObjectFormProperties", () => {

--- a/apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.ts
+++ b/apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.ts
@@ -64,10 +64,16 @@ export const hermesFormJsonSchemaFromZod = (
     nextProps[key] = sub;
   }
 
-  return {
-    ...raw,
-    properties: nextProps,
-  };
+  const nextRoot: Record<string, unknown> = { ...raw, properties: nextProps };
+  if (Array.isArray(raw.required)) {
+    const required = (raw.required as string[]).filter((key) => {
+      const prop = nextProps[key] as Record<string, unknown> | undefined;
+      return prop?.type !== "boolean";
+    });
+    nextRoot.required = required;
+  }
+
+  return nextRoot;
 };
 
 /**


### PR DESCRIPTION
## Summary

On the Mediapulse Users edit form, unchecking "Enabled" and saving was blocked by the browser with "Please check this box if you want to proceed", so an enabled user could never be disabled. The `enabled` field is a non-optional `z.boolean()`, so the generated form schema listed it as `required`, and the renderer turned that into an HTML `required` checkbox that must be ticked. This stops marking boolean fields as required so an unchecked box submits a valid `false`.

## Related issues

Closes #871

## Important changes

- `hermesFormJsonSchemaFromZod` now drops boolean-typed fields from the form schema `required` array. The fix is generic, so it also covers the boolean toggles on curated-sources and search-query-sets. Server-side Zod validation is unchanged, so the form still submits `false` when the box is unchecked.

## Other changes

- Added a test asserting boolean fields are excluded from `required` while non-boolean fields (for example email) stay required.

## Key files to review

- `apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.ts` - the required-array filtering.
- `apps/mediapulse/domain-api/src/lib/hermes-form-json-schema-from-zod.test.ts` - the regression test.

## How to test

1. `pnpm --filter @mediapulse/domain-api exec vitest run src/lib/hermes-form-json-schema-from-zod` - passes, including the boolean-not-required case.
2. In the Hermes dashboard, edit a Mediapulse user, uncheck "Enabled", and save. The save succeeds and the user is disabled, with no "please check this box" message.
