### PR TITLE
Fix analysis POST transaction timeout on large batches

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.test.ts
@@ -267,6 +267,36 @@ describe("applyAnalysisPost", () => {
     expect(result).toEqual({ articlesScored: 2, articlesRejected: 1 });
   });
 
+  it("commits section upserts in bounded chunks to stay under the transaction timeout", async () => {
+    const { db, upsert, $transaction, findMany } = buildDb();
+    const ids = Array.from(
+      { length: 45 },
+      (_, index) =>
+        `00000000-0000-4000-a000-${String(index).padStart(12, "0")}`,
+    );
+    findMany.mockResolvedValue(ids.map((id) => ({ id })));
+
+    await applyAnalysisPost(
+      {
+        articleSections: ids.map((id) => ({
+          dataSourceId: id,
+          tickerId: TICKER_ID,
+          section: "quickHits" as const,
+          score: 0.5,
+          reason: "x",
+        })),
+        analyzedDataSourceIds: ids,
+      },
+      { db: db as never },
+    );
+
+    // 45 upserts at chunk size 20 → 3 transactions (20 + 20 + 5).
+    expect(upsert).toHaveBeenCalledTimes(45);
+    expect($transaction).toHaveBeenCalledTimes(3);
+    expect(($transaction.mock.calls[0]?.[0] as unknown[]).length).toBe(20);
+    expect(($transaction.mock.calls[2]?.[0] as unknown[]).length).toBe(5);
+  });
+
   it("throws when a referenced data source is unknown", async () => {
     const { db, findMany } = buildDb();
     findMany.mockResolvedValue([]);

--- a/apps/mediapulse/agent-data-api/src/services/analysis.ts
+++ b/apps/mediapulse/agent-data-api/src/services/analysis.ts
@@ -23,6 +23,8 @@ import {
 const MAX_CANDIDATE_ARTICLE_SCAN = 1500;
 /** Only articles created within this window are considered for candidate pairs. */
 const CANDIDATE_ARTICLE_RECENCY_DAYS = 3;
+/** Per-(article, ticker) section upserts committed per transaction, to stay under the timeout. */
+const SECTION_UPSERT_CHUNK_SIZE = 20;
 
 /**
  * Thrown when the analysis POST body references data sources or tickers that do not exist.
@@ -339,8 +341,8 @@ export const applyAnalysisPost = async (
   }
 
   const analyzedAt = new Date();
-  const writes: Prisma.PrismaPromise<unknown>[] = body.articleSections.map(
-    (row) =>
+  const sectionWrites: Prisma.PrismaPromise<unknown>[] =
+    body.articleSections.map((row) =>
       db.dataSourceTickerSection.upsert({
         where: {
           dataSourceId_tickerId: {
@@ -363,19 +365,27 @@ export const applyAnalysisPost = async (
           analyzedAt,
         },
       } satisfies Prisma.DataSourceTickerSectionUpsertArgs),
-  );
-
-  if (body.analyzedDataSourceIds.length > 0) {
-    writes.push(
-      db.dataSource.updateMany({
-        where: { id: { in: body.analyzedDataSourceIds } },
-        data: { analyzedAt },
-      }),
     );
+
+  // Persist section classifications in bounded transactions. A whole batch of
+  // sequential upserts in one transaction overruns the default 5s transaction
+  // timeout on a pooled connection; smaller chunks stay well under it.
+  for (
+    let start = 0;
+    start < sectionWrites.length;
+    start += SECTION_UPSERT_CHUNK_SIZE
+  ) {
+    const chunk = sectionWrites.slice(start, start + SECTION_UPSERT_CHUNK_SIZE);
+    await db.$transaction(chunk);
   }
 
-  if (writes.length > 0) {
-    await db.$transaction(writes);
+  // Mark articles analyzed only after every section row is persisted, so the
+  // content-generation read never sees an analyzed article without its sections.
+  if (body.analyzedDataSourceIds.length > 0) {
+    await db.dataSource.updateMany({
+      where: { id: { in: body.analyzedDataSourceIds } },
+      data: { analyzedAt },
+    });
   }
 
   const articlesRejected = body.articleSections.filter(


### PR DESCRIPTION
## Summary

`POST /api/v1/analysis` was failing with a Prisma 5s transaction timeout on larger batches. The handler ran a whole batch of per-(article, ticker) `upsert`s plus the `updateMany` inside one `$transaction`; over the pooled connection ~100 sequential upserts took just past 5s, so the request 500'd and that batch's articles were never marked analyzed.

This chunks the section upserts into bounded transactions so the write stays well under the timeout at any batch size.

## Related issues

Closes #891

## Important changes

- **Chunk section upserts** at `SECTION_UPSERT_CHUNK_SIZE = 20` per transaction, in `apps/mediapulse/agent-data-api/src/services/analysis.ts`. Each transaction is ~1s instead of one ~5.3s transaction for the whole batch.
- **Mark articles analyzed after all section chunks persist**, as its own statement rather than inside the big transaction. Ordering matters: content-generation must never read an article flagged `analyzed` without its section rows.

Prisma's array-form `$transaction` doesn't accept a `timeout` option (only the interactive form does), and the error's own advice is to do less work per transaction. The upserts are idempotent and nothing is marked analyzed until every section lands, so a mid-batch failure just makes the agent safely re-process — no partial/corrupt state.

## Other changes

- Added a unit test asserting a 45-pair batch splits into 3 transactions (20 / 20 / 5).

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/analysis.ts` — chunked upserts + post-persist analyzed flag.

## How to test

- `pnpm --filter @mediapulse/agent-data-api run type:check test`
- `pnpm format:check`
