### PR TITLE
Classify articles with their issuer context

### DIFF
--- a/apps/mediapulse/agents/article-analysis/src/llm-classify-section.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-classify-section.test.ts
@@ -4,6 +4,7 @@ import {
   articleSectionClassificationSchema,
   buildSectionClassificationMessages,
   MAX_CONTENT_CHARS,
+  renderArticleTickerContext,
 } from "./llm-classify-section.js";
 
 const criteria = [
@@ -29,6 +30,31 @@ describe("buildSectionClassificationMessages", () => {
     expect(String(user.content)).toContain("Acme announced an acquisition.");
   });
 
+  it("includes the issuer context line when tickerContext is provided", () => {
+    const messages = buildSectionClassificationMessages({
+      title: "Rival bank cuts rates",
+      content: "A competitor lowered rates.",
+      acceptanceCriteria: criteria,
+      tickerContext: "Issuer context: collected for AGRO.",
+    });
+    const user = messages[1]!;
+
+    expect(String(user.content)).toContain(
+      "Issuer context: collected for AGRO.",
+    );
+  });
+
+  it("omits issuer context when tickerContext is absent", () => {
+    const messages = buildSectionClassificationMessages({
+      title: "t",
+      content: "c",
+      acceptanceCriteria: criteria,
+    });
+    const user = messages[1]!;
+
+    expect(String(user.content)).not.toContain("Issuer context");
+  });
+
   it("truncates long content to MAX_CONTENT_CHARS", () => {
     const longContent = "x".repeat(MAX_CONTENT_CHARS + 500);
     const messages = buildSectionClassificationMessages({
@@ -41,6 +67,40 @@ describe("buildSectionClassificationMessages", () => {
     expect(String(user.content)).not.toContain(
       "x".repeat(MAX_CONTENT_CHARS + 1),
     );
+  });
+});
+
+describe("renderArticleTickerContext", () => {
+  it("renders the issuer and its business descriptors", () => {
+    const line = renderArticleTickerContext({
+      symbol: "AGRO",
+      name: "PT Bank Raya Indonesia Tbk",
+      sector: "Keuangan",
+      industry: "Bank",
+      subIndustry: "Bank",
+      businessActivity: "Perbankan",
+    });
+
+    expect(line).toContain("AGRO (PT Bank Raya Indonesia Tbk)");
+    expect(line).toContain("main business Perbankan");
+  });
+
+  it("skips null descriptors and still names the issuer", () => {
+    const line = renderArticleTickerContext({
+      symbol: "AGRO",
+      name: "PT Bank Raya Indonesia Tbk",
+      sector: null,
+      industry: null,
+      subIndustry: null,
+      businessActivity: null,
+    });
+
+    expect(line).toContain("AGRO (PT Bank Raya Indonesia Tbk)");
+    expect(line).not.toContain("—");
+  });
+
+  it("returns null for ticker-agnostic rows", () => {
+    expect(renderArticleTickerContext(null)).toBeNull();
   });
 });
 

--- a/apps/mediapulse/agents/article-analysis/src/llm-classify-section.ts
+++ b/apps/mediapulse/agents/article-analysis/src/llm-classify-section.ts
@@ -3,6 +3,7 @@ import { generateObject, type ModelMessage } from "ai";
 import {
   MEDIAPULSE_NEWSLETTER_SECTIONS,
   NEWSLETTER_SECTION_IDS,
+  type AnalysisTickerContext,
 } from "@workspace/agent-data-api-contract";
 import { z } from "zod";
 
@@ -60,21 +61,55 @@ const renderCriteria = (
 };
 
 /**
+ * Renders the issuer the article was collected for into a one-line prompt block.
+ *
+ * @param ticker - Per-article ticker context from `analysis.get`, or `null` when ticker-agnostic.
+ * @returns A single context line, or `null` when there is no issuer to describe.
+ */
+export const renderArticleTickerContext = (
+  ticker: AnalysisTickerContext | null,
+): string | null => {
+  if (ticker === null) {
+    return null;
+  }
+
+  const descriptors: string[] = [];
+  if (ticker.sector) {
+    descriptors.push(`sector ${ticker.sector}`);
+  }
+  if (ticker.industry) {
+    descriptors.push(`industry ${ticker.industry}`);
+  }
+  if (ticker.subIndustry) {
+    descriptors.push(`sub-industry ${ticker.subIndustry}`);
+  }
+  if (ticker.businessActivity) {
+    descriptors.push(`main business ${ticker.businessActivity}`);
+  }
+  const descriptorText =
+    descriptors.length > 0 ? ` — ${descriptors.join(", ")}` : "";
+
+  return `Issuer context: this article was collected for ${ticker.symbol} (${ticker.name})${descriptorText}. Newsletter sections are defined relative to this issuer and its industry.`;
+};
+
+/**
  * Builds the chat messages for one article classification call.
  *
- * @param params - Article title/content and the acceptance criteria.
+ * @param params - Article title/content, the acceptance criteria, and optional issuer context.
  * @returns System + user messages for `generateObject`.
  */
 export const buildSectionClassificationMessages = (params: {
   title: string;
   content: string;
   acceptanceCriteria: AcceptanceCriteriaRule[];
+  tickerContext?: string;
 }): ModelMessage[] => {
   const truncatedContent = params.content.slice(0, MAX_CONTENT_CHARS);
   const userContent = [
     "Newsletter sections and acceptance criteria:",
     renderCriteria(params.acceptanceCriteria),
     "",
+    ...(params.tickerContext ? [params.tickerContext, ""] : []),
     `Article title: ${params.title}`,
     "",
     "Article content:",
@@ -100,6 +135,7 @@ export const classifyArticleSection = async (params: {
   title: string;
   content: string;
   acceptanceCriteria: AcceptanceCriteriaRule[];
+  tickerContext?: string;
 }): Promise<ArticleSectionClassification> => {
   const openai = createOpenAI({
     apiKey: params.apiKey,
@@ -113,6 +149,7 @@ export const classifyArticleSection = async (params: {
       title: params.title,
       content: params.content,
       acceptanceCriteria: params.acceptanceCriteria,
+      tickerContext: params.tickerContext,
     }),
   });
 

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -6,7 +6,10 @@ import crypto from "node:crypto";
 
 import type { ArticleAnalysisConfig } from "./config-schema.js";
 import type { ArticleAnalysisInput } from "./schemas/article-analysis-input-schema.js";
-import { classifyArticleSection } from "./llm-classify-section.js";
+import {
+  classifyArticleSection,
+  renderArticleTickerContext,
+} from "./llm-classify-section.js";
 import {
   narrativeRunStart,
   narrativeClassifying,
@@ -139,6 +142,7 @@ export async function run(
     dataSources,
     CLASSIFY_CONCURRENCY,
     async (dataSource): Promise<ClassifiedRow> => {
+      const tickerContext = renderArticleTickerContext(dataSource.ticker);
       const result = await classifyArticleSection({
         apiKey: config.acceptance.apiKey,
         baseUrl: config.acceptance.baseUrl,
@@ -146,6 +150,7 @@ export async function run(
         title: dataSource.title,
         content: dataSource.content,
         acceptanceCriteria: config.acceptanceCriteria,
+        ...(tickerContext ? { tickerContext } : {}),
       });
 
       return {


### PR DESCRIPTION
## Summary

The article-analysis classifier now knows which issuer each article was collected for. It folds the per-article ticker context from `analysis.get` into the classification prompt, so newsletter sections are judged relative to the issuer and its industry rather than from article wording alone. Builds on #880.

## Related issues

Closes #881

## Important changes

- Added `renderArticleTickerContext`, which turns the per-article `ticker` context into a single issuer line (e.g. "collected for AGRO (PT Bank Raya Indonesia Tbk) — sector Keuangan, industry Bank, sub-industry Bank, main business Perbankan"). Null descriptors are skipped; ticker-agnostic rows produce no line.
- `buildSectionClassificationMessages` and `classifyArticleSection` take an optional `tickerContext` and place it in the per-article user message. The system prompt is unchanged.
- `run.ts` builds the context from each `dataSource.ticker` and passes it through.

## Other changes

- Tests for the renderer (with/without descriptors, null row) and for prompt injection (present and absent).

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/llm-classify-section.ts` - the renderer and prompt wiring.
- `apps/mediapulse/agents/article-analysis/src/run.ts` - per-article context in the classify loop.

## How to test

1. `pnpm --filter @mediapulse/article-analysis test`
2. Confirm all pass, including the renderer and "includes the issuer context line" cases.
3. `pnpm --filter @mediapulse/article-analysis type:check` stays clean.
