### PR TITLE
Add shared email shell with localized footer and live preview

### DIFF
--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.test.ts
@@ -117,6 +117,7 @@ describe("deliverNewsletterToSubscribers", () => {
       tickerSymbol: "AAPL",
       mediapulseSiteUrl: DEFAULT_MEDIAPULSE_SITE_URL,
       hyperjumpSiteUrl: DEFAULT_HYPERJUMP_SITE_URL,
+      language: "en",
     });
     expect(acquire).toHaveBeenCalledOnce();
     expect(sendWithRetry).toHaveBeenCalledOnce();
@@ -173,6 +174,7 @@ describe("deliverNewsletterToSubscribers", () => {
     expect(renderCall).toMatchObject({
       title: "Subjek",
       bodyText: "Isi",
+      language: "id",
     });
 
     expect(sendWithRetry.mock.calls[0]?.[1]).toMatchObject({

--- a/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
+++ b/apps/mediapulse/agents/delivery/src/deliver-newsletter.ts
@@ -249,6 +249,7 @@ export async function deliverNewsletterToSubscribers(
       tickerSymbol: newsletter.symbol,
       mediapulseSiteUrl: config.branding.mediapulseSiteUrl,
       hyperjumpSiteUrl: config.branding.hyperjumpSiteUrl,
+      language: sub.language,
     });
     logger?.info?.(
       {

--- a/packages/shared/email-templates/.gitignore
+++ b/packages/shared/email-templates/.gitignore
@@ -1,0 +1,3 @@
+# react-email preview/export build artifacts
+.react-email/
+out/

--- a/packages/shared/email-templates/package.json
+++ b/packages/shared/email-templates/package.json
@@ -28,7 +28,9 @@
   "scripts": {
     "type:check": "tsc --noEmit",
     "test": "vitest run",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "email:dev": "email dev --dir ./src",
+    "email:export": "email export --dir ./src --outDir ./out"
   },
   "dependencies": {
     "@react-email/components": "^0.5.7",
@@ -37,9 +39,11 @@
     "react-dom": "catalog:"
   },
   "devDependencies": {
+    "@react-email/ui": "^6.6.5",
     "@types/react": "catalog:",
     "@types/react-dom": "catalog:",
     "@workspace/typescript-config": "workspace:*",
+    "react-email": "^6.6.5",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -1,21 +1,18 @@
-import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Link,
-  Preview,
-  Section,
-  Text,
-} from "@react-email/components";
-import { Fragment, type CSSProperties, type ReactElement } from "react";
+import { Heading, Hr, Link, Section, Text } from "@react-email/components";
+import { Fragment, type ReactElement } from "react";
 
 import { parseNewsletterBody } from "./parse-newsletter-body.js";
 import type { ParsedIndustrySection } from "./parse-industry-newsletter-wire.js";
 import { renderInlineMarkdownLinks } from "./render-inline-markdown-links.js";
-
+import {
+  DEFAULT_HYPERJUMP_SITE_URL,
+  DEFAULT_MEDIAPULSE_SITE_URL,
+  EmailHeading,
+  EmailShell,
+  emailLink as link,
+  emailLinkClassName,
+  type EmailLanguage,
+} from "../shared/email-shell.js";
 export interface DefaultNewsletterEmailProps {
   /** Shown as the main title inside the email body (typically matches the message subject). */
   title: string;
@@ -51,13 +48,19 @@ export interface DefaultNewsletterEmailProps {
    * values from Hermes when available.
    */
   hyperjumpSiteUrl?: string;
+  /**
+   * Footer chrome language. The newsletter body is translated upstream
+   * (NewsletterTranslation); this only localizes the static footer strings
+   * (branding line, feedback line, subscription note, unsubscribe label).
+   * Defaults to "en".
+   */
+  language?: FooterLanguage;
 }
 
-/** Default Mediapulse marketing site link used for previews and when Hermes config omits the URL. */
-export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.hyperjump.tech";
-
-/** Default Hyperjump marketing site link used for previews and when Hermes config omits the URL. */
-export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
+export {
+  DEFAULT_MEDIAPULSE_SITE_URL,
+  DEFAULT_HYPERJUMP_SITE_URL,
+} from "../shared/email-shell.js";
 
 /** Canonical section labels keyed by wire `machineKey`. */
 const SECTION_LABELS: Partial<
@@ -69,6 +72,47 @@ const SECTION_LABELS: Partial<
   "regulatory-policy-watch": "Regulatory & Policy Watch",
   "disruptors-or-tech": "Disruptors & Tech",
   "quick-hits": "Quick Hits",
+};
+
+/** Newsletter footer language. Alias of the shared {@link EmailLanguage}. */
+export type FooterLanguage = EmailLanguage;
+
+/** Newsletter-specific footer strings for one language (branding lives in the shell). */
+interface FooterCopy {
+  /** Reply-for-feedback line. */
+  feedback: string;
+  /** Subscription disclaimer, given a trimmed ticker symbol (empty when unknown). */
+  subscriptionNote: (ticker: string) => string;
+  /** Unsubscribe link label, given the resolved ticker or fallback noun. */
+  unsubscribeLabel: (tickerOrFallback: string) => string;
+  /** Noun used in the unsubscribe label when no ticker symbol is available. */
+  unsubscribeFallback: string;
+}
+
+/** Newsletter footer copy keyed by language. */
+const FOOTER_COPY: Record<FooterLanguage, FooterCopy> = {
+  en: {
+    feedback:
+      "Have feedback? Reply to this email and we will use it to improve the newsletter.",
+    subscriptionNote: (ticker) =>
+      ticker.length > 0
+        ? `You are receiving this because you subscribed to ${ticker} updates.`
+        : "You are receiving this because you subscribed to updates.",
+    unsubscribeLabel: (tickerOrFallback) =>
+      `Unsubscribe from ${tickerOrFallback} updates`,
+    unsubscribeFallback: "these",
+  },
+  id: {
+    feedback:
+      "Punya masukan? Balas email ini dan kami akan menggunakannya untuk meningkatkan buletin.",
+    subscriptionNote: (ticker) =>
+      ticker.length > 0
+        ? `Anda menerima email ini karena Anda berlangganan pembaruan ${ticker}.`
+        : "Anda menerima email ini karena Anda berlangganan pembaruan.",
+    unsubscribeLabel: (tickerOrFallback) =>
+      `Berhenti berlangganan pembaruan ${tickerOrFallback}`,
+    unsubscribeFallback: "ini",
+  },
 };
 
 /**
@@ -92,6 +136,12 @@ export const decomposeSectionHeading = (
   if (displayHeading.toLowerCase().startsWith(prefix.toLowerCase())) {
     const subtitle = displayHeading.slice(prefix.length).trim();
     return { eyebrow: label, subtitle: subtitle.length > 0 ? subtitle : null };
+  }
+
+  // When the heading is just the label itself, render it once instead of
+  // repeating it as both eyebrow and subtitle.
+  if (displayHeading.trim().toLowerCase() === label.toLowerCase()) {
+    return { eyebrow: label, subtitle: null };
   }
 
   return { eyebrow: label, subtitle: displayHeading };
@@ -134,7 +184,10 @@ export const renderSectionHeader = (
 
   if (subtitle === null) {
     return (
-      <Heading as="h2" style={sectionLabel}>
+      <Heading
+        as="h2"
+        className="m-0 mb-3 text-lg font-semibold leading-tight text-ink"
+      >
         {label}
       </Heading>
     );
@@ -142,8 +195,13 @@ export const renderSectionHeader = (
 
   return (
     <>
-      <Text style={sectionEyebrow}>{eyebrow ?? label}</Text>
-      <Heading as="h2" style={sectionLabel}>
+      <Text className="m-0 mb-1 text-xs font-semibold uppercase leading-snug tracking-[0.06em] text-muted">
+        {eyebrow ?? label}
+      </Text>
+      <Heading
+        as="h2"
+        className="m-0 mb-3 text-lg font-semibold leading-tight text-ink"
+      >
         {subtitle}
       </Heading>
     </>
@@ -154,14 +212,15 @@ export const renderSectionHeader = (
  * Builds the default subscription footer when no explicit `footerNote` is passed.
  *
  * @param tickerSymbol - Optional ticker symbol for personalized copy.
+ * @param language - Footer chrome language. Defaults to "en".
  * @returns Footer disclaimer text.
  */
-export const buildDefaultFooterNote = (tickerSymbol?: string): string => {
+export const buildDefaultFooterNote = (
+  tickerSymbol?: string,
+  language: FooterLanguage = "en",
+): string => {
   const trimmed = tickerSymbol?.trim() ?? "";
-  if (trimmed.length > 0) {
-    return `You are receiving this because you subscribed to ${trimmed} updates.`;
-  }
-  return "You are receiving this because you subscribed to updates.";
+  return FOOTER_COPY[language].subscriptionNote(trimmed);
 };
 
 /**
@@ -193,9 +252,13 @@ export const DefaultNewsletterEmail = ({
   tickerSymbol,
   mediapulseSiteUrl = DEFAULT_MEDIAPULSE_SITE_URL,
   hyperjumpSiteUrl = DEFAULT_HYPERJUMP_SITE_URL,
+  language = "en",
 }: DefaultNewsletterEmailProps): ReactElement => {
   const parsed = parseNewsletterBody(bodyText);
-  const resolvedFooterNote = footerNote ?? buildDefaultFooterNote(tickerSymbol);
+  const copy = FOOTER_COPY[language];
+  const resolvedFooterNote =
+    footerNote ?? buildDefaultFooterNote(tickerSymbol, language);
+  const unsubscribeTarget = tickerSymbol ?? copy.unsubscribeFallback;
 
   const renderIndustrySection = (
     section: ParsedIndustrySection,
@@ -209,7 +272,7 @@ export const DefaultNewsletterEmail = ({
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
           {renderSectionHeader(section.machineKey, section.displayHeading)}
-          <Text style={bodyParagraph}>
+          <Text className="m-0 whitespace-pre-wrap text-base leading-relaxed text-body">
             {renderInlineMarkdownLinks(section.prose, link)}
           </Text>
         </Section>
@@ -231,20 +294,22 @@ export const DefaultNewsletterEmail = ({
                 key={`${String(section.machineKey)}-b-${String(bulletIndex)}`}
               >
                 {bulletByline !== undefined ? (
-                  <Text style={newsItemByline}>{bulletByline}</Text>
+                  <Text className="m-0 mb-1 text-xs font-normal leading-normal text-muted">
+                    {bulletByline}
+                  </Text>
                 ) : null}
-                <Text style={newsItemSummary}>
+                <Text className="m-0 text-base leading-relaxed text-body">
                   {renderInlineMarkdownLinks(bullet.text, link)}
                 </Text>
                 {bullet.url !== undefined && bullet.url !== "" ? (
-                  <Text style={newsItemSourceLink}>
-                    <Link href={bullet.url} style={link}>
+                  <Text className="m-0 mt-2 text-sm leading-normal text-body">
+                    <Link href={bullet.url} className={emailLinkClassName}>
                       Read {bulletCtaLabel}
                     </Link>
                   </Text>
                 ) : null}
                 {bulletIndex < section.bullets.length - 1 ? (
-                  <Hr style={itemSeparator} />
+                  <Hr className="my-4 border-0 border-t border-rule" />
                 ) : null}
               </Section>
             );
@@ -263,20 +328,22 @@ export const DefaultNewsletterEmail = ({
             return (
               <Section key={`qh-${String(itemIndex)}`}>
                 {itemByline !== undefined ? (
-                  <Text style={newsItemByline}>{itemByline}</Text>
+                  <Text className="m-0 mb-1 text-xs font-normal leading-normal text-muted">
+                    {itemByline}
+                  </Text>
                 ) : null}
-                <Text style={newsItemTitle}>
+                <Text className="m-0 mb-2 text-base font-semibold leading-normal text-body">
                   {itemIndex + 1}. {item.text}
                 </Text>
                 {item.url !== undefined && item.url !== "" ? (
-                  <Text style={newsItemSourceLink}>
-                    <Link href={item.url} style={link}>
+                  <Text className="m-0 mt-2 text-sm leading-normal text-body">
+                    <Link href={item.url} className={emailLinkClassName}>
                       Read {itemCtaLabel}
                     </Link>
                   </Text>
                 ) : null}
                 {itemIndex < section.items.length - 1 ? (
-                  <Hr style={itemSeparator} />
+                  <Hr className="my-4 border-0 border-t border-rule" />
                 ) : null}
               </Section>
             );
@@ -302,272 +369,190 @@ export const DefaultNewsletterEmail = ({
       : [];
 
   return (
-    <Html>
-      <Head />
-      <Preview>{title}</Preview>
-      <Body style={main}>
-        <Container style={container}>
-          <Section style={header}>
-            <Heading style={heading}>{title}</Heading>
-            {industryPulseSection !== undefined ? (
-              <>
-                {(() => {
-                  const leadByline = formatArticleByline(industryPulseSection);
-                  return leadByline !== undefined ? (
-                    <Text style={newsItemByline}>{leadByline}</Text>
-                  ) : null;
-                })()}
-                <Text style={standfirst}>
-                  {renderInlineMarkdownLinks(industryPulseSection.prose, link)}
+    <EmailShell
+      preview={title}
+      language={language}
+      mediapulseSiteUrl={mediapulseSiteUrl}
+      hyperjumpSiteUrl={hyperjumpSiteUrl}
+      footer={{
+        feedback: copy.feedback,
+        note: resolvedFooterNote,
+        ...(unsubscribeUrl !== undefined && unsubscribeUrl !== ""
+          ? {
+              unsubscribe: {
+                url: unsubscribeUrl,
+                label: copy.unsubscribeLabel(unsubscribeTarget),
+              },
+            }
+          : {}),
+      }}
+    >
+      <Section>
+        <EmailHeading>{title}</EmailHeading>
+        {industryPulseSection !== undefined ? (
+          <>
+            {(() => {
+              const leadByline = formatArticleByline(industryPulseSection);
+              return leadByline !== undefined ? (
+                <Text className="m-0 mb-1 text-xs font-normal leading-normal text-muted">
+                  {leadByline}
                 </Text>
-                {industryPulseSection.url !== undefined ? (
-                  <Text style={newsItemSourceLink}>
-                    <Link href={industryPulseSection.url} style={link}>
-                      Read {industryPulseSection.displayHeading}
-                    </Link>
-                  </Text>
-                ) : null}
-              </>
+              ) : null;
+            })()}
+            <Text className="m-0 whitespace-pre-wrap text-[17px] leading-relaxed text-body">
+              {renderInlineMarkdownLinks(industryPulseSection.prose, link)}
+            </Text>
+            {industryPulseSection.url !== undefined ? (
+              <Text className="m-0 mt-2 text-sm leading-normal text-body">
+                <Link
+                  href={industryPulseSection.url}
+                  className={emailLinkClassName}
+                >
+                  Read {industryPulseSection.displayHeading}
+                </Link>
+              </Text>
             ) : null}
-          </Section>
-          <Hr style={hr} />
-          {parsed !== undefined ? (
-            parsed.format === "industry" ? (
-              <>
-                {industryBodySections.map((section, index) => (
-                  <Fragment key={`sec-${String(index)}`}>
-                    {index > 0 ? <Hr style={hr} /> : null}
-                    {renderIndustrySection(section, index)}
-                  </Fragment>
-                ))}
-              </>
-            ) : (
-              <>
-                <Heading as="h2" style={sectionLabel}>
-                  Executive Summary
-                </Heading>
-                <Text style={bodyParagraph}>
-                  {renderInlineMarkdownLinks(parsed.executiveSummary, link)}
-                </Text>
-                <Hr style={hr} />
-                <Heading as="h2" style={sectionLabel}>
-                  Top News
-                </Heading>
-                {parsed.topNewsItems.map(
-                  (
-                    item: (typeof parsed.topNewsItems)[number],
-                    index: number,
-                  ) => (
-                    <Section key={item.number}>
-                      <Text style={newsItemTitle}>
-                        {item.number}. {item.title}
-                      </Text>
-                      <Text style={newsItemSummary}>
-                        {renderInlineMarkdownLinks(item.summary, link)}
-                      </Text>
-                      {item.url !== undefined && item.url !== "" ? (
-                        <Text style={newsItemSourceLink}>
-                          <Link href={item.url} style={link}>
-                            Read {item.title}
-                          </Link>
-                        </Text>
-                      ) : null}
-                      {index < parsed.topNewsItems.length - 1 ? (
-                        <Hr style={itemSeparator} />
-                      ) : null}
-                    </Section>
-                  ),
-                )}
-              </>
-            )
-          ) : (
-            <Text style={bodyParagraph}>
-              {renderInlineMarkdownLinks(bodyText, link)}
+          </>
+        ) : null}
+      </Section>
+      <Hr className="my-6 border-0 border-t border-rule" />
+      {parsed !== undefined ? (
+        parsed.format === "industry" ? (
+          <>
+            {industryBodySections.map((section, index) => (
+              <Fragment key={`sec-${String(index)}`}>
+                {index > 0 ? (
+                  <Hr className="my-6 border-0 border-t border-rule" />
+                ) : null}
+                {renderIndustrySection(section, index)}
+              </Fragment>
+            ))}
+          </>
+        ) : (
+          <>
+            <Heading
+              as="h2"
+              className="m-0 mb-3 text-lg font-semibold leading-tight text-ink"
+            >
+              Executive Summary
+            </Heading>
+            <Text className="m-0 whitespace-pre-wrap text-base leading-relaxed text-body">
+              {renderInlineMarkdownLinks(parsed.executiveSummary, link)}
             </Text>
-          )}
-          <Hr style={hr} />
-          <Text style={brandingLine}>
-            Brought to you by{" "}
-            <Link href={mediapulseSiteUrl} style={link}>
-              Mediapulse
-            </Link>
-            , a product of{" "}
-            <Link href={hyperjumpSiteUrl} style={link}>
-              Hyperjump
-            </Link>
-            .
-          </Text>
-          <Text style={footer}>
-            Have feedback? Just reply to this email and we&apos;ll read it.
-          </Text>
-          <Text style={footer}>{resolvedFooterNote}</Text>
-          {unsubscribeUrl !== undefined && unsubscribeUrl !== "" ? (
-            <Text style={footerMuted}>
-              <Link href={unsubscribeUrl} style={link}>
-                Unsubscribe from {tickerSymbol ?? "these"} updates
-              </Link>
-            </Text>
-          ) : null}
-        </Container>
-      </Body>
-    </Html>
+            <Hr className="my-6 border-0 border-t border-rule" />
+            <Heading
+              as="h2"
+              className="m-0 mb-3 text-lg font-semibold leading-tight text-ink"
+            >
+              Top News
+            </Heading>
+            {parsed.topNewsItems.map(
+              (item: (typeof parsed.topNewsItems)[number], index: number) => (
+                <Section key={item.number}>
+                  <Text className="m-0 mb-2 text-base font-semibold leading-normal text-body">
+                    {item.number}. {item.title}
+                  </Text>
+                  <Text className="m-0 text-base leading-relaxed text-body">
+                    {renderInlineMarkdownLinks(item.summary, link)}
+                  </Text>
+                  {item.url !== undefined && item.url !== "" ? (
+                    <Text className="m-0 mt-2 text-sm leading-normal text-body">
+                      <Link href={item.url} className={emailLinkClassName}>
+                        Read {item.title}
+                      </Link>
+                    </Text>
+                  ) : null}
+                  {index < parsed.topNewsItems.length - 1 ? (
+                    <Hr className="my-4 border-0 border-t border-rule" />
+                  ) : null}
+                </Section>
+              ),
+            )}
+          </>
+        )
+      ) : (
+        <Text className="m-0 whitespace-pre-wrap text-base leading-relaxed text-body">
+          {renderInlineMarkdownLinks(bodyText, link)}
+        </Text>
+      )}
+    </EmailShell>
   );
 };
 
-DefaultNewsletterEmail.PreviewProps = {
-  title: "Weekly digest",
+/** Shared sample props for the preview wrappers (English base; id flips `language`). */
+export const NEWSLETTER_PREVIEW_PROPS = {
+  title: "ACME Weekly: Fixed broadband steadies the sector",
   bodyText: [
-    "EXECUTIVE SUMMARY",
+    "MP_NEWSLETTER",
     "",
-    "Markets rallied today as tech earnings exceeded expectations and the Fed signaled a measured approach to rate adjustments.",
+    "BEGIN industry-pulse",
+    "DISPLAY_HEADING",
+    "The sector repairs, quietly",
+    "SOURCE Market Wire",
+    "PROSE",
+    "The telecom sector is repairing rather than roaring. Fixed broadband net adds are carrying revenue growth while prepaid ARPU stays flat, and operators are leaning on bundling and home fiber to defend margins into the second half.",
+    "Read the full article: https://example.com/sector/broadband-outlook",
+    "END",
     "",
-    "---",
+    "BEGIN competitive-landscape",
+    "DISPLAY_HEADING",
+    "Competitive Landscape / Fiber is the new battleground",
+    "BULLET",
+    "TITLE Acme extends home-fiber lead",
+    "AUTHOR Jane Doe",
+    "SOURCE Market Wire",
+    "Acme Telecom added roughly 320,000 home-fiber subscribers in the quarter, widening its lead as rivals struggle to match its backbone reach in secondary cities.",
+    "Read the full article: https://example.com/acme/home-fiber",
+    "BULLET",
+    "TITLE Contoso Mobile leans on convergence",
+    "Contoso Mobile pushed converged mobile-plus-home plans to lift retention, trading near-term ARPU for lower churn in contested urban clusters.",
+    "Read the full article: https://example.com/contoso/convergence",
+    "END",
     "",
-    "TOP 3 NEWS",
+    "BEGIN deals-and-movements",
+    "DISPLAY_HEADING",
+    "Deals & Movements",
+    "BULLET",
+    "TITLE Northwind closes tower acquisition",
+    "Northwind Towers completed the purchase of about 2,800 sites, building the largest independent tower portfolio in the region.",
+    "Read the full article: https://example.com/northwind/tower-deal",
+    "END",
     "",
-    "1. Fed holds rates steady",
-    "The Federal Reserve announced no change to interest rates, citing stable inflation and strong employment data.",
-    "Read the full article: https://example.com/fed-holds-rates",
+    "BEGIN regulatory-policy-watch",
+    "DISPLAY_HEADING",
+    "Regulatory & Policy Watch / Spectrum on the agenda",
+    "BULLET",
+    "The regulator signaled a mid-band spectrum auction for next year, a prerequisite for wider 5G coverage beyond the largest cities.",
+    "Read the full article: https://example.com/policy/spectrum-auction",
+    "END",
     "",
-    "2. Apple beats estimates",
-    "Apple reported record quarterly revenue of $95B, driven by strong iPhone and services growth.",
-    "Read the full article: https://example.com/apple-earnings",
+    "BEGIN disruptors-or-tech",
+    "DISPLAY_HEADING",
+    "Disruptors & Tech / AI moves to the edge",
+    "FORMAT",
+    "prose",
+    "PROSE",
+    "Operators are piloting AI-driven network optimization to squeeze more capacity from existing sites, while fixed-wireless access is emerging as a cheaper path to homes that fiber has not yet reached.",
+    "END",
     "",
-    "3. Oil prices dip",
-    "Crude oil fell 2% amid easing geopolitical tensions and rising US production.",
-    "Read the full article: https://example.com/oil-prices",
+    "BEGIN quick-hits",
+    "DISPLAY_HEADING",
+    "Quick Hits",
+    "ITEM",
+    "Acme reaffirmed its full-year capex guidance.",
+    "ITEM",
+    "Contoso Mobile reported steady data traffic growth.",
+    "Read the full article: https://example.com/contoso/data-traffic",
+    "ITEM",
+    "Fabrikam expanded prepaid promotions ahead of the holiday quarter.",
+    "ITEM",
+    "A new submarine cable landing was approved in the east.",
+    "ITEM",
+    "The board reaffirmed its dividend timeline for the year.",
+    "END",
   ].join("\n"),
-  footerNote:
-    "You can unsubscribe from ticker updates in your account settings.",
-  unsubscribeUrl: "https://mediapulse.com/api/unsubscribe?token=example",
-  tickerSymbol: "AAPL",
+  unsubscribeUrl: "https://example.com/api/unsubscribe?token=preview",
+  tickerSymbol: "ACME",
   mediapulseSiteUrl: DEFAULT_MEDIAPULSE_SITE_URL,
   hyperjumpSiteUrl: DEFAULT_HYPERJUMP_SITE_URL,
 } satisfies DefaultNewsletterEmailProps;
-
-export default DefaultNewsletterEmail;
-
-const main: CSSProperties = {
-  backgroundColor: "#f6f9fc",
-  fontFamily:
-    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
-};
-
-const container: CSSProperties = {
-  backgroundColor: "#ffffff",
-  margin: "0 auto",
-  padding: "24px 20px 32px",
-  marginBottom: "32px",
-  maxWidth: "600px",
-};
-
-const header: CSSProperties = {
-  padding: "8px 0",
-};
-
-const heading: CSSProperties = {
-  color: "#1a1a1a",
-  fontSize: "24px",
-  fontWeight: "600",
-  lineHeight: "1.3",
-  margin: "0",
-};
-
-const standfirst: CSSProperties = {
-  color: "#374151",
-  fontSize: "17px",
-  lineHeight: "1.6",
-  margin: "12px 0 0",
-  whiteSpace: "pre-wrap",
-};
-
-const hr: CSSProperties = {
-  borderColor: "#e6ebf1",
-  margin: "20px 0",
-};
-
-const bodyParagraph: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  lineHeight: "1.6",
-  margin: "0",
-  whiteSpace: "pre-wrap",
-};
-
-const sectionEyebrow: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  fontWeight: "600",
-  letterSpacing: "0.06em",
-  lineHeight: "1.4",
-  margin: "0 0 4px",
-  textTransform: "uppercase",
-};
-
-const sectionLabel: CSSProperties = {
-  color: "#1a1a1a",
-  fontSize: "18px",
-  fontWeight: "600",
-  lineHeight: "1.3",
-  margin: "0 0 12px",
-};
-
-const newsItemTitle: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  fontWeight: "600",
-  lineHeight: "1.5",
-  margin: "0 0 4px",
-};
-
-const newsItemSummary: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  lineHeight: "1.6",
-  margin: "0",
-};
-
-const newsItemByline: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  fontWeight: "400",
-  lineHeight: "1.5",
-  margin: "0 0 4px",
-};
-
-const newsItemSourceLink: CSSProperties = {
-  color: "#374151",
-  fontSize: "14px",
-  lineHeight: "1.5",
-  margin: "8px 0 0",
-};
-
-const itemSeparator: CSSProperties = {
-  borderColor: "#e6ebf1",
-  margin: "16px 0",
-};
-
-const brandingLine: CSSProperties = {
-  color: "#374151",
-  fontSize: "13px",
-  lineHeight: "1.5",
-  margin: "0 0 12px",
-};
-
-const footer: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  lineHeight: "1.5",
-  margin: "0 0 8px",
-};
-
-const footerMuted: CSSProperties = {
-  color: "#9ca3af",
-  fontSize: "12px",
-  margin: "0",
-};
-
-const link: CSSProperties = {
-  color: "#2563eb",
-  textDecoration: "underline",
-};

