### PR TITLE
Retry fetch-provider 429s and jitter data-collection starts

### DIFF
--- a/apps/mediapulse/agents/data-collection/src/index.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/index.test.ts
@@ -193,7 +193,7 @@ describe("data-collection agent (HTTP)", () => {
         headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
-          config: {},
+          config: { collection: { startupJitterMs: 0 } },
         }),
       }),
     );
@@ -255,7 +255,7 @@ describe("data-collection agent (HTTP)", () => {
         headers: { ...AUTH_HEADERS, "Content-Type": "application/json" },
         body: JSON.stringify({
           input: { tickerId: TICKER_ID },
-          config: {},
+          config: { collection: { startupJitterMs: 0 } },
         }),
       }),
     );

--- a/apps/mediapulse/agents/data-collection/src/run.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.test.ts
@@ -54,6 +54,7 @@ const baseConfig = dataCollectionAgentConfigSchema.parse({
   collection: {
     targetSavedSources: 1,
     maxRounds: 3,
+    startupJitterMs: 0,
   },
 });
 

--- a/apps/mediapulse/agents/data-collection/src/run.ts
+++ b/apps/mediapulse/agents/data-collection/src/run.ts
@@ -49,8 +49,10 @@ import {
 import {
   classifyNoisyUrl,
   derivePublisherFromUrl,
+  sleep,
   type UrlNoiseReason,
 } from "@workspace/utils";
+import { computeStartupJitterMs } from "./utilities/startup-jitter";
 
 /** Run success criteria, formerly the configurable runPolicy section. */
 const RUN_POLICY: RunPolicy = {
@@ -109,6 +111,19 @@ export async function runDataCollection(
     },
     "data collection run started",
   );
+
+  // Random startup delay so concurrent ticker runs de-synchronize and don't burst the
+  // shared fetch-provider (e.g. Serper) rate limit in the same instant.
+  const startupJitterMs = computeStartupJitterMs(
+    config.collection.startupJitterMs,
+  );
+  if (startupJitterMs > 0) {
+    log.info(
+      { startupJitterMs },
+      "data collection run: applying startup jitter",
+    );
+    await sleep(startupJitterMs);
+  }
 
   const runPolicy = RUN_POLICY;
   const targetSavedSources = config.collection.targetSavedSources;

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.test.ts
@@ -65,6 +65,7 @@ describe("dataCollectionAgentConfigSchema", () => {
     expect(parsed.collection).toEqual({
       targetSavedSources: 15,
       maxRounds: 3,
+      startupJitterMs: 30_000,
     });
   });
 

--- a/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/config-schema.ts
@@ -128,6 +128,14 @@ const collectionSchema = z
       .positive()
       .default(3)
       .describe("Hard cap on search-fetch-filter-save rounds per run."),
+    startupJitterMs: z
+      .number()
+      .int()
+      .nonnegative()
+      .default(30_000)
+      .describe(
+        "Max random delay before a run starts fetching, so concurrent ticker runs de-synchronize and avoid bursting the shared fetch-provider rate limit. 0 disables.",
+      ),
   })
   .default({})
   .describe("Repeat-loop targets.");

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.test.ts
@@ -20,7 +20,7 @@ describe("buildFetchProviderConfigs", () => {
         rateLimit: { requests: 1, perSeconds: 1 },
         concurrency: 1,
         timeoutMs: 45_000,
-        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+        retry: { maxAttempts: 3, baseDelayMs: 1000, maxDelayMs: 8_000 },
       },
       {
         type: "firecrawl",
@@ -33,7 +33,7 @@ describe("buildFetchProviderConfigs", () => {
         rateLimit: { requests: 1, perSeconds: 1 },
         concurrency: 1,
         timeoutMs: 45_000,
-        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+        retry: { maxAttempts: 3, baseDelayMs: 1000, maxDelayMs: 8_000 },
       },
       {
         type: "jina",
@@ -46,7 +46,7 @@ describe("buildFetchProviderConfigs", () => {
         rateLimit: { requests: 1, perSeconds: 1 },
         concurrency: 1,
         timeoutMs: 45_000,
-        retry: { maxAttempts: 1, baseDelayMs: 1000, maxDelayMs: 10_000 },
+        retry: { maxAttempts: 3, baseDelayMs: 1000, maxDelayMs: 8_000 },
       },
     ]);
   });

--- a/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts
@@ -39,11 +39,16 @@ const FETCH_PROVIDER_DEFAULTS: Record<
 
 const FETCH_TIMEOUT_MS = 45_000;
 
-/** Fetch providers fail fast and rely on round-robin failover instead of retrying. */
+/**
+ * Fetch providers retry transient failures (HTTP 429/5xx, network) a few times with
+ * backoff that honors `Retry-After`, then fall through to round-robin failover. Only one
+ * provider is typically configured, so retry is the primary containment for rate limiting.
+ * `maxDelayMs` is kept well under `FETCH_TIMEOUT_MS` so a single backoff can't wedge the run.
+ */
 const FETCH_RETRY = {
-  maxAttempts: 1,
+  maxAttempts: 3,
   baseDelayMs: 1000,
-  maxDelayMs: 10_000,
+  maxDelayMs: 8_000,
 } as const;
 
 /**

--- a/apps/mediapulse/agents/data-collection/src/utilities/startup-jitter.test.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/startup-jitter.test.ts
@@ -1,0 +1,19 @@
+/** @vitest-environment node */
+
+import { describe, expect, it } from "vitest";
+
+import { computeStartupJitterMs } from "./startup-jitter";
+
+describe("computeStartupJitterMs", () => {
+  it("returns a delay within [0, maxJitterMs)", () => {
+    expect(computeStartupJitterMs(30_000, () => 0)).toBe(0);
+    expect(computeStartupJitterMs(30_000, () => 0.5)).toBe(15_000);
+    expect(computeStartupJitterMs(30_000, () => 0.999999)).toBeLessThan(30_000);
+  });
+
+  it("returns 0 when jitter is disabled or invalid", () => {
+    expect(computeStartupJitterMs(0, () => 0.9)).toBe(0);
+    expect(computeStartupJitterMs(-1000, () => 0.9)).toBe(0);
+    expect(computeStartupJitterMs(Number.NaN, () => 0.9)).toBe(0);
+  });
+});

--- a/apps/mediapulse/agents/data-collection/src/utilities/startup-jitter.ts
+++ b/apps/mediapulse/agents/data-collection/src/utilities/startup-jitter.ts
@@ -1,0 +1,19 @@
+/**
+ * Computes a random startup delay used to de-synchronize concurrent data-collection runs
+ * so they don't burst the shared fetch-provider rate limit in the same instant.
+ *
+ * @param maxJitterMs - Upper bound (exclusive) for the delay. Non-positive or non-finite
+ *   values return `0` (jitter disabled).
+ * @param random - Injectable source of randomness in `[0, 1)` (defaults to `Math.random`).
+ * @returns A delay in milliseconds within `[0, maxJitterMs)`.
+ */
+export const computeStartupJitterMs = (
+  maxJitterMs: number,
+  random: () => number = Math.random,
+): number => {
+  if (!Number.isFinite(maxJitterMs) || maxJitterMs <= 0) {
+    return 0;
+  }
+
+  return Math.floor(random() * maxJitterMs);
+};

--- a/packages/shared/agent-ingestion/src/fetch-providers/diffbot.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/diffbot.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -81,9 +80,8 @@ const fetchOneDiffbot = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.get(
       buildDiffbotEndpoint(config, url),
       {
@@ -101,7 +99,7 @@ const fetchOneDiffbot = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 

--- a/packages/shared/agent-ingestion/src/fetch-providers/exa.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/exa.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -61,9 +60,8 @@ const fetchOneExa = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.post(config.baseUrl, {
       json: { urls: [url], text: true },
       headers: {
@@ -83,7 +81,7 @@ const fetchOneExa = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 

--- a/packages/shared/agent-ingestion/src/fetch-providers/firecrawl.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/firecrawl.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -88,10 +87,9 @@ const fetchOneFirecrawl = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const endpoint = `${config.baseUrl.replace(/\/$/, "")}/v1/scrape`;
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.post(endpoint, {
       json: { url, formats: ["markdown"] },
       headers: {
@@ -109,7 +107,7 @@ const fetchOneFirecrawl = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 

--- a/packages/shared/agent-ingestion/src/fetch-providers/jina.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/jina.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -86,9 +85,8 @@ const fetchOneJina = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.post(config.baseUrl, {
       json: { url },
       headers: {
@@ -106,7 +104,7 @@ const fetchOneJina = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 

--- a/packages/shared/agent-ingestion/src/fetch-providers/retry.test.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/retry.test.ts
@@ -1,0 +1,150 @@
+/** @vitest-environment node */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HTTPError } from "got";
+import { z } from "zod";
+
+import { parseRetryAfterMs, retryAfterDelayMs, retryFetch } from "./retry";
+import { mockRateLimiter } from "./test-fixtures";
+import type { ProviderRequestContext } from "./types";
+
+const retryConfig = { maxAttempts: 3, baseDelayMs: 1000, maxDelayMs: 8000 };
+
+/**
+ * Builds a minimal {@link HTTPError} that exposes `response.statusCode` and
+ * `response.headers`, mirroring Got's internal request/response wiring.
+ */
+function createTestHttpError(
+  statusCode: number,
+  headers: Record<string, string> = {},
+): HTTPError {
+  const plainResponse: Record<string, unknown> = {
+    statusCode,
+    statusMessage: "Error",
+    headers,
+    requestUrl: new URL("http://example.test"),
+    redirectUrls: [],
+    isFromCache: false,
+    url: "http://example.test",
+    timings: {},
+    retryCount: 0,
+    ok: false,
+  };
+  plainResponse.request = {
+    _onResponse: () => {
+      /* noop — satisfies Got's request probe */
+    },
+    options: { method: "GET", url: new URL("http://example.test") },
+    response: plainResponse,
+  };
+
+  return new HTTPError(
+    plainResponse as unknown as ConstructorParameters<typeof HTTPError>[0],
+  );
+}
+
+/** Builds a provider context whose rate limiter records responses via a spy. */
+const buildContext = (): ProviderRequestContext =>
+  ({
+    rateLimiter: mockRateLimiter(),
+    logger: { info: vi.fn(), warn: vi.fn() },
+  }) as unknown as ProviderRequestContext;
+
+describe("parseRetryAfterMs", () => {
+  it("parses delta-seconds into milliseconds", () => {
+    expect(parseRetryAfterMs("2")).toBe(2000);
+  });
+
+  it("returns null for missing or blank values", () => {
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs("")).toBeNull();
+    expect(parseRetryAfterMs("   ")).toBeNull();
+  });
+
+  it("returns null for unparseable values", () => {
+    expect(parseRetryAfterMs("soon")).toBeNull();
+  });
+
+  it("parses a future HTTP-date into a positive delta", () => {
+    const now = () => Date.parse("2026-01-01T00:00:00.000Z");
+
+    expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:03 GMT", now)).toBe(3000);
+  });
+
+  it("clamps a past HTTP-date to zero", () => {
+    const now = () => Date.parse("2026-01-01T00:00:10.000Z");
+
+    expect(parseRetryAfterMs("Thu, 01 Jan 2026 00:00:00 GMT", now)).toBe(0);
+  });
+});
+
+describe("retryAfterDelayMs", () => {
+  it("honors a Retry-After header under the cap", () => {
+    const error = createTestHttpError(429, { "retry-after": "2" });
+
+    expect(retryAfterDelayMs(1, error, retryConfig)).toBe(2000);
+  });
+
+  it("caps an oversized Retry-After header", () => {
+    const error = createTestHttpError(429, { "retry-after": "100" });
+
+    expect(retryAfterDelayMs(1, error, retryConfig)).toBe(8000);
+  });
+
+  it("falls back to exponential backoff without a Retry-After header", () => {
+    const error = createTestHttpError(429);
+
+    expect(retryAfterDelayMs(1, error, retryConfig)).toBe(1000);
+    expect(retryAfterDelayMs(2, error, retryConfig)).toBe(2000);
+    expect(retryAfterDelayMs(3, error, retryConfig)).toBe(4000);
+  });
+
+  it("uses exponential backoff for non-HTTP errors", () => {
+    expect(retryAfterDelayMs(1, new Error("boom"), retryConfig)).toBe(1000);
+  });
+});
+
+describe("retryFetch", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries a transient failure and returns the eventual success", async () => {
+    const ctx = buildContext();
+    const task = vi
+      .fn()
+      .mockRejectedValueOnce(createTestHttpError(429, { "retry-after": "0" }))
+      .mockResolvedValueOnce("ok");
+
+    const result = await retryFetch(task, retryConfig, ctx);
+
+    expect(result).toBe("ok");
+    expect(task).toHaveBeenCalledTimes(2);
+    expect(ctx.rateLimiter.recordResponse).toHaveBeenCalledWith(429);
+    expect(ctx.rateLimiter.recordResponse).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws immediately on a non-retryable error", async () => {
+    const ctx = buildContext();
+    const task = vi.fn().mockRejectedValue(new z.ZodError([]));
+
+    await expect(retryFetch(task, retryConfig, ctx)).rejects.toBeInstanceOf(
+      z.ZodError,
+    );
+    expect(task).toHaveBeenCalledTimes(1);
+    expect(ctx.rateLimiter.recordResponse).not.toHaveBeenCalled();
+  });
+
+  it("gives up after maxAttempts", async () => {
+    const ctx = buildContext();
+    const task = vi
+      .fn()
+      .mockRejectedValue(createTestHttpError(429, { "retry-after": "0" }));
+
+    await expect(retryFetch(task, retryConfig, ctx)).rejects.toBeInstanceOf(
+      HTTPError,
+    );
+    expect(task).toHaveBeenCalledTimes(3);
+    expect(ctx.rateLimiter.recordResponse).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shared/agent-ingestion/src/fetch-providers/retry.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/retry.ts
@@ -1,0 +1,101 @@
+import { HTTPError } from "got";
+import { withRetryCustomDelay, type RetryConfig } from "@workspace/utils";
+
+import { isRetryableError } from "../error-classification";
+
+import type { ProviderRequestContext } from "./types";
+
+/**
+ * Upper bound on a honored `Retry-After` delay. A hostile or misconfigured provider can
+ * send a very large value; without a cap it would stall the run past the fetch timeout.
+ */
+const RETRY_AFTER_CAP_MS = 8_000;
+
+/**
+ * Parses an HTTP `Retry-After` header value into milliseconds.
+ *
+ * @param value - Raw header value: delta-seconds (e.g. `"2"`) or an HTTP-date.
+ * @param now - Current epoch milliseconds provider (injectable for tests).
+ * @returns Delay in milliseconds, or `null` when absent or unparseable.
+ */
+export const parseRetryAfterMs = (
+  value: string | undefined,
+  now: () => number = Date.now,
+): number | null => {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  if (/^\d+$/.test(trimmed)) {
+    return Number.parseInt(trimmed, 10) * 1000;
+  }
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) {
+    return null;
+  }
+  const delta = dateMs - now();
+
+  return delta > 0 ? delta : 0;
+};
+
+/**
+ * Computes the delay before retrying a failed fetch attempt.
+ *
+ * Honors a `Retry-After` header when the error is an HTTP error (capped at
+ * ``RETRY_AFTER_CAP_MS``); otherwise falls back to exponential backoff matching
+ * ``withRetry``'s schedule.
+ *
+ * @param attempt - 1-based index of the attempt that just failed.
+ * @param error - The thrown value from the fetch task.
+ * @param config - Retry limits (base/max delay).
+ * @returns Delay in milliseconds before the next attempt.
+ */
+export const retryAfterDelayMs = (
+  attempt: number,
+  error: unknown,
+  config: RetryConfig,
+): number => {
+  if (error instanceof HTTPError) {
+    const headerValue = error.response.headers["retry-after"];
+    const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+    const parsed = parseRetryAfterMs(raw);
+    if (parsed !== null) {
+      return Math.min(parsed, RETRY_AFTER_CAP_MS);
+    }
+  }
+  const exponential = config.baseDelayMs * Math.pow(2, attempt - 1);
+
+  return Math.min(config.maxDelayMs, exponential);
+};
+
+/**
+ * Runs a provider fetch task with retry on transient errors (429/5xx/network),
+ * honoring `Retry-After`.
+ *
+ * - Important: shared by every fetch provider, so the `Retry-After` handling and
+ *   adaptive-limiter feedback are provider-agnostic. Each retried failure is reported to
+ *   the run's rate limiter so its adaptive window widens promptly instead of only after
+ *   the final attempt.
+ *
+ * @param fetchTask - The single-attempt fetch (must itself acquire a rate-limit slot).
+ * @param config - Retry limits.
+ * @param ctx - Provider request context, used to feed the adaptive rate limiter.
+ * @returns The resolved fetch result.
+ */
+export const retryFetch = <T>(
+  fetchTask: () => Promise<T>,
+  config: RetryConfig,
+  ctx: ProviderRequestContext,
+): Promise<T> =>
+  withRetryCustomDelay(
+    fetchTask,
+    config.maxAttempts,
+    ({ attempt, error }) => {
+      const status =
+        error instanceof HTTPError ? error.response.statusCode : undefined;
+      ctx.rateLimiter.recordResponse(status);
+
+      return retryAfterDelayMs(attempt, error, config);
+    },
+    isRetryableError,
+  );

--- a/packages/shared/agent-ingestion/src/fetch-providers/serper.test.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/serper.test.ts
@@ -2,6 +2,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type got from "got";
+import { HTTPError } from "got";
 
 import { createSerperFetchProvider } from "./serper";
 import type { FetchProviderConfig } from "./types";
@@ -24,6 +25,36 @@ const mockGotPostResponse = (jsonValue: unknown, statusCode = 200) => ({
   statusCode,
   body: JSON.stringify(jsonValue),
 });
+
+/** Builds a minimal got {@link HTTPError} exposing status and headers. */
+const createTestHttpError = (
+  statusCode: number,
+  headers: Record<string, string> = {},
+): HTTPError => {
+  const plainResponse: Record<string, unknown> = {
+    statusCode,
+    statusMessage: "Error",
+    headers,
+    requestUrl: new URL("http://example.test"),
+    redirectUrls: [],
+    isFromCache: false,
+    url: "http://example.test",
+    timings: {},
+    retryCount: 0,
+    ok: false,
+  };
+  plainResponse.request = {
+    _onResponse: () => {
+      /* noop — satisfies Got's request probe */
+    },
+    options: { method: "GET", url: new URL("http://example.test") },
+    response: plainResponse,
+  };
+
+  return new HTTPError(
+    plainResponse as unknown as ConstructorParameters<typeof HTTPError>[0],
+  );
+};
 
 describe("createSerperFetchProvider", () => {
   afterEach(() => {
@@ -106,6 +137,32 @@ describe("createSerperFetchProvider", () => {
         logger: { info: vi.fn(), warn: vi.fn() },
       }),
     ).rejects.toThrow();
+  });
+
+  it("retries a 429 then returns the successful response", async () => {
+    // Setup
+    const postMock = vi
+      .fn()
+      .mockRejectedValueOnce(createTestHttpError(429, { "retry-after": "0" }))
+      .mockReturnValueOnce(mockGotPostResponse({ text: "Article body" }));
+    const rateLimiter = mockRateLimiter();
+    const provider = createSerperFetchProvider({
+      ...defaultConfig,
+      retry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 8 },
+    });
+
+    // Act
+    const result = await provider.fetchOne("http://example.com", {
+      gotClient: { post: postMock } as unknown as typeof got,
+      rateLimiter,
+      logger: { info: vi.fn(), warn: vi.fn() },
+    });
+
+    // Assert
+    expect(result).toEqual({ content: "Article body" });
+    expect(postMock).toHaveBeenCalledTimes(2);
+    expect(rateLimiter.acquire).toHaveBeenCalledTimes(2);
+    expect(rateLimiter.recordResponse).toHaveBeenCalledWith(429);
   });
 
   it("throws when text is empty", async () => {

--- a/packages/shared/agent-ingestion/src/fetch-providers/serper.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/serper.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -82,9 +81,8 @@ const fetchOneSerper = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.post(config.baseUrl, {
       json: { url },
       headers: {
@@ -102,7 +100,7 @@ const fetchOneSerper = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 

--- a/packages/shared/agent-ingestion/src/fetch-providers/tavily.ts
+++ b/packages/shared/agent-ingestion/src/fetch-providers/tavily.ts
@@ -1,7 +1,6 @@
 import { z } from "zod";
 
-import { withRetry } from "../resilience";
-import { isRetryableError } from "../error-classification";
+import { retryFetch } from "./retry";
 
 import type {
   FetchProvider,
@@ -52,9 +51,8 @@ const fetchOneTavily = async (
   config: FetchProviderConfig,
   ctx: ProviderRequestContext,
 ): Promise<NormalizedFetchData> => {
-  await ctx.rateLimiter.acquire();
-
   const fetchTask = async () => {
+    await ctx.rateLimiter.acquire();
     const response = await ctx.gotClient.post(config.baseUrl, {
       json: { urls: [url] },
       headers: {
@@ -74,7 +72,7 @@ const fetchOneTavily = async (
   };
 
   return config.retry
-    ? await withRetry(fetchTask, config.retry, isRetryableError)
+    ? await retryFetch(fetchTask, config.retry, ctx)
     : await fetchTask();
 };
 


### PR DESCRIPTION
## Summary

Data collection was dropping most fetched URLs to Serper HTTP 429s. Concurrent ticker runs each throttled to 1 req/s but collectively overran the shared account, and a URL that came back 429 was discarded with no retry. This adds a shared, provider-agnostic retry that honors `Retry-After`, and staggers run starts so tickers stop bursting the account at the same instant. Hermes is untouched and there is no database migration.

## Related issues

Closes #897

## Important changes

- New shared `retryFetch` helper in `agent-ingestion` retries transient fetch failures (429/5xx/network), honoring the `Retry-After` header (capped at 8s, exponential fallback) and reporting each retried failure to the adaptive rate limiter so its window widens promptly.
- All six fetch providers (Serper, Tavily, Exa, Jina, Firecrawl, Diffbot) now use `retryFetch` and acquire their rate-limit slot inside the retried task, so retries re-throttle instead of slipping past the limiter.
- Fetch retry is enabled: `FETCH_RETRY` goes from 1 attempt to 3, with the max backoff lowered to 8s so a single retry can't approach the 45s fetch timeout.
- New `startupJitterMs` config knob (default 30s, 0 disables) adds a random delay at the start of a data-collection run so concurrent ticker runs de-synchronize.

## Other changes

- Updated data-collection test fixtures for the new config defaults and set `startupJitterMs: 0` in run/index tests so they stay deterministic and fast.

## Key files to review

- `packages/shared/agent-ingestion/src/fetch-providers/retry.ts` - the shared retry, `Retry-After` parsing, and limiter feedback.
- `packages/shared/agent-ingestion/src/fetch-providers/serper.ts` - representative provider wiring (acquire moved inside the retried task); the other five change the same way.
- `apps/mediapulse/agents/data-collection/src/utilities/fetch-provider-config.ts` - retry attempts and backoff cap.
- `apps/mediapulse/agents/data-collection/src/run.ts` - startup jitter at run start.
- `apps/mediapulse/agents/data-collection/src/utilities/startup-jitter.ts` - jitter computation.

## How to test

1. `pnpm --filter @workspace/agent-ingestion test` - retry helper (`retry.test.ts`) and the Serper 429-retry case pass.
2. `pnpm --filter @mediapulse/data-collection test` - config, jitter, and run tests pass and stay fast.
3. After rollout, watch daily `mediapulse.collection_url_outcome` rows where `reason_detail LIKE '%HTTP 429%'` trend down, and confirm more sources persist per run.
