### PR TITLE
Ground the relevance judge in business activity and peers

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -165,6 +165,12 @@ describe("data-collection agent (HTTP)", () => {
       symbol: "BBCA",
       name: "Bank Central Asia",
       aliases: ["BCA"],
+      sector: "Keuangan",
+      industry: "Perbankan",
+      subSector: "Bank",
+      subIndustry: "Bank",
+      businessActivity: "Jasa Perbankan",
+      peers: [{ symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" }],
     });
   });
 

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -271,6 +271,10 @@ describe("runDataCollection", () => {
       aliases: ["BCA"],
       sector: "Keuangan",
       industry: "Perbankan",
+      subSector: "Bank",
+      subIndustry: "Bank",
+      businessActivity: "Jasa Perbankan",
+      peers: [{ symbol: "BBRI", name: "Bank Rakyat Indonesia Tbk" }],
     });
   });
 

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -141,6 +141,7 @@ export async function runDataCollection(
     tickerRecord.sector,
     tickerRecord.industry,
   );
+  const peerNames = tickerRecord.peers.map((peer) => peer.symbol);
   const subject = { symbol: tickerRecord.symbol, name: tickerRecord.name };
 
   report(...narrativeRunStart(subject));
@@ -530,6 +531,9 @@ export async function runDataCollection(
           tickerName: subject.name,
           tickerAliases,
           industryAliases,
+          businessActivity: tickerRecord.businessActivity,
+          subIndustry: tickerRecord.subIndustry,
+          peerNames,
           contractBrief,
           llm: config.relevance,
           logger: log,

--- a/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.test.ts
@@ -96,6 +96,31 @@ describe("judgeRelevance", () => {
     expect(capturedPrompt).toContain("bri agro");
   });
 
+  it("includes business activity and peer competitors in the LLM prompt", async () => {
+    let capturedPrompt = "";
+    const generate = (async (options: { prompt: string }) => {
+      capturedPrompt = options.prompt;
+
+      return { object: { relevant: true, reason: "t" } };
+    }) as unknown as typeof generateObject;
+
+    await judgeRelevance(
+      baseInput({
+        contractBrief: "Track AGRO news.",
+        tickerSymbol: "AGRO",
+        tickerName: "PT Bank Raya Indonesia Tbk",
+        businessActivity: "Perbankan",
+        subIndustry: "Bank",
+        peerNames: ["BBRI", "BBCA"],
+        generate,
+      }),
+    );
+
+    expect(capturedPrompt).toContain("its main business is Perbankan");
+    expect(capturedPrompt).toContain("its sub-industry is Bank");
+    expect(capturedPrompt).toContain("Known peers and competitors: BBRI, BBCA");
+  });
+
   it("falls back to keyword matching when the LLM call throws", async () => {
     const generate = (async () => {
       throw new Error("llm down");

--- a/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts
@@ -33,6 +33,12 @@ export interface JudgeRelevanceInput {
   tickerAliases: string[];
   /** Lowercased industry aliases used by the keyword fallback. */
   industryAliases: string[];
+  /** Main business activity (IDX `KegiatanUsahaUtama`), when known. */
+  businessActivity?: string | null;
+  /** Sub-industry label (IDX `SubIndustri`), when known. */
+  subIndustry?: string | null;
+  /** Peer/competitor display names surfaced for competitive-landscape relevance. */
+  peerNames?: string[];
   /** Agent contract brief. When empty, the keyword fallback is used. */
   contractBrief?: string;
   llm: RelevanceConfig;
@@ -75,10 +81,29 @@ const buildPrompt = (input: JudgeRelevanceInput): string => {
       ? `This company is also referred to as: ${otherNames.join(", ")}. Treat any of these names as referring to the same company.`
       : null;
 
+  const businessParts: string[] = [];
+  if (input.businessActivity) {
+    businessParts.push(`its main business is ${input.businessActivity}`);
+  }
+  if (input.subIndustry) {
+    businessParts.push(`its sub-industry is ${input.subIndustry}`);
+  }
+  const businessLine =
+    businessParts.length > 0
+      ? `Context: ${businessParts.join(", ")}. Judge relevance against this actual business, not just a name match.`
+      : null;
+
+  const peerLine =
+    input.peerNames && input.peerNames.length > 0
+      ? `Known peers and competitors: ${input.peerNames.join(", ")}. Pages about these are relevant as competitive-landscape coverage.`
+      : null;
+
   return [
     `Decide whether this web page is relevant for an investor tracking ${input.tickerSymbol} (${input.tickerName}) in ${industry}.`,
     "Relevant means the page is about this company, its industry, its peers and competitors, or events that materially affect it. Generic, unrelated, or spam pages are not relevant.",
+    ...(businessLine ? [businessLine] : []),
     ...(aliasLine ? [aliasLine] : []),
+    ...(peerLine ? [peerLine] : []),
     "",
     `Title: ${input.title}`,
     "",


### PR DESCRIPTION
## Summary

The data-collection relevance judge now knows what a company does and who it competes with. It folds the ticker's main business activity, sub-industry, and peer symbols (from `ticker.get`) into the prompt, so judgments rest on the real business rather than a name match, and pages about named competitors count as competitive-landscape coverage. Builds on #876.

## Related issues

Closes #877

## Important changes

- `judge-relevance.ts` — the prompt gains a context line ("its main business is Perbankan, its sub-industry is Bank — judge against this actual business, not just a name match") and a peers line ("Known peers and competitors: BBRI, BBCA — pages about these are relevant as competitive-landscape coverage"). New input fields are optional, so an absent value just omits its line.
- `run.ts` — passes `businessActivity`, `subIndustry`, and peer symbols from `tickerRecord` into `judgeRelevance`.

## Other changes

- Added a judge test asserting business activity and peers reach the prompt.
- Updated the ticker mocks in `run.test.ts` and `index.test.ts` for the enriched `ticker.get` shape.

## Key files to review

- `apps/mediapulse/agents/data-collection/src/utilities/filter/judge-relevance.ts` - prompt construction.
- `apps/mediapulse/agents/data-collection/src/run.ts` - where the fields are threaded in.

## How to test

1. `pnpm --filter @mediapulse/data-collection test`
2. Confirm all pass, including "includes business activity and peer competitors in the LLM prompt".
3. `pnpm --filter @mediapulse/data-collection type:check` stays clean.