--- a/packages/shared/email-templates/src/newsletter/newsletter-en.tsx
+++ b/packages/shared/email-templates/src/newsletter/newsletter-en.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+
+import {
+  DefaultNewsletterEmail,
+  NEWSLETTER_PREVIEW_PROPS,
+} from "./default-newsletter.js";
+import type { DefaultNewsletterEmailProps } from "./default-newsletter.js";
+
+/**
+ * Preview-only English newsletter. Gives the React Email dev server a clean
+ * "newsletter-en" entry. Not exported from the package barrel; delivery renders
+ * {@link DefaultNewsletterEmail} directly with the subscriber's language.
+ *
+ * @param props - Same props as {@link DefaultNewsletterEmail}.
+ * @returns The newsletter email with the English footer.
+ */
+const NewsletterEnglishPreview = (
+  props: DefaultNewsletterEmailProps,
+): ReactElement => <DefaultNewsletterEmail {...props} />;
+
+NewsletterEnglishPreview.PreviewProps = {
+  ...NEWSLETTER_PREVIEW_PROPS,
+  language: "en",
+} satisfies DefaultNewsletterEmailProps;
+
+export default NewsletterEnglishPreview;

--- a/packages/shared/email-templates/src/newsletter/newsletter-id.tsx
+++ b/packages/shared/email-templates/src/newsletter/newsletter-id.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from "react";
+
+import {
+  DefaultNewsletterEmail,
+  NEWSLETTER_PREVIEW_PROPS,
+} from "./default-newsletter.js";
+import type { DefaultNewsletterEmailProps } from "./default-newsletter.js";
+
+/**
+ * Preview-only Indonesian newsletter. Gives the React Email dev server a clean
+ * "newsletter-id" entry so the localized footer can be eyeballed next to the
+ * English one. Not exported from the package barrel.
+ *
+ * @param props - Same props as {@link DefaultNewsletterEmail}.
+ * @returns The newsletter email with the Indonesian footer.
+ */
+const NewsletterIndonesianPreview = (
+  props: DefaultNewsletterEmailProps,
+): ReactElement => <DefaultNewsletterEmail {...props} />;
+
+NewsletterIndonesianPreview.PreviewProps = {
+  ...NEWSLETTER_PREVIEW_PROPS,
+  language: "id",
+} satisfies DefaultNewsletterEmailProps;
+
+export default NewsletterIndonesianPreview;

