### PR TITLE
Add cross-day dedup to content generation

### DIFF
--- a/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
+++ b/apps/mediapulse/agent-data-api/src/services/content-generation.test.ts
@@ -35,6 +35,7 @@ import {
   getCompetitorsForTicker,
   getDataSourcesForTicker,
   getLatestNewsletter,
+  getRecentNewsletterBullets,
   getRecentNewsletterSubjects,
 } from "./content-generation.js";
 
@@ -569,6 +570,62 @@ describe("getRecentNewsletterSubjects", () => {
           createdAt: expect.objectContaining({ gte: expect.any(Date) }),
         }),
         select: { subject: true, createdAt: true },
+        orderBy: { createdAt: "desc" },
+      }),
+    );
+  });
+});
+
+describe("getRecentNewsletterBullets", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("flattens bullets from recent newsletters within the lookback window", async () => {
+    // Setup
+    const db = createMockNewsletterDb();
+    const wire = [
+      "MP_NEWSLETTER",
+      "",
+      "BEGIN competitive-landscape",
+      "DISPLAY_HEADING",
+      "Competition",
+      "BULLET",
+      "Rival A underbid.",
+      "BULLET",
+      "Fleet oversupply.",
+      "END",
+      "",
+    ].join("\n");
+    db.newsletter.findMany.mockResolvedValue([
+      {
+        id: "nl-1",
+        content: wire,
+        createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      },
+    ]);
+
+    // Act
+    const result = await getRecentNewsletterBullets(
+      "ticker-1",
+      14,
+      db as unknown as Parameters<typeof getRecentNewsletterBullets>[2],
+    );
+
+    // Assert
+    expect(result.items).toHaveLength(2);
+    expect(result.items.map((item) => item.sectionKey)).toEqual([
+      "competitiveLandscape",
+      "competitiveLandscape",
+    ]);
+    expect(result.items[0]?.bulletText).toContain("Rival A underbid.");
+    expect(result.items[0]?.newsletterId).toBe("nl-1");
+    expect(db.newsletter.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tickerId: "ticker-1",
+          createdAt: expect.objectContaining({ gte: expect.any(Date) }),
+        }),
         orderBy: { createdAt: "desc" },
       }),
     );

--- a/apps/mediapulse/agents/content-generation/src/config-schema.ts
+++ b/apps/mediapulse/agents/content-generation/src/config-schema.ts
@@ -108,6 +108,20 @@ export const CONTENT_GENERATION_CONSTANTS = {
     dedupeScope: "newsletter",
     withinRunDedupSimilarity: 0.55,
   },
