### PR TITLE
Cap data-collection fetch time so one slow host cannot wedge a run

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -62,6 +62,13 @@ const RUN_POLICY: RunPolicy = {
 const DEAD_URL_LOOKUP_BATCH_SIZE = 50;
 
 /**
+ * Hard wall-clock budget for a single data-collection run. Once exceeded, the round
+ * loop stops and the in-flight fetch stage abandons remaining URLs, so one slow or
+ * hostile host cannot wedge the run (and the pipeline behind it) for hours.
+ */
+const RUN_WALL_CLOCK_BUDGET_MS = 15 * 60 * 1000;
+
+/**
  * Executes the data-collection pipeline: load search queries, run web search and fetch,
  * persist sources and failures, and record run metadata.
  *
@@ -204,7 +211,9 @@ export async function runDataCollection(
     | "max_rounds_reached"
     | "no_progress"
     | "no_queries"
+    | "wall_clock_exceeded"
     | null = null;
+  const runDeadlineEpochMs = startedAt.getTime() + RUN_WALL_CLOCK_BUDGET_MS;
   let persistedThisRunCount = 0;
   let searchSuccessCount = 0;
   let searchFailedCount = 0;
@@ -243,6 +252,14 @@ export async function runDataCollection(
     report(...narrativeSearching(subject, queries.length));
 
     for (let round = 1; round <= maxTotalRounds; round += 1) {
+      if (Date.now() >= runDeadlineEpochMs) {
+        refillStopReason = "wall_clock_exceeded";
+        log.warn(
+          { round, budgetMs: RUN_WALL_CLOCK_BUDGET_MS },
+          "run wall-clock budget exceeded; stopping before next round",
+        );
+        break;
+      }
       roundsExecuted += 1;
       const searchAttemptResults = await performWebSearch(queries, {
         config: config.web_search,
@@ -633,6 +650,7 @@ export async function runDataCollection(
           logger: log,
           throttleStats: fetchThrottleStats,
           hostErrorTracker,
+          deadlineEpochMs: runDeadlineEpochMs,
           onOutcome: async (outcome) => {
             if (outcome.success !== null) {
               await persistFetchedPage(outcome.success);

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.test.ts
@@ -115,6 +115,21 @@ describe("narrativeRunComplete", () => {
     expect(description).toContain("10");
   });
 
+  it("notes the time budget when stopReason is wall_clock_exceeded", () => {
+    const [, description] = narrativeRunComplete(subject, {
+      status: "partial_success",
+      persisted: 3,
+      droppedByRelevance: 0,
+      droppedByFreshness: 0,
+      contentQualityDropped: 0,
+      failureCount: 0,
+      stopReason: "wall_clock_exceeded",
+      roundsExecuted: 1,
+      targetSavedSources: 15,
+    });
+    expect(description).toContain("time budget");
+  });
+
   it("notes the missing search queries when stopReason is no_queries", () => {
     const [, description] = narrativeRunComplete(subject, {
       status: "success",

--- a/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/build-activity-narrative.ts
@@ -78,6 +78,8 @@ export function narrativeRunComplete(
     stopClause = ` No new articles were found in the last round.`;
   } else if (opts.stopReason === "no_queries") {
     stopClause = ` No active search queries were configured.`;
+  } else if (opts.stopReason === "wall_clock_exceeded") {
+    stopClause = ` The run reached its time budget and stopped early.`;
   }
 
   const failureClause =

--- a/packages/shared/agent-ingestion/src/fetch-providers/diffbot.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/diffbot.ts
@@ -91,6 +91,8 @@ const fetchOneDiffbot = async (
           Accept: "application/json",
         },
         timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+        retry: { limit: 0 },
+        signal: ctx.signal,
       },
     );
     ctx.rateLimiter.recordResponse(response.statusCode);

--- a/packages/shared/agent-ingestion/src/fetch-providers/exa.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/exa.ts
@@ -74,6 +74,8 @@ const fetchOneExa = async (
           : {}),
       },
       timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      retry: { limit: 0 },
+      signal: ctx.signal,
     });
     ctx.rateLimiter.recordResponse(response.statusCode);
     const raw = JSON.parse(response.body) as unknown;

--- a/packages/shared/agent-ingestion/src/fetch-providers/firecrawl.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/firecrawl.ts
@@ -100,6 +100,8 @@ const fetchOneFirecrawl = async (
         ...buildAuthHeaders(config),
       },
       timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      retry: { limit: 0 },
+      signal: ctx.signal,
     });
     ctx.rateLimiter.recordResponse(response.statusCode);
     const raw = JSON.parse(response.body) as unknown;

--- a/packages/shared/agent-ingestion/src/fetch-providers/jina.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/jina.ts
@@ -97,6 +97,8 @@ const fetchOneJina = async (
         ...buildAuthHeaders(config),
       },
       timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      retry: { limit: 0 },
+      signal: ctx.signal,
     });
     ctx.rateLimiter.recordResponse(response.statusCode);
     const raw = JSON.parse(response.body) as unknown;

--- a/packages/shared/agent-ingestion/src/fetch-providers/serper.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/serper.ts
@@ -93,6 +93,8 @@ const fetchOneSerper = async (
         ...buildAuthHeaders(config),
       },
       timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      retry: { limit: 0 },
+      signal: ctx.signal,
     });
     ctx.rateLimiter.recordResponse(response.statusCode);
     const raw = JSON.parse(response.body) as unknown;

--- a/packages/shared/agent-ingestion/src/fetch-providers/tavily.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/tavily.ts
@@ -65,6 +65,8 @@ const fetchOneTavily = async (
           : {}),
       },
       timeout: config.timeoutMs ? { request: config.timeoutMs } : undefined,
+      retry: { limit: 0 },
+      signal: ctx.signal,
     });
     ctx.rateLimiter.recordResponse(response.statusCode);
     const raw = JSON.parse(response.body) as unknown;

--- a/packages/shared/agent-ingestion/src/fetch-providers/types.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/types.ts
@@ -47,6 +47,8 @@ export type ProviderRequestContext = {
   gotClient: typeof got;
   rateLimiter: RateLimiter;
   logger: FetchProviderLogger;
+  /** Hard-deadline abort signal; aborting cancels the in-flight HTTP request. */
+  signal?: AbortSignal;
 };
 
 /** Contract implemented by every web-fetch provider adapter. */