--- a/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.tsx
+++ b/packages/shared/email-templates/src/newsletter/render-inline-markdown-links.tsx
@@ -28,6 +28,8 @@ export const defaultIsAllowedNewsletterLinkUrl = (href: string): boolean => {
 export type RenderInlineMarkdownLinksDependencies = {
   /** Override URL policy (defaults to {@link defaultIsAllowedNewsletterLinkUrl}). */
   isAllowedUrl?: IsAllowedNewsletterLinkUrl;
+  /** Optional className applied to each rendered link (e.g. for dark-mode color). */
+  linkClassName?: string;
 };
 
 /**
@@ -69,6 +71,7 @@ export const renderInlineMarkdownLinks = (
           href={href}
           key={`newsletter-inline-link-${linkKey++}`}
           style={linkStyle}
+          className={dependencies.linkClassName}
         >
           {label}
         </Link>,

--- a/packages/shared/email-templates/src/registration/invalid-ticker.tsx
+++ b/packages/shared/email-templates/src/registration/invalid-ticker.tsx
@@ -1,15 +1,11 @@
+import type { ReactElement } from "react";
+
 import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-} from "@react-email/components";
-import type { CSSProperties, ReactElement } from "react";
+  EmailDivider,
+  EmailHeading,
+  EmailParagraph,
+  EmailShell,
+} from "../shared/email-shell.js";
 
 export interface InvalidTickerEmailProps {
   /** The ticker symbol the user tried to subscribe to. */
@@ -26,35 +22,27 @@ export const InvalidTickerEmail = ({
   tickerSymbol,
 }: InvalidTickerEmailProps): ReactElement => {
   return (
-    <Html>
-      <Head />
-      <Preview>Invalid Ticker Selection - MediaPulse</Preview>
-      <Body style={main}>
-        <Container style={container}>
-          <Section style={header}>
-            <Heading style={heading}>Invalid Ticker Selection</Heading>
-          </Section>
-          <Hr style={hr} />
-          <Text style={bodyParagraph}>
-            Hello,
-            {"\n\n"}
-            The ticker '{tickerSymbol}' you selected is invalid or not
-            recognized by our system.
-            {"\n\n"}
-            Please visit the registration site and select a valid ticker.
-            {"\n\n"}
-            Thank you,
-            {"\n"}
-            MediaPulse Team
-          </Text>
-          <Hr style={hr} />
-          <Text style={footer}>
-            You are receiving this because you attempted to subscribe to updates
-            on MediaPulse.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailShell
+      preview="Invalid Ticker Selection - MediaPulse"
+      footer={{
+        note: "You are receiving this because you attempted to subscribe to updates on MediaPulse.",
+      }}
+    >
+      <EmailHeading>Invalid Ticker Selection</EmailHeading>
+      <EmailDivider />
+      <EmailParagraph>
+        Hello,
+        {"\n\n"}
+        The ticker '{tickerSymbol}' you selected is invalid or not recognized by
+        our system.
+        {"\n\n"}
+        Please visit the registration site and select a valid ticker.
+        {"\n\n"}
+        Thank you,
+        {"\n"}
+        The MediaPulse Team
+      </EmailParagraph>
+    </EmailShell>
   );
 };
 
@@ -63,49 +51,3 @@ InvalidTickerEmail.PreviewProps = {
 } satisfies InvalidTickerEmailProps;
 
 export default InvalidTickerEmail;
-
-const main: CSSProperties = {
-  backgroundColor: "#f6f9fc",
-  fontFamily:
-    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
-};
-
-const container: CSSProperties = {
-  backgroundColor: "#ffffff",
-  margin: "0 auto",
-  padding: "24px 20px 32px",
-  marginBottom: "32px",
-  maxWidth: "600px",
-};
-
-const header: CSSProperties = {
-  padding: "8px 0",
-};
-
-const heading: CSSProperties = {
-  color: "#1a1a1a",
-  fontSize: "24px",
-  fontWeight: "600",
-  lineHeight: "1.3",
-  margin: "0",
-};
-
-const hr: CSSProperties = {
-  borderColor: "#e6ebf1",
-  margin: "20px 0",
-};
-
-const bodyParagraph: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  lineHeight: "1.6",
-  margin: "0",
-  whiteSpace: "pre-wrap",
-};
-
-const footer: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  lineHeight: "1.5",
-  margin: "0 0 8px",
-};

