### PR TITLE
Add business context and peers to the ticker.get response

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.ts
+++ b/apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.ts
@@ -61,6 +61,27 @@ export const extractTickerSectorIndustry = (
 });
 
 /**
+ * Extracts sub-sector, sub-industry, and main business activity from ticker metadata.
+ *
+ * @param metadata - Ticker JSON metadata.
+ * @returns Sub-classification labels when present.
+ */
+export const extractTickerBusinessContext = (
+  metadata: unknown,
+): {
+  subSector?: string;
+  subIndustry?: string;
+  businessActivity?: string;
+} => ({
+  subSector: pickMetadataString(metadata, ["SubSektor", "sub_sector"]),
+  subIndustry: pickMetadataString(metadata, ["SubIndustri", "sub_industry"]),
+  businessActivity: pickMetadataString(metadata, [
+    "KegiatanUsahaUtama",
+    "business_activity",
+  ]),
+});
+
+/**
  * Parses market-cap style numeric metadata for peer ordering.
  *
  * @param metadata - Ticker JSON metadata.

--- a/apps/mediapulse/agent-data-api/src/services/ticker.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/ticker.test.ts
@@ -6,6 +6,7 @@ vi.mock("@mediapulse/database", () => ({
   prisma: {
     ticker: {
       findUnique: vi.fn(),
+      findMany: vi.fn(),
     },
   },
 }));
@@ -32,18 +33,35 @@ describe("getTickerForAgent", () => {
     expect(result).toBeNull();
   });
 
-  it("returns symbol, name, metadata aliases, and sector labels", async () => {
+  it("returns identity, aliases, sector labels, business context, and peers", async () => {
     // Setup
     vi.mocked(prisma.ticker.findUnique).mockResolvedValueOnce({
       id: "11111111-1111-4111-a111-111111111111",
-      symbol: "BBCA",
-      name: "Bank Central Asia Tbk",
+      symbol: "AGRO",
+      name: "PT Bank Raya Indonesia Tbk",
       metadata: {
-        aliases: ["BCA", "Bank Central Asia", "BCA"],
+        aliases: ["BRI Agro", "Bank Agroniaga", "BRI Agro"],
         Sektor: "Keuangan",
-        Industri: "Perbankan",
+        Industri: "Bank",
+        SubSektor: "Bank",
+        SubIndustri: "Bank",
+        KegiatanUsahaUtama: "Perbankan",
       },
     } as never);
+    vi.mocked(prisma.ticker.findMany).mockResolvedValueOnce([
+      {
+        id: "22222222-2222-4222-a222-222222222222",
+        symbol: "BBCA",
+        name: "Bank Central Asia Tbk",
+        metadata: { marketCap: 100 },
+      },
+      {
+        id: "33333333-3333-4333-a333-333333333333",
+        symbol: "BBRI",
+        name: "Bank Rakyat Indonesia Tbk",
+        metadata: { marketCap: 200 },
+      },
+    ] as never);
 
     // Act
     const result = await getTickerForAgent(
@@ -53,11 +71,48 @@ describe("getTickerForAgent", () => {
     // Assert
     expect(result).toEqual({
       id: "11111111-1111-4111-a111-111111111111",
-      symbol: "BBCA",
-      name: "Bank Central Asia Tbk",
-      aliases: ["BCA", "Bank Central Asia"],
+      symbol: "AGRO",
+      name: "PT Bank Raya Indonesia Tbk",
+      aliases: ["BRI Agro", "Bank Agroniaga"],
       sector: "Keuangan",
-      industry: "Perbankan",
+      industry: "Bank",
+      subSector: "Bank",
+      subIndustry: "Bank",
+      businessActivity: "Perbankan",
+      peers: [
+        { symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" },
+        { symbol: "BBCA", name: "Bank Central Asia Tbk" },
+      ],
+    });
+  });
+
+  it("returns empty peers and null business context when metadata lacks them", async () => {
+    // Setup
+    vi.mocked(prisma.ticker.findUnique).mockResolvedValueOnce({
+      id: "11111111-1111-4111-a111-111111111111",
+      symbol: "XYZ",
+      name: "Example Corp",
+      metadata: { aliases: [] },
+    } as never);
+
+    // Act
+    const result = await getTickerForAgent(
+      "11111111-1111-4111-a111-111111111111",
+    );
+
+    // Assert
+    expect(prisma.ticker.findMany).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      id: "11111111-1111-4111-a111-111111111111",
+      symbol: "XYZ",
+      name: "Example Corp",
+      aliases: [],
+      sector: null,
+      industry: null,
+      subSector: null,
+      subIndustry: null,
+      businessActivity: null,
+      peers: [],
     });
   });
 });

--- a/apps/mediapulse/agent-data-api/src/services/ticker.ts
+++ b/apps/mediapulse/agent-data-api/src/services/ticker.ts
@@ -1,8 +1,14 @@
-import { prisma } from "@mediapulse/database";
+import { prisma, type Prisma } from "@mediapulse/database";
 import type { GetTickerResponse } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
-import { extractTickerSectorIndustry } from "./query-analysis-context-helpers";
+import {
+  QUERY_ANALYSIS_PEER_LIMIT,
+  buildPeerMetadataOrFilters,
+  extractTickerBusinessContext,
+  extractTickerSectorIndustry,
+  sortAndLimitPeers,
+} from "./query-analysis-context-helpers";
 
 const tickerMetadataSchema = z
   .object({
@@ -46,6 +52,25 @@ export const getTickerForAgent = async (
   }
 
   const { sector, industry } = extractTickerSectorIndustry(row.metadata);
+  const { subSector, subIndustry, businessActivity } =
+    extractTickerBusinessContext(row.metadata);
+
+  const peerFilters = buildPeerMetadataOrFilters(sector, industry);
+  const peerCandidates =
+    peerFilters === undefined
+      ? []
+      : await prisma.ticker.findMany({
+          where: {
+            id: { not: row.id },
+            OR: peerFilters,
+          },
+          select: { id: true, symbol: true, name: true, metadata: true },
+          take: QUERY_ANALYSIS_PEER_LIMIT * 4,
+        } satisfies Prisma.TickerFindManyArgs);
+  const peers = sortAndLimitPeers(peerCandidates).map((peer) => ({
+    symbol: peer.symbol,
+    name: peer.name,
+  }));
 
   return {
     id: row.id,
@@ -54,5 +79,9 @@ export const getTickerForAgent = async (
     aliases,
     sector: sector ?? null,
     industry: industry ?? null,
+    subSector: subSector ?? null,
+    subIndustry: subIndustry ?? null,
+    businessActivity: businessActivity ?? null,
+    peers,
   };
 };

--- a/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
+++ b/dev-docs/docs/mediapulse/apps/agent-data-api.mdx
@@ -52,6 +52,7 @@ Agents should not call these HTTP paths directly. In agent code, use `@workspace
 | GET    | `/api/v1/user-registration-unsubscribe`          | Resolve an unsubscribe token status for the user-registration UI           |
 | POST   | `/api/v1/user-registration-unsubscribe`          | Apply one-click unsubscribe from the user-registration app                 |
 | POST   | `/api/v1/newsletter-feedback-record`             | Record a classified newsletter reply (idempotent on `graphMessageId`)      |
+| GET    | `/api/v1/ticker`                                 | Get ticker identity, aliases, sector/industry, business context, and peers |
 | GET    | `/api/v1/query-analysis`                         | Get query-analysis context by ticker                                       |
 | POST   | `/api/v1/query-analysis`                         | Store and activate a versioned query set                                   |
 | GET    | `/api/v1/section-coverage-rollup`                | Per-section average query coverage and newsletter fill by contract version |

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -707,6 +707,10 @@ describe("agent-data-api path helpers", () => {
         aliases: ["BCA"],
         sector: "Keuangan",
         industry: "Perbankan",
+        subSector: "Bank",
+        subIndustry: "Bank",
+        businessActivity: "Jasa Perbankan",
+        peers: [{ symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" }],
       }),
       statusCode: 200,
     });

--- a/packages/shared/agent-data-api-contract/src/index.ts
+++ b/packages/shared/agent-data-api-contract/src/index.ts
@@ -240,8 +240,10 @@ export {
 export {
   getTickerQuerySchema,
   getTickerResponseSchema,
+  tickerPeerSchema,
   type GetTickerQuery,
   type GetTickerResponse,
+  type TickerPeer,
 } from "./ticker.js";
 export * from "./user-registration.js";
 export * from "./newsletter-feedback.js";

--- a/packages/shared/agent-data-api-contract/src/ticker.test.ts
+++ b/packages/shared/agent-data-api-contract/src/ticker.test.ts
@@ -17,7 +17,7 @@ describe("getTickerQuerySchema", () => {
 });
 
 describe("getTickerResponseSchema", () => {
-  it("accepts a ticker payload with aliases", () => {
+  it("accepts a ticker payload with aliases, business context, and peers", () => {
     // Act
     const parsed = getTickerResponseSchema.parse({
       id: "11111111-1111-4111-a111-111111111111",
@@ -26,11 +26,19 @@ describe("getTickerResponseSchema", () => {
       aliases: ["BCA", "Bank Central Asia"],
       sector: "Keuangan",
       industry: "Perbankan",
+      subSector: "Bank",
+      subIndustry: "Bank",
+      businessActivity: "Jasa Perbankan",
+      peers: [{ symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" }],
     });
 
     // Assert
     expect(parsed.aliases).toEqual(["BCA", "Bank Central Asia"]);
     expect(parsed.sector).toBe("Keuangan");
     expect(parsed.industry).toBe("Perbankan");
+    expect(parsed.businessActivity).toBe("Jasa Perbankan");
+    expect(parsed.peers).toEqual([
+      { symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" },
+    ]);
   });
 });

--- a/packages/shared/agent-data-api-contract/src/ticker.ts
+++ b/packages/shared/agent-data-api-contract/src/ticker.ts
@@ -4,6 +4,12 @@ export const getTickerQuerySchema = z.object({
   tickerId: z.string().trim().min(1),
 });
 
+/** A sector/industry peer surfaced for competitive-landscape relevance. */
+export const tickerPeerSchema = z.object({
+  symbol: z.string(),
+  name: z.string(),
+});
+
 export const getTickerResponseSchema = z.object({
   id: z.string().uuid(),
   symbol: z.string(),
@@ -14,7 +20,17 @@ export const getTickerResponseSchema = z.object({
   sector: z.string().nullable(),
   /** Industry label from ticker metadata (IDX `Industri` or English `industry`), when present. */
   industry: z.string().nullable(),
+  /** Sub-sector label from ticker metadata (IDX `SubSektor` or English `sub_sector`), when present. */
+  subSector: z.string().nullable(),
+  /** Sub-industry label from ticker metadata (IDX `SubIndustri` or English `sub_industry`), when present. */
+  subIndustry: z.string().nullable(),
+  /** Main business activity from ticker metadata (IDX `KegiatanUsahaUtama` or English `business_activity`), when present. */
+  businessActivity: z.string().nullable(),
+  /** Sector/industry peers (ordered by market cap, capped) for competitive-landscape relevance. */
+  peers: z.array(tickerPeerSchema),
 });
+
+export type TickerPeer = z.infer<typeof tickerPeerSchema>;
 
 export type GetTickerQuery = z.infer<typeof getTickerQuerySchema>;
 export type GetTickerResponse = z.infer<typeof getTickerResponseSchema>;


### PR DESCRIPTION
## Summary

`ticker.get` now returns what a company does and who it competes with, sourced from data already in the system. This is the data plumbing for a follow-up that teaches the data-collection relevance judge to use it.

## Related issues

Closes #875

## Important changes

- Added `subSector`, `subIndustry`, and `businessActivity` (all nullable) to the `ticker.get` response, read from IDX metadata (`SubSektor` / `SubIndustri` / `KegiatanUsahaUtama`) with English fallbacks. `businessActivity` is the field that tells AGRO ("Perbankan") apart from a coffee company ("Bergerak dalam Bisnis Kedai Kopi").
- Added `peers` to the response: sector/industry peers ordered by market cap and capped, reusing the existing query-analysis peer helpers, so a consumer gets competitors without a second endpoint call.

## Other changes

- Documented the previously unlisted `GET /api/v1/ticker` route.
- Updated contract, SDK, and service tests for the new fields and peer ordering.

## Key files to review

- `packages/shared/agent-data-api-contract/src/ticker.ts` - the new response fields and peer schema.
- `apps/mediapulse/agent-data-api/src/services/ticker.ts` - field extraction and the peer lookup.
- `apps/mediapulse/agent-data-api/src/services/query-analysis-context-helpers.ts` - `extractTickerBusinessContext`.

## How to test

1. `pnpm --filter @workspace/agent-data-api-contract test`
2. `pnpm --filter @workspace/agent-data-api-client test`
3. `pnpm --filter @mediapulse/agent-data-api test`
4. All pass; `pnpm --filter @mediapulse/data-collection type:check` stays clean (consumer unaffected).