--- a/packages/shared/agent-ingestion/src/web-fetch.test.ts
+++ b/packages/shared/agent-ingestion/src/web-fetch.test.ts
@@ -339,6 +339,61 @@ describe("performWebFetch", () => {
     expect(result).toHaveLength(2);
   });
 
+  it("skips remaining URLs once the wall-clock deadline has passed", async () => {
+    // Setup
+    const postMock = vi.fn();
+    const warnMock = vi.fn();
+    const fakeGot = { post: postMock } as unknown as typeof got;
+
+    // Act — a deadline already in the past skips every URL
+    const result = await performWebFetch([baseSearchResult, baseSearchResult], {
+      config: { providers: [jinaProviderConfig] },
+      gotClient: fakeGot,
+      logger: { info: vi.fn(), warn: warnMock },
+      deadlineEpochMs: Date.now() - 1,
+    });
+
+    // Assert
+    expect(postMock).not.toHaveBeenCalled();
+    expect(result).toHaveLength(2);
+    expect(
+      result.every(
+        (outcome) => outcome.success === null && outcome.failures.length === 0,
+      ),
+    ).toBe(true);
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ skippedAfterDeadline: 2 }),
+      "web fetch: wall-clock deadline reached, skipped remaining URLs",
+    );
+  });
+
+  it("abandons a provider that hangs past the hard per-attempt timeout", async () => {
+    // Setup — a provider that ignores the abort signal and never resolves
+    vi.useFakeTimers();
+    const postMock = vi.fn().mockReturnValue(new Promise(() => {}));
+    const fakeGot = { post: postMock } as unknown as typeof got;
+    const hangingConfig = { ...jinaProviderConfig, timeoutMs: 10 };
+
+    // Act — advance past the hard ceiling (timeoutMs + buffer) so the race aborts
+    const pending = performWebFetch([baseSearchResult], {
+      config: { providers: [hangingConfig] },
+      gotClient: fakeGot,
+    });
+    await vi.advanceTimersByTimeAsync(10 + 5_000);
+    const result = await pending;
+
+    vi.useRealTimers();
+
+    // Assert
+    expect(result[0]?.success).toBeNull();
+    expect(result[0]?.failures).toEqual([
+      expect.objectContaining({
+        provider: "jina",
+        errorCategory: "internal_processing_error",
+      }),
+    ]);
+  });
+
   it("logs a warning with a truncated URL when fetch fails and the URL is very long", async () => {
     // Setup
     const warnMock = vi.fn();

--- a/packages/shared/agent-ingestion/src/web-fetch.ts
+++ b/packages/shared/agent-ingestion/src/web-fetch.ts
@@ -79,7 +79,56 @@ export interface WebFetchDeps {
    * aborts the batch the same way a failing fetch would.
    */
   onOutcome?: (outcome: WebFetchOutcome) => void | Promise<void>;
+  /**
+   * Optional absolute wall-clock deadline (epoch ms). Once reached, URLs not yet
+   * started are skipped instead of fetched so a slow batch cannot wedge the run.
+   */
+  deadlineEpochMs?: number;
 }
+
+/**
+ * Extra time beyond a provider's request timeout before the hard per-attempt abort
+ * fires. Covers rate-limiter wait plus response parsing so the provider's own timeout
+ * (which yields a clean classified error) trips first and the abort is only a backstop.
+ */
+const ATTEMPT_ABORT_BUFFER_MS = 5_000;
+
+/** Fallback hard per-attempt ceiling when a provider config omits `timeoutMs`. */
+const DEFAULT_HARD_ATTEMPT_TIMEOUT_MS = 60_000;
+
+/**
+ * Races a provider fetch against a hard deadline. On timeout it aborts the request
+ * (cancelling the in-flight HTTP call) and rejects, so the chain advances even if a
+ * provider ignores the abort signal. The losing promise is always handled, avoiding
+ * unhandled rejections when it settles late.
+ *
+ * @param fetchPromise - In-flight provider fetch.
+ * @param timeoutMs - Hard ceiling before the attempt is abandoned.
+ * @param controller - Abort controller wired into the provider request.
+ */
+const fetchWithHardTimeout = <T>(
+  fetchPromise: Promise<T>,
+  timeoutMs: number,
+  controller: AbortController,
+): Promise<T> =>
+  new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      controller.abort();
+      reject(
+        new Error(`web fetch attempt exceeded hard timeout of ${timeoutMs}ms`),
+      );
+    }, timeoutMs);
+    fetchPromise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        clearTimeout(timer);
+        reject(error as Error);
+      },
+    );
+  });
 
 type ProviderChainEntry = {
   provider: FetchProvider;
@@ -180,13 +229,22 @@ const fetchOneResult = async (
 
   for (const entry of rotated) {
     const providerName = toWebFetchProviderName(entry.provider.type);
+    const hardTimeoutMs =
+      (entry.config.timeoutMs ?? DEFAULT_HARD_ATTEMPT_TIMEOUT_MS) +
+      ATTEMPT_ABORT_BUFFER_MS;
+    const abortController = new AbortController();
 
     try {
-      const data = await entry.provider.fetchOne(result.url, {
-        gotClient,
-        rateLimiter: entry.rateLimiter,
-        logger: log,
-      });
+      const data = await fetchWithHardTimeout(
+        entry.provider.fetchOne(result.url, {
+          gotClient,
+          rateLimiter: entry.rateLimiter,
+          logger: log,
+          signal: abortController.signal,
+        }),
+        hardTimeoutMs,
+        abortController,
+      );
 
       hostErrorTracker?.record(hostFromUrl(result.url), true);
 
@@ -283,9 +341,12 @@ export async function performWebFetch(
     logger: logOpt,
     throttleStats,
     onOutcome,
+    deadlineEpochMs,
   } = deps;
   const log = logOpt ?? defaultLogger;
   const providerConfigs = config.providers;
+  const deadline = deadlineEpochMs ?? Infinity;
+  let skippedAfterDeadline = 0;
 
   log.info(
     {
@@ -312,6 +373,12 @@ export async function performWebFetch(
     async (result) => {
       const startOffset = dispatchIndex;
       dispatchIndex += 1;
+      // Once the wall-clock deadline passes, stop starting new fetches so one
+      // slow batch cannot wedge the run. Remaining URLs resolve as unfetched.
+      if (Date.now() >= deadline) {
+        skippedAfterDeadline += 1;
+        return { success: null, failures: [] } satisfies WebFetchOutcome;
+      }
       const outcome = await fetchOneResult(
         result,
         chain,
@@ -325,6 +392,16 @@ export async function performWebFetch(
     },
     { concurrency },
   );
+
+  if (skippedAfterDeadline > 0) {
+    log.warn(
+      {
+        skippedAfterDeadline,
+        urlCount: searchResults.length,
+      },
+      "web fetch: wall-clock deadline reached, skipped remaining URLs",
+    );
+  }
 
   if (throttleStats) {
     throttleStats.throttleEvents += chain.reduce(


### PR DESCRIPTION
## Summary

A data-collection run could grind for hours and stall the whole pipeline behind it. One BBCA run sat in `running` for **7+ hours** after saving just 3 sources, while TLKM in the same execution finished normally with 20. The fetch stage had no overall time budget, and the per-request timeout was not actually a hard ceiling.

This adds two guards: a true hard timeout on every fetch attempt, and a wall-clock budget for the whole run.

## Related issues

Closes #889

## Important changes

- **got's internal retry is now off** on every fetch provider (`retry: { limit: 0 }`). Previously a timed-out request could be retried by got up to two more times on GET providers (diffbot), so the "45s" timeout was really up to ~135s per attempt.
- **Each attempt has a hard ceiling** via `fetchWithHardTimeout` in `web-fetch.ts`: an `AbortController` plus a race at `timeoutMs + 5s`. It aborts the in-flight request *and* guarantees the provider chain advances even if a provider ignores the abort signal. The signal is threaded through `ProviderRequestContext` into all six providers.
- **A run now has a wall-clock budget** (`RUN_WALL_CLOCK_BUDGET_MS`, 15 min). The round loop stops when it is exceeded, and the budget is passed into `performWebFetch` as `deadlineEpochMs` so an in-progress fetch batch stops starting new URLs mid-round — the exact case that wedged BBCA. A new `wall_clock_exceeded` stop reason is surfaced in the activity narrative.

Sources collected before the deadline are still persisted (the per-URL `onOutcome` already streams saves), so a capped run is a partial success, not a loss.

## Other changes

- Added a narrative clause for the `wall_clock_exceeded` stop reason.
- Tests: deadline-skip path, a hanging provider abandoned at the hard timeout, and the new narrative case.

## Key files to review

- `packages/shared/agent-ingestion/src/web-fetch.ts` — hard per-attempt timeout + stage deadline.
- `packages/shared/agent-ingestion/src/fetch-providers/*.ts` — `retry: { limit: 0 }` + abort signal.
- `apps/mediapulse/agents/data-collection/src/run.ts` — run wall-clock budget and stop reason.

## How to test

- `pnpm --filter @workspace/agent-ingestion --filter @mediapulse/data-collection run type:check test`
- `pnpm format:check`
- The providers are unchanged in behavior on success; round-robin failover (including back to serper) still works.
