### PR TITLE
Raise email-templates test timeout for Tailwind cold render

### DIFF
--- a/packages/shared/email-templates/vitest.config.ts
+++ b/packages/shared/email-templates/vitest.config.ts
@@ -3,6 +3,10 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    // React Email's <Tailwind> compiles the Tailwind engine on its first render,
+    // which is slow on cold/shared CI runners. Every email renders through the
+    // shared shell, so give those render tests headroom over the 5s default.
+    testTimeout: 30000,
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],


### PR DESCRIPTION
## Summary

Code Quality went red on `main` after #894 because three email-templates render tests timed out in CI. Raise the per-test timeout so the cold `<Tailwind>` compile fits.

## Related issues

Closes #895

## Important changes

- `packages/shared/email-templates/vitest.config.ts`: set `testTimeout` to 30s. React Email's `<Tailwind>` compiles its engine on the first render, and now that every email renders through the shared shell, the first render in several test files exceeded vitest's 5s default on the CI runner. Tests pass locally in ~3s; this only times out on cold/shared CI.

## Other changes

None.

## Key files to review

- `packages/shared/email-templates/vitest.config.ts` - the timeout bump and the reason in a comment.

## How to test

1. `pnpm --filter @workspace/email-templates test:coverage` - 92 tests pass.
2. Confirm the Code Quality check on this PR (or on `main` after merge) is green.
