### PR TITLE
Render Quick Hits like other newsletter sections

### DIFF
--- a/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
+++ b/packages/shared/email-templates/src/newsletter/default-newsletter.tsx
@@ -319,6 +319,9 @@ export const DefaultNewsletterEmail = ({
     }
 
     if (section.machineKey === "quick-hits") {
+      if (section.items.length === 0) {
+        return <Fragment key={`${section.machineKey}-${String(index)}`} />;
+      }
       return (
         <Section key={`${section.machineKey}-${String(index)}`}>
           {renderSectionHeader(section.machineKey, section.displayHeading)}
@@ -332,8 +335,8 @@ export const DefaultNewsletterEmail = ({
                     {itemByline}
                   </Text>
                 ) : null}
-                <Text className="m-0 mb-2 text-base font-semibold leading-normal text-body">
-                  {itemIndex + 1}. {item.text}
+                <Text className="m-0 text-base leading-relaxed text-body">
+                  {renderInlineMarkdownLinks(item.text, link)}
                 </Text>
                 {item.url !== undefined && item.url !== "" ? (
                   <Text className="m-0 mt-2 text-sm leading-normal text-body">


### PR DESCRIPTION
## Summary

The Quick Hits section in the industry newsletter rendered differently from every other body section: bold text, numeric prefixes (1., 2., 3.), a tighter line-height, and raw text that skipped inline-link parsing. This change makes Quick Hits items render exactly like the bullet sections, so the whole newsletter reads consistently.

## Related issues

Closes #903

## Important changes

- `default-newsletter.tsx`: the Quick Hits item text now uses the same style as bullet items (`text-base leading-relaxed text-body`, regular weight), drops the `1. 2. 3.` numbering, and runs through `renderInlineMarkdownLinks` so inline links work the same way.

## Other changes

- Added the empty-array guard the bullet block already has, so a Quick Hits section with no items renders nothing instead of an empty header.

## Key files to review

- `packages/shared/email-templates/src/newsletter/default-newsletter.tsx` - the `quick-hits` rendering block now mirrors the bullet block.

## How to test

1. `pnpm --filter @workspace/email-templates test` - all tests pass.
2. Optionally open the React Email preview and compare the `newsletter-en` and `newsletter-id` entries: Quick Hits items should look like the other sections (regular weight, no numbers), and the parity holds across both locales since they share one template.
