### PR TITLE
Give the relevance judge alternate names and peer scope

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.test.ts
@@ -74,6 +74,28 @@ describe("judgeRelevance", () => {
     expect(decision).toEqual({ keep: false, reason: "irrelevant", via: "llm" });
   });
 
+  it("includes alternate company names in the LLM prompt", async () => {
+    let capturedPrompt = "";
+    const generate = (async (options: { prompt: string }) => {
+      capturedPrompt = options.prompt;
+
+      return { object: { relevant: true, reason: "t" } };
+    }) as unknown as typeof generateObject;
+
+    await judgeRelevance(
+      baseInput({
+        contractBrief: "Track AGRO news.",
+        tickerSymbol: "AGRO",
+        tickerName: "PT Bank Raya Indonesia Tbk",
+        tickerAliases: ["agro", "pt bank raya indonesia tbk", "bri agro"],
+        generate,
+      }),
+    );
+
+    expect(capturedPrompt).toContain("also referred to as");
+    expect(capturedPrompt).toContain("bri agro");
+  });
+
   it("falls back to keyword matching when the LLM call throws", async () => {
     const generate = (async () => {
       throw new Error("llm down");

--- a/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts
@@ -65,9 +65,20 @@ const buildPrompt = (input: JudgeRelevanceInput): string => {
       : "its industry";
   const head = input.content.slice(0, HEAD_CHARS);
 
+  const otherNames = input.tickerAliases.filter(
+    (alias) =>
+      alias !== input.tickerSymbol.toLowerCase() &&
+      alias !== input.tickerName.toLowerCase(),
+  );
+  const aliasLine =
+    otherNames.length > 0
+      ? `This company is also referred to as: ${otherNames.join(", ")}. Treat any of these names as referring to the same company.`
+      : null;
+
   return [
     `Decide whether this web page is relevant for an investor tracking ${input.tickerSymbol} (${input.tickerName}) in ${industry}.`,
-    "Relevant means the page is about this company, its industry, or events that materially affect it. Generic, unrelated, or spam pages are not relevant.",
+    "Relevant means the page is about this company, its industry, its peers and competitors, or events that materially affect it. Generic, unrelated, or spam pages are not relevant.",
+    ...(aliasLine ? [aliasLine] : []),
     "",
     `Title: ${input.title}`,
     "",


### PR DESCRIPTION
## Summary

The data-collection relevance judge was dropping pages that are actually relevant to the target ticker. The LLM prompt only knew the ticker symbol and current legal name, and its relevance rule said nothing about competitors. So a story that named the company by another name, or one about a peer, could be judged irrelevant. This widens the prompt to fix both cases.

## Related issues

Closes #873

## Important changes

- `judgeRelevance` now passes the ticker's alternate names into the LLM prompt and tells the model to treat them as the same company. The aliases were already available to the function but only the keyword fallback used them. Example: an AGRO (PT Bank Raya Indonesia Tbk) run no longer drops an enforcement story that names the issuer as "BRI Agro".
- The relevance definition now counts the company, its industry, **its peers and competitors**, and material events as relevant, so peer coverage (BBRI, BBCA for a bank like AGRO) survives the filter.

## Other changes

- Added a test asserting the alternate names reach the LLM prompt.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts` - the `buildPrompt` change: alias line and the broadened relevance sentence.
- `apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.test.ts` - new assertion that aliases appear in the prompt.

## How to test

1. `pnpm --filter @mediapulse/data-collection test`
2. Confirm all tests pass, including "includes alternate company names in the LLM prompt".
3. `pnpm --filter @mediapulse/data-collection type:check` exits clean.