+  /**
+   * Cross-day (cross-run) dedup so consecutive newsletters do not repeat points.
+   * Hardcoded (not Hermes config) to match the rest of this agent's pipeline.
+   */
+  crossRunDedup: {
+    /** Kill switch: when false, no recent-bullet fetch, prompt block, or drop pass runs. */
+    enabled: true,
+    /** Lookback in calendar days for the recent-bullet corpus. */
+    windowDays: 14,
+    /** Jaccard threshold for the post-generation drop; matches within-run dedup. */
+    similarity: 0.55,
+    /** Max recent bullets injected into the "avoid repeating" prompt block. */
+    promptBulletLimit: 20,
+  },
 } as const;
 
 /**

--- a/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+
+import type { IndustryNewsletterResolved } from "../industry-newsletter-urls.js";
+
+import {
+  dedupeAgainstRecentBullets,
+  type RecentBullet,
+} from "./cross-run-dedup.js";
+
+const URL_A = "https://source.example/a";
+const URL_B = "https://source.example/b";
+const basePulse = { displayHeading: "Pulse", prose: "Lead prose." };
+
+const REPEATED_TEXT =
+  "Rival launches new premium coffee subscription service nationwide next quarter";
+const NOVEL_TEXT =
+  "Regulator approves updated banking capital adequacy framework guidance today";
+
+describe("dedupeAgainstRecentBullets", () => {
+  it("is a no-op when the recent corpus is empty", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [{ text: REPEATED_TEXT, url: URL_A }],
+      },
+    };
+
+    const result = dedupeAgainstRecentBullets(resolved, []);
+
+    expect(result.removedCount).toBe(0);
+    expect(result.resolved).toBe(resolved);
+  });
+
+  it("drops a bullet that repeats a recent bullet and keeps a novel one", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      competitiveLandscape: {
+        displayHeading: "Competition",
+        bullets: [
+          { text: REPEATED_TEXT, url: URL_A },
+          { text: NOVEL_TEXT, url: URL_B },
+        ],
+      },
+    };
+    const recent: RecentBullet[] = [
+      { sectionKey: "competitiveLandscape", bulletText: REPEATED_TEXT },
+    ];
+
+    const result = dedupeAgainstRecentBullets(resolved, recent);
+
+    expect(result.resolved.competitiveLandscape?.bullets).toHaveLength(1);
+    expect(result.resolved.competitiveLandscape?.bullets[0]?.text).toBe(
+      NOVEL_TEXT,
+    );
+    expect(result.removedCount).toBe(1);
+    expect(result.bySection.competitiveLandscape).toBe(1);
+  });
+
+  it("keeps uncited bullets (no url) even when their text repeats a recent bullet", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [{ text: REPEATED_TEXT }],
+      },
+    };
+    const recent: RecentBullet[] = [
+      { sectionKey: "dealsAndMovements", bulletText: REPEATED_TEXT },
+    ];
+
+    const result = dedupeAgainstRecentBullets(resolved, recent);
+
+    expect(result.resolved.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(result.removedCount).toBe(0);
+  });
+
+  it("never empties a section: rescues the most novel item when every item repeats", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      dealsAndMovements: {
+        displayHeading: "Deals",
+        bullets: [
+          { text: REPEATED_TEXT, url: URL_A },
+          { text: NOVEL_TEXT, url: URL_B },
+        ],
+      },
+    };
+    // Both generated bullets match a recent bullet, so both would drop without the floor.
+    const recent: RecentBullet[] = [
+      { sectionKey: "dealsAndMovements", bulletText: REPEATED_TEXT },
+      { sectionKey: "dealsAndMovements", bulletText: NOVEL_TEXT },
+    ];
+
+    const result = dedupeAgainstRecentBullets(resolved, recent);
+
+    expect(result.resolved.dealsAndMovements).toBeDefined();
+    expect(result.resolved.dealsAndMovements?.bullets).toHaveLength(1);
+    expect(result.removedCount).toBe(1);
+    expect(result.bySection.dealsAndMovements).toBe(1);
+  });
+
+  it("applies to quickHits items", () => {
+    const resolved: IndustryNewsletterResolved = {
+      subject: "S",
+      industryPulse: basePulse,
+      quickHits: {
+        displayHeading: "Quick hits",
+        items: [
+          { text: REPEATED_TEXT, url: URL_A },
+          { text: NOVEL_TEXT, url: URL_B },
+        ],
+      },
+    };
+    const recent: RecentBullet[] = [
+      { sectionKey: "quickHits", bulletText: REPEATED_TEXT },
+    ];
+
+    const result = dedupeAgainstRecentBullets(resolved, recent);
+
+    expect(result.resolved.quickHits?.items).toHaveLength(1);
+    expect(result.resolved.quickHits?.items[0]?.text).toBe(NOVEL_TEXT);
+    expect(result.bySection.quickHits).toBe(1);
+  });
+});

--- a/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.ts
+++ b/apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.ts
@@ -1,0 +1,199 @@
+import type {
+  IndustryBulletResolved,
+  IndustryNewsletterResolved,
+  IndustryQuickHitResolved,
+} from "../industry-newsletter-urls.js";
+
+import {
+  buildWordShingles,
+  shingleJaccardSimilarity,
+} from "./citation-grounding.js";
+import { tokenize } from "./phrase-link-injector.js";
+
+/** A previously published bullet, flattened from a recent newsletter. */
+export type RecentBullet = {
+  sectionKey: string;
+  bulletText: string;
+};
+
+/** Outcome of the cross-run (cross-day) dedup pass. */
+export type CrossRunDedupResult = {
+  resolved: IndustryNewsletterResolved;
+  removedCount: number;
+  /** Removed counts keyed by section. Only sections with removals appear. */
+  bySection: Record<string, number>;
+};
+
+/**
+ * Jaccard threshold above which a bullet is treated as repeating a recently published one.
+ * Matches the within-run dedup threshold so both passes agree on what "the same story" means.
+ */
+export const CROSS_RUN_DEDUP_SIMILARITY = 0.55;
+
+/**
+ * Minimum items kept per originally non-empty section. The wire serializer refuses to emit a
+ * zero-row section, and gutting a section on an overlapping day is worse than one repeated point,
+ * so this pass never empties a section — it rescues the most novel item when every item matched.
+ */
+const MIN_KEPT_PER_SECTION = 1;
+
+type ResolvedItem = IndustryBulletResolved | IndustryQuickHitResolved;
+
+const itemComparisonText = (item: ResolvedItem): string =>
+  `${item.title ?? ""} ${item.text}`;
+
+/**
+ * Filters one section's items against the recent-bullet shingle corpus.
+ *
+ * An item is dropped when its max Jaccard similarity to any recent bullet is `>= minSimilarity`.
+ * Uncited items (no `url`) are always kept, mirroring the within-run pass. At least
+ * ``MIN_KEPT_PER_SECTION`` item(s) are always retained (the most novel), so a non-empty section is
+ * never emptied by this pass.
+ */
+const dedupeSectionAgainstRecent = <Item extends ResolvedItem>(
+  items: Item[],
+  corpusShingles: ReadonlyArray<Set<string>>,
+  minSimilarity: number,
+): { kept: Item[]; removedCount: number } => {
+  if (items.length === 0 || corpusShingles.length === 0) {
+    return { kept: items, removedCount: 0 };
+  }
+
+  const decisions = items.map((item) => {
+    if (item.url === undefined) {
+      return { item, similarity: -1, drop: false };
+    }
+    const itemShingles = buildWordShingles(tokenize(itemComparisonText(item)));
+    let maxSimilarity = 0;
+    for (const shingles of corpusShingles) {
+      const similarity = shingleJaccardSimilarity(itemShingles, shingles);
+      if (similarity > maxSimilarity) {
+        maxSimilarity = similarity;
+      }
+    }
+    return {
+      item,
+      similarity: maxSimilarity,
+      drop: maxSimilarity >= minSimilarity,
+    };
+  });
+
+  // Floor: never empty a section. Rescue the most novel (lowest-similarity) dropped item(s).
+  const keptCount = decisions.filter((decision) => !decision.drop).length;
+  if (keptCount < MIN_KEPT_PER_SECTION) {
+    const rescueCandidates = decisions
+      .filter((decision) => decision.drop)
+      .sort((left, right) => left.similarity - right.similarity);
+    const rescueNeeded = MIN_KEPT_PER_SECTION - keptCount;
+    for (
+      let index = 0;
+      index < rescueNeeded && index < rescueCandidates.length;
+      index += 1
+    ) {
+      rescueCandidates[index]!.drop = false;
+    }
+  }
+
+  const kept = decisions
+    .filter((decision) => !decision.drop)
+    .map((decision) => decision.item);
+
+  return { kept, removedCount: items.length - kept.length };
+};
+
+/**
+ * Removes bullets that repeat recently published newsletter bullets (cross-day dedup).
+ *
+ * Mirrors {@link dedupeWithinRun} but compares each item against an external corpus of recent
+ * bullets (not the current run), using n-gram Jaccard similarity, and enforces a per-section floor
+ * so a section is never emptied purely by this pass. Runs on the resolved structure after the
+ * within-run dedup and before wire serialization.
+ *
+ * @param resolved - Resolved newsletter after URL attachment, citation pruning, and within-run dedup.
+ * @param recentBullets - Bullets published in recent newsletters for this ticker.
+ * @param minSimilarity - Jaccard threshold above which an item repeats a recent bullet.
+ */
+export const dedupeAgainstRecentBullets = (
+  resolved: IndustryNewsletterResolved,
+  recentBullets: ReadonlyArray<RecentBullet>,
+  minSimilarity: number = CROSS_RUN_DEDUP_SIMILARITY,
+): CrossRunDedupResult => {
+  const bySection: Record<string, number> = {};
+  if (recentBullets.length === 0) {
+    return { resolved, removedCount: 0, bySection };
+  }
+
+  const corpusShingles = recentBullets.map((bullet) =>
+    buildWordShingles(tokenize(bullet.bulletText)),
+  );
+  let removedCount = 0;
+
+  const applySection = <Item extends ResolvedItem>(
+    key: string,
+    items: Item[],
+  ): Item[] | undefined => {
+    const { kept, removedCount: removed } = dedupeSectionAgainstRecent(
+      items,
+      corpusShingles,
+      minSimilarity,
+    );
+    if (removed > 0) {
+      bySection[key] = removed;
+      removedCount += removed;
+    }
+
+    return kept.length > 0 ? kept : undefined;
+  };
+
+  const next: IndustryNewsletterResolved = { ...resolved };
+
+  if (next.competitiveLandscape !== undefined) {
+    const kept = applySection(
+      "competitiveLandscape",
+      next.competitiveLandscape.bullets,
+    );
+    next.competitiveLandscape = kept
+      ? { ...next.competitiveLandscape, bullets: kept }
+      : undefined;
+  }
+
+  if (next.dealsAndMovements !== undefined) {
+    const kept = applySection(
+      "dealsAndMovements",
+      next.dealsAndMovements.bullets,
+    );
+    next.dealsAndMovements = kept
+      ? { ...next.dealsAndMovements, bullets: kept }
+      : undefined;
+  }
+
+  if (next.regulatoryPolicyWatch !== undefined) {
+    const kept = applySection(
+      "regulatoryPolicyWatch",
+      next.regulatoryPolicyWatch.bullets,
+    );
+    next.regulatoryPolicyWatch = kept
+      ? { ...next.regulatoryPolicyWatch, bullets: kept }
+      : undefined;
+  }
+
+  if (
+    next.disruptorsOrTech !== undefined &&
+    next.disruptorsOrTech.format === "bullets"
+  ) {
+    const kept = applySection(
+      "disruptorsOrTech",
+      next.disruptorsOrTech.bullets,
+    );
+    next.disruptorsOrTech = kept
+      ? { ...next.disruptorsOrTech, bullets: kept }
+      : undefined;
+  }
+
+  if (next.quickHits !== undefined) {
+    const kept = applySection("quickHits", next.quickHits.items);
+    next.quickHits = kept ? { ...next.quickHits, items: kept } : undefined;
+  }
+
+  return { resolved: next, removedCount, bySection };
+};

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.test.ts
@@ -8,6 +8,7 @@ import {
   resolveContentGenerationConfig,
 } from "./config-schema.js";
 import {
+  buildAvoidRecentBulletsBlock,
   buildCompetitorPromptBlock,
   generateNewsletterWithLlm,
   groupSourcesBySection,
@@ -611,5 +612,108 @@ describe("generateNewsletterWithLlm — contract brief", () => {
     );
 
     expect(withBrief.systemPrompt).not.toBe(withoutBrief.systemPrompt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildAvoidRecentBulletsBlock
+// ---------------------------------------------------------------------------
+
+describe("buildAvoidRecentBulletsBlock", () => {
+  it("returns an empty string with no recent bullets or a non-positive limit", () => {
+    expect(buildAvoidRecentBulletsBlock([], 20)).toBe("");
+    expect(buildAvoidRecentBulletsBlock([{ bulletText: "Something" }], 0)).toBe(
+      "",
+    );
+  });
+
+  it("lists the recent bullets under an avoidance directive, capped at the limit", () => {
+    const block = buildAvoidRecentBulletsBlock(
+      [
+        { bulletText: "First recent point" },
+        { bulletText: "Second recent point" },
+        { bulletText: "Third recent point" },
+      ],
+      2,
+    );
+
+    expect(block).toContain("AVOID REPEATING");
+    expect(block).toContain("First recent point");
+    expect(block).toContain("Second recent point");
+    expect(block).not.toContain("Third recent point");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-day dedup integration
+// ---------------------------------------------------------------------------
+
+const DUP_TEXT =
+  "Acme Bank acquires rival fintech startup for five hundred million dollars";
+const NOVEL_TEXT =
+  "Regulator publishes fresh capital adequacy guidance for digital lenders";
+
+const crossRunSources: SourceForGeneration[] = [
+  {
+    url: "https://example.com/dup",
+    title: "Dup",
+    content: DUP_TEXT,
+    section: "competitiveLandscape",
+  },
+  {
+    url: "https://example.com/novel",
+    title: "Novel",
+    content: NOVEL_TEXT,
+    section: "competitiveLandscape",
+  },
+];
+
+const crossRunGenerateFn = (): GenerateNewsletterObjectFn =>
+  makeSuccessfulGenerateFn({
+    competitiveLandscape: {
+      displayHeading: "Competitive",
+      bullets: [
+        { title: "Dup", text: DUP_TEXT, articleIndex: 1 },
+        { title: "Novel", text: NOVEL_TEXT, articleIndex: 2 },
+      ],
+    },
+  });
+
+describe("generateNewsletterWithLlm — cross-day dedup", () => {
+  it("injects the avoidance block and drops a bullet repeating a recent one", async () => {
+    const result = await generateNewsletterWithLlm(
+      crossRunSources,
+      baseConfig,
+      {
+        ...testContext,
+        recentBullets: [
+          { sectionKey: "competitiveLandscape", bulletText: DUP_TEXT },
+        ],
+      },
+      { generateObjectFn: crossRunGenerateFn() },
+    );
+
+    // Prompt-level avoidance directive is present.
+    expect(result.resolvedUserPrompt).toContain("AVOID REPEATING");
+    expect(result.resolvedUserPrompt).toContain(DUP_TEXT);
+
+    // Post-generation drop removed the repeated bullet, kept the novel one.
+    expect(result.crossRunDedupSummary?.removedCount).toBe(1);
+    expect(result.crossRunDedupSummary?.bySection.competitiveLandscape).toBe(1);
+    expect(result.content).toContain(NOVEL_TEXT);
+    expect(result.content).not.toContain(DUP_TEXT);
+  });
+
+  it("does not inject the block or run the drop when no recent bullets are provided", async () => {
+    const result = await generateNewsletterWithLlm(
+      crossRunSources,
+      baseConfig,
+      { ...testContext },
+      { generateObjectFn: crossRunGenerateFn() },
+    );
+
+    expect(result.resolvedUserPrompt).not.toContain("AVOID REPEATING");
+    expect(result.crossRunDedupSummary).toBeUndefined();
+    expect(result.content).toContain(DUP_TEXT);
   });
 });

--- a/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
+++ b/apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts
@@ -26,6 +26,10 @@ import {
   type PruneSummary,
   type WithinRunDedupResult,
 } from "./lib/prune-uncited-rows.js";
+import {
+  dedupeAgainstRecentBullets,
+  type RecentBullet,
+} from "./lib/cross-run-dedup.js";
 import { isRetryableLlmError } from "./llm-classify-error.js";
 import {
   groundNewsletterCitations,
@@ -131,6 +135,11 @@ export interface GeneratedContentWithProvenance extends GeneratedContent {
   requireCitationSummary?: PruneSummary;
   /** Per-section bullet counts and removed-section list from the final resolved newsletter. */
   sectionFillSnapshot?: SectionFillSnapshot;
+  /** Cross-day dedup counters, present when a recent-bullet corpus was provided. */
+  crossRunDedupSummary?: {
+    removedCount: number;
+    bySection: Record<string, number>;
+  };
 }
 
 /** Minimal arguments for a single `generateObject` call for newsletter generation. */
@@ -324,6 +333,30 @@ export const buildCompetitorPromptBlock = (
 };
 
 /**
+ * Builds the "avoid repeating recent bullets" directive injected into the user prompt.
+ *
+ * Returns an empty string when there are no recent bullets, so the caller can include it
+ * without a length guard. At most `limit` bullets are listed to bound prompt size.
+ *
+ * @param recentBullets - Bullets published in recent newsletters for this ticker.
+ * @param limit - Max bullet lines to include.
+ */
+export const buildAvoidRecentBulletsBlock = (
+  recentBullets: ReadonlyArray<{ bulletText: string }>,
+  limit: number,
+): string => {
+  if (recentBullets.length === 0 || limit <= 0) return "";
+  const lines = recentBullets
+    .slice(0, limit)
+    .map((bullet) => `- ${bullet.bulletText}`)
+    .join("\n");
+  return [
+    "AVOID REPEATING these points already published in recent newsletters. Do not restate the same story or facts; surface only genuinely new developments:",
+    lines,
+  ].join("\n");
+};
+
+/**
  * Builds the LLM user prompt from the list of data sources, substituting
  * placeholders in the provided template.
  *
@@ -357,18 +390,23 @@ export function buildUserPrompt(
   options: {
     /** Competitor directive injected above article summaries when the KG has named peers. */
     competitorSection?: string;
+    /** "Avoid repeating recent bullets" directive injected above article summaries. */
+    avoidRecentSection?: string;
   } = {},
 ): string {
   const sourceSummaries = buildArticleSummariesBlock(sources);
 
-  const competitorPrefix =
-    options.competitorSection !== undefined &&
-    options.competitorSection.length > 0
-      ? `${options.competitorSection}\n\n`
-      : "";
+  const directiveBlocks = [
+    options.avoidRecentSection,
+    options.competitorSection,
+  ]
+    .filter((block): block is string => block !== undefined && block.length > 0)
+    .join("\n\n");
+  const directivePrefix =
+    directiveBlocks.length > 0 ? `${directiveBlocks}\n\n` : "";
 
   return template
-    .replaceAll("{{sourceSummaries}}", `${competitorPrefix}${sourceSummaries}`)
+    .replaceAll("{{sourceSummaries}}", `${directivePrefix}${sourceSummaries}`)
     .replaceAll("{{tickerId}}", context.tickerId)
     .replaceAll("{{tickerName}}", context.tickerName ?? context.tickerId)
     .replaceAll("{{tickerSymbol}}", context.tickerSymbol ?? context.tickerId)
@@ -410,6 +448,8 @@ export async function generateNewsletterWithLlm(
     issuerAliases?: string[];
     /** Opaque product brief from the Agent Contract; appended to the system prompt when present. */
     brief?: string;
+    /** Recently published bullets for this ticker, used for cross-day dedup. */
+    recentBullets?: RecentBullet[];
   },
   deps: {
     generateObjectFn?: GenerateNewsletterObjectFn;
@@ -462,6 +502,12 @@ export async function generateNewsletterWithLlm(
     context.tickerName ?? context.tickerId,
   );
 
+  const recentBullets = context.recentBullets ?? [];
+  const avoidRecentSection = buildAvoidRecentBulletsBlock(
+    recentBullets,
+    CONTENT_GENERATION_CONSTANTS.crossRunDedup.promptBulletLimit,
+  );
+
   const prompt = buildUserPrompt(
     promptSources,
     DEFAULT_USER_PROMPT_TEMPLATE,
@@ -472,7 +518,7 @@ export async function generateNewsletterWithLlm(
       tickerName: context.tickerName,
       tickerSymbol: context.tickerSymbol,
     },
-    { competitorSection },
+    { competitorSection, avoidRecentSection },
   );
 
   const result = await retryWithBackoff(
@@ -576,6 +622,37 @@ export async function generateNewsletterWithLlm(
     );
   }
 
+  // Cross-day dedup: drop bullets that repeat recently published newsletters. Runs only when a
+  // recent-bullet corpus was supplied (run.ts fetches it when crossRunDedup is enabled).
+  let crossRunDedupSummary:
+    | { removedCount: number; bySection: Record<string, number> }
+    | undefined;
+  if (recentBullets.length > 0) {
+    const crossRunDeduped = dedupeAgainstRecentBullets(
+      resolved,
+      recentBullets,
+      CONTENT_GENERATION_CONSTANTS.crossRunDedup.similarity,
+    );
+    resolved = crossRunDeduped.resolved;
+    crossRunDedupSummary = {
+      removedCount: crossRunDeduped.removedCount,
+      bySection: crossRunDeduped.bySection,
+    };
+
+    if (crossRunDeduped.removedCount > 0) {
+      logger.info(
+        {
+          tickerId: context.tickerId,
+          removedCount: crossRunDeduped.removedCount,
+          bySection: crossRunDeduped.bySection,
+          minSimilarity: CONTENT_GENERATION_CONSTANTS.crossRunDedup.similarity,
+          event: "cross_run_dedup",
+        },
+        `Cross-run dedup: removed ${String(crossRunDeduped.removedCount)} bullet(s) repeating recent newsletters`,
+      );
+    }
+  }
+
   const content = formatIndustryNewsletterWire(resolved);
 
   const rawTitle =
@@ -608,5 +685,6 @@ export async function generateNewsletterWithLlm(
       bySection: computeNewsletterSectionFill(resolved),
       sectionsRemoved: prunedSectionsRemoved,
     },
+    ...(crossRunDedupSummary ? { crossRunDedupSummary } : {}),
   };
 }

--- a/apps/mediapulse/agents/content-generation/src/run.test.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.test.ts
@@ -13,6 +13,7 @@ import {
 const contentGenerationGet = vi.fn();
 const contentGenerationCreate = vi.fn();
 const contentGenerationNewslettersLatestGet = vi.fn();
+const contentGenerationBulletsRecentGet = vi.fn();
 const contentGenerationRunsCreate = vi.fn();
 const newsletterTranslationCreate = vi.fn();
 
@@ -24,6 +25,9 @@ vi.mock("@workspace/agent-data-api-client", () => ({
     },
     contentGenerationNewslettersLatest: {
       get: contentGenerationNewslettersLatestGet,
+    },
+    contentGenerationBulletsRecent: {
+      get: contentGenerationBulletsRecentGet,
     },
     contentGenerationRuns: {
       create: contentGenerationRunsCreate,
@@ -159,6 +163,8 @@ describe("run", () => {
     contentGenerationGet.mockReset();
     contentGenerationCreate.mockReset();
     contentGenerationNewslettersLatestGet.mockReset();
+    contentGenerationBulletsRecentGet.mockReset();
+    contentGenerationBulletsRecentGet.mockResolvedValue({ items: [] });
     contentGenerationRunsCreate.mockReset();
     newsletterTranslationCreate.mockReset();
     vi.spyOn(LlmGenerate, "generateNewsletterWithLlm").mockReset();
@@ -189,6 +195,64 @@ describe("run", () => {
     expect(contentGenerationGet).toHaveBeenCalledTimes(1);
     expect(LlmGenerate.generateNewsletterWithLlm).toHaveBeenCalledTimes(1);
     expect(contentGenerationCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches recent bullets over the configured window and passes them to generation", async () => {
+    contentGenerationNewslettersLatestGet.mockResolvedValue({
+      hasNewsletter: false,
+      newsletterId: null,
+    });
+    contentGenerationGet.mockResolvedValue(makeGetResponse());
+    contentGenerationBulletsRecentGet.mockResolvedValue({
+      items: [
+        {
+          newsletterId: "nl-0",
+          sectionKey: "quickHits",
+          bulletText: "Prior point",
+          createdAt: "2026-04-20T12:00:00.000Z",
+        },
+      ],
+    });
+    contentGenerationCreate.mockResolvedValue({ message: "ok", id: "nl-1" });
+    const generateSpy = vi
+      .spyOn(LlmGenerate, "generateNewsletterWithLlm")
+      .mockResolvedValue(generatedNewsletter);
+
+    await run(makeContext());
+
+    expect(contentGenerationBulletsRecentGet).toHaveBeenCalledWith({
+      tickerId: TEST_TICKER_ID,
+      days: 14,
+    });
+    expect(generateSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({
+        recentBullets: [{ sectionKey: "quickHits", bulletText: "Prior point" }],
+      }),
+    );
+  });
+
+  it("still succeeds and generates when the recent-bullets fetch fails", async () => {
+    contentGenerationNewslettersLatestGet.mockResolvedValue({
+      hasNewsletter: false,
+      newsletterId: null,
+    });
+    contentGenerationGet.mockResolvedValue(makeGetResponse());
+    contentGenerationBulletsRecentGet.mockRejectedValue(new Error("boom"));
+    contentGenerationCreate.mockResolvedValue({ message: "ok", id: "nl-1" });
+    const generateSpy = vi
+      .spyOn(LlmGenerate, "generateNewsletterWithLlm")
+      .mockResolvedValue(generatedNewsletter);
+
+    const result = await run(makeContext());
+
+    expect(result.success).toBe(true);
+    expect(generateSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ recentBullets: [] }),
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/apps/mediapulse/agents/content-generation/src/run.ts
+++ b/apps/mediapulse/agents/content-generation/src/run.ts
@@ -5,7 +5,11 @@ import { logger } from "@workspace/logger";
 
 import { AGENT_VERSION } from "./agent-version.js";
 import type { ContentGenerationConfig } from "./config-schema.js";
-import { resolveContentGenerationConfig } from "./config-schema.js";
+import {
+  CONTENT_GENERATION_CONSTANTS,
+  resolveContentGenerationConfig,
+} from "./config-schema.js";
+import type { RecentBullet } from "./lib/cross-run-dedup.js";
 import { classifyPersistError } from "./classify-persist-error.js";
 import { classifyLlmError } from "./llm-classify-error.js";
 import { computeConfigVersion } from "./compute-config-version.js";
@@ -363,6 +367,27 @@ export async function run({
 
   const sourcesForLlm = groupSourcesBySection(mappedSources);
 
+  // Cross-day dedup corpus: recently published bullets steer the model away from repeats and
+  // seed the post-generation drop. Best-effort — a fetch failure must not block generation.
+  let recentBullets: RecentBullet[] = [];
+  if (CONTENT_GENERATION_CONSTANTS.crossRunDedup.enabled) {
+    try {
+      const recent = await dataApiClient.contentGenerationBulletsRecent.get({
+        tickerId: input.tickerId,
+        days: CONTENT_GENERATION_CONSTANTS.crossRunDedup.windowDays,
+      });
+      recentBullets = recent.items.map((item) => ({
+        sectionKey: item.sectionKey,
+        bulletText: item.bulletText,
+      }));
+    } catch (err) {
+      logger.warn(
+        { tickerId: input.tickerId, err },
+        "Cross-run dedup: failed to fetch recent bullets; proceeding without",
+      );
+    }
+  }
+
   // Generate newsletter with retry-wrapped generateObject.
   let generated: Awaited<ReturnType<typeof generateNewsletterWithLlm>>;
   report(...narrativeGenerating(subject, sourcesForLlm.length));
@@ -375,6 +400,7 @@ export async function run({
       tickerSymbol,
       competitors,
       issuerAliases,
+      recentBullets,
       ...(contract !== undefined ? { brief: contract.brief } : {}),
     });
   } catch (err) {


### PR DESCRIPTION
## Summary

Widening the source-selection window (#901) lets consecutive newsletters overlap, so the same story could show up on back-to-back days. This wires the already-existing but unused `getRecentNewsletterBullets` endpoint into the content-generation agent to steer the model away from repeats and drop the ones that slip through. No contract, SDK, or Hermes-config changes.

## Related issues

Closes #900

## Important changes

- New `lib/cross-run-dedup.ts`: drops bullets that repeat recently published ones (Jaccard >= 0.55 against the recent corpus), reusing the existing `buildWordShingles` / `shingleJaccardSimilarity` / `tokenize` utilities and mirroring the within-run dedup pass. It enforces a per-section floor so a section is never emptied — which is also a correctness requirement, since the wire serializer refuses to emit a zero-row section.
- `run.ts` fetches recent bullets via `contentGenerationBulletsRecent.get({ tickerId, days })` and passes them into generation. The fetch is best-effort: a failure logs a warning and generation proceeds without a corpus.
- `llm-generate-newsletter.ts` injects an "avoid repeating these recent bullets" prompt block (capped at 20) above the article summaries, runs the drop pass between within-run dedup and wire serialization, and surfaces counts in `crossRunDedupSummary`.

## Other changes

- Settings live in `CONTENT_GENERATION_CONSTANTS.crossRunDedup` (enabled / windowDays / similarity / promptBulletLimit) as hardcoded constants — not Hermes config — matching how within-run dedup, citation grounding, and require-citation are configured in this agent.

## Key files to review

- `apps/mediapulse/agents/content-generation/src/lib/cross-run-dedup.ts` - the drop pass, similarity reuse, and per-section floor.
- `apps/mediapulse/agents/content-generation/src/llm-generate-newsletter.ts` - prompt block + where the pass runs in the pipeline.
- `apps/mediapulse/agents/content-generation/src/run.ts` - the guarded, best-effort recent-bullets fetch.

## How to test

1. `pnpm --filter @mediapulse/content-generation test` - cross-run-dedup unit tests (drop, floor, uncited-keep, quickHits), the prompt-block + end-to-end drop integration tests, and the run.ts fetch-wiring tests pass.
2. `pnpm --filter @mediapulse/agent-data-api test` - the added `getRecentNewsletterBullets` service test passes.
3. After rollout, watch newsletters for repeated bullets across consecutive days and the `cross_run_dedup` log line reporting removed counts.