--- a/packages/shared/email-templates/src/registration/registration-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-confirmation.tsx
@@ -1,15 +1,12 @@
+import type { ReactElement } from "react";
+
 import {
-  Body,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-} from "@react-email/components";
-import type { CSSProperties, ReactElement } from "react";
+  EmailCallout,
+  EmailDivider,
+  EmailHeading,
+  EmailParagraph,
+  EmailShell,
+} from "../shared/email-shell.js";
 
 export interface RegistrationConfirmationEmailProps {
   /** The ticker symbol the user subscribed to. */
@@ -22,6 +19,7 @@ export interface RegistrationConfirmationEmailProps {
  * Email sent when a user's subscription to a newsletter is successfully confirmed.
  *
  * @param props.tickerSymbol - The ticker symbol that was confirmed.
+ * @param props.nextDeliveryLabel - Optional label for the first delivery time.
  * @returns The confirmation email React Email component.
  */
 export const RegistrationConfirmationEmail = ({
@@ -29,40 +27,33 @@ export const RegistrationConfirmationEmail = ({
   nextDeliveryLabel,
 }: RegistrationConfirmationEmailProps): ReactElement => {
   return (
-    <Html>
-      <Head />
-      <Preview>Subscription Confirmed - MediaPulse</Preview>
-      <Body style={main}>
-        <Container style={container}>
-          <Section style={header}>
-            <Heading style={heading}>Subscription Confirmed</Heading>
-          </Section>
-          <Hr style={hr} />
-          <Text style={bodyParagraph}>
-            Hello,
-            {"\n\n"}
-            Your subscription to the '{tickerSymbol}' newsletter has been
-            confirmed.
-            {nextDeliveryLabel !== undefined
-              ? `\n\nYou will receive your first ${tickerSymbol} newsletter ${nextDeliveryLabel}.`
-              : ""}
-            {"\n\n"}
-            We've attached a contact card to this email. Open it to add
-            MediaPulse to your contacts and ensure future newsletters land in
-            your inbox, not spam or junk.
-            {"\n\n"}
-            Thank you,
-            {"\n"}
-            MediaPulse Team
-          </Text>
-          <Hr style={hr} />
-          <Text style={footer}>
-            You are receiving this because you subscribed to updates on
-            MediaPulse.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailShell
+      preview="Subscription Confirmed - MediaPulse"
+      footer={{
+        note: "You are receiving this because you subscribed to updates on MediaPulse.",
+      }}
+    >
+      <EmailHeading>Subscription Confirmed</EmailHeading>
+      <EmailDivider />
+      <EmailParagraph>
+        Hello,
+        {"\n\n"}
+        Your subscription to the '{tickerSymbol}' newsletter has been confirmed
+        {nextDeliveryLabel !== undefined
+          ? ` and you will receive your first newsletter ${nextDeliveryLabel}.`
+          : "."}
+      </EmailParagraph>
+      <EmailCallout title="Add MediaPulse to your contacts">
+        Open the attached contact card (.vcf) and select "Add to Contacts". This
+        marks MediaPulse as a trusted sender, so future newsletters reach your
+        inbox instead of the spam or promotions folder.
+      </EmailCallout>
+      <EmailParagraph>
+        Thank you,
+        {"\n"}
+        The MediaPulse Team
+      </EmailParagraph>
+    </EmailShell>
   );
 };
 
@@ -72,49 +63,3 @@ RegistrationConfirmationEmail.PreviewProps = {
 } satisfies RegistrationConfirmationEmailProps;
 
 export default RegistrationConfirmationEmail;
-
-const main: CSSProperties = {
-  backgroundColor: "#f6f9fc",
-  fontFamily:
-    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
-};
-
-const container: CSSProperties = {
-  backgroundColor: "#ffffff",
-  margin: "0 auto",
-  padding: "24px 20px 32px",
-  marginBottom: "32px",
-  maxWidth: "600px",
-};
-
-const header: CSSProperties = {
-  padding: "8px 0",
-};
-
-const heading: CSSProperties = {
-  color: "#1a1a1a",
-  fontSize: "24px",
-  fontWeight: "600",
-  lineHeight: "1.3",
-  margin: "0",
-};
-
-const hr: CSSProperties = {
-  borderColor: "#e6ebf1",
-  margin: "20px 0",
-};
-
-const bodyParagraph: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  lineHeight: "1.6",
-  margin: "0",
-  whiteSpace: "pre-wrap",
-};
-
-const footer: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  lineHeight: "1.5",
-  margin: "0 0 8px",
-};

--- a/packages/shared/email-templates/src/registration/registration-pending-confirmation.tsx
+++ b/packages/shared/email-templates/src/registration/registration-pending-confirmation.tsx
@@ -1,16 +1,12 @@
-import {
-  Body,
-  Button,
-  Container,
-  Head,
-  Heading,
-  Hr,
-  Html,
-  Preview,
-  Section,
-  Text,
-} from "@react-email/components";
+import { Button, Section, Text } from "@react-email/components";
 import type { CSSProperties, ReactElement } from "react";
+
+import {
+  EmailDivider,
+  EmailHeading,
+  EmailParagraph,
+  EmailShell,
+} from "../shared/email-shell.js";
 
 export interface RegistrationPendingConfirmationEmailProps {
   /** The ticker symbol the user wants to subscribe to. */
@@ -37,41 +33,33 @@ export const RegistrationPendingConfirmationEmail = ({
   const greeting = name?.trim() ? `Hello ${name.trim()},` : "Hello,";
 
   return (
-    <Html>
-      <Head />
-      <Preview>Confirm your MediaPulse subscription</Preview>
-      <Body style={main}>
-        <Container style={container}>
-          <Section style={header}>
-            <Heading style={heading}>Confirm your subscription</Heading>
-          </Section>
-          <Hr style={hr} />
-          <Text style={bodyParagraph}>
-            {greeting}
-            {"\n\n"}
-            Tap the button below to confirm your subscription to the '
-            {tickerSymbol}' newsletter on MediaPulse.
-            {"\n\n"}
-            If you did not request this, you can ignore this email.
-          </Text>
-          <Section style={buttonContainer}>
-            <Button href={confirmUrl} style={button}>
-              Confirm subscription
-            </Button>
-          </Section>
-          <Text style={linkFallback}>
-            Or copy and paste this link into your browser:
-            {"\n"}
-            {confirmUrl}
-          </Text>
-          <Hr style={hr} />
-          <Text style={footer}>
-            You are receiving this because someone requested MediaPulse updates
-            using this email address.
-          </Text>
-        </Container>
-      </Body>
-    </Html>
+    <EmailShell
+      preview="Confirm your MediaPulse subscription"
+      footer={{
+        note: "You are receiving this because someone requested MediaPulse updates using this email address.",
+      }}
+    >
+      <EmailHeading>Confirm your subscription</EmailHeading>
+      <EmailDivider />
+      <EmailParagraph>
+        {greeting}
+        {"\n\n"}
+        Please use the button below to confirm your subscription to the '
+        {tickerSymbol}' newsletter on MediaPulse.
+        {"\n\n"}
+        If you did not request this subscription, you may disregard this email.
+      </EmailParagraph>
+      <Section style={buttonContainer}>
+        <Button href={confirmUrl} style={button}>
+          Confirm subscription
+        </Button>
+      </Section>
+      <Text style={linkFallback}>
+        Alternatively, copy and paste the following link into your browser:
+        {"\n"}
+        {confirmUrl}
+      </Text>
+    </EmailShell>
   );
 };
 
@@ -82,45 +70,6 @@ RegistrationPendingConfirmationEmail.PreviewProps = {
 } satisfies RegistrationPendingConfirmationEmailProps;
 
 export default RegistrationPendingConfirmationEmail;
-
-const main: CSSProperties = {
-  backgroundColor: "#f6f9fc",
-  fontFamily:
-    '-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Ubuntu,sans-serif',
-};
-
-const container: CSSProperties = {
-  backgroundColor: "#ffffff",
-  margin: "0 auto",
-  padding: "24px 20px 32px",
-  marginBottom: "32px",
-  maxWidth: "600px",
-};
-
-const header: CSSProperties = {
-  padding: "8px 0",
-};
-
-const heading: CSSProperties = {
-  color: "#1a1a1a",
-  fontSize: "24px",
-  fontWeight: "600",
-  lineHeight: "1.3",
-  margin: "0",
-};
-
-const hr: CSSProperties = {
-  borderColor: "#e6ebf1",
-  margin: "20px 0",
-};
-
-const bodyParagraph: CSSProperties = {
-  color: "#374151",
-  fontSize: "16px",
-  lineHeight: "1.6",
-  margin: "0",
-  whiteSpace: "pre-wrap",
-};
 
 const buttonContainer: CSSProperties = {
   margin: "24px 0",
@@ -143,14 +92,7 @@ const linkFallback: CSSProperties = {
   color: "#6b7280",
   fontSize: "13px",
   lineHeight: "1.5",
-  margin: "0",
+  margin: "16px 0 0",
   whiteSpace: "pre-wrap",
   wordBreak: "break-all",
-};
-
-const footer: CSSProperties = {
-  color: "#6b7280",
-  fontSize: "12px",
-  lineHeight: "1.5",
-  margin: "0 0 8px",
 };

--- a/packages/shared/email-templates/src/render-newsletter-email.test.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.test.tsx
@@ -215,7 +215,7 @@ describe("renderNewsletterEmail", () => {
     );
   });
 
-  it("renders default Mediapulse and Hyperjump branding links in the footer", async () => {
+  it("renders default MediaPulse and Hyperjump branding links in the footer", async () => {
     // Act
     const { html, text } = await renderNewsletterEmail({
       title: "Morning Briefing",
@@ -225,7 +225,7 @@ describe("renderNewsletterEmail", () => {
     // Assert
     expect(html).toMatch(
       new RegExp(
-        `<a[^>]+href=["']?${DEFAULT_MEDIAPULSE_SITE_URL}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        `<a[^>]+href=["']?${DEFAULT_MEDIAPULSE_SITE_URL}["']?[^>]*>\\s*MediaPulse\\s*</a>`,
         "i",
       ),
     );
@@ -257,7 +257,7 @@ describe("renderNewsletterEmail", () => {
     // Assert
     expect(html).toMatch(
       new RegExp(
-        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*MediaPulse\\s*</a>`,
         "i",
       ),
     );
@@ -289,7 +289,7 @@ describe("renderNewsletterEmail", () => {
     expect(html).not.toMatch(/this digest covers/i);
     expect(html).toMatch(
       new RegExp(
-        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*Mediapulse\\s*</a>`,
+        `<a[^>]+href=["']?${mediapulseSiteUrl}["']?[^>]*>\\s*MediaPulse\\s*</a>`,
         "i",
       ),
     );
@@ -667,5 +667,57 @@ describe("renderNewsletterEmail", () => {
     expect(text).toContain(
       "You are receiving this because you subscribed to TLKM updates.",
     );
+  });
+
+  it("renders the footer chrome in Indonesian when language is id", async () => {
+    const { html, text } = await renderNewsletterEmail({
+      title: "Buletin TLKM",
+      bodyText: "Isi buletin",
+      tickerSymbol: "TLKM",
+      unsubscribeUrl: "https://app.example.com/api/unsubscribe?token=abc",
+      language: "id",
+    });
+
+    expect(html).toContain("Dipersembahkan oleh");
+    expect(html).toContain(", produk dari");
+    expect(html).toContain(
+      "Punya masukan? Balas email ini dan kami akan menggunakannya untuk meningkatkan buletin.",
+    );
+    expect(html).toContain(
+      "Anda menerima email ini karena Anda berlangganan pembaruan TLKM.",
+    );
+    expect(html).toMatch(/Berhenti berlangganan pembaruan.*TLKM/i);
+    expect(text).toContain(
+      "Anda menerima email ini karena Anda berlangganan pembaruan TLKM.",
+    );
+    // English chrome must not leak into an Indonesian render.
+    expect(html).not.toContain("Brought to you by");
+    expect(html).not.toMatch(/reply to this email/i);
+  });
+
+  it("uses the Indonesian generic copy and fallback unsubscribe noun when tickerSymbol is omitted", async () => {
+    const { html } = await renderNewsletterEmail({
+      title: "Buletin",
+      bodyText: "Isi buletin",
+      unsubscribeUrl: "https://app.example.com/api/unsubscribe?token=abc",
+      language: "id",
+    });
+
+    expect(html).toContain(
+      "Anda menerima email ini karena Anda berlangganan pembaruan.",
+    );
+    expect(html).toMatch(/Berhenti berlangganan pembaruan.*ini/i);
+  });
+
+  it("keeps the footer chrome in English when language is omitted", async () => {
+    const { html } = await renderNewsletterEmail({
+      title: "Morning Briefing",
+      bodyText: "Body content",
+      tickerSymbol: "TLKM",
+    });
+
+    expect(html).toContain("Brought to you by");
+    expect(html).toMatch(/reply to this email/i);
+    expect(html).not.toContain("Dipersembahkan oleh");
   });
 });

--- a/packages/shared/email-templates/src/render-newsletter-email.tsx
+++ b/packages/shared/email-templates/src/render-newsletter-email.tsx
@@ -1,7 +1,7 @@
 import { render } from "@react-email/render";
 import type { ReactElement } from "react";
 
-import DefaultNewsletterEmail from "./newsletter/default-newsletter.js";
+import { DefaultNewsletterEmail } from "./newsletter/default-newsletter.js";
 import type { DefaultNewsletterEmailProps } from "./newsletter/default-newsletter.js";
 import RegistrationConfirmationEmail from "./registration/registration-confirmation.js";
 import type { RegistrationConfirmationEmailProps } from "./registration/registration-confirmation.js";
@@ -23,6 +23,7 @@ export type RenderNewsletterEmailInput =
         tickerSymbol?: string;
         mediapulseSiteUrl?: string;
         hyperjumpSiteUrl?: string;
+        language?: "en" | "id";
       })
   | ({
       variant: "registration-confirmation";
@@ -93,6 +94,7 @@ function newsletterElementForVariant(
           tickerSymbol={input.tickerSymbol}
           mediapulseSiteUrl={input.mediapulseSiteUrl}
           hyperjumpSiteUrl={input.hyperjumpSiteUrl}
+          language={input.language}
         />
       );
     case "registration-confirmation":

--- a/packages/shared/email-templates/src/shared/email-shell.tsx
+++ b/packages/shared/email-templates/src/shared/email-shell.tsx
@@ -1,0 +1,249 @@
+import {
+  Body,
+  Container,
+  Head,
+  Heading,
+  Hr,
+  Html,
+  Link,
+  Preview,
+  Section,
+  Tailwind,
+  Text,
+} from "@react-email/components";
+import type { CSSProperties, ReactElement, ReactNode } from "react";
+
+/** Languages the shared email chrome (branding line) is translated into. */
+export type EmailLanguage = "en" | "id";
+
+/** Default Mediapulse marketing site link used for previews and when config omits the URL. */
+export const DEFAULT_MEDIAPULSE_SITE_URL = "https://mediapulse.hyperjump.tech";
+
+/** Default Hyperjump marketing site link used for previews and when config omits the URL. */
+export const DEFAULT_HYPERJUMP_SITE_URL = "https://hyperjump.tech";
+
+/** Brand link color, shared by the Tailwind palette and inline link styles. */
+const BRAND_BLUE = "#2563eb";
+
+/**
+ * Tailwind theme shared by every email. Semantic color tokens keep text, rules,
+ * and surfaces consistent; spacing and sizing use the default Tailwind scale
+ * (4px base) applied via utility classes.
+ */
+export const emailTailwindConfig = {
+  theme: {
+    extend: {
+      colors: {
+        ink: "#1a1a1a",
+        body: "#374151",
+        muted: "#6b7280",
+        faint: "#9ca3af",
+        brand: BRAND_BLUE,
+        rule: "#e6ebf1",
+        canvas: "#f6f9fc",
+      },
+    },
+  },
+};
+
+/**
+ * Inline link style for anchors rendered outside the Tailwind tree (inline
+ * markdown links and template body links). Matches the `brand` palette token.
+ */
+export const emailLink: CSSProperties = {
+  color: BRAND_BLUE,
+  textDecoration: "underline",
+};
+
+/**
+ * Layered box-shadow that makes the card read as a small stack of paper: two
+ * sheets peek out below the card (a white one, then a fainter gray one), each
+ * with a soft drop shadow. Degrades to a flat card in clients that ignore
+ * box-shadow (e.g. Outlook).
+ */
+const cardStack: CSSProperties = {
+  boxShadow: [
+    "0 1px 3px rgba(16,24,40,0.08)",
+    "0 10px 0 -5px #ffffff",
+    "0 10px 5px -5px rgba(16,24,40,0.10)",
+    "0 20px 0 -10px #f3f4f6",
+    "0 20px 6px -10px rgba(16,24,40,0.08)",
+  ].join(", "),
+};
+
+/** Branding line copy, split around the Mediapulse and Hyperjump links. */
+const BRANDING_COPY: Record<
+  EmailLanguage,
+  { prefix: string; middle: string; suffix: string }
+> = {
+  en: { prefix: "Brought to you by ", middle: ", a product of ", suffix: "." },
+  id: { prefix: "Dipersembahkan oleh ", middle: ", produk dari ", suffix: "." },
+};
+
+/** Shared heading style used for the title of every email. */
+export const emailHeadingClassName =
+  "m-0 mb-2 text-2xl font-semibold leading-tight text-ink";
+
+/** Shared paragraph style used for body copy in every email. */
+export const emailParagraphClassName =
+  "m-0 whitespace-pre-wrap text-base leading-relaxed text-body";
+
+/** Shared full-width divider style. */
+export const emailDividerClassName = "my-6 border-0 border-t border-rule";
+
+/** Shared link style used for anchors styled with a className. Blue in both schemes. */
+export const emailLinkClassName = "text-brand underline";
+
+/** Footer copy passed by a template; rendered in the shared centered footer. */
+export interface EmailFooterContent {
+  /** Optional feedback invitation line. */
+  feedback?: string;
+  /** Optional context/disclaimer line (e.g. the subscription note). */
+  note?: ReactNode;
+  /** Optional unsubscribe link. */
+  unsubscribe?: { url: string; label: string };
+}
+
+export interface EmailShellProps {
+  /** Inbox preview text. */
+  preview: string;
+  /** Card body content. */
+  children: ReactNode;
+  /** Branding line language. Defaults to "en". */
+  language?: EmailLanguage;
+  /** HTTPS URL for the Mediapulse footer link. */
+  mediapulseSiteUrl?: string;
+  /** HTTPS URL for the Hyperjump footer link. */
+  hyperjumpSiteUrl?: string;
+  /** Footer lines shown below the branding line. */
+  footer?: EmailFooterContent;
+}
+
+/**
+ * Shared layout for every Mediapulse email: a paper-stack white card holding the
+ * `children`, with a centered footer rendered outside the card. The branding
+ * line is localized; templates pass their own footer lines.
+ *
+ * @param props - See {@link EmailShellProps}.
+ * @returns The email document tree.
+ */
+export const EmailShell = ({
+  preview,
+  children,
+  language = "en",
+  mediapulseSiteUrl = DEFAULT_MEDIAPULSE_SITE_URL,
+  hyperjumpSiteUrl = DEFAULT_HYPERJUMP_SITE_URL,
+  footer,
+}: EmailShellProps): ReactElement => {
+  const branding = BRANDING_COPY[language];
+
+  return (
+    <Html>
+      <Tailwind config={emailTailwindConfig}>
+        <Head />
+        <Preview>{preview}</Preview>
+        <Body className="m-0 bg-canvas p-0 font-sans">
+          <Container
+            className="mx-auto my-8 max-w-[600px] bg-white px-6 py-8 max-sm:mt-0"
+            style={cardStack}
+          >
+            {children}
+          </Container>
+          <Container className="mx-auto max-w-[650px] px-6 pb-8 text-center">
+            <Text className="m-0 mb-2 text-center text-[13px] leading-normal text-body">
+              {branding.prefix}
+              <Link href={mediapulseSiteUrl} className={emailLinkClassName}>
+                MediaPulse
+              </Link>
+              {branding.middle}
+              <Link href={hyperjumpSiteUrl} className={emailLinkClassName}>
+                Hyperjump
+              </Link>
+              {branding.suffix}
+            </Text>
+            {footer?.feedback !== undefined ? (
+              <Text className="m-0 mb-2 text-center text-xs leading-normal text-muted">
+                {footer.feedback}
+              </Text>
+            ) : null}
+            {footer?.note !== undefined ? (
+              <Text className="m-0 mb-2 text-center text-xs leading-normal text-muted">
+                {footer.note}
+              </Text>
+            ) : null}
+            {footer?.unsubscribe !== undefined ? (
+              <Text className="m-0 text-center text-xs text-faint">
+                <Link
+                  href={footer.unsubscribe.url}
+                  className={emailLinkClassName}
+                >
+                  {footer.unsubscribe.label}
+                </Link>
+              </Text>
+            ) : null}
+          </Container>
+        </Body>
+      </Tailwind>
+    </Html>
+  );
+};
+
+/**
+ * Title heading for an email body.
+ *
+ * @param props.children - Heading text.
+ * @returns A styled `Heading`.
+ */
+export const EmailHeading = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => (
+  <Heading className={emailHeadingClassName}>{children}</Heading>
+);
+
+/**
+ * Body paragraph for an email.
+ *
+ * @param props.children - Paragraph content.
+ * @returns A styled `Text`.
+ */
+export const EmailParagraph = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => <Text className={emailParagraphClassName}>{children}</Text>;
+
+/**
+ * Full-width divider between an email's heading and body.
+ *
+ * @returns A styled `Hr`.
+ */
+export const EmailDivider = (): ReactElement => (
+  <Hr className={emailDividerClassName} />
+);
+
+/**
+ * Highlighted info callout for an actionable tip. Rendered as a tinted box with
+ * a brand accent so it stands out from the surrounding body copy.
+ *
+ * @param props.title - Optional bold lead line.
+ * @param props.children - Callout body content.
+ * @returns A styled `Section`.
+ */
+export const EmailCallout = ({
+  title,
+  children,
+}: {
+  title?: string;
+  children: ReactNode;
+}): ReactElement => (
+  <Section className="my-4 rounded-lg border border-l-4 border-rule border-l-brand bg-canvas px-4 py-3">
+    {title !== undefined ? (
+      <Text className="m-0 mb-1 text-sm font-semibold text-ink">{title}</Text>
+    ) : null}
+    <Text className="m-0 whitespace-pre-wrap text-sm leading-relaxed text-body">
+      {children}
+    </Text>
+  </Section>
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       resend:
         specifier: ^6.9.1
-        version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 6.9.2(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       route-action-gen:
         specifier: 'catalog:'
         version: 0.0.10(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(zod@3.25.76)
@@ -601,7 +601,7 @@ importers:
         version: 0.6.0(hono@4.11.9)(pino@10.3.1)
       openai:
         specifier: ^6.34.0
-        version: 6.34.0(ws@8.18.3)(zod@3.25.76)
+        version: 6.34.0(ws@8.21.0)(zod@3.25.76)
       p-retry:
         specifier: ^8.0.0
         version: 8.0.0
@@ -738,7 +738,7 @@ importers:
         version: 19.2.4
       resend:
         specifier: ^6.9.1
-        version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 6.9.2(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -1013,7 +1013,7 @@ importers:
         version: 0.6.0(hono@4.11.9)(pino@10.3.1)
       resend:
         specifier: ^6.9.1
-        version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 6.9.2(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -1159,7 +1159,7 @@ importers:
         version: 19.2.4(react@19.2.4)
       resend:
         specifier: ^6.9.1
-        version: 6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 6.9.2(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       sonner:
         specifier: 'catalog:'
         version: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1896,6 +1896,9 @@ importers:
         specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
     devDependencies:
+      '@react-email/ui':
+        specifier: ^6.6.5
+        version: 6.6.5(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: 'catalog:'
         version: 19.2.14
@@ -1905,6 +1908,9 @@ importers:
       '@workspace/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      react-email:
+        specifier: ^6.6.5
+        version: 6.6.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2325,6 +2331,11 @@ packages:
     resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.29.0':
     resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
@@ -2356,6 +2367,10 @@ packages:
 
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.29.0':
@@ -2484,6 +2499,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
@@ -2492,6 +2519,18 @@ packages:
 
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -2508,6 +2547,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
@@ -2516,6 +2567,18 @@ packages:
 
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -2532,6 +2595,18 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
     engines: {node: '>=18'}
@@ -2540,6 +2615,18 @@ packages:
 
   '@esbuild/darwin-x64@0.27.3':
     resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -2556,6 +2643,18 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
     engines: {node: '>=18'}
@@ -2564,6 +2663,18 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.3':
     resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -2580,6 +2691,18 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
     engines: {node: '>=18'}
@@ -2588,6 +2711,18 @@ packages:
 
   '@esbuild/linux-arm@0.27.3':
     resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -2604,6 +2739,18 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
     engines: {node: '>=18'}
@@ -2612,6 +2759,18 @@ packages:
 
   '@esbuild/linux-loong64@0.27.3':
     resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -2628,6 +2787,18 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
     engines: {node: '>=18'}
@@ -2636,6 +2807,18 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.3':
     resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -2652,6 +2835,18 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
     engines: {node: '>=18'}
@@ -2660,6 +2855,18 @@ packages:
 
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -2676,6 +2883,18 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
@@ -2684,6 +2903,18 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.3':
     resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -2700,6 +2931,18 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
@@ -2708,6 +2951,18 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.3':
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -2724,6 +2979,18 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
@@ -2732,6 +2999,18 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.3':
     resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -2748,6 +3027,18 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
@@ -2756,6 +3047,18 @@ packages:
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -2772,6 +3075,18 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
     engines: {node: '>=18'}
@@ -2780,6 +3095,18 @@ packages:
 
   '@esbuild/win32-x64@0.27.3':
     resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -3467,11 +3794,20 @@ packages:
   '@next/env@16.2.3':
     resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+
   '@next/eslint-plugin-next@15.5.12':
     resolution: {integrity: sha512-+ZRSDFTv4aC96aMb5E41rMjysx8ApkryevnvEYZvPZO52KvkqP5rNExLUXJFr9P4s0f3oqNQR6vopCZsPWKDcQ==}
 
   '@next/swc-darwin-arm64@16.2.3':
     resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -3482,8 +3818,21 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
   '@next/swc-linux-arm64-gnu@16.2.3':
     resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -3496,8 +3845,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -3510,14 +3873,33 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
   '@next/swc-win32-x64-msvc@16.2.3':
     resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -4663,6 +5045,13 @@ packages:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
       react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-email/render@2.0.9':
+    resolution: {integrity: sha512-M89LiXy2q+9tmQ4VMR0rYGuEe6NJ6HhZsSxBMoLwIia5fVOLcZQcZe2GEO0nAkLZspDjEhn7mtMRPmeMKECEdQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@react-email/row@0.0.12':
     resolution: {integrity: sha512-HkCdnEjvK3o+n0y0tZKXYhIXUNPDx+2vq1dJTmqappVHXS5tXS6W5JOPZr5j+eoZ8gY3PShI2LWj5rWF7ZEtIQ==}
     engines: {node: '>=18.0.0'}
@@ -4690,6 +5079,9 @@ packages:
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/ui@6.6.5':
+    resolution: {integrity: sha512-LoPALZc9TVsaBsJhZnFMFjhoCN+UeL5xEMsjkSEcK3OvAF2bJdL8tvi+zMVc/VapmR1JJqr7LHuR6wCYlXt7lg==}
 
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
@@ -4873,6 +5265,9 @@ packages:
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
@@ -5083,6 +5478,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -5172,6 +5570,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
@@ -5361,6 +5762,10 @@ packages:
 
   abstract-logging@2.0.1:
     resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
 
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -5599,6 +6004,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -5609,6 +6018,10 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
@@ -5661,6 +6074,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5835,6 +6252,9 @@ packages:
   citty@0.2.0:
     resolution: {integrity: sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==}
 
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
   cjs-module-lexer@1.4.3:
     resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
 
@@ -5963,6 +6383,10 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -5979,6 +6403,10 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
@@ -6090,10 +6518,6 @@ packages:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  css-tree@3.1.0:
-    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
-    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
-
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
@@ -6195,6 +6619,14 @@ packages:
 
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -6459,6 +6891,14 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.9:
+    resolution: {integrity: sha512-clKkw4C7nJ22mGgoVcCg6V/W/TxdNyIOTr89k2ONZu81qqkddPFDF0LXcbAwhzPD8DjkiRCjzuiO6Y+fkpD4vg==}
+    engines: {node: '>=10.2.0'}
+
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
@@ -6549,6 +6989,16 @@ packages:
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7089,6 +7539,10 @@ packages:
     resolution: {integrity: sha512-035InabNu/c1lW0tzPhAgapKctblppqsKKG9ZaNzbr+gXwWMjXoiyGSyB9sArzrjG7jY+zntRq5ZSUYemrnWVQ==}
     engines: {node: 20 || >=22}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -7096,6 +7550,10 @@ packages:
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -7732,6 +8190,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -7841,6 +8303,10 @@ packages:
   kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
 
   kuler@2.0.0:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
@@ -8022,6 +8488,10 @@ packages:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
@@ -8130,9 +8600,6 @@ packages:
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
 
-  mdn-data@2.12.2:
-    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
-
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -8169,8 +8636,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -8214,6 +8689,10 @@ packages:
     resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -8242,6 +8721,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -8312,6 +8795,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
@@ -8339,6 +8826,27 @@ packages:
 
   next@16.2.3:
     resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -8465,6 +8973,11 @@ packages:
 
   nypm@0.6.5:
     resolution: {integrity: sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -8755,6 +9268,10 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
 
@@ -8835,6 +9352,10 @@ packages:
 
   picoquery@2.5.0:
     resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
+
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
 
   pino-abstract-transport@3.0.0:
     resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
@@ -8969,6 +9490,10 @@ packages:
     resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
     engines: {node: '>= 0.6.0'}
 
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -9066,6 +9591,14 @@ packages:
     resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
     peerDependencies:
       react: ^19.2.4
+
+  react-email@6.6.5:
+    resolution: {integrity: sha512-IO2NXS17K5xEn9v8QVt28g8Nl6D4gmaKZZc61tOGiZla4X2F+veWjuSKCJC7HDIuEtZXF27chHo9sE6Mtey6tQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -9529,6 +10062,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
   sitemapper@3.2.24:
     resolution: {integrity: sha512-AWOmGaRyShZAoAPr4StgX0bgk15+J04J165qP6z9CpZ+8EUvmOpV0F0Gol28WbQW2prNALWFRf3X04q6lUr4mA==}
     engines: {node: '>= 10.0.0'}
@@ -9562,6 +10098,17 @@ packages:
 
   snake-case@2.1.0:
     resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
+
+  socket.io-adapter@2.5.8:
+    resolution: {integrity: sha512-6Oy52pbg+kvdCVvjcN+FnY7BvxZ7cIHNScbvztT/It5d0vbwoJoVZmF2gjJmnV0/4WlXRfG15zc45ySk9Ah8bw==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
 
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
@@ -9712,6 +10259,10 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
 
   strip-dirs@3.0.0:
     resolution: {integrity: sha512-I0sdgcFTfKQlUPZyAqPJmSG3HLO9rWDFnxonnIbskYNM3DwFOeTNB5KzVq3dA1GdRAc/25b5Y7UO2TQfKWw4aQ==}
@@ -9876,6 +10427,10 @@ packages:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
     engines: {node: '>=18'}
 
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -9978,6 +10533,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
@@ -10090,6 +10649,10 @@ packages:
   uid-safe@2.1.5:
     resolution: {integrity: sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==}
     engines: {node: '>= 0.8'}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   ulid@3.0.1:
     resolution: {integrity: sha512-dPJyqPzx8preQhqq24bBG1YNkvigm87K8kVEHCD+ruZg24t6IFEFv00xMWfxcC4djmFtiTLdFuADn4+DOz6R7Q==}
@@ -10516,6 +11079,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
     engines: {node: '>=20'}
@@ -10592,6 +11167,10 @@ packages:
 
   yoctocolors-cjs@2.1.3:
     resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
   yoga-wasm-web@0.3.3:
@@ -10749,6 +11328,10 @@ snapshots:
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
 
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/parser@7.29.0':
     dependencies:
       '@babel/types': 7.29.0
@@ -10776,6 +11359,18 @@ snapshots:
       '@babel/code-frame': 7.29.0
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3(supports-color@10.2.2)
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -10914,10 +11509,22 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.27.2':
@@ -10926,10 +11533,22 @@ snapshots:
   '@esbuild/android-arm@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.27.2':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.2':
@@ -10938,10 +11557,22 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.2':
@@ -10950,10 +11581,22 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.27.2':
@@ -10962,10 +11605,22 @@ snapshots:
   '@esbuild/linux-arm64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.27.2':
@@ -10974,10 +11629,22 @@ snapshots:
   '@esbuild/linux-ia32@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.2':
@@ -10986,10 +11653,22 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.2':
@@ -10998,10 +11677,22 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
@@ -11010,10 +11701,22 @@ snapshots:
   '@esbuild/linux-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -11022,10 +11725,22 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -11034,10 +11749,22 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.27.2':
@@ -11046,10 +11773,22 @@ snapshots:
   '@esbuild/sunos-x64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.27.2':
@@ -11058,10 +11797,22 @@ snapshots:
   '@esbuild/win32-ia32@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
@@ -11662,7 +12413,7 @@ snapshots:
       find-up: 7.0.0
       minimatch: 9.0.5
       read-pkg: 9.0.1
-      semver: 7.7.2
+      semver: 7.7.4
       yaml: 2.8.2
       yargs: 17.7.2
 
@@ -11710,7 +12461,7 @@ snapshots:
       resolve: 2.0.0-next.5
       rfdc: 1.4.1
       safe-json-stringify: 1.2.0
-      semver: 7.7.2
+      semver: 7.7.4
       string-width: 7.2.0
       supports-color: 10.2.2
       terminal-link: 4.0.0
@@ -11781,7 +12532,7 @@ snapshots:
       image-size: 2.0.2
       js-image-generator: 1.0.4
       parse-gitignore: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       tmp-promise: 3.0.3
       uuid: 11.1.0
       write-file-atomic: 5.0.1
@@ -11799,7 +12550,7 @@ snapshots:
       image-size: 2.0.2
       js-image-generator: 1.0.4
       parse-gitignore: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       tmp-promise: 3.0.3
       uuid: 13.0.0
       write-file-atomic: 5.0.1
@@ -11839,7 +12590,7 @@ snapshots:
       p-wait-for: 5.0.2
       parse-imports: 2.2.1
       path-key: 4.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       tar: 7.5.7
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
@@ -12018,7 +12769,7 @@ snapshots:
       precinct: 12.2.0(supports-color@10.2.2)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.7.2
+      semver: 7.7.4
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -12034,6 +12785,8 @@ snapshots:
 
   '@next/env@16.2.3': {}
 
+  '@next/env@16.2.6': {}
+
   '@next/eslint-plugin-next@15.5.12':
     dependencies:
       fast-glob: 3.3.1
@@ -12041,25 +12794,49 @@ snapshots:
   '@next/swc-darwin-arm64@16.2.3':
     optional: true
 
+  '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
   '@next/swc-darwin-x64@16.2.3':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
   '@next/swc-linux-arm64-gnu@16.2.3':
     optional: true
 
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
   '@next/swc-linux-arm64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
   '@next/swc-linux-x64-gnu@16.2.3':
     optional: true
 
+  '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
   '@next/swc-linux-x64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     optional: true
 
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    optional: true
+
   '@next/swc-win32-x64-msvc@16.2.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@nicnocquee/dataqueue@1.40.1(pg@8.18.0)':
@@ -13245,6 +14022,13 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       react-promise-suspense: 0.3.4
 
+  '@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@react-email/row@0.0.12(react@19.2.4)':
     dependencies:
       react: 19.2.4
@@ -13260,6 +14044,20 @@ snapshots:
   '@react-email/text@0.1.5(react@19.2.4)':
     dependencies:
       react: 19.2.4
+
+  '@react-email/ui@6.6.5(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      esbuild: 0.28.0
+      next: 16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@opentelemetry/api'
+      - '@playwright/test'
+      - babel-plugin-macros
+      - babel-plugin-react-compiler
+      - react
+      - react-dom
+      - sass
 
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
@@ -13374,6 +14172,8 @@ snapshots:
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@stablelib/base64@1.0.1': {}
 
@@ -13628,6 +14428,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.2.3
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -13719,6 +14523,10 @@ snapshots:
   '@types/tinycolor2@1.4.6': {}
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.2.3
 
   '@types/yauzl@2.10.3':
     dependencies:
@@ -14073,6 +14881,11 @@ snapshots:
 
   abstract-logging@2.0.1: {}
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -14320,9 +15133,13 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   base64-js@1.5.1: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.19: {}
 
@@ -14396,6 +15213,10 @@ snapshots:
   brace-expansion@2.0.2:
     dependencies:
       balanced-match: 1.0.2
+
+  brace-expansion@5.0.7:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -14612,6 +15433,8 @@ snapshots:
 
   citty@0.2.0: {}
 
+  citty@0.2.2: {}
+
   cjs-module-lexer@1.4.3: {}
 
   class-variance-authority@0.7.1:
@@ -14720,6 +15543,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@13.1.0: {}
+
   commander@2.20.3: {}
 
   comment-json@4.3.0:
@@ -14739,6 +15564,18 @@ snapshots:
       readable-stream: 4.7.0
 
   concat-map@0.0.1: {}
+
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.17.1
+      ajv-formats: 3.0.1(ajv@8.17.1)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.7.4
+      uint8array-extras: 1.5.0
 
   confbox@0.1.8: {}
 
@@ -14848,16 +15685,10 @@ snapshots:
       mdn-data: 2.0.28
       source-map-js: 1.2.1
 
-  css-tree@3.1.0:
-    dependencies:
-      mdn-data: 2.12.2
-      source-map-js: 1.2.1
-
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
-    optional: true
 
   css-what@6.2.2: {}
 
@@ -14952,6 +15783,12 @@ snapshots:
   date-fns@4.1.0: {}
 
   dateformat@4.6.3: {}
+
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
 
   debug@4.4.3(supports-color@10.2.2):
     dependencies:
@@ -15207,6 +16044,25 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.9:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.2.3
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3(supports-color@10.2.2)
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
@@ -15417,6 +16273,64 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.3
       '@esbuild/win32-ia32': 0.27.3
       '@esbuild/win32-x64': 0.27.3
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 
@@ -15759,7 +16673,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       toad-cache: 3.7.0
 
   fastq@1.20.1:
@@ -16011,7 +16925,7 @@ snapshots:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.7.2
+      semver: 7.7.4
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -16054,6 +16968,12 @@ snapshots:
       minipass: 7.1.2
       path-scurry: 2.0.1
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -16066,6 +16986,8 @@ snapshots:
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
+
+  globals@11.12.0: {}
 
   globals@14.0.0: {}
 
@@ -16234,7 +17156,7 @@ snapshots:
 
   hosted-git-info@9.0.2:
     dependencies:
-      lru-cache: 11.2.6
+      lru-cache: 11.3.3
 
   hot-shots@11.4.0:
     optionalDependencies:
@@ -16794,6 +17716,8 @@ snapshots:
       filelist: 1.0.6
       picocolors: 1.1.1
 
+  jiti@2.4.2: {}
+
   jiti@2.6.1: {}
 
   jose@6.2.0: {}
@@ -16880,7 +17804,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.2
+      semver: 7.7.4
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -16917,6 +17841,8 @@ snapshots:
       '@keyv/serialize': 1.1.1
 
   kind-of@6.0.3: {}
+
+  kleur@3.0.3: {}
 
   kuler@2.0.0: {}
 
@@ -17077,6 +18003,11 @@ snapshots:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   log-update@6.1.0:
     dependencies:
       ansi-escapes: 7.2.0
@@ -17114,8 +18045,7 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
-  lru-cache@11.3.3:
-    optional: true
+  lru-cache@11.3.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -17172,10 +18102,7 @@ snapshots:
 
   mdn-data@2.0.28: {}
 
-  mdn-data@2.12.2: {}
-
-  mdn-data@2.27.1:
-    optional: true
+  mdn-data@2.27.1: {}
 
   media-typer@1.1.0: {}
 
@@ -17203,7 +18130,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -17228,6 +18161,10 @@ snapshots:
   minimatch@10.1.2:
     dependencies:
       '@isaacs/brace-expansion': 5.0.1
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.7
 
   minimatch@3.1.2:
     dependencies:
@@ -17254,6 +18191,8 @@ snapshots:
   minipass@5.0.0: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -17326,6 +18265,8 @@ snapshots:
       picocolors: 1.1.1
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -17494,6 +18435,31 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  next@16.2.6(@opentelemetry/api@1.9.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.9.19
+      caniuse-lite: 1.0.30001769
+      postcss: 8.4.31
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
+      '@opentelemetry/api': 1.9.0
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   no-case@2.3.2:
     dependencies:
       lower-case: 1.1.4
@@ -17562,7 +18528,7 @@ snapshots:
   normalize-package-data@7.0.1:
     dependencies:
       hosted-git-info: 8.1.0
-      semver: 7.7.2
+      semver: 7.7.4
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@8.0.0:
@@ -17598,6 +18564,12 @@ snapshots:
       citty: 0.2.0
       pathe: 2.0.3
       tinyexec: 1.0.2
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
 
   object-assign@4.1.1: {}
 
@@ -17684,9 +18656,9 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.34.0(ws@8.18.3)(zod@3.25.76):
+  openai@6.34.0(ws@8.21.0)(zod@3.25.76):
     optionalDependencies:
-      ws: 8.18.3
+      ws: 8.21.0
       zod: 3.25.76
 
   optionator@0.9.4:
@@ -17903,6 +18875,11 @@ snapshots:
       lru-cache: 11.2.6
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.3
+      minipass: 7.1.3
+
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
@@ -17965,6 +18942,8 @@ snapshots:
   picomatch@4.0.3: {}
 
   picoquery@2.5.0: {}
+
+  picospinner@3.0.0: {}
 
   pino-abstract-transport@3.0.0:
     dependencies:
@@ -18121,6 +19100,11 @@ snapshots:
   process-warning@5.0.0: {}
 
   process@0.11.10: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prop-types@15.8.1:
     dependencies:
@@ -18280,6 +19264,37 @@ snapshots:
     dependencies:
       react: 19.2.4
       scheduler: 0.27.0
+
+  react-email@6.6.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.1
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      socket.io: 4.8.3
+      tailwindcss: 4.1.18
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   react-is@16.13.1: {}
 
@@ -18500,12 +19515,12 @@ snapshots:
 
   requires-port@1.0.0: {}
 
-  resend@6.9.2(@react-email/render@1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
+  resend@6.9.2(@react-email/render@2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)):
     dependencies:
       postal-mime: 2.7.3
       svix: 1.84.1
     optionalDependencies:
-      '@react-email/render': 1.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@react-email/render': 2.0.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   resolve-alpn@1.2.1: {}
 
@@ -18840,6 +19855,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sisteransi@1.0.5: {}
+
   sitemapper@3.2.24:
     dependencies:
       fast-xml-parser: 4.5.4
@@ -18873,6 +19890,36 @@ snapshots:
   snake-case@2.1.0:
     dependencies:
       no-case: 2.3.2
+
+  socket.io-adapter@2.5.8:
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3(supports-color@10.2.2)
+      engine.io: 6.6.9
+      socket.io-adapter: 2.5.8
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -19063,6 +20110,8 @@ snapshots:
     dependencies:
       ansi-regex: 6.2.2
 
+  strip-bom@3.0.0: {}
+
   strip-dirs@3.0.0:
     dependencies:
       inspect-with-kind: 1.0.5
@@ -19130,7 +20179,7 @@ snapshots:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.1.0
+      css-tree: 3.2.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
@@ -19221,6 +20270,8 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.2.4: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -19317,6 +20368,12 @@ snapshots:
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
+
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
 
   tslib@1.14.1: {}
 
@@ -19433,6 +20490,8 @@ snapshots:
     dependencies:
       random-bytes: 1.0.0
 
+  uint8array-extras@1.5.0: {}
+
   ulid@3.0.1: {}
 
   unbox-primitive@1.1.0:
@@ -19484,7 +20543,7 @@ snapshots:
       chokidar: 5.0.0
       destr: 2.0.5
       h3: 1.15.5
-      lru-cache: 11.2.6
+      lru-cache: 11.3.3
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.3
@@ -19520,7 +20579,7 @@ snapshots:
       is-npm: 6.1.0
       latest-version: 9.0.0
       pupa: 3.3.0
-      semver: 7.7.2
+      semver: 7.7.4
       xdg-basedir: 5.1.0
 
   upper-case-first@1.1.2:
@@ -19886,6 +20945,8 @@ snapshots:
 
   ws@8.18.3: {}
 
+  ws@8.21.0: {}
+
   wsl-utils@0.3.1:
     dependencies:
       is-wsl: 3.1.0
@@ -19947,6 +21008,8 @@ snapshots:
   yocto-queue@1.2.2: {}
 
   yoctocolors-cjs@2.1.3: {}
+
+  yoctocolors@2.1.2: {}
 
   yoga-wasm-web@0.3.3: {}
 


### PR DESCRIPTION
## Summary

Every Mediapulse email now renders through one shared `EmailShell`, and the newsletter footer is localized so an Indonesian subscriber gets a fully Indonesian email instead of an Indonesian body with an English footer. The email-templates package also gains a live preview server.

## Related issues

Closes #893

## Important changes

- **Shared `EmailShell`** (`packages/shared/email-templates/src/shared/email-shell.tsx`): a white card with a layered paper-stack shadow, a centered footer rendered outside the card, the localized MediaPulse/Hyperjump branding line, and consistent Tailwind spacing. The newsletter and all three registration emails render through it.
- **Indonesian footer**: a static `language` dictionary in the newsletter selects the feedback line, subscription note, and unsubscribe label; the shell localizes the branding line. Delivery passes the subscriber's language into the render, so `id` subscribers get a fully Indonesian email and `en` subscribers are unchanged.
- **Live preview**: `react-email` is a dev dependency with `email:dev` / `email:export` scripts. The dev server lists `newsletter-en` and `newsletter-id` entries.

## Other changes

- Info callout for the confirmation email's "add us to contacts" tip, plus formal, consistent English copy across the registration emails and the brand rendered as "MediaPulse".
- The base newsletter component drops its default export so the preview wrappers own the dev-server entries; the render entry and barrel use the named export.
- Dark mode is intentionally not supported; the emails render the same regardless of the recipient's OS theme.

## Key files to review

- `packages/shared/email-templates/src/shared/email-shell.tsx` - the shared layout, footer, callout, and paper-stack card.
- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` - footer localization and the shell refactor.
- `apps/mediapulse/agents/delivery/src/deliver-newsletter.ts` - threads `sub.language` into the render call.
- `packages/shared/email-templates/src/render-newsletter-email.test.tsx` - en/id footer assertions.

## How to test

1. `pnpm --filter @workspace/email-templates test` and `pnpm --filter @mediapulse/delivery test` - both green (92 and 58 tests).
2. `pnpm --filter @workspace/email-templates email:dev`, then open `newsletter-id` and confirm the footer reads Indonesian (`Berhenti berlangganan pembaruan TLKM`); open `newsletter-en` for the English footer.
3. In delivery, an `id` subscriber with a translation produces HTML whose footer is Indonesian; an `en` subscriber stays English.
