### PR TITLE
Drain article-analysis backlog each run so newsletters fill

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -159,6 +159,7 @@ describe("loadAnalysisContext — candidate pairs (ticker-agnostic)", () => {
             { collectionGateStatus: "passed", tickerId: null },
             { tickerId: { not: null } },
           ],
+          createdAt: { gte: expect.any(Date) },
         }),
       }),
     );

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -20,7 +20,9 @@ import {
 } from "./issuer-context.js";
 
 /** Newest-first cap on eligible articles scanned per candidate-pair request. */
-const MAX_CANDIDATE_ARTICLE_SCAN = 500;
+const MAX_CANDIDATE_ARTICLE_SCAN = 1500;
+/** Only articles created within this window are considered for candidate pairs. */
+const CANDIDATE_ARTICLE_RECENCY_DAYS = 3;
 
 /**
  * Thrown when the analysis POST body references data sources or tickers that do not exist.
@@ -147,20 +149,23 @@ const buildAnalysisCandidatePairs = async (
     | "entityRelation"
   >,
 ): Promise<GetAnalysisResponse> => {
+  const recencyFloor = new Date(
+    Date.now() - CANDIDATE_ARTICLE_RECENCY_DAYS * 24 * 60 * 60 * 1000,
+  );
   const createdAtWhere =
     query.start !== undefined || query.end !== undefined
       ? ({
           ...(query.start !== undefined ? { gte: new Date(query.start) } : {}),
           ...(query.end !== undefined ? { lte: new Date(query.end) } : {}),
         } satisfies Prisma.DateTimeFilter)
-      : undefined;
+      : ({ gte: recencyFloor } satisfies Prisma.DateTimeFilter);
 
   const where = {
     OR: [
       { collectionGateStatus: "passed" as const, tickerId: null },
       { tickerId: { not: null } },
     ],
-    ...(createdAtWhere ? { createdAt: createdAtWhere } : {}),
+    createdAt: createdAtWhere,
   } satisfies Prisma.DataSourceWhereInput;
 
   const activeSets = await db.searchQuerySet.findMany({

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -14,6 +14,7 @@ import {
   narrativeRunStart,
   narrativeClassifying,
   narrativeRunComplete,
+  type AnalysisStopReason,
 } from "./utilities/build-activity-narrative.js";
 
 /** (article, ticker) pairs fetched per drain iteration (also bounded by the GET contract). */
