### PR TITLE
Fix content-generation no_sources via per-ticker section classification

### DIFF
--- a/apps/mediapulse/agent-data-api/src/index.test.ts
+++ b/apps/mediapulse/agent-data-api/src/index.test.ts
@@ -176,26 +176,16 @@ describe("agent-data-api", () => {
       vi.mocked(mod.getDataSourcesForTicker).mockResolvedValue({
         dataSources: [
           {
-            id: "ds-1",
             url: "https://example.com",
-            canonicalUrl: "https://example.com",
             title: "Example",
             content: "Content",
             author: null,
             source: null,
-            metadata: null,
-            publishedAt: null,
             tickerId: TICKER_ID,
             searchQueryId: SEARCH_QUERY_ID,
-            curatedSourceId: null,
-            collectionGateStatus: null,
-            collectionGateReason: null,
-            analyzedAt: null,
             section: "competitiveLandscape",
             sectionScore: 0.8,
             sectionReason: "Mentions a rival.",
-            createdAt: new Date("2026-03-19T00:00:00.000Z"),
-            updatedAt: new Date("2026-03-19T00:00:00.000Z"),
           },
         ],
         tickerSymbol: "TEST",
@@ -480,11 +470,19 @@ describe("agent-data-api", () => {
         dataSources: [
           {
             id: "33333333-3333-4333-a333-333333333333",
+            tickerId: TICKER_ID,
             url: "https://example.com",
             title: "Example",
             content: "Body",
             createdAt: new Date("2026-03-19T00:00:00.000Z"),
-            ticker: null,
+            ticker: {
+              symbol: "TEST",
+              name: "Test Company",
+              sector: null,
+              industry: null,
+              subIndustry: null,
+              businessActivity: null,
+            },
           },
         ],
         dataSourceTotalCount: 1,
@@ -564,6 +562,7 @@ describe("agent-data-api", () => {
           articleSections: [
             {
               dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              tickerId: "44444444-4444-4444-8444-444444444444",
               section: "competitiveLandscape",
               score: 0.5,
               reason: "Mentions a rival.",

--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -12,15 +12,21 @@ import {
   loadAnalysisContext,
 } from "./analysis.js";
 
-describe("loadAnalysisContext", () => {
-  it("loads unanalyzed sources oldest-first with per-article ticker context and the total backlog count", async () => {
+const TICKER_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const SEARCH_ARTICLE = "11111111-1111-4111-8111-111111111111";
+const CURATED_MATCH = "22222222-2222-4222-8222-222222222222";
+const CURATED_MISS = "33333333-3333-4333-8333-333333333333";
+
+describe("loadAnalysisContext — ticker-scoped baseline", () => {
+  it("counts a ticker's unanalyzed articles and maps issuer context", async () => {
     const rows = [
       {
-        id: "11111111-1111-4111-8111-111111111111",
+        id: SEARCH_ARTICLE,
         url: "https://example.com/a",
         title: "A",
         content: "body",
         createdAt: new Date("2026-01-01T00:00:00Z"),
+        tickerId: TICKER_ID,
         ticker: {
           symbol: "AGRO",
           name: "PT Bank Raya Indonesia Tbk",
@@ -32,125 +38,229 @@ describe("loadAnalysisContext", () => {
           },
         },
       },
-      {
-        id: "22222222-2222-4222-8222-222222222222",
-        url: "https://example.com/b",
-        title: "B",
-        content: "body",
-        createdAt: new Date("2026-01-02T00:00:00Z"),
-        ticker: null,
-      },
     ];
     const findMany = vi.fn().mockResolvedValue(rows);
     const count = vi.fn().mockResolvedValue(7);
 
     const result = await loadAnalysisContext(
-      { unanalyzed: true, limit: 5 },
+      { unanalyzed: true, limit: 5, tickerId: TICKER_ID },
       { db: { dataSource: { findMany, count } } as never },
     );
 
     expect(findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { collectionGateStatus: "passed", analyzedAt: null },
+        where: { tickerId: TICKER_ID, analyzedAt: null },
         orderBy: { createdAt: "asc" },
         take: 5,
-        select: expect.objectContaining({
-          ticker: { select: { symbol: true, name: true, metadata: true } },
+      }),
+    );
+    expect(result.dataSourceTotalCount).toBe(7);
+    expect(result.dataSources).toEqual([
+      {
+        id: SEARCH_ARTICLE,
+        tickerId: TICKER_ID,
+        url: "https://example.com/a",
+        title: "A",
+        content: "body",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        ticker: {
+          symbol: "AGRO",
+          name: "PT Bank Raya Indonesia Tbk",
+          sector: "Keuangan",
+          industry: "Bank",
+          subIndustry: "Bank",
+          businessActivity: "Perbankan",
+        },
+      },
+    ]);
+  });
+});
+
+describe("loadAnalysisContext — candidate pairs (ticker-agnostic)", () => {
+  const buildDb = (articles: unknown[]) => {
+    const searchQuerySet = {
+      findMany: vi.fn().mockResolvedValue([{ tickerId: TICKER_ID }]),
+    };
+    const ticker = {
+      findMany: vi.fn().mockResolvedValue([
+        {
+          id: TICKER_ID,
+          symbol: "BBCA",
+          name: "Bank Central Asia",
+          metadata: {},
+        },
+      ]),
+      findUnique: vi
+        .fn()
+        .mockResolvedValue({ symbol: "BBCA", name: "Bank Central Asia" }),
+    };
+    // No seeded COMPANY entity -> issuer anchor falls back to symbol/name aliases.
+    const entityType = { findFirst: vi.fn().mockResolvedValue(null) };
+    const tickerEntity = { findFirst: vi.fn() };
+    const entityRelation = { findMany: vi.fn().mockResolvedValue([]) };
+    const dataSource = {
+      findMany: vi.fn().mockResolvedValue(articles),
+      count: vi.fn(),
+    };
+
+    return {
+      dataSource,
+      searchQuerySet,
+      ticker,
+      entityType,
+      tickerEntity,
+      entityRelation,
+    };
+  };
+
+  it("pairs a search-query article with its own ticker and fans curated matches out by alias", async () => {
+    const db = buildDb([
+      {
+        id: SEARCH_ARTICLE,
+        url: "https://example.com/s",
+        title: "Search hit",
+        content: "anything",
+        createdAt: new Date("2026-01-03T00:00:00Z"),
+        tickerId: TICKER_ID,
+        ticker: { symbol: "BBCA", name: "Bank Central Asia", metadata: {} },
+        tickerSections: [],
+      },
+      {
+        id: CURATED_MATCH,
+        url: "https://example.com/c",
+        title: "Bank Central Asia posts record profit",
+        content: "the issuer did well",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        tickerId: null,
+        ticker: null,
+        tickerSections: [],
+      },
+      {
+        id: CURATED_MISS,
+        url: "https://example.com/d",
+        title: "Unrelated commodity news",
+        content: "no issuer mention here",
+        createdAt: new Date("2026-01-01T00:00:00Z"),
+        tickerId: null,
+        ticker: null,
+        tickerSections: [],
+      },
+    ]);
+
+    const result = await loadAnalysisContext(
+      { unanalyzed: true, limit: 10 },
+      { db: db as never },
+    );
+
+    expect(db.dataSource.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: [
+            { collectionGateStatus: "passed", tickerId: null },
+            { tickerId: { not: null } },
+          ],
         }),
       }),
     );
-    expect(result).toEqual({
-      dataSources: [
-        {
-          id: "11111111-1111-4111-8111-111111111111",
-          url: "https://example.com/a",
-          title: "A",
-          content: "body",
-          createdAt: new Date("2026-01-01T00:00:00Z"),
-          ticker: {
-            symbol: "AGRO",
-            name: "PT Bank Raya Indonesia Tbk",
-            sector: "Keuangan",
-            industry: "Bank",
-            subIndustry: "Bank",
-            businessActivity: "Perbankan",
-          },
-        },
-        {
-          id: "22222222-2222-4222-8222-222222222222",
-          url: "https://example.com/b",
-          title: "B",
-          content: "body",
-          createdAt: new Date("2026-01-02T00:00:00Z"),
-          ticker: null,
-        },
-      ],
-      dataSourceTotalCount: 7,
-    });
+    expect(result.dataSourceTotalCount).toBe(2);
+    expect(result.dataSources.map((pair) => pair.id)).toEqual([
+      SEARCH_ARTICLE,
+      CURATED_MATCH,
+    ]);
+    for (const pair of result.dataSources) {
+      expect(pair.tickerId).toBe(TICKER_ID);
+      expect(pair.ticker.symbol).toBe("BBCA");
+    }
   });
 
-  it("drops the analyzedAt filter when unanalyzed is false", async () => {
-    const findMany = vi.fn().mockResolvedValue([]);
-    const count = vi.fn().mockResolvedValue(0);
+  it("skips a pair that is already classified for the ticker", async () => {
+    const db = buildDb([
+      {
+        id: CURATED_MATCH,
+        url: "https://example.com/c",
+        title: "Bank Central Asia posts record profit",
+        content: "the issuer did well",
+        createdAt: new Date("2026-01-02T00:00:00Z"),
+        tickerId: null,
+        ticker: null,
+        tickerSections: [{ tickerId: TICKER_ID }],
+      },
+    ]);
 
-    await loadAnalysisContext(
-      { unanalyzed: false },
-      { db: { dataSource: { findMany, count } } as never },
+    const result = await loadAnalysisContext(
+      { unanalyzed: true, limit: 10 },
+      { db: db as never },
     );
 
-    expect(findMany).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { collectionGateStatus: "passed" } }),
-    );
+    expect(result.dataSources).toEqual([]);
+    expect(result.dataSourceTotalCount).toBe(0);
   });
 });
 
 describe("applyAnalysisPost", () => {
   const buildDb = () => {
-    const update = vi.fn((args) => ({ __update: args }));
+    const upsert = vi.fn((args) => ({ __upsert: args }));
     const updateMany = vi.fn((args) => ({ __updateMany: args }));
     const findMany = vi.fn();
     const $transaction = vi.fn((writes: unknown[]) => Promise.resolve(writes));
     return {
-      db: { dataSource: { findMany, update, updateMany }, $transaction },
-      update,
+      db: {
+        dataSource: { findMany, updateMany },
+        dataSourceTickerSection: { upsert },
+        $transaction,
+      },
+      upsert,
       updateMany,
       findMany,
       $transaction,
     };
   };
 
-  it("writes section fields, marks analyzed, and returns counts", async () => {
-    const { db, update, updateMany, findMany } = buildDb();
-    const a = "11111111-1111-4111-8111-111111111111";
-    const b = "22222222-2222-4222-8222-222222222222";
-    findMany.mockResolvedValue([{ id: a }, { id: b }]);
+  it("upserts per-(article, ticker) sections, marks analyzed, and returns counts", async () => {
+    const { db, upsert, updateMany, findMany } = buildDb();
+    findMany.mockResolvedValue([{ id: SEARCH_ARTICLE }, { id: CURATED_MATCH }]);
 
     const result = await applyAnalysisPost(
       {
         articleSections: [
           {
-            dataSourceId: a,
+            dataSourceId: SEARCH_ARTICLE,
+            tickerId: TICKER_ID,
             section: "dealsAndMovements",
             score: 0.9,
             reason: "deal",
           },
-          { dataSourceId: b, section: null, score: 0.1, reason: "no fit" },
+          {
+            dataSourceId: CURATED_MATCH,
+            tickerId: TICKER_ID,
+            section: null,
+            score: 0.1,
+            reason: "no fit",
+          },
         ],
-        analyzedDataSourceIds: [a, b],
+        analyzedDataSourceIds: [SEARCH_ARTICLE, CURATED_MATCH],
       },
       { db: db as never },
     );
 
-    expect(update).toHaveBeenCalledWith({
-      where: { id: a },
-      data: {
-        section: "dealsAndMovements",
-        sectionScore: 0.9,
-        sectionReason: "deal",
-      },
-    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          dataSourceId_tickerId: {
+            dataSourceId: SEARCH_ARTICLE,
+            tickerId: TICKER_ID,
+          },
+        },
+        create: expect.objectContaining({
+          dataSourceId: SEARCH_ARTICLE,
+          tickerId: TICKER_ID,
+          section: "dealsAndMovements",
+          sectionScore: 0.9,
+        }),
+      }),
+    );
     expect(updateMany).toHaveBeenCalledWith({
-      where: { id: { in: [a, b] } },
+      where: { id: { in: [SEARCH_ARTICLE, CURATED_MATCH] } },
       data: { analyzedAt: expect.any(Date) },
     });
     expect(result).toEqual({ articlesScored: 2, articlesRejected: 1 });
@@ -158,16 +268,21 @@ describe("applyAnalysisPost", () => {
 
   it("throws when a referenced data source is unknown", async () => {
     const { db, findMany } = buildDb();
-    const a = "11111111-1111-4111-8111-111111111111";
     findMany.mockResolvedValue([]);
 
     await expect(
       applyAnalysisPost(
         {
           articleSections: [
-            { dataSourceId: a, section: "quickHits", score: 0.5, reason: "x" },
+            {
+              dataSourceId: SEARCH_ARTICLE,
+              tickerId: TICKER_ID,
+              section: "quickHits",
+              score: 0.5,
+              reason: "x",
+            },
           ],
-          analyzedDataSourceIds: [a],
+          analyzedDataSourceIds: [SEARCH_ARTICLE],
         },
         { db: db as never },
       ),
@@ -180,7 +295,7 @@ describe("deleteAnalysisDataSource", () => {
     const deleteMany = vi.fn().mockResolvedValue({ count: 1 });
 
     const result = await deleteAnalysisDataSource(
-      { dataSourceId: "11111111-1111-4111-8111-111111111111", tickerId: "t1" },
+      { dataSourceId: SEARCH_ARTICLE, tickerId: "t1" },
       { db: { dataSource: { deleteMany } } as never },
     );
 

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -1,4 +1,5 @@
 import type {
+  AnalysisTickerContext,
   GetAnalysisQuery,
   GetAnalysisResponse,
   PostAnalysisDataSourceDeleteBody,
@@ -11,10 +12,18 @@ import type { Prisma } from "@mediapulse/database";
 import {
   extractTickerBusinessContext,
   extractTickerSectorIndustry,
-} from "./query-analysis-context-helpers";
+} from "./query-analysis-context-helpers.js";
+import {
+  findIssuerAnchorForTicker,
+  getCompetitorsForTicker,
+  normalizeName,
+} from "./issuer-context.js";
+
+/** Newest-first cap on eligible articles scanned per candidate-pair request. */
+const MAX_CANDIDATE_ARTICLE_SCAN = 500;
 
 /**
- * Thrown when the analysis POST body references data sources that do not exist.
+ * Thrown when the analysis POST body references data sources or tickers that do not exist.
  */
 export class AnalysisPostValidationError extends Error {
   /**
@@ -31,17 +40,25 @@ type AnalysisDb = {
     typeof prisma.dataSource,
     "findMany" | "count" | "update" | "updateMany" | "deleteMany"
   >;
+  dataSourceTickerSection: Pick<
+    typeof prisma.dataSourceTickerSection,
+    "upsert"
+  >;
+  ticker: Pick<typeof prisma.ticker, "findMany" | "findUnique" | "findFirst">;
+  searchQuerySet: Pick<typeof prisma.searchQuerySet, "findMany">;
+  entityType: Pick<typeof prisma.entityType, "findFirst">;
+  tickerEntity: Pick<typeof prisma.tickerEntity, "findFirst">;
+  entityRelation: Pick<typeof prisma.entityRelation, "findMany">;
   $transaction: typeof prisma.$transaction;
 };
 
 const defaultDb: AnalysisDb = prisma;
 
-/** Maps a joined ticker row into the per-article issuer context, reusing the metadata extractors. */
-const mapTickerContext = (
-  ticker: { symbol: string; name: string; metadata: unknown } | null,
-): GetAnalysisResponse["dataSources"][number]["ticker"] => {
+type TickerRow = { symbol: string; name: string; metadata: unknown } | null;
+
+const mapTickerContext = (ticker: TickerRow): AnalysisTickerContext => {
   if (ticker === null) {
-    return null;
+    throw new Error("mapTickerContext called with null ticker");
   }
   const { sector, industry } = extractTickerSectorIndustry(ticker.metadata);
   const { subIndustry, businessActivity } = extractTickerBusinessContext(
@@ -58,19 +75,78 @@ const mapTickerContext = (
   };
 };
 
-/**
- * Loads unanalyzed articles (any ticker) for the article-analysis agent to classify.
- *
- * @param query - Parsed GET query (`unanalyzed` defaults to incremental backlog only).
- * @param deps - Injectable database delegates for tests.
- * @returns Eligible data sources (oldest first, capped by `limit`) plus the total backlog count.
- */
-export const loadAnalysisContext = async (
-  query: GetAnalysisQuery,
-  deps: { db?: Pick<AnalysisDb, "dataSource"> } = {},
-): Promise<GetAnalysisResponse> => {
-  const db = deps.db ?? defaultDb;
+const escapeRegExp = (value: string): string =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 
+/** Compiles a word-boundary matcher over a ticker's issuer + peer aliases. */
+const compileAliasMatcher = (aliases: string[]): RegExp | null => {
+  const cleaned = [
+    ...new Set(aliases.map((alias) => alias.trim()).filter(Boolean)),
+  ];
+  if (cleaned.length === 0) return null;
+  const pattern = cleaned.map(escapeRegExp).join("|");
+
+  return new RegExp(`\\b(${pattern})\\b`, "i");
+};
+
+type TickerGatingContext = {
+  tickerId: string;
+  context: AnalysisTickerContext;
+  matcher: RegExp | null;
+};
+
+/** Builds issuer context + alias matcher for one active ticker. */
+const buildTickerGatingContext = async (
+  ticker: { id: string; symbol: string; name: string; metadata: unknown },
+  db: Pick<
+    AnalysisDb,
+    "ticker" | "entityType" | "tickerEntity" | "entityRelation"
+  >,
+): Promise<TickerGatingContext> => {
+  const anchor = await findIssuerAnchorForTicker(ticker.id, db);
+  const issuerAliases =
+    anchor?.aliases ??
+    [ticker.symbol, ticker.name].filter((value) => value.length > 0);
+  const competitors = anchor
+    ? await getCompetitorsForTicker(
+        anchor.entityId,
+        new Set(issuerAliases.map(normalizeName)),
+        {},
+        db,
+      )
+    : [];
+  const aliases = [
+    ...issuerAliases,
+    ...competitors.map((competitor) => competitor.name),
+    ...competitors.flatMap((competitor) => competitor.aliases),
+  ];
+
+  return {
+    tickerId: ticker.id,
+    context: mapTickerContext(ticker),
+    matcher: compileAliasMatcher(aliases),
+  };
+};
+
+/**
+ * Builds candidate (article, ticker) pairs for the article-analysis agent.
+ *
+ * Curated articles (gated, ticker-agnostic) fan out to active tickers whose issuer/peer aliases
+ * the article mentions. Search-query articles pair against their own ticker. Pairs already present
+ * in `data_source_ticker_section` are skipped.
+ */
+const buildAnalysisCandidatePairs = async (
+  query: GetAnalysisQuery,
+  db: Pick<
+    AnalysisDb,
+    | "dataSource"
+    | "ticker"
+    | "searchQuerySet"
+    | "entityType"
+    | "tickerEntity"
+    | "entityRelation"
+  >,
+): Promise<GetAnalysisResponse> => {
   const createdAtWhere =
     query.start !== undefined || query.end !== undefined
       ? ({
@@ -80,11 +156,115 @@ export const loadAnalysisContext = async (
       : undefined;
 
   const where = {
-    // Ticker-scoped requests (data-collection daily baseline) count every source for the
-    // ticker in the window; ticker-agnostic requests (article-analysis) only see gated articles.
-    ...(query.tickerId !== undefined
-      ? { tickerId: query.tickerId }
-      : { collectionGateStatus: "passed" as const }),
+    OR: [
+      { collectionGateStatus: "passed" as const, tickerId: null },
+      { tickerId: { not: null } },
+    ],
+    ...(createdAtWhere ? { createdAt: createdAtWhere } : {}),
+  } satisfies Prisma.DataSourceWhereInput;
+
+  const activeSets = await db.searchQuerySet.findMany({
+    where: { isActive: true },
+    select: { tickerId: true },
+  } satisfies Prisma.SearchQuerySetFindManyArgs);
+  const activeTickerIds = [...new Set(activeSets.map((row) => row.tickerId))];
+
+  const activeTickers = await db.ticker.findMany({
+    where: { id: { in: activeTickerIds } },
+    select: { id: true, symbol: true, name: true, metadata: true },
+  } satisfies Prisma.TickerFindManyArgs);
+  const gatingContexts = await Promise.all(
+    activeTickers.map((ticker) => buildTickerGatingContext(ticker, db)),
+  );
+
+  const articles = await db.dataSource.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+    take: MAX_CANDIDATE_ARTICLE_SCAN,
+    select: {
+      id: true,
+      url: true,
+      title: true,
+      content: true,
+      createdAt: true,
+      tickerId: true,
+      ticker: { select: { symbol: true, name: true, metadata: true } },
+      tickerSections: { select: { tickerId: true } },
+    },
+  } satisfies Prisma.DataSourceFindManyArgs);
+
+  const pairs: GetAnalysisResponse["dataSources"] = [];
+
+  for (const article of articles) {
+    const classifiedTickerIds = new Set(
+      article.tickerSections.map((row) => row.tickerId),
+    );
+
+    if (article.tickerId !== null) {
+      if (classifiedTickerIds.has(article.tickerId)) continue;
+      pairs.push({
+        id: article.id,
+        tickerId: article.tickerId,
+        url: article.url,
+        title: article.title,
+        content: article.content,
+        createdAt: article.createdAt,
+        ticker: mapTickerContext(article.ticker),
+      });
+      continue;
+    }
+
+    const haystack = `${article.title}\n${article.content}`;
+    for (const gating of gatingContexts) {
+      if (classifiedTickerIds.has(gating.tickerId)) continue;
+      if (gating.matcher === null || !gating.matcher.test(haystack)) continue;
+      pairs.push({
+        id: article.id,
+        tickerId: gating.tickerId,
+        url: article.url,
+        title: article.title,
+        content: article.content,
+        createdAt: article.createdAt,
+        ticker: gating.context,
+      });
+    }
+  }
+
+  return {
+    dataSources: query.limit ? pairs.slice(0, query.limit) : pairs,
+    dataSourceTotalCount: pairs.length,
+  };
+};
+
+/**
+ * Loads candidate (article, ticker) pairs for the article-analysis agent, or — when scoped to a
+ * single ticker — that ticker's article backlog (data-collection daily baseline count).
+ *
+ * @param query - Parsed GET query (`unanalyzed` defaults to incremental backlog only).
+ * @param deps - Injectable database delegates for tests.
+ * @returns Eligible (article, ticker) pairs (capped by `limit`) plus the total backlog count.
+ */
+export const loadAnalysisContext = async (
+  query: GetAnalysisQuery,
+  deps: { db?: AnalysisDb } = {},
+): Promise<GetAnalysisResponse> => {
+  const db = deps.db ?? defaultDb;
+
+  if (query.tickerId === undefined) {
+    return buildAnalysisCandidatePairs(query, db);
+  }
+
+  const scopedTickerId = query.tickerId;
+  const createdAtWhere =
+    query.start !== undefined || query.end !== undefined
+      ? ({
+          ...(query.start !== undefined ? { gte: new Date(query.start) } : {}),
+          ...(query.end !== undefined ? { lte: new Date(query.end) } : {}),
+        } satisfies Prisma.DateTimeFilter)
+      : undefined;
+
+  const where = {
+    tickerId: scopedTickerId,
     ...(createdAtWhere ? { createdAt: createdAtWhere } : {}),
     ...(query.unanalyzed ? { analyzedAt: null } : {}),
   } satisfies Prisma.DataSourceWhereInput;
@@ -100,6 +280,7 @@ export const loadAnalysisContext = async (
         title: true,
         content: true,
         createdAt: true,
+        tickerId: true,
         ticker: { select: { symbol: true, name: true, metadata: true } },
       },
     } satisfies Prisma.DataSourceFindManyArgs),
@@ -108,6 +289,7 @@ export const loadAnalysisContext = async (
 
   const dataSources = rows.map((row) => ({
     id: row.id,
+    tickerId: row.tickerId ?? scopedTickerId,
     url: row.url,
     title: row.title,
     content: row.content,
@@ -119,11 +301,11 @@ export const loadAnalysisContext = async (
 };
 
 /**
- * Persists per-article section classifications onto their data sources and marks them analyzed.
+ * Persists per-(article, ticker) section classifications and marks the articles analyzed.
  *
  * @param body - Validated analysis POST body (section rows + analyzed ids).
  * @param deps - Injectable database delegates for tests.
- * @returns Counts of scored and rejected (section `null`) rows.
+ * @returns Counts of scored and rejected (section `null`) pairs.
  * @throws {AnalysisPostValidationError} When a referenced data source does not exist.
  */
 export const applyAnalysisPost = async (
@@ -151,23 +333,38 @@ export const applyAnalysisPost = async (
     }
   }
 
+  const analyzedAt = new Date();
   const writes: Prisma.PrismaPromise<unknown>[] = body.articleSections.map(
     (row) =>
-      db.dataSource.update({
-        where: { id: row.dataSourceId },
-        data: {
+      db.dataSourceTickerSection.upsert({
+        where: {
+          dataSourceId_tickerId: {
+            dataSourceId: row.dataSourceId,
+            tickerId: row.tickerId,
+          },
+        },
+        create: {
+          dataSourceId: row.dataSourceId,
+          tickerId: row.tickerId,
           section: row.section,
           sectionScore: row.score,
           sectionReason: row.reason,
+          analyzedAt,
         },
-      }),
+        update: {
+          section: row.section,
+          sectionScore: row.score,
+          sectionReason: row.reason,
+          analyzedAt,
+        },
+      } satisfies Prisma.DataSourceTickerSectionUpsertArgs),
   );
 
   if (body.analyzedDataSourceIds.length > 0) {
     writes.push(
       db.dataSource.updateMany({
         where: { id: { in: body.analyzedDataSourceIds } },
-        data: { analyzedAt: new Date() },
+        data: { analyzedAt },
       }),
     );
   }

--- a/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@mediapulse/database", () => ({
   prisma: {
-    dataSource: {
+    dataSourceTickerSection: {
       findMany: vi.fn(),
     },
     ticker: {
@@ -36,7 +36,7 @@ import {
 } from "./content-generation.js";
 
 type MockDb = {
-  dataSource: {
+  dataSourceTickerSection: {
     findMany: ReturnType<typeof vi.fn>;
   };
   ticker: {
@@ -59,7 +59,7 @@ type MockDb = {
 };
 
 const createMockDb = (): MockDb => ({
-  dataSource: {
+  dataSourceTickerSection: {
     findMany: vi.fn(),
   },
   ticker: {
@@ -113,32 +113,36 @@ describe("getDataSourcesForTicker", () => {
       symbol: "TEST",
       name: "Test Company",
     });
-    db.dataSource.findMany.mockResolvedValue([
+    db.dataSourceTickerSection.findMany.mockResolvedValue([
       {
-        id: "ds-low",
-        url: "https://example.com/low",
-        title: "Low score",
-        content: "Low",
-        metadata: null,
-        tickerId: "ticker-1",
-        searchQueryId: "sq-1",
-        section: "quickHits",
-        sectionScore: 0.62,
-        createdAt: new Date("2026-03-19T08:00:00.000Z"),
-        updatedAt: new Date("2026-03-19T08:00:00.000Z"),
-      },
-      {
-        id: "ds-high",
-        url: "https://example.com/high",
-        title: "High score",
-        content: "High",
-        metadata: null,
-        tickerId: "ticker-1",
-        searchQueryId: "sq-2",
         section: "competitiveLandscape",
         sectionScore: 0.93,
-        createdAt: new Date("2026-03-19T09:00:00.000Z"),
-        updatedAt: new Date("2026-03-19T09:00:00.000Z"),
+        sectionReason: "peer move",
+        dataSource: {
+          url: "https://example.com/high",
+          title: "High score",
+          content: "High",
+          author: null,
+          source: "Reuters",
+          searchQueryId: "sq-2",
+          metadata: null,
+          publishedAt: null,
+        },
+      },
+      {
+        section: "quickHits",
+        sectionScore: 0.62,
+        sectionReason: "minor",
+        dataSource: {
+          url: "https://example.com/low",
+          title: "Low score",
+          content: "Low",
+          author: null,
+          source: null,
+          searchQueryId: null,
+          metadata: null,
+          publishedAt: null,
+        },
       },
     ]);
 
@@ -150,19 +154,20 @@ describe("getDataSourcesForTicker", () => {
 
     // Assert
     const expectedStartOfToday = new Date("2026-03-19T00:00:00.000Z");
-    expect(db.dataSource.findMany).toHaveBeenCalledWith({
-      where: {
-        tickerId: "ticker-1",
-        section: { not: null },
-        analyzedAt: { gte: expectedStartOfToday },
-      },
-      orderBy: {
-        createdAt: "desc",
-      },
-    });
+    expect(db.dataSourceTickerSection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tickerId: "ticker-1",
+          section: { not: null },
+          analyzedAt: { gte: expectedStartOfToday },
+        },
+        orderBy: { sectionScore: "desc" },
+      }),
+    );
     expect(result.dataSources).toHaveLength(2);
-    expect(result.dataSources[0]?.id).toBe("ds-high");
-    expect(result.dataSources[1]?.id).toBe("ds-low");
+    expect(result.dataSources[0]?.title).toBe("High score");
+    expect(result.dataSources[0]?.tickerId).toBe("ticker-1");
+    expect(result.dataSources[1]?.title).toBe("Low score");
     expect(result.tickerSymbol).toBe("TEST");
     expect(result.tickerName).toBe("Test Company");
   });
@@ -174,7 +179,7 @@ describe("getDataSourcesForTicker", () => {
       symbol: "EMPTY",
       name: "Empty Corp",
     });
-    db.dataSource.findMany.mockResolvedValue([]);
+    db.dataSourceTickerSection.findMany.mockResolvedValue([]);
 
     // Act
     const result = await getDataSourcesForTicker("ticker-1", {
@@ -782,7 +787,7 @@ describe("getDataSourcesForTicker — competitors and issuerAliases in response"
       symbol: "BBCA",
       name: "Bank Central Asia",
     });
-    db.dataSource.findMany.mockResolvedValue([]);
+    db.dataSourceTickerSection.findMany.mockResolvedValue([]);
     db.entityType.findFirst.mockResolvedValue({ id: "type-company" });
     db.tickerEntity.findFirst.mockResolvedValue({
       entityId: "entity-bbca",
@@ -825,7 +830,7 @@ describe("getDataSourcesForTicker — competitors and issuerAliases in response"
       name: "New Company",
     });
     // ticker.findUnique returns null by default in createMockDb — anchor lookup short-circuits
-    db.dataSource.findMany.mockResolvedValue([]);
+    db.dataSourceTickerSection.findMany.mockResolvedValue([]);
 
     // Act
     const result = await getDataSourcesForTicker("ticker-new", {
@@ -852,7 +857,7 @@ describe("getDataSourcesForTicker — competitors and issuerAliases in response"
       symbol: "SOLO",
       name: "Solo Corp",
     });
-    db.dataSource.findMany.mockResolvedValue([]);
+    db.dataSourceTickerSection.findMany.mockResolvedValue([]);
     db.entityType.findFirst.mockResolvedValue({ id: "type-company" });
     db.tickerEntity.findFirst.mockResolvedValue({
       entityId: "entity-solo",

--- a/apps/mediapulse/agent-data-api/src/services/content-generation.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.ts
@@ -5,196 +5,53 @@ import type { PostContentGenerationBody } from "@workspace/agent-data-api-contra
 import type { Prisma } from "@mediapulse/database";
 
 import { flattenBulletsFromNewsletterWire } from "../lib/flatten-newsletter-wire-bullets.js";
+import {
+  findIssuerAnchorForTicker,
+  getCompetitorsForTicker,
+  normalizeName,
+} from "./issuer-context.js";
+
+export type { CompetitorEntry } from "./issuer-context.js";
+export {
+  findIssuerAnchorForTicker,
+  getCompetitorsForTicker,
+} from "./issuer-context.js";
 
 const MAX_RECENT_BULLETS = 200;
-const MAX_COMPETITOR_EDGE_FETCH = 50;
-const MAX_COMPETITORS_DEFAULT = 8;
-
-type DataSourceWithScore = Prisma.DataSourceGetPayload<object>;
 
 type ContentGenerationDb = {
-  dataSource: Pick<typeof prisma.dataSource, "findMany">;
+  dataSourceTickerSection: Pick<
+    typeof prisma.dataSourceTickerSection,
+    "findMany"
+  >;
   ticker: Pick<typeof prisma.ticker, "findUniqueOrThrow" | "findUnique">;
   newsletter: Pick<
     typeof prisma.newsletter,
     "create" | "findFirst" | "findMany"
   >;
-  entity: Pick<typeof prisma.entity, "findFirst" | "findMany">;
-  entityAlias: Pick<typeof prisma.entityAlias, "findMany">;
-  tickerEntity: Pick<typeof prisma.tickerEntity, "findFirst" | "findMany">;
+  tickerEntity: Pick<typeof prisma.tickerEntity, "findFirst">;
   entityRelation: Pick<typeof prisma.entityRelation, "findMany">;
-  relationType: Pick<typeof prisma.relationType, "findMany">;
   entityType: Pick<typeof prisma.entityType, "findFirst">;
 };
 
-type IssuerAnchor = {
-  entityId: string;
-  canonicalName: string;
-  aliases: string[];
-};
-
-export type CompetitorEntry = {
-  name: string;
-  aliases: string[];
-  relation: string;
-  weight: number;
-};
-
-const normalizeName = (value: string): string => value.trim().toLowerCase();
-
-async function findIssuerAnchorForTicker(
-  tickerId: string,
-  db: Pick<ContentGenerationDb, "ticker" | "entityType" | "tickerEntity">,
-): Promise<IssuerAnchor | null> {
-  const ticker = await db.ticker.findUnique({
-    where: { id: tickerId },
-    select: { symbol: true, name: true },
-  } satisfies Prisma.TickerFindUniqueArgs);
-  if (!ticker) return null;
-
-  const companyType = await db.entityType.findFirst({
-    where: { name: "COMPANY" },
-    select: { id: true },
-  } satisfies Prisma.EntityTypeFindFirstArgs);
-  if (!companyType) return null;
-
-  const tickerEntityRow = await db.tickerEntity.findFirst({
-    where: {
-      tickerId,
-      source: "SEED",
-      entity: { typeId: companyType.id },
-    },
-    select: {
-      entityId: true,
-      entity: {
-        select: {
-          canonicalName: true,
-          aliases: { select: { alias: true } },
-        },
-      },
-    },
-  } satisfies Prisma.TickerEntityFindFirstArgs);
-  if (!tickerEntityRow) return null;
-
-  const storedAliases = tickerEntityRow.entity.aliases.map((row) => row.alias);
-  const aliases = [
-    ...new Set(
-      [ticker.symbol, ticker.name, ...storedAliases].filter(
-        (value) => value.length > 0,
-      ),
-    ),
-  ];
-
-  return {
-    entityId: tickerEntityRow.entityId,
-    canonicalName: tickerEntityRow.entity.canonicalName,
-    aliases,
-  };
-}
-
 /**
- * Reads COMPETITOR and SECTOR_PEER edges from the issuer entity, returning a
- * ranked, capped, self-excluded list of peer COMPANY entities.
+ * Returns today's classified data sources for a ticker, plus the ticker's name, symbol,
+ * competitors, and issuer aliases. Reads the per-(article, ticker) section table.
  *
- * @param issuerEntityId - KG entity id for the ticker's issuer anchor.
- * @param issuerNormalizedAliasSet - Normalized alias strings for the issuer (self-exclusion guard).
- * @param opts - Optional cap override.
- * @param db - Database delegates.
- * @returns Competitor entries ordered by weight desc, then lastSeenAt desc.
- */
-export async function getCompetitorsForTicker(
-  issuerEntityId: string,
-  issuerNormalizedAliasSet: ReadonlySet<string>,
-  opts: { maxCompetitors?: number },
-  db: Pick<ContentGenerationDb, "entityRelation">,
-): Promise<CompetitorEntry[]> {
-  const maxCompetitors = opts.maxCompetitors ?? MAX_COMPETITORS_DEFAULT;
-
-  const relations = await db.entityRelation.findMany({
-    where: {
-      OR: [{ fromEntityId: issuerEntityId }, { toEntityId: issuerEntityId }],
-      relationType: {
-        name: { in: ["COMPETITOR", "SECTOR_PEER"] },
-      },
-    },
-    select: {
-      fromEntityId: true,
-      toEntityId: true,
-      weight: true,
-      relationType: { select: { name: true } },
-      fromEntity: {
-        select: {
-          id: true,
-          canonicalName: true,
-          type: { select: { name: true } },
-          aliases: { select: { alias: true } },
-        },
-      },
-      toEntity: {
-        select: {
-          id: true,
-          canonicalName: true,
-          type: { select: { name: true } },
-          aliases: { select: { alias: true } },
-        },
-      },
-    },
-    orderBy: [{ weight: "desc" }, { lastSeenAt: "desc" }],
-    take: MAX_COMPETITOR_EDGE_FETCH,
-  } satisfies Prisma.EntityRelationFindManyArgs);
-
-  const seenEntityIds = new Set<string>();
-  const competitors: CompetitorEntry[] = [];
-
-  for (const relation of relations) {
-    if (competitors.length >= maxCompetitors) break;
-
-    const peerEntity =
-      relation.fromEntityId === issuerEntityId
-        ? relation.toEntity
-        : relation.fromEntity;
-
-    if (peerEntity.type.name !== "COMPANY") continue;
-    if (peerEntity.id === issuerEntityId) continue;
-
-    const peerNormalizedName = normalizeName(peerEntity.canonicalName);
-    if (issuerNormalizedAliasSet.has(peerNormalizedName)) continue;
-    const peerNormalizedAliases = peerEntity.aliases.map((aliasRow) =>
-      normalizeName(aliasRow.alias),
-    );
-    if (
-      peerNormalizedAliases.some((alias) => issuerNormalizedAliasSet.has(alias))
-    )
-      continue;
-
-    if (seenEntityIds.has(peerEntity.id)) continue;
-    seenEntityIds.add(peerEntity.id);
-
-    competitors.push({
-      name: peerEntity.canonicalName,
-      aliases: peerEntity.aliases.map((aliasRow) => aliasRow.alias),
-      relation: relation.relationType.name,
-      weight: relation.weight,
-    });
-  }
-
-  return competitors;
-}
-
-/**
- * Returns today's selected data sources for a ticker, plus the ticker's
- * human-readable name and exchange symbol, ordered by relevance score.
- *
- * @param tickerId - Ticker id used to scope data sources and relevance rows.
+ * @param tickerId - Ticker id used to scope the per-ticker section rows.
  * @param deps - Optional dependencies for database and current time.
- * @returns Data sources filtered to selected article relevance rows scored today (UTC), plus `tickerName` and `tickerSymbol`.
+ * @returns Data sources sectioned for this ticker today (UTC), ordered by section score desc.
  */
 export const getDataSourcesForTicker = async (
   tickerId: string,
   deps: {
     db?: Pick<
       ContentGenerationDb,
-      "dataSource" | "ticker" | "entityType" | "tickerEntity" | "entityRelation"
+      | "dataSourceTickerSection"
+      | "ticker"
+      | "entityType"
+      | "tickerEntity"
+      | "entityRelation"
     >;
     now?: () => Date;
   } = {},
@@ -203,30 +60,50 @@ export const getDataSourcesForTicker = async (
   const startOfTodayUtc = now();
   startOfTodayUtc.setUTCHours(0, 0, 0, 0);
 
-  const [ticker, dataSourcesWithScores] = await Promise.all([
+  const [ticker, sectionRows] = await Promise.all([
     db.ticker.findUniqueOrThrow({
       where: { id: tickerId },
       select: { symbol: true, name: true },
     } satisfies Prisma.TickerFindUniqueOrThrowArgs),
-    db.dataSource.findMany({
+    db.dataSourceTickerSection.findMany({
       where: {
         tickerId,
         section: { not: null },
         analyzedAt: { gte: startOfTodayUtc },
       },
-      orderBy: {
-        createdAt: "desc",
+      select: {
+        section: true,
+        sectionScore: true,
+        sectionReason: true,
+        dataSource: {
+          select: {
+            url: true,
+            title: true,
+            content: true,
+            author: true,
+            source: true,
+            searchQueryId: true,
+            metadata: true,
+            publishedAt: true,
+          },
+        },
       },
-    } satisfies Prisma.DataSourceFindManyArgs),
+      orderBy: { sectionScore: "desc" },
+    } satisfies Prisma.DataSourceTickerSectionFindManyArgs),
   ]);
 
-  const dataSources = [...dataSourcesWithScores].sort(
-    (left: DataSourceWithScore, right: DataSourceWithScore) => {
-      const leftScore = left.sectionScore ?? 0;
-      const rightScore = right.sectionScore ?? 0;
-      return rightScore - leftScore;
-    },
-  );
+  const dataSources = sectionRows.map((row) => ({
+    url: row.dataSource.url,
+    title: row.dataSource.title,
+    content: row.dataSource.content,
+    author: row.dataSource.author,
+    source: row.dataSource.source,
+    tickerId,
+    searchQueryId: row.dataSource.searchQueryId,
+    section: row.section,
+    sectionScore: row.sectionScore,
+    sectionReason: row.sectionReason,
+  }));
 
   const anchor = await findIssuerAnchorForTicker(tickerId, db);
   const issuerAliases: string[] =

--- a/apps/mediapulse/agent-data-api/src/services/issuer-context.ts
+++ b/apps/mediapulse/agent-data-api/src/services/issuer-context.ts
@@ -1,0 +1,174 @@
+import { prisma } from "@mediapulse/database";
+import type { Prisma } from "@mediapulse/database";
+
+const MAX_COMPETITOR_EDGE_FETCH = 50;
+const MAX_COMPETITORS_DEFAULT = 8;
+
+export type IssuerAnchor = {
+  entityId: string;
+  canonicalName: string;
+  aliases: string[];
+};
+
+export type CompetitorEntry = {
+  name: string;
+  aliases: string[];
+  relation: string;
+  weight: number;
+};
+
+export type IssuerContextDb = {
+  ticker: Pick<typeof prisma.ticker, "findUnique">;
+  entityType: Pick<typeof prisma.entityType, "findFirst">;
+  tickerEntity: Pick<typeof prisma.tickerEntity, "findFirst">;
+  entityRelation: Pick<typeof prisma.entityRelation, "findMany">;
+};
+
+export const normalizeName = (value: string): string =>
+  value.trim().toLowerCase();
+
+/**
+ * Resolves a ticker's issuer anchor entity (KG COMPANY seeded for the ticker), plus its aliases.
+ *
+ * @param tickerId - Ticker id to anchor.
+ * @param db - Database delegates.
+ * @returns The issuer anchor, or `null` when the ticker has no seeded COMPANY entity.
+ */
+export async function findIssuerAnchorForTicker(
+  tickerId: string,
+  db: Pick<IssuerContextDb, "ticker" | "entityType" | "tickerEntity">,
+): Promise<IssuerAnchor | null> {
+  const ticker = await db.ticker.findUnique({
+    where: { id: tickerId },
+    select: { symbol: true, name: true },
+  } satisfies Prisma.TickerFindUniqueArgs);
+  if (!ticker) return null;
+
+  const companyType = await db.entityType.findFirst({
+    where: { name: "COMPANY" },
+    select: { id: true },
+  } satisfies Prisma.EntityTypeFindFirstArgs);
+  if (!companyType) return null;
+
+  const tickerEntityRow = await db.tickerEntity.findFirst({
+    where: {
+      tickerId,
+      source: "SEED",
+      entity: { typeId: companyType.id },
+    },
+    select: {
+      entityId: true,
+      entity: {
+        select: {
+          canonicalName: true,
+          aliases: { select: { alias: true } },
+        },
+      },
+    },
+  } satisfies Prisma.TickerEntityFindFirstArgs);
+  if (!tickerEntityRow) return null;
+
+  const storedAliases = tickerEntityRow.entity.aliases.map((row) => row.alias);
+  const aliases = [
+    ...new Set(
+      [ticker.symbol, ticker.name, ...storedAliases].filter(
+        (value) => value.length > 0,
+      ),
+    ),
+  ];
+
+  return {
+    entityId: tickerEntityRow.entityId,
+    canonicalName: tickerEntityRow.entity.canonicalName,
+    aliases,
+  };
+}
+
+/**
+ * Reads COMPETITOR and SECTOR_PEER edges from the issuer entity, returning a
+ * ranked, capped, self-excluded list of peer COMPANY entities.
+ *
+ * @param issuerEntityId - KG entity id for the ticker's issuer anchor.
+ * @param issuerNormalizedAliasSet - Normalized alias strings for the issuer (self-exclusion guard).
+ * @param opts - Optional cap override.
+ * @param db - Database delegates.
+ * @returns Competitor entries ordered by weight desc, then lastSeenAt desc.
+ */
+export async function getCompetitorsForTicker(
+  issuerEntityId: string,
+  issuerNormalizedAliasSet: ReadonlySet<string>,
+  opts: { maxCompetitors?: number },
+  db: Pick<IssuerContextDb, "entityRelation">,
+): Promise<CompetitorEntry[]> {
+  const maxCompetitors = opts.maxCompetitors ?? MAX_COMPETITORS_DEFAULT;
+
+  const relations = await db.entityRelation.findMany({
+    where: {
+      OR: [{ fromEntityId: issuerEntityId }, { toEntityId: issuerEntityId }],
+      relationType: {
+        name: { in: ["COMPETITOR", "SECTOR_PEER"] },
+      },
+    },
+    select: {
+      fromEntityId: true,
+      toEntityId: true,
+      weight: true,
+      relationType: { select: { name: true } },
+      fromEntity: {
+        select: {
+          id: true,
+          canonicalName: true,
+          type: { select: { name: true } },
+          aliases: { select: { alias: true } },
+        },
+      },
+      toEntity: {
+        select: {
+          id: true,
+          canonicalName: true,
+          type: { select: { name: true } },
+          aliases: { select: { alias: true } },
+        },
+      },
+    },
+    orderBy: [{ weight: "desc" }, { lastSeenAt: "desc" }],
+    take: MAX_COMPETITOR_EDGE_FETCH,
+  } satisfies Prisma.EntityRelationFindManyArgs);
+
+  const seenEntityIds = new Set<string>();
+  const competitors: CompetitorEntry[] = [];
+
+  for (const relation of relations) {
+    if (competitors.length >= maxCompetitors) break;
+
+    const peerEntity =
+      relation.fromEntityId === issuerEntityId
+        ? relation.toEntity
+        : relation.fromEntity;
+
+    if (peerEntity.type.name !== "COMPANY") continue;
+    if (peerEntity.id === issuerEntityId) continue;
+
+    const peerNormalizedName = normalizeName(peerEntity.canonicalName);
+    if (issuerNormalizedAliasSet.has(peerNormalizedName)) continue;
+    const peerNormalizedAliases = peerEntity.aliases.map((aliasRow) =>
+      normalizeName(aliasRow.alias),
+    );
+    if (
+      peerNormalizedAliases.some((alias) => issuerNormalizedAliasSet.has(alias))
+    )
+      continue;
+
+    if (seenEntityIds.has(peerEntity.id)) continue;
+    seenEntityIds.add(peerEntity.id);
+
+    competitors.push({
+      name: peerEntity.canonicalName,
+      aliases: peerEntity.aliases.map((aliasRow) => aliasRow.alias),
+      relation: relation.relationType.name,
+      weight: relation.weight,
+    });
+  }
+
+  return competitors;
+}

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -16,13 +16,14 @@ import {
   narrativeRunComplete,
 } from "./utilities/build-activity-narrative.js";
 
-/** Max data sources fetched and classified per run (also bounded by the GET contract). */
-const MAX_SOURCES = 10;
+/** Max (article, ticker) pairs fetched and classified per run (also bounded by the GET contract). */
+const MAX_PAIRS = 10;
 /** Max concurrent classification calls. */
 const CLASSIFY_CONCURRENCY = 4;
 
 type ClassifiedRow = {
   dataSourceId: string;
+  tickerId: string;
   section: string | null;
   score: number;
   reason: string;
@@ -105,7 +106,7 @@ export async function run(
   const { dataSources, dataSourceTotalCount } =
     await dataApiClient.analysis.get({
       unanalyzed: true,
-      limit: MAX_SOURCES,
+      limit: MAX_PAIRS,
     });
 
   log.info(
@@ -155,6 +156,7 @@ export async function run(
 
       return {
         dataSourceId: dataSource.id,
+        tickerId: dataSource.tickerId,
         section: result.section,
         score: result.score,
         reason: result.reason,
@@ -183,8 +185,10 @@ export async function run(
     };
   }
 
-  // Every fetched source is marked analyzed, even if its classification call failed.
-  const analyzedDataSourceIds = dataSources.map((dataSource) => dataSource.id);
+  // Every fetched article is marked analyzed (article-level), even if a classification call failed.
+  const analyzedDataSourceIds = [
+    ...new Set(dataSources.map((dataSource) => dataSource.id)),
+  ];
 
   const { articlesScored, articlesRejected } =
     await dataApiClient.analysis.create({

--- a/packages/mediapulse/database/prisma/migrations/20260630030117_add_data_source_ticker_section/migration.sql
+++ b/packages/mediapulse/database/prisma/migrations/20260630030117_add_data_source_ticker_section/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "data_source_ticker_section" (
+    "id" TEXT NOT NULL,
+    "data_source_id" TEXT NOT NULL,
+    "ticker_id" TEXT NOT NULL,
+    "section" TEXT,
+    "section_score" DOUBLE PRECISION,
+    "section_reason" TEXT,
+    "analyzed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "data_source_ticker_section_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "data_source_ticker_section_ticker_id_section_analyzed_at_idx" ON "data_source_ticker_section"("ticker_id", "section", "analyzed_at");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "data_source_ticker_section_data_source_id_ticker_id_key" ON "data_source_ticker_section"("data_source_id", "ticker_id");
+
+-- AddForeignKey
+ALTER TABLE "data_source_ticker_section" ADD CONSTRAINT "data_source_ticker_section_data_source_id_fkey" FOREIGN KEY ("data_source_id") REFERENCES "data_source"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "data_source_ticker_section" ADD CONSTRAINT "data_source_ticker_section_ticker_id_fkey" FOREIGN KEY ("ticker_id") REFERENCES "ticker"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/mediapulse/database/prisma/schema.prisma
+++ b/packages/mediapulse/database/prisma/schema.prisma
@@ -100,18 +100,44 @@ model DataSource {
   createdAt            DateTime              @default(now()) @map("created_at")
   updatedAt            DateTime              @updatedAt @map("updated_at")
 
-  ticker                 Ticker?                  @relation(fields: [tickerId], references: [id])
-  searchQuery            SearchQuery?             @relation(fields: [searchQueryId], references: [id])
-  curatedSource          CuratedSource?           @relation(fields: [curatedSourceId], references: [id], onDelete: SetNull)
+  ticker                 Ticker?                   @relation(fields: [tickerId], references: [id])
+  searchQuery            SearchQuery?              @relation(fields: [searchQueryId], references: [id])
+  curatedSource          CuratedSource?            @relation(fields: [curatedSourceId], references: [id], onDelete: SetNull)
   articleEntities        ArticleEntity[]
   articleRelevances      ArticleRelevance[]
   entityEvidence         EntityEvidence[]
   entityRelationEvidence EntityRelationEvidence[]
+  tickerSections         DataSourceTickerSection[]
 
   @@index([curatedSourceId])
   @@index([collectionGateStatus, analyzedAt])
   @@index([tickerId, section])
   @@map("data_source")
+}
+
+/// Per-(article, ticker) newsletter-section classification produced by article-analysis.
+/// Replaces the 1:1 DataSource.section/sectionScore/sectionReason columns so one curated/global
+/// article can belong to a different section for each active ticker.
+model DataSourceTickerSection {
+  id            String   @id @default(uuid())
+  dataSourceId  String   @map("data_source_id")
+  tickerId      String   @map("ticker_id")
+  /// Newsletter section id; null = classified-but-rejected for this ticker.
+  section       String?  @map("section")
+  /// Section-fit score 0–1.
+  sectionScore  Float?   @map("section_score")
+  /// AI reason for the section choice or rejection.
+  sectionReason String?  @map("section_reason") @db.Text
+  analyzedAt    DateTime @default(now()) @map("analyzed_at")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  dataSource DataSource @relation(fields: [dataSourceId], references: [id], onDelete: Cascade)
+  ticker     Ticker     @relation(fields: [tickerId], references: [id], onDelete: Cascade)
+
+  @@unique([dataSourceId, tickerId])
+  @@index([tickerId, section, analyzedAt])
+  @@map("data_source_ticker_section")
 }
 
 /// Negative cache for URLs that recently failed terminally during data collection.
@@ -467,6 +493,7 @@ model Ticker {
   collectionUrlOutcomes  CollectionUrlOutcome[]
   deliveryRuns           DeliveryRun[]
   contentGenerationRuns  ContentGenerationRun[]
+  tickerSections         DataSourceTickerSection[]
 
   @@map("ticker")
 }

--- a/packages/shared/agent-data-api-client/src/index.test.ts
+++ b/packages/shared/agent-data-api-client/src/index.test.ts
@@ -240,6 +240,7 @@ describe("createAgentDataApiClient", () => {
         dataSources: [
           {
             id: "33333333-3333-4333-a333-333333333333",
+            tickerId: "44444444-4444-4444-8444-444444444444",
             url: "https://example.com",
             title: "Example",
             content: "Body",
@@ -296,6 +297,7 @@ describe("createAgentDataApiClient", () => {
       articleSections: [
         {
           dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          tickerId: "44444444-4444-4444-8444-444444444444",
           section: "competitiveLandscape",
           score: 0.7,
           reason: "Mentions a rival.",
@@ -311,6 +313,7 @@ describe("createAgentDataApiClient", () => {
           articleSections: [
             {
               dataSourceId: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+              tickerId: "44444444-4444-4444-8444-444444444444",
               section: "competitiveLandscape",
               score: 0.7,
               reason: "Mentions a rival.",

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -46,18 +46,22 @@ export const getAnalysisQuerySchema = z.object({
 });
 
 export const postAnalysisBodySchema = z.object({
-  /** One classification row per scored article. `section: null` means the article was rejected. */
+  /**
+   * One classification row per scored (article, ticker) pair. `section: null` means the article
+   * was rejected for that ticker. The same article may appear once per active ticker.
+   */
   articleSections: z
     .array(
       z.object({
         dataSourceId: z.string().uuid(),
+        tickerId: z.string().uuid(),
         section: sectionEnum.nullable(),
         score: z.number().min(0).max(1),
         reason: z.string().trim().min(1).max(2000),
       }),
     )
     .default([]),
-  /** Marks the processed articles as analyzed (covers rejected rows too). */
+  /** Marks the processed articles as analyzed at the article level (covers rejected rows too). */
   analyzedDataSourceIds: z.array(z.string().uuid()).default([]),
 });
 
@@ -73,17 +77,20 @@ export const analysisTickerContextSchema = z.object({
 
 export const analysisDataSourceSchema = z.object({
   id: z.string().uuid(),
+  /** Active ticker this article is being classified against (one row per (article, ticker) pair). */
+  tickerId: z.string().uuid(),
   url: z.string(),
   title: z.string(),
   content: z.string(),
   createdAt: z.coerce.date(),
-  /** Issuer the article was collected for, or `null` when ticker-agnostic. */
-  ticker: analysisTickerContextSchema.nullable(),
+  /** Issuer context for the paired ticker, used to ground section classification. */
+  ticker: analysisTickerContextSchema,
 });
 
 export const getAnalysisResponseSchema = z.object({
+  /** Candidate (article, ticker) pairs to classify (each carries its own issuer context). */
   dataSources: z.array(analysisDataSourceSchema),
-  /** Count of data sources matching the GET filters (ignores `limit` on the request). */
+  /** Count of (article, ticker) pairs matching the GET filters (ignores `limit` on the request). */
   dataSourceTotalCount: z.number().int().nonnegative(),
 });
 

--- a/packages/shared/agent-data-api-contract/src/content-generation.ts
+++ b/packages/shared/agent-data-api-contract/src/content-generation.ts
@@ -29,7 +29,8 @@ export const contentGenerationDataSourceSchema = z
     author: z.string().nullable().optional(),
     source: z.string().nullable().optional(),
     tickerId: z.string().trim().min(1),
-    searchQueryId: z.string().uuid(),
+    /** Search query that surfaced the article; `null` for curated/global sources. */
+    searchQueryId: z.string().uuid().nullable().optional(),
     description: z.string().nullable().optional(),
     /** Newsletter section assigned by article-analysis 3.0.0 (used to group sources at generation time). */
     section: z.enum(NEWSLETTER_SECTION_IDS as unknown as [string, ...string[]]),


### PR DESCRIPTION
## Summary

`content-generation` skipped every ticker with `no_sources` because its query needed one `data_source` row to have **both** a `ticker_id` and a `section`, and no row ever did. Curated articles (page-collection) get sectioned but carry no `ticker_id`; search-query articles (data-collection) carry a `ticker_id` but were never sectioned. This change classifies each article **per active ticker** and stores the result in a new per-(article, ticker) table that content-generation reads.

## Related issues

Closes #883

## Important changes

- New `DataSourceTickerSection` model and migration (`data_source_ticker_section`), unique on `(data_source_id, ticker_id)`. One article can now hold a different section per ticker.
- `analysis.get` (ticker-agnostic) returns candidate `(article, ticker)` pairs instead of bare articles. Curated articles fan out to active tickers (from active `SearchQuerySet`s) whose issuer or peer aliases they mention; search-query articles pair against their own `ticker_id`. Pairs already in `data_source_ticker_section` are skipped, so late-activated tickers still get classified.
- `analysis.create` upserts per-pair section rows and keeps marking articles analyzed at the article level.
- `content-generation` reads today's sectioned pairs for the ticker from the new table. The contract's `searchQueryId` is now nullable since curated sources have none.

## Other changes

- Extracted `findIssuerAnchorForTicker` / `getCompetitorsForTicker` / `normalizeName` into a shared `services/issuer-context.ts` used by both services (re-exported from content-generation for existing imports).
- article-analysis run loop carries `tickerId` per pair and dedupes article-level analyzed ids.

## Key files to review

- `packages/mediapulse/database/prisma/schema.prisma` - new model + back-relations.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` - candidate-pair gating and per-pair upsert.
- `apps/mediapulse/agent-data-api/src/services/content-generation.ts` - read path through the new table.
- `apps/mediapulse/agent-data-api/src/services/issuer-context.ts` - shared issuer/peer helpers.
- `packages/shared/agent-data-api-contract/src/{analysis,content-generation}.ts` - contract shape changes.

## How to test

1. `pnpm --filter @mediapulse/database db:migrate:dev` against a local DB to apply the migration.
2. `pnpm --filter @mediapulse/agent-data-api --filter @workspace/agent-data-api-contract --filter @workspace/agent-data-api-client --filter @mediapulse/article-analysis run type:check lint test` - all green.
3. After a deploy, run article-analysis, then confirm for a ticker:
   ```sql
   SELECT count(*) FROM data_source_ticker_section
   WHERE ticker_id = '<ticker>' AND section IS NOT NULL
     AND analyzed_at >= date_trunc('day', now() AT TIME ZONE 'UTC');
   ```
   should be `> 0`, and the `Newsletter Creation & Delivery` run no longer reports `no_sources`.

## Notes

The flat `data_source.section*` columns and the deprecated `article_relevance` table are left in place; a follow-up migration drops them after production validation. No data backfill is needed since the old flat sections were unreadable by content-generation.
