### PR TITLE
Widen content-generation source window to a rolling 24h lookback

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
@@ -115,7 +115,7 @@ describe("getDataSourcesForTicker", () => {
     vi.restoreAllMocks();
   });
 
-  it("filters by classified section analyzed today in UTC and sorts by section score desc", async () => {
+  it("filters by classified section analyzed within the rolling lookback window and sorts by section score desc", async () => {
     // Setup
     const db = createMockDb();
     db.ticker.findUniqueOrThrow.mockResolvedValue({
@@ -161,14 +161,14 @@ describe("getDataSourcesForTicker", () => {
       now: () => new Date("2026-03-19T15:30:00.000Z"),
     });
 
-    // Assert
-    const expectedStartOfToday = new Date("2026-03-19T00:00:00.000Z");
+    // Assert — cutoff is 24h before `now`, not the UTC start of day.
+    const expectedCutoff = new Date("2026-03-18T15:30:00.000Z");
     expect(db.dataSourceTickerSection.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
           tickerId: "ticker-1",
           section: { not: null },
-          analyzedAt: { gte: expectedStartOfToday },
+          analyzedAt: { gte: expectedCutoff },
         },
         orderBy: { sectionScore: "desc" },
       }),
@@ -181,7 +181,39 @@ describe("getDataSourcesForTicker", () => {
     expect(result.tickerName).toBe("Test Company");
   });
 
-  it("returns empty dataSources and ticker metadata when no selected articles exist for today", async () => {
+  it("includes an article analyzed during the prior UTC day (rolling-window regression)", async () => {
+    // Setup — mirror the incident: a run at 02:00 UTC must still see the prior day's articles.
+    const db = createMockDb();
+    db.ticker.findUniqueOrThrow.mockResolvedValue({
+      symbol: "TEST",
+      name: "Test Company",
+    });
+    db.dataSourceTickerSection.findMany.mockResolvedValue([]);
+
+    // Act
+    await getDataSourcesForTicker("ticker-1", {
+      db: db as unknown as NonNullable<GetDataSourcesDeps["db"]>,
+      now: () => new Date("2026-07-01T02:00:00.000Z"),
+    });
+
+    // Assert — the cutoff reaches into the prior UTC day.
+    const call = db.dataSourceTickerSection.findMany.mock.calls[0]?.[0];
+    const cutoff = call?.where?.analyzedAt?.gte as Date;
+
+    expect(cutoff).toEqual(new Date("2026-06-30T02:00:00.000Z"));
+
+    // An article analyzed 06-30 03:48 UTC (as in the incident) is now inside the window, where the
+    // old UTC-calendar-day boundary (00:00 UTC 07-01) would have excluded it.
+    const priorDayAnalyzedAt = new Date("2026-06-30T03:48:00.000Z");
+    const oldDayBoundary = new Date("2026-07-01T00:00:00.000Z");
+
+    expect(priorDayAnalyzedAt.getTime()).toBeGreaterThanOrEqual(
+      cutoff.getTime(),
+    );
+    expect(priorDayAnalyzedAt.getTime()).toBeLessThan(oldDayBoundary.getTime());
+  });
+
+  it("returns empty dataSources and ticker metadata when no articles exist within the lookback window", async () => {
     // Setup
     const db = createMockDb();
     db.ticker.findUniqueOrThrow.mockResolvedValue({

--- a/apps/mediapulse/agent-data-api/src/services/content-generation.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.ts
@@ -19,6 +19,18 @@ export {
 
 const MAX_RECENT_BULLETS = 200;
 
+/**
+ * Rolling lookback (hours) for the source-selection window in {@link getDataSourcesForTicker}.
+ *
+ * - Important: this must match the window used by the domain-api newsletter-detail mirror
+ *   (`domain-api/src/resources/newsletters/selected-sources-window.ts`). Changing one without the
+ *   other makes the detail view disagree with what the agent could actually select.
+ *
+ * The pipeline runs at ~02:00 UTC; a 24h window reaches back to ~02:00 UTC the prior day so a full
+ * collect→analyze cycle is visible, instead of the ~2h that a UTC-calendar-day boundary yields.
+ */
+const SOURCE_LOOKBACK_HOURS = 24;
+
 type ContentGenerationDb = {
   dataSourceTickerSection: Pick<
     typeof prisma.dataSourceTickerSection,
@@ -36,12 +48,16 @@ type ContentGenerationDb = {
 };
 
 /**
- * Returns today's classified data sources for a ticker, plus the ticker's name, symbol,
+ * Returns the recently classified data sources for a ticker, plus the ticker's name, symbol,
  * competitors, and issuer aliases. Reads the per-(article, ticker) section table.
+ *
+ * Sources are selected with a rolling ``SOURCE_LOOKBACK_HOURS`` window (`analyzedAt >= now - lookback`)
+ * so a full collect→analyze cycle is visible at the ~02:00 UTC run time, rather than the ~2h a
+ * UTC-calendar-day boundary would yield.
  *
  * @param tickerId - Ticker id used to scope the per-ticker section rows.
  * @param deps - Optional dependencies for database and current time.
- * @returns Data sources sectioned for this ticker today (UTC), ordered by section score desc.
+ * @returns Data sources sectioned for this ticker within the lookback window, ordered by section score desc.
  */
 export const getDataSourcesForTicker = async (
   tickerId: string,
@@ -59,8 +75,7 @@ export const getDataSourcesForTicker = async (
   } = {},
 ) => {
   const { db = prisma, now = () => new Date() } = deps;
-  const startOfTodayUtc = now();
-  startOfTodayUtc.setUTCHours(0, 0, 0, 0);
+  const cutoff = new Date(now().getTime() - SOURCE_LOOKBACK_HOURS * 3_600_000);
 
   const [ticker, sectionRows] = await Promise.all([
     db.ticker.findUniqueOrThrow({
@@ -71,7 +86,7 @@ export const getDataSourcesForTicker = async (
       where: {
         tickerId,
         section: { not: null },
-        analyzedAt: { gte: startOfTodayUtc },
+        analyzedAt: { gte: cutoff },
       },
       select: {
         section: true,

--- a/apps/mediapulse/agents/content-generation/src/freshness-window.ts
+++ b/apps/mediapulse/agents/content-generation/src/freshness-window.ts
@@ -7,15 +7,14 @@
  *
  * The interval is half-open: [windowStart, windowEnd).
  *
- * **Deliberate divergence from source-selection (v1):**
- * The data-source selection window in `getDataSourcesForTicker` uses UTC start-of-day
- * (`scoredAt >= startOfTodayUtc`). This skip-if-fresh window uses the configured IANA
- * timezone instead. These windows are intentionally different in v1:
- *   - Source selection is a broader query that benefits from UTC simplicity.
+ * **Deliberate divergence from source-selection:**
+ * The data-source selection window in `getDataSourcesForTicker` uses a rolling lookback
+ * (`analyzedAt >= now - SOURCE_LOOKBACK_HOURS`). This skip-if-fresh window instead uses the
+ * configured IANA timezone calendar day. These windows are intentionally different:
+ *   - Source selection is a broad "recent enough to include" query.
  *   - The freshness check must reflect "today" as perceived by the end user (in
- *     `config.freshness.timezone`), so that a newsletter generated at 11 PM Jakarta
+ *     `config.duplicateGuard.timezone`), so that a newsletter generated at 11 PM Jakarta
  *     time is considered "today's" newsletter even though it falls in the previous UTC day.
- * Aligning these windows is deferred to a later phase.
  *
  * **Delivery-agent coordination:**
  * When the content-generation step is skipped (`skipped_fresh_newsletter_exists`), no

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -193,11 +193,10 @@ export async function run({
   //   windowEnd   = start of the next calendar day in config.duplicateGuard.timezone
   //   Interval is half-open: [windowStart, windowEnd).
   //
-  // **Deliberate divergence from source-selection (v1):**
-  // The data-source selection window in `getDataSourcesForTicker` uses UTC start-of-day
-  // (`scoredAt >= startOfTodayUtc`). This duplicate-guard window uses the configured IANA
-  // timezone instead. These windows are intentionally different in v1. Aligning them
-  // is deferred to a future phase.
+  // **Deliberate divergence from source-selection:**
+  // The data-source selection window in `getDataSourcesForTicker` uses a rolling lookback
+  // (`analyzedAt >= now - SOURCE_LOOKBACK_HOURS`). This duplicate-guard window uses the configured
+  // IANA timezone calendar day instead. These windows are intentionally different.
   //
   // **Delivery-agent coordination:**
   // When this step is skipped, a new newsletter row is NOT written. The delivery agent

--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import { buildSelectedSources } from "./build-selected-sources";
 
 describe("buildSelectedSources", () => {
-  it("queries the per-day window matching the newsletter createdAt", async () => {
+  it("queries the rolling lookback window ending at the newsletter createdAt", async () => {
     const findMany = vi.fn().mockResolvedValue([]);
 
     const result = await buildSelectedSources(
@@ -13,8 +13,8 @@ describe("buildSelectedSources", () => {
       { dataSource: { findMany } },
     );
 
-    expect(result.windowStart).toBe("2026-05-14T00:00:00.000Z");
-    expect(result.windowEnd).toBe("2026-05-15T00:00:00.000Z");
+    expect(result.windowStart).toBe("2026-05-13T13:42:11.123Z");
+    expect(result.windowEnd).toBe("2026-05-14T13:42:11.123Z");
 
     const args = findMany.mock.calls[0]?.[0];
     expect(args?.where?.tickerId).toBe("tk-1");
@@ -22,8 +22,8 @@ describe("buildSelectedSources", () => {
       tickerId: "tk-1",
       selected: true,
       scoredAt: {
-        gte: new Date("2026-05-14T00:00:00.000Z"),
-        lt: new Date("2026-05-15T00:00:00.000Z"),
+        gte: new Date("2026-05-13T13:42:11.123Z"),
+        lt: new Date("2026-05-14T13:42:11.123Z"),
       },
     });
   });

--- a/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/build-selected-sources.ts
@@ -32,17 +32,18 @@ export type BuildSelectedSourcesDeps = {
 };
 
 /**
- * Collects DataSources selected for the ticker during the same UTC calendar
- * day as the newsletter's `createdAt`, mirroring the window used by the
- * content-generation agent (`getDataSourcesForTicker`).
+ * Collects DataSources selected for the ticker within the rolling lookback window ending at the
+ * newsletter's `createdAt`, mirroring the window used by the content-generation agent
+ * (`getDataSourcesForTicker`). See `buildSelectedSourcesWindow` for the window shape and the
+ * `analyzedAt` vs `scoredAt` field note.
  *
  * The result is sorted by descending relevance score (highest-scoring first),
  * with ties broken by `scoredAt` descending.
  *
  * @param newsletterId - Caller can use this for logging; the helper itself
- *   doesn't filter on it (the window is per-day, not per-newsletter).
+ *   doesn't filter on it (the window is a rolling lookback, not per-newsletter).
  * @param tickerId - Ticker the newsletter belongs to.
- * @param newsletterCreatedAt - Newsletter's `createdAt` (defines the window).
+ * @param newsletterCreatedAt - Newsletter's `createdAt` (anchors the window).
  * @param deps - Prisma `dataSource` delegate.
  * @returns Window boundaries and the ordered list of selected sources.
  */

--- a/apps/mediapulse/domain-api/src/resources/newsletters/selected-sources-window.test.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/selected-sources-window.test.ts
@@ -3,31 +3,31 @@ import { describe, expect, it } from "vitest";
 import { buildSelectedSourcesWindow } from "./selected-sources-window";
 
 describe("buildSelectedSourcesWindow", () => {
-  it("snaps window start to UTC midnight of the newsletter day", () => {
+  it("spans a 24h rolling lookback ending at the newsletter createdAt", () => {
     const result = buildSelectedSourcesWindow(
       new Date("2026-05-14T13:42:11.123Z"),
     );
 
-    expect(result.windowStartIso).toBe("2026-05-14T00:00:00.000Z");
-    expect(result.windowEndIso).toBe("2026-05-15T00:00:00.000Z");
+    expect(result.windowStartIso).toBe("2026-05-13T13:42:11.123Z");
+    expect(result.windowEndIso).toBe("2026-05-14T13:42:11.123Z");
   });
 
-  it("handles dates already at UTC midnight", () => {
+  it("crosses day boundaries when subtracting the lookback", () => {
     const result = buildSelectedSourcesWindow(
       new Date("2026-01-01T00:00:00.000Z"),
     );
 
-    expect(result.windowStartIso).toBe("2026-01-01T00:00:00.000Z");
-    expect(result.windowEndIso).toBe("2026-01-02T00:00:00.000Z");
+    expect(result.windowStartIso).toBe("2025-12-31T00:00:00.000Z");
+    expect(result.windowEndIso).toBe("2026-01-01T00:00:00.000Z");
   });
 
   it("crosses month boundaries cleanly", () => {
     const result = buildSelectedSourcesWindow(
-      new Date("2026-02-28T22:10:00.000Z"),
+      new Date("2026-03-01T05:10:00.000Z"),
     );
 
-    expect(result.windowStartIso).toBe("2026-02-28T00:00:00.000Z");
-    expect(result.windowEndIso).toBe("2026-03-01T00:00:00.000Z");
+    expect(result.windowStartIso).toBe("2026-02-28T05:10:00.000Z");
+    expect(result.windowEndIso).toBe("2026-03-01T05:10:00.000Z");
   });
 
   it("does not mutate the input date", () => {

--- a/apps/mediapulse/domain-api/src/resources/newsletters/selected-sources-window.ts
+++ b/apps/mediapulse/domain-api/src/resources/newsletters/selected-sources-window.ts
@@ -1,12 +1,23 @@
 /**
- * Builds the UTC calendar-day window used by
- * `getDataSourcesForTicker` (see `agent-data-api/src/services/content-generation.ts`)
- * so the newsletter detail handler mirrors what the content-generation agent
- * actually saw at send time.
+ * Rolling lookback (hours) mirroring the source-selection window used by
+ * `getDataSourcesForTicker` (`agent-data-api/src/services/content-generation.ts`).
  *
- * The window starts at the beginning of `newsletter.createdAt` in UTC and ends
- * 24 hours later (exclusive upper bound). Callers should pass `windowStart` as
- * `>=` and `windowEnd` as `<` when querying `ArticleRelevance.scoredAt`.
+ * - Important: this must match `SOURCE_LOOKBACK_HOURS` in that service. Changing one without the
+ *   other makes the newsletter-detail view disagree with what the agent could actually select.
+ */
+const SOURCE_LOOKBACK_HOURS = 24;
+
+/**
+ * Builds the rolling lookback window used to reconstruct the sources a newsletter could draw from,
+ * so the newsletter detail handler mirrors what the content-generation agent saw at send time.
+ *
+ * The window is anchored on `newsletter.createdAt`: it starts `SOURCE_LOOKBACK_HOURS` before it and
+ * ends at `createdAt` (the newsletter is written at the end of selection). Callers should pass
+ * `windowStart` as `>=` and `windowEnd` as `<`.
+ *
+ * - Important: the agent selects on `DataSourceTickerSection.analyzedAt`, while this mirror queries
+ *   `ArticleRelevance.scoredAt` — a related-but-distinct lifecycle timestamp. The mirror therefore
+ *   approximates the agent's window on `scoredAt`; the window *shape* matches, the field does not.
  *
  * @param newsletterCreatedAt - The newsletter's `createdAt`.
  * @returns ISO strings + Dates for the [start, end) window.
@@ -19,10 +30,10 @@ export const buildSelectedSourcesWindow = (
   windowStartIso: string;
   windowEndIso: string;
 } => {
-  const windowStart = new Date(newsletterCreatedAt);
-  windowStart.setUTCHours(0, 0, 0, 0);
-  const windowEnd = new Date(windowStart);
-  windowEnd.setUTCDate(windowEnd.getUTCDate() + 1);
+  const windowEnd = new Date(newsletterCreatedAt);
+  const windowStart = new Date(
+    windowEnd.getTime() - SOURCE_LOOKBACK_HOURS * 3_600_000,
+  );
   return {
     windowStart,
     windowEnd,


### PR DESCRIPTION
## Summary

The content-generation pipeline picked sources with a UTC calendar-day window (`analyzedAt >= start-of-today-UTC`). Because the pipeline runs ~02:00 UTC, that window was only ~2 hours wide at run time and excluded the prior day's whole analysis cycle — starving newsletters of sources (one real run saw a single article while 14 diverse-publisher articles from the prior day were excluded). This swaps the boundary for a rolling 24h lookback and mirrors the same window in the newsletter-detail view.

## Related issues

Closes #899
Refs #900

## Important changes

- `getDataSourcesForTicker` now selects on a rolling `SOURCE_LOOKBACK_HOURS = 24` window (`analyzedAt >= now - 24h`) instead of UTC start-of-day. At the ~02:00 UTC run time this reaches back into the prior day, so a full collect→analyze cycle is visible. Hardcoded constant — no env var, no contract change.
- The domain-api newsletter-detail "selected sources" view reconstructs the same rolling window anchored on `newsletter.createdAt`, with a matching constant and cross-referencing comments so the two can't silently drift. Its existing `articleRelevance.scoredAt` field is kept (the `analyzedAt` vs `scoredAt` difference is intentional and documented).

## Other changes

- Fixed stale "deliberate divergence" doc comments that described the selection filter as `scoredAt` on a UTC-day boundary (freshness-window.ts, run.ts).
- Updated the three window-assertion tests to the rolling boundary and added a regression test: an article analyzed during the prior UTC day is now included where the old boundary excluded it. The duplicate-guard (freshness) window is unchanged.

## Key files to review

- `apps/mediapulse/agent-data-api/src/services/content-generation.ts` - the rolling cutoff + `SOURCE_LOOKBACK_HOURS`.
- `apps/mediapulse/domain-api/src/resources/newsletters/selected-sources-window.ts` - the mirror window + matching constant.
- `apps/mediapulse/agent-data-api/src/services/content-generation.test.ts` - boundary + prior-day regression assertions.

## How to test

1. `pnpm --filter @mediapulse/agent-data-api test` and `pnpm --filter @mediapulse/domain-api test` pass.
2. After rollout, for a recent run compare sectioned rows in `mediapulse.data_source_ticker_section` under the old (`analyzed_at >= date_trunc('day', now() at time zone 'utc')`) vs new (`analyzed_at >= now() - interval '24 hours'`) window and confirm the new window returns more, including prior-day publishers.

## Notes

Widening the window can let consecutive newsletters overlap sources; cross-day dedup is intentionally out of scope and tracked in #900 (the `getRecentNewsletterBullets` endpoint already exists but is unused).