@@ -108,13 +109,20 @@ export async function run(
   let totalScored = 0;
   let totalRejected = 0;
   let totalReturned = 0;
+  let failureCount = 0;
   let backlog = 0;
   let startReported = false;
+  let stopReason: AnalysisStopReason = null;
 
   // Drain the recent unclassified backlog in batches until empty (or the per-run safety cap is hit).
   // Each posted batch upserts section rows, so the next fetch excludes those pairs and the loop
   // makes forward progress; a batch that classifies nothing means no progress is possible, so stop.
-  while (totalReturned < MAX_PAIRS_PER_RUN) {
+  while (true) {
+    if (totalReturned >= MAX_PAIRS_PER_RUN) {
+      stopReason = "max_pairs_reached";
+      break;
+    }
+
     const { dataSources, dataSourceTotalCount } =
       await dataApiClient.analysis.get({
         unanalyzed: true,
@@ -123,19 +131,17 @@ export async function run(
     backlog = dataSourceTotalCount;
 
     if (!startReported) {
-      log.info(
-        { returned: dataSources.length, backlog },
-        "article-analysis run started",
-      );
-      report(...narrativeRunStart(dataSources.length));
+      log.info({ backlog }, "article-analysis run started");
+      report(...narrativeRunStart(backlog));
       startReported = true;
     }
 
     if (dataSources.length === 0) {
+      stopReason = totalReturned === 0 ? "nothing_to_do" : "drained";
       break;
     }
 
-    report(...narrativeClassifying(dataSources.length));
+    report(...narrativeClassifying(dataSources.length, totalReturned, backlog));
 
     const classified = await mapWithConcurrency(
       dataSources,
@@ -165,10 +171,12 @@ export async function run(
     const articleSections = classified.filter(
       (row): row is ClassifiedRow => row !== null,
     );
+    failureCount += dataSources.length - articleSections.length;
 
     // No pair in this batch could be classified: no section rows would be written, so the same
     // pairs would be returned again. Stop to avoid an infinite loop.
     if (articleSections.length === 0) {
+      stopReason = "no_progress";
       break;
     }
 
@@ -196,23 +204,40 @@ export async function run(
   }
 
   const totalAssigned = totalScored - totalRejected;
+  const status: "success" | "partial_success" | "failed" =
+    totalScored > 0
+      ? failureCount > 0
+        ? "partial_success"
+        : "success"
+      : stopReason === "nothing_to_do"
+        ? "success"
+        : "failed";
 
   log.info(
-    { scored: totalScored, assigned: totalAssigned, rejected: totalRejected },
+    {
+      status,
+      scored: totalScored,
+      assigned: totalAssigned,
+      rejected: totalRejected,
+      failed: failureCount,
+      stopReason,
+    },
     "article-analysis run completed",
   );
   report(
     ...narrativeRunComplete({
-      status: "success",
+      status,
       scored: totalScored,
       assigned: totalAssigned,
       rejected: totalRejected,
+      failureCount,
+      stopReason,
     }),
     "completed",
   );
 
   return {
-    success: true,
+    success: status !== "failed",
     message:
       totalScored === 0
         ? "No unanalyzed articles to classify."
@@ -221,6 +246,7 @@ export async function run(
       scored: totalScored,
       assigned: totalAssigned,
       rejected: totalRejected,
+      failed: failureCount,
       backlog,
     },
   };

--- a/apps/mediapulse/agents/article-analysis/src/run.ts
+++ b/apps/mediapulse/agents/article-analysis/src/run.ts
@@ -16,10 +16,12 @@ import {
   narrativeRunComplete,
 } from "./utilities/build-activity-narrative.js";
 
-/** Max (article, ticker) pairs fetched and classified per run (also bounded by the GET contract). */
-const MAX_PAIRS = 10;
+/** (article, ticker) pairs fetched per drain iteration (also bounded by the GET contract). */
+const BATCH_SIZE = 100;
+/** Safety bound on total pairs classified in a single run. */
+const MAX_PAIRS_PER_RUN = 1000;
 /** Max concurrent classification calls. */
-const CLASSIFY_CONCURRENCY = 4;
+const CLASSIFY_CONCURRENCY = 8;
 
 type ClassifiedRow = {
   dataSourceId: string;
@@ -103,124 +105,123 @@ export async function run(
     token,
   });
 
-  const { dataSources, dataSourceTotalCount } =
-    await dataApiClient.analysis.get({
-      unanalyzed: true,
-      limit: MAX_PAIRS,
-    });
+  let totalScored = 0;
+  let totalRejected = 0;
+  let totalReturned = 0;
+  let backlog = 0;
+  let startReported = false;
 
-  log.info(
-    { returned: dataSources.length, backlog: dataSourceTotalCount },
-    "article-analysis run started",
-  );
-  report(...narrativeRunStart(dataSources.length));
+  // Drain the recent unclassified backlog in batches until empty (or the per-run safety cap is hit).
+  // Each posted batch upserts section rows, so the next fetch excludes those pairs and the loop
+  // makes forward progress; a batch that classifies nothing means no progress is possible, so stop.
+  while (totalReturned < MAX_PAIRS_PER_RUN) {
+    const { dataSources, dataSourceTotalCount } =
+      await dataApiClient.analysis.get({
+        unanalyzed: true,
+        limit: BATCH_SIZE,
+      });
+    backlog = dataSourceTotalCount;
 
-  if (dataSources.length === 0) {
-    report(
-      ...narrativeRunComplete({
-        status: "success",
-        scored: 0,
-        assigned: 0,
-        rejected: 0,
-      }),
-      "completed",
-    );
-    return {
-      success: true,
-      message: "No unanalyzed articles to classify.",
-      details: {
-        scored: 0,
-        assigned: 0,
-        rejected: 0,
-        backlog: dataSourceTotalCount,
+    if (!startReported) {
+      log.info(
+        { returned: dataSources.length, backlog },
+        "article-analysis run started",
+      );
+      report(...narrativeRunStart(dataSources.length));
+      startReported = true;
+    }
+
+    if (dataSources.length === 0) {
+      break;
+    }
+
+    report(...narrativeClassifying(dataSources.length));
+
+    const classified = await mapWithConcurrency(
+      dataSources,
+      CLASSIFY_CONCURRENCY,
+      async (dataSource): Promise<ClassifiedRow> => {
+        const tickerContext = renderArticleTickerContext(dataSource.ticker);
+        const result = await classifyArticleSection({
+          apiKey: config.acceptance.apiKey,
+          baseUrl: config.acceptance.baseUrl,
+          model: config.acceptance.model,
+          title: dataSource.title,
+          content: dataSource.content,
+          acceptanceCriteria: config.acceptanceCriteria,
+          ...(tickerContext ? { tickerContext } : {}),
+        });
+
+        return {
+          dataSourceId: dataSource.id,
+          tickerId: dataSource.tickerId,
+          section: result.section,
+          score: result.score,
+          reason: result.reason,
+        };
       },
-    };
-  }
+    );
 
-  report(...narrativeClassifying(dataSources.length));
+    const articleSections = classified.filter(
+      (row): row is ClassifiedRow => row !== null,
+    );
 
-  const classified = await mapWithConcurrency(
-    dataSources,
-    CLASSIFY_CONCURRENCY,
-    async (dataSource): Promise<ClassifiedRow> => {
-      const tickerContext = renderArticleTickerContext(dataSource.ticker);
-      const result = await classifyArticleSection({
-        apiKey: config.acceptance.apiKey,
-        baseUrl: config.acceptance.baseUrl,
-        model: config.acceptance.model,
-        title: dataSource.title,
-        content: dataSource.content,
-        acceptanceCriteria: config.acceptanceCriteria,
-        ...(tickerContext ? { tickerContext } : {}),
+    // No pair in this batch could be classified: no section rows would be written, so the same
+    // pairs would be returned again. Stop to avoid an infinite loop.
+    if (articleSections.length === 0) {
+      break;
+    }
+
+    const analyzedDataSourceIds = [
+      ...new Set(dataSources.map((dataSource) => dataSource.id)),
+    ];
+
+    const { articlesScored, articlesRejected } =
+      await dataApiClient.analysis.create({
+        articleSections,
+        analyzedDataSourceIds,
       });
 
-      return {
-        dataSourceId: dataSource.id,
-        tickerId: dataSource.tickerId,
-        section: result.section,
-        score: result.score,
-        reason: result.reason,
-      };
-    },
-  );
-
-  const articleSections = classified.filter(
-    (row): row is ClassifiedRow => row !== null,
-  );
-
-  if (articleSections.length === 0) {
-    report(
-      ...narrativeRunComplete({
-        status: "failed",
-        scored: 0,
-        assigned: 0,
-        rejected: 0,
-      }),
-      "completed",
+    totalScored += articlesScored;
+    totalRejected += articlesRejected;
+    totalReturned += dataSources.length;
+    log.info(
+      {
+        batchScored: articlesScored,
+        totalScored,
+        remainingBacklog: Math.max(0, backlog - totalReturned),
+      },
+      "article-analysis batch completed",
     );
-    return {
-      success: false,
-      message: "Failed to classify any articles this run.",
-      details: { returned: dataSources.length, scored: 0 },
-    };
   }
 
-  // Every fetched article is marked analyzed (article-level), even if a classification call failed.
-  const analyzedDataSourceIds = [
-    ...new Set(dataSources.map((dataSource) => dataSource.id)),
-  ];
-
-  const { articlesScored, articlesRejected } =
-    await dataApiClient.analysis.create({
-      articleSections,
-      analyzedDataSourceIds,
-    });
-
-  const assigned = articlesScored - articlesRejected;
+  const totalAssigned = totalScored - totalRejected;
 
   log.info(
-    { scored: articlesScored, assigned, rejected: articlesRejected },
+    { scored: totalScored, assigned: totalAssigned, rejected: totalRejected },
     "article-analysis run completed",
   );
   report(
     ...narrativeRunComplete({
       status: "success",
-      scored: articlesScored,
-      assigned,
-      rejected: articlesRejected,
+      scored: totalScored,
+      assigned: totalAssigned,
+      rejected: totalRejected,
     }),
     "completed",
   );
 
   return {
     success: true,
-    message: `Classified ${articlesScored} article(s): ${assigned} assigned, ${articlesRejected} rejected.`,
+    message:
+      totalScored === 0
+        ? "No unanalyzed articles to classify."
+        : `Classified ${totalScored} article(s): ${totalAssigned} assigned, ${totalRejected} rejected.`,
     details: {
-      returned: dataSources.length,
-      scored: articlesScored,
-      assigned,
-      rejected: articlesRejected,
-      backlog: dataSourceTotalCount,
+      scored: totalScored,
+      assigned: totalAssigned,
+      rejected: totalRejected,
+      backlog,
     },
   };
 }

--- a/apps/mediapulse/agents/article-analysis/src/utilities/build-activity-narrative.test.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/build-activity-narrative.test.ts
@@ -7,36 +7,81 @@ import {
 } from "./build-activity-narrative.js";
 
 describe("build-activity-narrative", () => {
-  it("describes the run start with article count", () => {
+  it("describes the run start with the backlog count", () => {
     expect(narrativeRunStart(3)).toEqual([
       "Analyzing articles",
-      "Loading 3 unanalyzed articles to classify.",
+      "Found 3 articles awaiting classification and starting to score them.",
     ]);
   });
 
-  it("singularizes the article count", () => {
-    expect(narrativeRunStart(1)[1]).toContain("1 unanalyzed article ");
+  it("singularizes the backlog count", () => {
+    expect(narrativeRunStart(1)[1]).toContain(
+      "1 article awaiting classification",
+    );
   });
 
-  it("describes the classifying phase", () => {
-    expect(narrativeClassifying(5)).toEqual([
+  it("describes an empty backlog at start", () => {
+    expect(narrativeRunStart(0)[1]).toBe(
+      "Checking for articles awaiting classification.",
+    );
+  });
+
+  it("describes the classifying phase with progress", () => {
+    expect(narrativeClassifying(5, 10, 40)).toEqual([
       "Classifying articles",
-      "Scoring 5 articles against the acceptance criteria.",
+      "Scoring 5 articles against the acceptance criteria (10 of 40 so far).",
     ]);
   });
 
-  it("summarizes a successful run", () => {
+  it("omits the progress suffix when the backlog is unknown", () => {
+    expect(narrativeClassifying(5, 0, 0)[1]).toBe(
+      "Scoring 5 articles against the acceptance criteria.",
+    );
+  });
+
+  it("summarizes a fully drained run", () => {
     expect(
       narrativeRunComplete({
         status: "success",
         scored: 5,
         assigned: 4,
         rejected: 1,
+        failureCount: 0,
+        stopReason: "drained",
       }),
     ).toEqual([
       "Analysis complete",
-      "Scored 5 articles; assigned 4 articles across sections; 1 article rejected.",
+      "Classified 5 articles: assigned 4 articles across sections, 1 rejected. The backlog was fully drained.",
     ]);
+  });
+
+  it("reports the per-run cap and classification errors on a partial run", () => {
+    expect(
+      narrativeRunComplete({
+        status: "partial_success",
+        scored: 100,
+        assigned: 80,
+        rejected: 20,
+        failureCount: 3,
+        stopReason: "max_pairs_reached",
+      }),
+    ).toEqual([
+      "Analysis complete",
+      "Classified 100 articles: assigned 80 articles across sections, 20 rejected. The per-run limit was reached; the rest is left for the next run. 3 classification errors recorded.",
+    ]);
+  });
+
+  it("summarizes a run with nothing to do", () => {
+    expect(
+      narrativeRunComplete({
+        status: "success",
+        scored: 0,
+        assigned: 0,
+        rejected: 0,
+        failureCount: 0,
+        stopReason: "nothing_to_do",
+      }),
+    ).toEqual(["Analysis complete", "No articles needed classification."]);
   });
 
   it("reports a failed run", () => {
@@ -46,6 +91,8 @@ describe("build-activity-narrative", () => {
         scored: 0,
         assigned: 0,
         rejected: 0,
+        failureCount: 4,
+        stopReason: "no_progress",
       }),
     ).toEqual(["Analysis failed", "No articles could be classified this run."]);
   });

--- a/apps/mediapulse/agents/article-analysis/src/utilities/build-activity-narrative.ts
+++ b/apps/mediapulse/agents/article-analysis/src/utilities/build-activity-narrative.ts
@@ -2,25 +2,45 @@ function n(count: number, singular: string, pluralForm?: string): string {
   return `${count} ${count === 1 ? singular : (pluralForm ?? `${singular}s`)}`;
 }
 
-export function narrativeRunStart(total: number): [string, string] {
+export type AnalysisStopReason =
+  | "drained"
+  | "max_pairs_reached"
+  | "no_progress"
+  | "nothing_to_do"
+  | null;
+
+export function narrativeRunStart(backlog: number): [string, string] {
   return [
     "Analyzing articles",
-    `Loading ${n(total, "unanalyzed article")} to classify.`,
+    backlog > 0
+      ? `Found ${n(backlog, "article awaiting classification", "articles awaiting classification")} and starting to score them.`
+      : "Checking for articles awaiting classification.",
   ];
 }
 
-export function narrativeClassifying(count: number): [string, string] {
+export function narrativeClassifying(
+  batchCount: number,
+  processed: number,
+  backlog: number,
+): [string, string] {
+  const progress =
+    backlog > 0
+      ? ` (${Math.min(processed, backlog)} of ${backlog} so far)`
+      : "";
+
   return [
     "Classifying articles",
-    `Scoring ${n(count, "article")} against the acceptance criteria.`,
+    `Scoring ${n(batchCount, "article")} against the acceptance criteria${progress}.`,
   ];
 }
 
 export function narrativeRunComplete(opts: {
-  status: "success" | "failed";
+  status: "success" | "partial_success" | "failed";
   scored: number;
   assigned: number;
   rejected: number;
+  failureCount: number;
+  stopReason: AnalysisStopReason;
 }): [string, string] {
   const title =
     opts.status === "failed" ? "Analysis failed" : "Analysis complete";
@@ -29,10 +49,27 @@ export function narrativeRunComplete(opts: {
     return [title, "No articles could be classified this run."];
   }
 
-  const description =
+  const scoredClause =
     opts.scored === 0
-      ? "No unanalyzed articles were available."
-      : `Scored ${n(opts.scored, "article")}; assigned ${n(opts.assigned, "article")} across sections; ${n(opts.rejected, "article")} rejected.`;
+      ? "No articles needed classification"
+      : `Classified ${n(opts.scored, "article")}: assigned ${n(opts.assigned, "article")} across sections, ${opts.rejected} rejected`;
+
+  let stopClause = "";
+  if (opts.stopReason === "drained") {
+    stopClause = " The backlog was fully drained.";
+  } else if (opts.stopReason === "max_pairs_reached") {
+    stopClause =
+      " The per-run limit was reached; the rest is left for the next run.";
+  } else if (opts.stopReason === "no_progress") {
+    stopClause = " Classification stalled, so the run stopped early.";
+  }
+
+  const failureClause =
+    opts.failureCount > 0
+      ? ` ${n(opts.failureCount, "classification error")} recorded.`
+      : "";
+
+  const description = `${scoredClause}.${stopClause}${failureClause}`;
 
   return [title, description];
 }

--- a/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.test.ts
@@ -19,7 +19,7 @@ describe("ContentGenerationConfigSchema", () => {
     expect(parsed.credentials.baseUrl).toBeUndefined();
     expect(parsed.credentials.chatModel).toBe("{{OPENAI_MODEL}}");
     expect(parsed.credentials.timeoutMs).toBe(120_000);
-    expect(parsed.output.topNewsCount).toBe(10);
+    expect(parsed.output.topNewsCount).toBe(30);
     expect(parsed.inputs.context.maxCharsPerSource).toBe(8000);
     expect(parsed.inputs.context.maxTotalContextChars).toBe(100_000);
     expect(parsed.reliability.llmRetry.maxAttempts).toBe(3);

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -522,7 +522,7 @@ const outputSchema = z
       .number()
       .int()
       .positive()
-      .default(10)
+      .default(30)
       .describe("Number of top news items to include in the output."),
   })
   .default({})

--- a/packages/shared/agent-data-api-contract/src/analysis.ts
+++ b/packages/shared/agent-data-api-contract/src/analysis.ts
@@ -6,7 +6,7 @@ import { NEWSLETTER_SECTION_IDS } from "./newsletter-sections.js";
  * Max `limit` on analysis GET (query param). The article consumer
  * (`analysisGetDataSourceLimitMax` in Hermes config) should cap at this value so requests stay valid.
  */
-export const ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX = 10;
+export const ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX = 100;
 
 const sectionEnum = z.enum(
   NEWSLETTER_SECTION_IDS as unknown as [string, ...string[]],


### PR DESCRIPTION
## Summary

Newsletters were reliably thin and most tickers got none, because `article-analysis` classified only **10 `(article, ticker)` pairs per run, once daily**, while ~350 articles arrive daily (backlog ~4,600). It could never keep up. This makes throughput self-adjusting: each run **drains the recent unclassified backlog** instead of a fixed 10, and `content-generation` intake is raised so sections fill.

## Related issues

Closes #885

## Important changes

- **article-analysis drains in a loop** (`apps/mediapulse/agents/article-analysis/src/run.ts`): fetch a batch of 100, classify with concurrency 8, post, repeat until a batch returns nothing or the per-run safety cap (`MAX_PAIRS_PER_RUN = 1000`) is hit. Each batch commits its section rows, so the next fetch excludes them — the loop always makes forward progress, and a timed-out run resumes next time with no lost work. A batch that classifies nothing stops the loop (no infinite retry).
- **Analysis GET ceiling** raised: `ANALYSIS_GET_DATA_SOURCE_LIMIT_MAX` 10 → 100.
- **Candidate scan** (`agent-data-api/src/services/analysis.ts`): `MAX_CANDIDATE_ARTICLE_SCAN` 500 → 1500 plus a 3-day `createdAt` recency window, so a busy day is covered, results stay fresh, and the ancient backlog isn't churned.
- **content-generation intake**: `topNewsCount` default 10 → 30 so the writer has enough candidates to fill each section. Editorial per-section caps are unchanged (newsletters fill, they don't get longer).

## Other changes

- Tests updated: config-schema default (30), candidate-scan recency assertion.

## Key files to review

- `apps/mediapulse/agents/article-analysis/src/run.ts` - the drain loop and its termination guards.
- `apps/mediapulse/agent-data-api/src/services/analysis.ts` - scan cap + recency window.
- `packages/shared/agent-data-api-contract/src/analysis.ts` - batch ceiling.
- `apps/mediapulse/agents/content-generation/src/config-schema.ts` - intake default.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api --filter @workspace/agent-data-api-contract --filter @workspace/agent-data-api-client --filter @mediapulse/article-analysis --filter @mediapulse/content-generation run type:check lint test` - all green.
2. After deploy + the Hermes config change, trigger `Article Analysis` and confirm logs show the backlog draining to ~0, then:
   ```sql
   SELECT ticker_id, count(*) FILTER (WHERE section IS NOT NULL) sectioned
   FROM mediapulse.data_source_ticker_section
   WHERE analyzed_at >= date_trunc('day', now() AT TIME ZONE 'UTC')
   GROUP BY 1 ORDER BY 2 DESC;
   ```
   Expect rows for ~all 20 active tickers, most with 10-40+.
3. Trigger `Newsletter Creation & Delivery`; confirm `content_generation_run` shows ~all tickers `success` and a newsletter fills its sections.

## Notes

The content-generation `topNewsCount` / `maxTotalContextChars` live in the Hermes `agent_config` override (id `59df5a98`), which wins over the code default — that change is applied separately in Hermes (`topNewsCount` → 30, `maxTotalContextChars` → 200000). The first drain is a one-time backlog cost; steady state is ~daily volume, bounded and resumable per run.
